### PR TITLE
Optimizing pooling in FlxQuadTree & FlxList - better

### DIFF
--- a/src/org/flixel/system/debug/Perf.hx
+++ b/src/org/flixel/system/debug/Perf.hx
@@ -6,6 +6,8 @@ import nme.system.System;
 import nme.text.TextField;
 import nme.text.TextFormat;
 import nme.Lib;
+import org.flixel.system.FlxList;
+import org.flixel.system.FlxQuadTree;
 
 import org.flixel.FlxU;
 import org.flixel.FlxG;
@@ -73,7 +75,7 @@ class Perf extends FlxWindow
 		#end
 		
 		super(Title, Width, Height, Resizable, Bounds, BGColor, TopColor);
-		resize(90, 80);
+		resize(90, 110);
 		
 		_lastTime = 0;
 		_updateTimer = 0;
@@ -207,6 +209,9 @@ class Perf extends FlxWindow
 			output += "\nDrwTls:" + drawCallsCount;
 			_drawCallsMarker = 0;
 			#end
+			
+			output += "\nQuadTrees:" + FlxQuadTree._NUM_CACHED_QUAD_TREES;
+			output += "\nLists:" + FlxList._NUM_CACHED_FLX_LIST;
 			
 			_text.text = output;
 			


### PR DESCRIPTION
I'm happy with this implementation, it's a little confusing, but essentially, FlxQuadTree now has a "head" and "next" references of type FlxQuadTree, essentially turning it into a Linked List. FlxList already is a linked list, so it didn't need many changes.

There's no allocation unless a new FlxQuadTree or FlxList are absolutely necessary, and storing objects to be recycled is blazing fast.

I also added some values into the perf window to help identify potential memory issues.
