### PR TITLE
arrayToCSV() fixed for use in Neko

### DIFF
--- a/src/org/flixel/FlxTilemap.hx
+++ b/src/org/flixel/FlxTilemap.hx
@@ -1740,7 +1740,7 @@ class FlxTilemap extends FlxObject
 			column = 0;
 			while(column < Width)
 			{
-				index = Data[row * Width + column];
+				index = Data[Std.int(row * Width + column)];
 				if(Invert)
 				{
 					if (index == 0)


### PR DESCRIPTION
It seems neko converts Int arithmetic to a Float, which is an invalid accessor for arrays.
