### PR TITLE
Fixed sprite positioning off after scaling

### DIFF
--- a/src/org/flixel/FlxSprite.hx
+++ b/src/org/flixel/FlxSprite.hx
@@ -711,8 +711,8 @@ class FlxSprite extends FlxObject
 			_point.x = x - (camera.scroll.x * scrollFactor.x) - (offset.x);
 			_point.y = y - (camera.scroll.y * scrollFactor.y) - (offset.y);
 			
-			_point.x = (_point.x) + origin.x;
-			_point.y = (_point.y) + origin.y;
+			_point.x = (_point.x) + origin.x * scale.x;
+			_point.y = (_point.y) + origin.y * scale.y;
 			
 			#if js
 			_point.x = Math.floor(_point.x);
@@ -739,7 +739,7 @@ class FlxSprite extends FlxObject
 				{
 					_matrix.rotate(angle * FlxG.RAD);
 				}
-				_matrix.translate(_point.x + origin.x, _point.y + origin.y);
+				_matrix.translate(_point.x + origin.x * scale.x, _point.y + origin.y * scale.y);
 				camera.buffer.draw(framePixels, _matrix, null, blend, null, antialiasing);
 			}
 #else


### PR DESCRIPTION
Never mind my previous pull request, ignore it. This is the correct one.

From my understanding, origin is used for the center of rotation and scaling,
it should not effect in positioning, but currently it is. To test it:
- set origin to the bottom right corner of a sprite: 
  origin.x = width;
  origin.y = height;
- set offset to 0,0 ( top-left )
- set scale to 2 for x and y

The sprite now grow to north west direction.

But the position now is centered on the sprite when it should get back to top-left corner. 

Remember, origin should not affect positioning, the offset is. When we set offset to 0,0 we expect the sprite to always be positioned relative to top-left corner. This happened because the origin is not scaled and when the system try to reposition back the sprite to where it was before scaling and rotation it only goes half way.

To fix it, set this in FlxSprite.draw()

// for !flash
_point.x = (_point.x) + origin.x \* scale.x;
_point.y = (_point.y) + origin.y \* scale.y;

// for flash
_matrix.translate(_point.x + origin.x \* scale.x, _point.y + origin.y \* scale.y);
