### PR TITLE
Improved error log for invalid keys

### DIFF
--- a/src/org/flixel/system/input/FlxInputStates.hx
+++ b/src/org/flixel/system/input/FlxInputStates.hx
@@ -82,6 +82,7 @@ class FlxInputStates
 			return _keyBools.get(Key);
 		}
 		
+		FlxG.log("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
 		return false; 
 	}
 	
@@ -98,7 +99,7 @@ class FlxInputStates
 		}
 		else
 		{
-			FlxG.log("Function and numpad keys can only be used in flash and js");
+			FlxG.log("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
 			return false;
 		}
 	}
@@ -116,7 +117,7 @@ class FlxInputStates
 		}
 		else
 		{
-			FlxG.log("Function and numpad keys can only be used in flash and js");
+			FlxG.log("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
 			return false;
 		}
 	}


### PR DESCRIPTION
- `pressed()` in FlxInputStates now also calls `FlxG.log()`. Otherwise, you're left clueless why the key code you're trying to use doesn't work
- The Key string is now logged as well, making the error log more
  helpful.
- The error log also covers the possiblity of the key being invalid
  without being a function or number key. Before, it just assumed that the invalid key string is caused by the use of numpad or function keys.
#318
