### PR TITLE
Make _cursorContainer public

### DIFF
--- a/src/org/flixel/system/input/FlxMouse.hx
+++ b/src/org/flixel/system/input/FlxMouse.hx
@@ -70,7 +70,7 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	 * A display container for the mouse cursor.
 	 * This container is a child of FlxGame and sits at the right "height".
 	 */
-	private var _cursorContainer:Sprite;
+	public var cursorContainer:Sprite;
 	/**
 	 * Don't update cursor unless we have to (this is essentially a "visible" bool, so we avoid checking the visible property in the Sprite which is slow in cpp).
 	 */
@@ -103,9 +103,9 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	public function new(CursorContainer:Sprite)
 	{
 		super();
-		_cursorContainer = CursorContainer;
-		_cursorContainer.mouseChildren = false;
-		_cursorContainer.mouseEnabled = false;
+		cursorContainer = CursorContainer;
+		cursorContainer.mouseChildren = false;
+		cursorContainer.mouseEnabled = false;
 		_lastX = screenX = 0;
 		_lastY = screenY = 0;
 		_lastWheel = wheel = 0;
@@ -272,7 +272,7 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	 */
 	public function destroy():Void
 	{
-		_cursorContainer = null;
+		cursorContainer = null;
 		_cursor = null;
 		_point = null;
 		_globalScreenPosition = null;
@@ -298,7 +298,7 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	public function show(Graphic:Dynamic = null, Scale:Float = 1, XOffset:Int = 0, YOffset:Int = 0):Void
 	{
 		_updateCursorContainer = true;
-		_cursorContainer.visible = true;
+		cursorContainer.visible = true;
 		if (Graphic != null)
 		{
 			load(Graphic, Scale, XOffset, YOffset);
@@ -319,7 +319,7 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	inline public function hide():Void
 	{
 		_updateCursorContainer = false;
-		_cursorContainer.visible = false;
+		cursorContainer.visible = false;
 	}
 	
 	/**
@@ -341,7 +341,7 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	{
 		if (_cursor != null)
 		{
-			_cursorContainer.removeChild(_cursor);
+			cursorContainer.removeChild(_cursor);
 		}
 		
 		if (Graphic == null)
@@ -371,7 +371,7 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 		_cursor.scaleX = Scale;
 		_cursor.scaleY = Scale;
 		
-		_cursorContainer.addChild(_cursor);
+		cursorContainer.addChild(_cursor);
 	}
 	
 	/**
@@ -382,13 +382,13 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	{
 		if(_cursor != null)
 		{
-			if (_cursorContainer.visible)
+			if (cursorContainer.visible)
 			{
 				load();
 			}
 			else
 			{
-				_cursorContainer.removeChild(_cursor);
+				cursorContainer.removeChild(_cursor);
 				_cursor = null;
 			}
 		}
@@ -434,8 +434,8 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 		//actually position the flixel mouse cursor graphic
 		if (_updateCursorContainer)
 		{
-			_cursorContainer.x = _globalScreenPosition.x;
-			_cursorContainer.y = _globalScreenPosition.y;
+			cursorContainer.x = _globalScreenPosition.x;
+			cursorContainer.y = _globalScreenPosition.y;
 		}
 		
 		//update the x, y, screenX, and screenY variables based on the default camera.


### PR DESCRIPTION
#316

I made  `_cursorContainer` in `FlxMouse` public, which allows you to do a lot more with it than previously, like using blend modes, changing the alpha value or scaling it. I also removed the underscore indicating it's an internal var, so now it's `cursorContainer`.
