### PR TITLE
Fixed Tilemap tearing when camera scrolls with zoom

### DIFF
--- a/src/org/flixel/FlxTilemap.hx
+++ b/src/org/flixel/FlxTilemap.hx
@@ -413,8 +413,8 @@ class FlxTilemap extends FlxObject
 		Buffer.fill();
 	#else
 		#if !js
-		_helperPoint.x = Math.floor((x - Camera.scroll.x * scrollFactor.x) * 5) / 5; //copied from getScreenXY()
-		_helperPoint.y = Math.floor((y - Camera.scroll.y * scrollFactor.y) * 5) / 5;
+		_helperPoint.x = Math.floor((x - Math.floor(Camera.scroll.x) * scrollFactor.x) * 5) / 5 + 0.1; //copied from getScreenXY()
+		_helperPoint.y = Math.floor((y - Math.floor(Camera.scroll.y) * scrollFactor.y) * 5) / 5 + 0.1;
 		#else
 		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x; //copied from getScreenXY()
 		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y;


### PR DESCRIPTION
Use this demo to test: https://dl.dropbox.com/u/8217321/TilemapDemo.zip (default zoom: 0.5)
I've tested on Linux with some different zoom levels (out and in), seems to be completely fixed now.
