### PR TITLE
Two small fixes for FlixelNape:

### DIFF
--- a/src/org/flixel/nape/FlxPhysSprite.hx
+++ b/src/org/flixel/nape/FlxPhysSprite.hx
@@ -1,5 +1,5 @@
-package org.flixel.nape;
 
+package org.flixel.nape;
 import nape.geom.Vec2;
 import nape.phys.Body;
 import nape.phys.BodyType;
@@ -63,13 +63,13 @@ class FlxPhysSprite extends FlxSprite
 	/**
 	 * Override core physics velocity etc
 	 */
-	override public function postUpdate():Void
+	override public function update():Void
 	{
+		super.update();
 		if (moves)
 		{
 			updatePhysObjects();
 		}
-		updateAnimation();
 	}
 
 	/**

--- a/src/org/flixel/nape/FlxPhysState.hx
+++ b/src/org/flixel/nape/FlxPhysState.hx
@@ -116,6 +116,9 @@ class FlxPhysState extends FlxState
 	override public function update():Void 
 	{
 		space.step(FlxG.elapsed, velocityIterations, positionIterations);
+		#if !FLX_NO_DEBUG
+		drawPhysDebug();
+		#end
 		super.update();
 	}
 	


### PR DESCRIPTION
I'm fix a bit a pull request of ProG4mr
- Fix for PostUpdate() no longer exists.
- Nape debug graphics were being draw on drawDebug cycle of flixel, which forces to use and see flixel debug to see nape debug graphics  ( please nooooo ).

Conflicts:
    src/org/flixel/nape/FlxPhysSprite.hx
