### PR TITLE
Support of rotated sprites in TexturePacker atlases

### DIFF
--- a/src/org/flixel/FlxSprite.hx
+++ b/src/org/flixel/FlxSprite.hx
@@ -209,6 +209,11 @@ class FlxSprite extends FlxObject
 	
 	private var _halfWidth:Float;
 	private var _halfHeight:Float;
+
+	/**
+	 * Internal, additional rotation for sprite. Used in FlxSpriteTex.
+	 */
+	private var _additionalAngle : Float;
 	#end
 	
 	/**
@@ -262,6 +267,7 @@ class FlxSprite extends FlxObject
 		_blue = 1.0;
 		
 		_frameID = 0;
+		_additionalAngle = 0.0;
 		#end
 		
 		if (SimpleGraphic == null)
@@ -775,12 +781,12 @@ class FlxSprite extends FlxObject
 				_matrix.scale(scale.x, scale.y);
 				if ((angle != 0) && (bakedRotation <= 0))
 				{
-					_matrix.rotate(angle * FlxG.RAD);	
+					_matrix.rotate((angle) * FlxG.RAD);	
 				}
 				_matrix.translate(_point.x + origin.x, _point.y + origin.y);
 				camera.buffer.draw(framePixels, _matrix, null, blend, null, antialiasing);
 				#else
-				radians = -angle * FlxG.RAD;
+				radians = -(angle + _additionalAngle) * FlxG.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 				
@@ -975,7 +981,11 @@ class FlxSprite extends FlxObject
 		if (bakedRotation > 0)
 		{
 			var oldIndex:Int = _curIndex;
-			var angleHelper:Int = Math.floor(angle % 360);
+#if flash
+			var angleHelper:Int = Math.floor((angle) % 360);
+#else
+			var angleHelper:Int = Math.floor((angle + _additionalAngle) % 360);
+#end
 			
 			#if flash
 			if (angleHelper < 0)
@@ -1502,7 +1512,11 @@ class FlxSprite extends FlxObject
 		_point.y = _point.y - offset.y;
 		
 		var result:Bool = false;
-		if (((angle == 0) || (bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1))
+		var notRotated = angle == 0.0;
+#if !flash
+		notRotated = notRotated && _additionalAngle != 0.0;
+#end
+		if ((notRotated || (bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1))
 		{
 			result = ((_point.x + frameWidth > 0) && (_point.x < Camera.width) && (_point.y + frameHeight > 0) && (_point.y < Camera.height));
 		}
@@ -1835,7 +1849,7 @@ class FlxSprite extends FlxObject
 		#if flash
 		return (((angle == 0) || (bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1) && (blend == null));
 		#else
-		return (((angle == 0) || (bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1));
+		return (((angle == 0 && _additionalAngle == 0) || (bakedRotation > 0)) && (scale.x == 1) && (scale.y == 1));
 		#end
 	}
 	

--- a/src/org/flixel/plugin/texturepacker/FlxSpriteTex.hx
+++ b/src/org/flixel/plugin/texturepacker/FlxSpriteTex.hx
@@ -9,6 +9,7 @@ import org.flixel.system.layer.Atlas;
 #end
 
 import nme.geom.Point;
+import nme.geom.Rectangle;
 import nme.display.BitmapData;
 
 class FlxSpriteTex extends FlxSprite
@@ -23,18 +24,36 @@ class FlxSpriteTex extends FlxSprite
 #if !flash
     super (x, y, tex.assetName);
 #else
+    super (x, y);
+
     var spriteInfo = _tex.sprites[_spriteId];
     var bm : BitmapData = new BitmapData (
         Std.int (spriteInfo.source.width),
         Std.int (spriteInfo.source.height),
         true, 0x00ffffff);
 
-    var dst : Point = new Point (
-          (spriteInfo.source.width - spriteInfo.frame.width) * 0.5,
-          (spriteInfo.source.height - spriteInfo.frame.height) * 0.5);
+    if (spriteInfo.rotated)
+    {
+      _matrix.identity ();
+      _matrix.translate (-spriteInfo.source.width * 0.5,
+          -spriteInfo.source.height * 0.5);
+      _matrix.rotate (-90.0 * FlxG.RAD);
+      _matrix.translate (spriteInfo.source.width * 0.5,
+          spriteInfo.source.height * 0.5);
+      _matrix.translate (spriteInfo.offset.x, spriteInfo.offset.y);
 
-    bm.copyPixels (_tex.asset, spriteInfo.frame, dst);
-    super (x, y);
+      var r = new Rectangle (spriteInfo.frame.x,
+          spriteInfo.frame.y,
+          spriteInfo.frame.width + spriteInfo.offset.x,
+          spriteInfo.frame.height + spriteInfo.offset.y);
+      bm.draw (_tex.asset, _matrix, null, null, r, false);
+    }
+    else
+    {
+      var dst : Point = new Point (spriteInfo.offset.x, spriteInfo.offset.y);
+      bm.copyPixels (_tex.asset, spriteInfo.frame, dst);
+    }
+
     loadGraphic (bm, false, false, 0, 0, false, _tex.assetName + spriteName);
 #end
   }
@@ -43,14 +62,12 @@ class FlxSpriteTex extends FlxSprite
   {
 #if !flash
     var spriteInfo = _tex.sprites[_spriteId];
-
     width = frameWidth = Std.int (spriteInfo.source.width);
     height = frameHeight = Std.int (spriteInfo.source.height);
-    if (spriteInfo.trimmed)
+    offset = spriteInfo.offset;
+    if (spriteInfo.rotated)
     {
-      offset = new FlxPoint (
-          -(spriteInfo.source.width - spriteInfo.frame.width) * 0.5,
-          -(spriteInfo.source.height - spriteInfo.frame.height) * 0.5);
+      _additionalAngle = -90.0;
     }
 #end
     super.resetHelpers ();

--- a/src/org/flixel/plugin/texturepacker/TexturePackerSprites.hx
+++ b/src/org/flixel/plugin/texturepacker/TexturePackerSprites.hx
@@ -37,13 +37,37 @@ class TexturePackerSprite
   public var frame : Rectangle;
   public var source : Rectangle;
   public var trimmed : Bool;
+  public var rotated : Bool;
+  public var offset : FlxPoint;
 
   public function new (s : Dynamic)
   {
-    frame = new Rectangle (s.frame.x, s.frame.y, s.frame.w, s.frame.h);
-    source = new Rectangle (0, 0,
-        s.sourceSize.w, s.sourceSize.h);
     trimmed = s.trimmed;
+    rotated = s.rotated;
+    source = new Rectangle (0, 0, s.sourceSize.w, s.sourceSize.h);
+    offset = new FlxPoint (0, 0);
+#if !flash
+    // we use negative offset because code in FlxSprite.draw
+    // use it in such way
+    offset.make (
+        -(s.sourceSize.w - s.frame.w) * 0.5,
+        -(s.sourceSize.h - s.frame.h) * 0.5);
+    if (rotated)
+    {
+      frame = new Rectangle (s.frame.x, s.frame.y, s.frame.h, s.frame.w);
+    }
+    else
+    {
+      frame = new Rectangle (s.frame.x, s.frame.y, s.frame.w, s.frame.h);
+    }
+#else
+    frame = new Rectangle (s.frame.x, s.frame.y, s.frame.w, s.frame.h);
+    // we use positive offset because in FlxSpriteTex.new
+    // we need to translate a sprite
+    offset.make (
+        (s.sourceSize.w - s.frame.w) * 0.5,
+        (s.sourceSize.h - s.frame.h) * 0.5);
+#end
   }
 }
 


### PR DESCRIPTION
For cpp target used _additionalAngel to rotate sprite.
For flash target FlxSprite create with BitmapData, that cut and rotate from TexturePacker atlas.
