### PR TITLE
Fixing input and state reset issues with threaded builds.

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -1677,14 +1677,6 @@ class FlxG
 	}
 	
 	/**
-	 * Called by the game object to update all the inputs enabled in FlxInputs
-	 */
-	inline static public function updateInputs():Void
-	{
-		FlxInputs.updateInputs();
-	}
-	
-	/**
 	 * Called by the game object to lock all the camera buffers and clear them for the next draw pass.
 	 */
 	inline static public function lockCameras():Void

--- a/src/org/flixel/nape/FlxPhysState.hx
+++ b/src/org/flixel/nape/FlxPhysState.hx
@@ -73,95 +73,7 @@ class FlxPhysState extends FlxState
 		#end
 	}
 	
-	/**
-	 * Override this method and add <code>super.update()</code>. 
-	 */
-	override public function update():Void 
-	{
-		#if !FLX_NO_DEBUG
-		if (_physDbgSpr != null) 
-		{
-			_physDbgSpr.clear();
-			_physDbgSpr.draw(space);
-			
-			var cam = FlxG.camera;
-			var zoom = cam.zoom;
-			
-			_physDbgSpr.display.scaleX = zoom; 
-			_physDbgSpr.display.scaleY = zoom;
-			
-			if (cam.target == null) 
-			{
-				_physDbgSpr.display.x = cam.scroll.x * zoom;
-				_physDbgSpr.display.y = cam.scroll.y * zoom;
-			} else 
-			{
-				_physDbgSpr.display.x = -cam.scroll.x * zoom;
-				_physDbgSpr.display.y = -cam.scroll.y * zoom;
-				_physDbgSpr.display.x += (FlxG.width - FlxG.width * zoom) / 2; 
-				_physDbgSpr.display.y += (FlxG.height - FlxG.height * zoom) / 2;
-			}
-			
-		}
-		#end
-		
-		space.step(FlxG.elapsed, velocityIterations, positionIterations);
-		
-		super.update();
-		
-	}
-	
-	/**
-	 * Override this function to null out variables or manually call
-	 * <code>destroy()</code> on class members if necessary.
-	 * Don't forget to call <code>super.destroy()</code>!
-	 */
-	override public function destroy():Void 
-	{
-		super.destroy();
-		space.clear();
-		
-		#if !FLX_NO_DEBUG
-		disablePhysDebug();
-		#end
-	}
-	
-	#if !FLX_NO_DEBUG
-	/**
-	 * Enables debug graphics for nape physics.
-	 */
-	public function enablePhysDebug() 
-	{
-		if (_physDbgSpr != null) 
-		{
-			disablePhysDebug();
-		}
-		
-		_physDbgSpr = new ShapeDebug(FlxG.width, FlxG.height);
-		_physDbgSpr.drawConstraints = true;
-		
-		FlxG.stage.addChild(_physDbgSpr.display);
-		//FlxG.camera._flashSprite.addChild(_physDbgSpr.display);
-		//_physDbgSpr.display.x = 100;
-		//_physDbgSpr.display.y = 140;
-	}
-	
-	/**
-	 * Disables debug graphics.
-	 */
-	public function disablePhysDebug()
-	{
-		if (_physDbgSpr == null) 
-		{
-			return;
-		}
-		
-		FlxG.stage.removeChild(_physDbgSpr.display);
-		_physDbgSpr = null;
-	}
-	#end
-	
-	/**
+		/**
 	 * Creates simple walls around game area - usefull for prototying.
 	 * 
 	 * @param	minX	The smallest X value of your level (usually 0).
@@ -187,16 +99,108 @@ class FlxPhysState extends FlxState
 		// left wall
 		walls.shapes.add(new Polygon(Polygon.rect(minX, minY, thickness, maxY + Math.abs(minY))));
 		// right wall
-        walls.shapes.add(new Polygon(Polygon.rect(maxX - thickness, minY, thickness, maxY + Math.abs(minY))));
+		walls.shapes.add(new Polygon(Polygon.rect(maxX - thickness, minY, thickness, maxY + Math.abs(minY))));
 		// upper wall
-        walls.shapes.add(new Polygon(Polygon.rect(minX, minY, maxX + Math.abs(minX), thickness)));
+		walls.shapes.add(new Polygon(Polygon.rect(minX, minY, maxX + Math.abs(minX), thickness)));
 		// bottom wall
-        walls.shapes.add(new Polygon(Polygon.rect(minX, maxY - thickness, maxX + Math.abs(minX), thickness)));
-		
+		walls.shapes.add(new Polygon(Polygon.rect(minX, maxY - thickness, maxX + Math.abs(minX), thickness)));
 		
 		walls.space = space;
 		walls.setShapeMaterials(material);
 		return walls;
 	}
 	
+	/**
+	 * Override this method and add <code>super.update()</code>. 
+	 */
+	override public function update():Void 
+	{
+		space.step(FlxG.elapsed, velocityIterations, positionIterations);
+		super.update();
+	}
+	
+	/**
+	 * Override this method to draw debug physics shapes
+	 */
+	override public function draw():Void 
+	{
+		super.draw();
+		#if !FLX_NO_DEBUG
+		drawPhysDebug();
+		#end
+	}
+	
+	/**
+	 * Override this function to null out variables or manually call
+	 * <code>destroy()</code> on class members if necessary.
+	 * Don't forget to call <code>super.destroy()</code>!
+	 */
+	override public function destroy():Void 
+	{
+		super.destroy();
+		space.clear();
+		
+		#if !FLX_NO_DEBUG
+		disablePhysDebug();
+		#end
+	}
+	
+	#if !FLX_NO_DEBUG
+	/**
+	 * Enables debug graphics for nape physics.
+	 */
+	public function enablePhysDebug() 
+	{
+		if (_physDbgSpr != null) 
+			disablePhysDebug();
+		
+		_physDbgSpr = new ShapeDebug(FlxG.width, FlxG.height);
+		_physDbgSpr.drawConstraints = true;
+		
+		FlxG.stage.addChild(_physDbgSpr.display);
+	}
+	
+	/**
+	 * Disables debug graphics.
+	 */
+	public function disablePhysDebug()
+	{
+		if (_physDbgSpr == null) 
+			return;
+		
+		FlxG.stage.removeChild(_physDbgSpr.display);
+		_physDbgSpr = null;
+	}
+	
+	/**
+	 * Draws debug graphics.
+	 */
+	private function drawPhysDebug()
+	{
+		if (_physDbgSpr == null) 
+			return;
+		
+		_physDbgSpr.clear();
+		_physDbgSpr.draw(space);
+		
+		var cam = FlxG.camera;
+		var zoom = cam.zoom;
+		
+		_physDbgSpr.display.scaleX = zoom; 
+		_physDbgSpr.display.scaleY = zoom;
+		
+		if (cam.target == null) 
+		{
+			_physDbgSpr.display.x = cam.scroll.x * zoom;
+			_physDbgSpr.display.y = cam.scroll.y * zoom;
+		} 
+		else
+		{
+			_physDbgSpr.display.x = -cam.scroll.x * zoom;
+			_physDbgSpr.display.y = -cam.scroll.y * zoom;
+			_physDbgSpr.display.x += (FlxG.width - FlxG.width * zoom) / 2; 
+			_physDbgSpr.display.y += (FlxG.height - FlxG.height * zoom) / 2;
+		}
+	}
+	#end
 }


### PR DESCRIPTION
Only change to `FlxPhysState` was to make the debug shape drawing happen in the `draw()` function instead of `update()`. This was needed since it was causing a crash. I also moved around some code, that's why it seems like I made lots of changes in the file.
