### PR TITLE
FlxTilemap.arrayToCSV() fixed for Neko compatibility

### DIFF
--- a/src/org/flixel/FlxTilemap.hx
+++ b/src/org/flixel/FlxTilemap.hx
@@ -1735,12 +1735,13 @@ class FlxTilemap extends FlxObject
 		var csv:String = "";
 		var Height:Int = Std.int(Data.length / Width);
 		var index:Int;
+		var offset:Int = 0;
 		while(row < Height)
 		{
 			column = 0;
 			while(column < Width)
 			{
-				index = Data[Std.int(row * Width + column)];
+				index = Data[offset];
 				if(Invert)
 				{
 					if (index == 0)
@@ -1769,6 +1770,7 @@ class FlxTilemap extends FlxObject
 					csv += ", "+index;
 				}
 				column++;
+				offset++;
 			}
 			row++;
 		}


### PR DESCRIPTION
It seems Neko converts `Int` arithmetic to a `Float`, which is an invalid accessor for arrays.
