### PR TITLE
Fixes issue #128

### DIFF
--- a/src/org/flixel/FlxGame.hx
+++ b/src/org/flixel/FlxGame.hx
@@ -230,11 +230,7 @@ class FlxGame extends Sprite
 		_requestedReset = true;
 		_created = false;
 		
-		#if iphone
-		Lib.current.stage.addEventListener(Event.RESIZE, create);
-		#else
 		addEventListener(Event.ADDED_TO_STAGE, create);
-		#end
 	}
 	
 	/**
@@ -839,16 +835,10 @@ class FlxGame extends Sprite
 			return;
 		}
 		
-		#if iphone
-		Lib.current.stage.removeEventListener(Event.RESIZE, create);
-		#else
 		removeEventListener(Event.ADDED_TO_STAGE, create);
-		#end
 		
 		_total = Lib.getTimer();
-		//Set up the view window and double buffering
-		stage.scaleMode = StageScaleMode.NO_SCALE;
-		stage.align = StageAlign.TOP_LEFT;
+		
 		stage.frameRate = _flashFramerate;
 		
 		FlxG.supportsTouchEvents = Multitouch.supportsTouchEvents;

--- a/template/Source/Main.hx.tpl
+++ b/template/Source/Main.hx.tpl
@@ -31,9 +31,7 @@ class Main extends Sprite
 		{
 			removeEventListener(Event.ADDED_TO_STAGE, init);
 		}
-		
-		initialize();
-		
+				
 		var demo:FlxGame = new ${PROJECT_CLASS}();
 		addChild(demo);
 		
@@ -51,12 +49,6 @@ class Main extends Sprite
 		}
 	}
 	#end
-	
-	private function initialize():Void 
-	{
-		Lib.current.stage.align = StageAlign.TOP_LEFT;
-		Lib.current.stage.scaleMode = StageScaleMode.NO_SCALE;
-	}
 	
 	// Entry point
 	public static function main() {


### PR DESCRIPTION
Removes iPhone-specific RESIZE event handler in FlxGame. Also removes unecessary setting of stage scaleMode and align, as mentioned in the comments for this issue: https://github.com/Beeblerox/HaxeFlixel/issues/128
