### PR TITLE
Fix small issue with log scrolling in flash

### DIFF
--- a/src/org/flixel/system/debug/Log.hx
+++ b/src/org/flixel/system/debug/Log.hx
@@ -100,7 +100,7 @@ class Log extends FlxWindow
 			_text.appendText(Text + "\n");
 		}
 		#if flash
-		_text.scrollV = Std.int(_text.height);
+		_text.scrollV = Std.int(_text.maxScrollV);
 		#elseif !js
 		_text.scrollV = _text.maxScrollV - Std.int(_text.height / _text.defaultTextFormat.size) + 1;
 		#end


### PR DESCRIPTION
The scrolling of the `log` textfield was kind of broken on the flash target - as soon as the number of lines exceeded `MAX_LOG_LINES` (which is 200), the textfield would get at about half of its height / lines (around line 109 I think). Setting it to `maxScrollV` seems to fix it.

There's another issue regarding scrolling on non-flash-targets (windows at least), the scrolling of the textfield lags behind by a couple of lines. I haven't really been able to figure out how to fix that, though.
