### PR TITLE
Fixes for Neko target on haxe 3 branch.

### DIFF
--- a/src/org/flixel/FlxTextField.hx
+++ b/src/org/flixel/FlxTextField.hx
@@ -160,17 +160,9 @@ class FlxTextField extends FlxText
 	/**
 	 * @private
 	 */
-	#if flash
-	override private function set_color(Color:UInt):UInt
-	#else
-	override private function set_color(Color:BitmapInt32):BitmapInt32
-	#end
+	override private function set_color(Color:Int):Int
 	{
-		#if neko
-		_format.color = Color.rgb;
-		#else
 		_format.color = Color;
-		#end
 		updateTextField();
 		return Color;
 	}

--- a/src/org/flixel/nape/FlxPhysState.hx
+++ b/src/org/flixel/nape/FlxPhysState.hx
@@ -32,6 +32,9 @@ class FlxPhysState extends FlxState
 	 * Contains the sprite used for nape debug graphics.
 	 */
 	private var _physDbgSpr:ShapeDebug;
+	
+	public static var debug(get_debug, null):ShapeDebug;
+	public static function get_debug() { return cast(FlxG.state, FlxPhysState)._physDbgSpr; }
 	#end
 	
 	/**

--- a/src/org/flixel/plugin/pxText/FlxBitmapTextField.hx
+++ b/src/org/flixel/plugin/pxText/FlxBitmapTextField.hx
@@ -681,10 +681,6 @@ class FlxBitmapTextField extends FlxSprite
 			red *= (_color >> 16);
 			green *= (_color >> 8 & 0xff);
 			blue *= (_color & 0xff);
-			#elseif neko
-			red *= (_color.rgb >> 16);
-			green *= (_color.rgb >> 8 & 0xff);
-			blue *= (_color.rgb & 0xff);
 			#end
 			
 			_bgDrawData.push(red);

--- a/src/org/flixel/plugin/pxText/PxButton.hx
+++ b/src/org/flixel/plugin/pxText/PxButton.hx
@@ -25,11 +25,7 @@ class PxButton extends FlxTypedButton<FlxBitmapTextField>
 			label.setWidth(80);
 			label.text = Label;
 			label.fontScale = 0.7 * 10 / 11;
-			#if !neko
 			label.color = 0x333333;
-			#else
-			label.color = {rgb: 0x333333, a: 0xff};
-			#end
 			label.useTextColor = false;
 			label.alignment = PxTextAlign.CENTER;
 			labelOffset = new FlxPoint(0, 5);

--- a/src/org/flixel/plugin/pxText/PxDefaultFontGenerator.hx
+++ b/src/org/flixel/plugin/pxText/PxDefaultFontGenerator.hx
@@ -19,11 +19,7 @@ class PxDefaultFontGenerator
 	public static function generateAndStoreDefaultFont():Void 
 	{
 		var letters:String = "";
-		#if neko
-		var bd:BitmapData = new BitmapData(700, 9, true, {rgb: 0x888888, a: 0xFF});
-		#else
 		var bd:BitmapData = new BitmapData(700, 9, true, 0xFF888888);
-		#end
 		
 		var letterPos:Int = 0;
 		var i:Int = 0;

--- a/src/org/flixel/tweens/motion/CircularMotion.hx
+++ b/src/org/flixel/tweens/motion/CircularMotion.hx
@@ -91,5 +91,5 @@ class CircularMotion extends Motion
 	private var _radius:Float;
 	private var _angleStart:Float;
 	private var _angleFinish:Float;
-	private static inline var _CIRC:Float = Math.PI * 2;
+	private static var _CIRC:Float = Math.PI * 2;
 }


### PR DESCRIPTION
Neko target seems to be having issues with colors. It's likely caused because Ints in Neko have one less bit than other targets, we might have to look into [Int32](http://nekovm.org/doc/view/int32).
