### PR TITLE
FlxTrail: Turn solid into property, fix missing semicolon

### DIFF
--- a/src/org/flixel/addons/FlxTrail.hx
+++ b/src/org/flixel/addons/FlxTrail.hx
@@ -172,11 +172,10 @@ class FlxTrail extends FlxTypedGroup<FlxSprite>
 			add(trailSprite);
 			trailSprite.alpha = transp;
 			transp -= difference;
+			trailSprite.solid = solid;
 			
 			if (trailSprite.alpha <= 0) trailSprite.kill();
 		}	
-		
-		solid = false;
 	}
 
 	/**


### PR DESCRIPTION
Sorry, seems like I forgot a semicolon in the `getSolid()`-function of `FlxTrail` which means it wasn't compilable. 

Also turned `solid` into an actual property as opposed to a private variable accessed by two functions named `getSolid()` and `setSolid()`.
