### PR TITLE
Improved FlxMouse documentation

### DIFF
--- a/src/org/flixel/system/input/FlxMouse.hx
+++ b/src/org/flixel/system/input/FlxMouse.hx
@@ -522,36 +522,42 @@ class FlxMouse extends FlxPoint, implements IFlxInput
 	#if (FLX_MOUSE_ADVANCED && !js)
 	/**
 	 * Check to see if the right mouse button is pressed.
+	 * Requires the <code>FLX_MOUSE_ADVANCED</code> flag in the .nmml to be set.
 	 * @return	Whether the right mouse button is pressed.
 	 */
 	public function pressedRight():Bool { return _currentRight > 0; }
 	
 	/**
 	 * Check to see if the right mouse button was just pressed.
+	 * Requires the <code>FLX_MOUSE_ADVANCED</code> flag in the .nmml to be set.
 	 * @return Whether the right mouse button was just pressed.
 	 */
 	public function justPressedRight():Bool { return (_currentRight == 2 || _currentRight == -2); }
 	
 	/**
 	 * Check to see if the right mouse button was just released.
+	 * Requires the <code>FLX_MOUSE_ADVANCED</code> flag in the .nmml to be set.
 	 * @return	Whether the right mouse button was just released.
 	 */
 	public function justReleasedRight():Bool { return (_currentRight == -1 || _currentRight == -2); }
 	
 	/**
 	 * Check to see if the middle mouse button is pressed.
+	 * Requires the <code>FLX_MOUSE_ADVANCED</code> flag in the .nmml to be set.
 	 * @return	Whether the middle mouse button is pressed.
 	 */
 	public function pressedMiddle():Bool { return _currentMiddle > 0; }
 	
 	/**
 	 * Check to see if the middle mouse button was just pressed.
+	 * Requires the <code>FLX_MOUSE_ADVANCED</code> flag in the .nmml to be set.
 	 * @return Whether the middle mouse button was just pressed.
 	 */
 	public function justPressedMiddle():Bool { return (_currentMiddle == 2 || _currentMiddle == -2); }
 	
 	/**
 	 * Check to see if the middle mouse button was just released.
+	 * Requires the <code>FLX_MOUSE_ADVANCED</code> flag in the .nmml to be set.
 	 * @return	Whether the middle mouse button was just released.
 	 */
 	public function justReleasedMiddle ():Bool { return (_currentMiddle == -1 || _currentMiddle == -2); }


### PR DESCRIPTION
In hindsight, the newly added functions in `FlxMouse` (#352) probably require a better documentation - namely that the `FLX_MOUSE_ADVANCED` flag needs to be set in order to be able to use them. Otherwise, this could cause confusion, as the functions will appear in auto-completion, but not really be available / cause compiler errors. To someone who hasn't used compiler conditionals yet, this could cause a lot of trouble - I guess it's not that much of an issue for the `FLX_NO`-Style conditionals, as they remove features on demand rather than adding them.
