### PR TITLE
Added a postUpdate call to plugins that gets called after the state update

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -1823,6 +1823,25 @@ class FlxG
 	}
 	
 	/**
+	 * Used by the game object to call <code>postUpdate()</code> on all the plugins. Called after the current state has been updated.
+	 */
+	inline static public function postUpdatePlugins():Void
+	{
+		var plugin:FlxBasic;
+		var pluginList:Array<FlxBasic> = FlxG.plugins;
+		var i:Int = 0;
+		var l:Int = pluginList.length;
+		while(i < l)
+		{
+			plugin = pluginList[i++];
+			if (plugin.exists && plugin.active)
+			{
+				plugin.postUpdate();
+			}
+		}
+	}
+	
+	/**
 	 * Used by the game object to call <code>draw()</code> on all the plugins.
 	 */
 	inline static public function drawPlugins():Void

--- a/src/org/flixel/FlxGame.hx
+++ b/src/org/flixel/FlxGame.hx
@@ -566,6 +566,7 @@ class FlxGame extends Sprite
 		FlxG.updateSounds();
 		FlxG.updatePlugins();
 		_state.tryUpdate();
+		FlxG.postUpdatePlugins();
 		
 		if (FlxG.tweener.active && FlxG.tweener.hasTween) 
 		{


### PR DESCRIPTION
...and before the draw call. One use for this might be if you wanted to call FlxG.collide() inside a plugin, it's best done after the state update after all other motions are accounted for. Giving plugins more control might make them more attractive to work with.
