### PR TITLE
FlxParticle / FlxEmitter improvements

### DIFF
--- a/src/org/flixel/FlxEmitter.hx
+++ b/src/org/flixel/FlxEmitter.hx
@@ -81,6 +81,17 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	 */
 	public var lifespan:Float;
 	/**
+	 * If this is set to true, particles will slowly fade away by 
+	 * decreasing their alpha value based on their lifespan.
+	 */
+	public var fadingAway:Bool = false;
+	/**
+	 * If this is set to true, particles will slowly decrease in scale 
+	 * based on their lifespan.
+	 * WARNING: This severely impacts performance.
+	 */
+	public var decreasingSize:Bool = false;
+	/**
 	 * How much each particle should bounce.  1 = full bounce, 0 = no bounce.
 	 */
 	public var bounce:Float;
@@ -342,8 +353,10 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	public function emitParticle():Void
 	{
 		var particle:FlxParticle = recycle(cast _particleClass);
-		particle.lifespan = lifespan;
+		particle.lifespan = particle.maxLifespan = lifespan;
 		particle.elasticity = bounce;
+		particle.decreasingSize = decreasingSize;
+		particle.fadingAway = fadingAway;
 		particle.reset(x - (Std.int(particle.width) >> 1) + FlxG.random() * width, y - (Std.int(particle.height) >> 1) + FlxG.random() * height);
 		particle.visible = true;
 		

--- a/src/org/flixel/FlxParticle.hx
+++ b/src/org/flixel/FlxParticle.hx
@@ -26,6 +26,24 @@ class FlxParticle extends FlxSprite
 	public var friction:Float;
 	
 	/**
+	 * If this is set to true, particles will slowly fade away by 
+	 * decreasing their alpha value based on their lifespan.
+	 */
+	public var fadingAway:Bool = false;
+	
+	/**
+	 * If this is set to true, particles will slowly decrease in scale 
+	 * based on their lifespan.
+	 * WARNING: This severely impacts performance.
+	 */
+	public var decreasingSize:Bool = false;
+	
+	/**
+	 * Helper variable for fading and sizeDecreasing effects.
+	 */
+	public var maxLifespan:Float;
+	
+	/**
 	 * Instantiate a new particle.  Like <code>FlxSprite</code>, all meaningful creation
 	 * happens during <code>loadGraphic()</code> or <code>makeGraphic()</code> or whatever.
 	 */
@@ -34,6 +52,7 @@ class FlxParticle extends FlxSprite
 		super();
 		lifespan = 0;
 		friction = 500;
+		exists = false;
 	}
 	
 	/**
@@ -71,6 +90,18 @@ class FlxParticle extends FlxSprite
 				kill();
 			}
 			
+			// Fading away
+			if (fadingAway)
+			{
+				alpha -= (FlxG.elapsed / maxLifespan);
+			}
+			
+			// Decreasing size
+			if (decreasingSize) 
+			{
+				scale.x = scale.y -= (FlxG.elapsed / maxLifespan);
+			}
+		
 			//simpler bounce/spin behavior for now
 			if (touching != 0)
 			{

--- a/src/org/flixel/addons/FlxEmitterExt.hx
+++ b/src/org/flixel/addons/FlxEmitterExt.hx
@@ -98,7 +98,9 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<T:FlxParticle>
 			
 		particle.velocity.x = Math.cos(a) * d;
 		particle.velocity.y = Math.sin(a) * d;
-		particle.lifespan = lifespan + FlxG.random() * lifespanRange;
+		particle.lifespan = particle.maxLifespan = lifespan + FlxG.random() * lifespanRange;
+		particle.decreasingSize = decreasingSize;
+		particle.fadingAway = fadingAway;
 	}
 	
 	/**


### PR DESCRIPTION
I added the features mentioend in #304.

`FlxParticle` has now 2 more boolean variables: `decreasingSize` and `fadingAway` (feel free to suggest better names for either of them). They can be used in conjunction and are based on `lifespan`, which makes them really easy to use. This also required the addition of the `maxLifespan` variable. It's a really nice effect and looks much better.
The implementation is really simple. Both `scale` and `alpha` are decremented each frame so that `scale` / `alpha` will be nearly zero when the particle's `lifespan` has expired. However, this may cause trouble if particles start with a `scale` level / `alpha` value different than one. Two additional variables would be required to make that work propery, which save the initial values for those properties. Not sure if this is worth adding.

You can use the features simply by setting the flags to true and using a `lifespan` other than 0. It also works with `FlxEmitterExt`:

``` AS3
var emitter:FlxEmitter;
emitter.sizeDecreasing = true;
emitter.fadingAway = true;
add(emitter);
emitter.start(true, 2);
```

I've also created a really [simple demo](https://dl.dropboxusercontent.com/u/18627942/Demos/index.html) to show this off. I guess I'll upload it to the haxeflixel-site some time soon, unless you want me to add any features / make any changes to it.

I have also added the line `exists = false` to the constructor of `FlxParticle`. This fixes a bug where you create particles for an emitter without using `makeParticles` which normally does that flag (I guess technically, that line could be removed from there, which I didn't do). The particles wouldn't have a graphic / use the flixel logo. I don't think this causes any issues, but I can't be a 100% sure.
