### PR TITLE
FlxSprite.draw() problem with blendingMode in targets != flash || js

### DIFF
--- a/src/org/flixel/FlxSprite.hx
+++ b/src/org/flixel/FlxSprite.hx
@@ -824,7 +824,11 @@ class FlxSprite extends FlxObject
 		#if !flash
 		_calculatedPixelsIndex = -1;
 		#end
-		_pixels.draw(bitmapData, _matrix, null, brushBlend, null, Brush.antialiasing);
+		#if (flash || js)
+			_pixels.draw(bitmapData, _matrix, null, Brush.blend, null, Brush.antialiasing);
+		#else
+			_pixels.draw(bitmapData, _matrix, null, cast(Brush.blend,String), null, Brush.antialiasing);
+		#end
 		#if flash
 		calcFrame();
 		#end


### PR DESCRIPTION
FlxSprite: cast blendingMode to String in targets != (flash || js)
