### PR TITLE
Making preUpdate and postUpdate functions inlined in FlxState

### DIFF
--- a/src/org/flixel/FlxState.hx
+++ b/src/org/flixel/FlxState.hx
@@ -91,4 +91,15 @@ class FlxState extends FlxGroup
 	{
 		
 	}
+	
+	/**
+	 * This function is inlined because it never gets called on FlxState objects.
+	 * Put your code in the update() function.
+	 */
+	override public inline function preUpdate():Void {}
+	/**
+	 * This function is inlined because it never gets called on FlxState objects.
+	 * Put your code in the update() function.
+	 */
+	override public inline function postUpdate():Void {}
 }


### PR DESCRIPTION
They never get called, so adding the inline keyword prevents them from being overridden and implemented in child classes.

This commit fixes issue #188.
