### PR TITLE
nape: addPremadeBody fails with static body

### DIFF
--- a/src/org/flixel/nape/FlxPhysSprite.hx
+++ b/src/org/flixel/nape/FlxPhysSprite.hx
@@ -97,9 +97,9 @@ class FlxPhysSprite extends FlxSprite
 		if (this.body != null) 
 			destroyPhysObjects();
 		
-		body.space = FlxPhysState.space;
 		body.position.x = x;
 		body.position.y = y;
+		body.space = FlxPhysState.space;
 		this.body = body;
 		setBodyMaterial();
 	}


### PR DESCRIPTION
Nape fails upon addPremadeBody with static body and non zero position of sprite (Error Cannot move a static object once inside a Space)
