### PR TITLE
little fix on FlxAnalog for compile errors when FLX_NO_TOUCH specified

### DIFF
--- a/src/org/flixel/system/input/FlxAnalog.hx
+++ b/src/org/flixel/system/input/FlxAnalog.hx
@@ -96,7 +96,9 @@ class FlxAnalog extends FlxTypedGroup<FlxSprite>
 		_amount = 0;
 		acceleration = new FlxPoint();
 		
+		#if !FLX_NO_TOUCH
 		_tempTouches = [];
+		#end
 		_point = new FlxPoint();
 		
 		createBase();
@@ -172,8 +174,10 @@ class FlxAnalog extends FlxTypedGroup<FlxSprite>
 		_base = null;
 		_pad = null;
 		
+		#if !FLX_NO_TOUCH
 		_currentTouch = null;
 		_tempTouches = null;
+		#end
 		_point = null;
 	}
 	


### PR DESCRIPTION
Description:
Definitions of _tempTouches and _currentTouch are in the "#if !FLX_NO_TOUCH ... #end" block.
But they are used outside this block here and there in this class.
This will cause a undefined error when compiling with FLX_NO_TOUCH specified.
