### PR TITLE
Reset widthInTiles on multiple loadMap calls

### DIFF
--- a/src/org/flixel/FlxTilemap.hx
+++ b/src/org/flixel/FlxTilemap.hx
@@ -253,6 +253,7 @@ class FlxTilemap extends FlxObject
 			var columns:Array<String>;
 			var rows:Array<String> = MapData.split("\n");
 			heightInTiles = rows.length;
+			widthInTiles = 0;
 			var row:Int = 0;
 			var column:Int;
 			while (row < heightInTiles)


### PR DESCRIPTION
Fixes the issue in FlxTilemap.loadMap where calling 
it on the same FlxTilemap more than once
wouldn't reset the widthInTiles field.
