### PR TITLE
Advanced logging system

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -15,6 +15,8 @@ import nme.geom.Rectangle;
 import nme.media.Sound;
 import nme.media.SoundTransform;
 import org.flixel.system.debug.Console;
+import org.flixel.system.debug.LogStyle;
+import org.flixel.system.debug.Log;
 import org.flixel.system.layer.Atlas;
 import org.flixel.system.layer.TileSheetData;
 import org.flixel.plugin.pxText.PxBitmapFont;
@@ -358,14 +360,69 @@ class FlxG
 	
 	/**
 	 * Log data to the debugger.
-	 * @param	Data		Anything you want to log to the console.
 	 */
-	static public inline function log(Data:Dynamic):Void
+	static public var log:Dynamic;
+	
+	static private inline function _log(Data:Array<Dynamic>):Void
+	{
+		#if !FLX_NO_DEBUG
+		if ((_game != null) && (_game.debugger != null))
+			advancedLog(Data, Log.STYLE_NORMAL); 
+		#end
+	}
+	
+	/**
+	 * Add a warning to the debugger.
+	 */
+	static public var warn:Dynamic;
+	
+	static private inline function _warn(Data:Array<Dynamic>):Void
+	{
+		#if !FLX_NO_DEBUG
+		if ((_game != null) && (_game.debugger != null))
+			advancedLog(Data, Log.STYLE_WARNING); 
+		#end
+	}
+	
+	/**
+	 * Add an error to the debugger.
+	 */
+	static public var error:Dynamic;
+	
+	static private inline function _error(Data:Array<Dynamic>):Void
+	{
+		#if !FLX_NO_DEBUG
+		if ((_game != null) && (_game.debugger != null))
+			advancedLog(Data, Log.STYLE_ERROR); 
+		#end
+	}
+	
+	/**
+	 * Add a notice to the debugger.
+	 */
+	static public var notice:Dynamic;
+	
+	static private inline function _notice(Data:Array<Dynamic>):Void
+	{
+		#if !FLX_NO_DEBUG
+		if ((_game != null) && (_game.debugger != null))
+			advancedLog(Data, Log.STYLE_NOTICE); 
+		#end
+	}
+	
+	static public function advancedLog(Data:Dynamic, Style:LogStyle):Void
 	{
 		#if !FLX_NO_DEBUG
 		if ((_game != null) && (_game.debugger != null))
 		{
-			_game.debugger.log.add((Data == null) ? "ERROR: null object" : (Std.is(Data, Array) ? FlxU.formatArray(cast(Data, Array<Dynamic>)):Std.string(Data)));
+			_game.debugger.log.add(Data, Style);
+			
+			if (Style.errorSound != null)
+				FlxG.play(Style.errorSound);
+			if (Style.openConsole) 
+				_game.debugger.visible = _game._debuggerUp = true;
+			if (Reflect.isFunction(Style.callbackFunction))
+				Reflect.callMethod(null, Style.callbackFunction, []);
 		}
 		#end
 	}
@@ -721,7 +778,7 @@ class FlxG
 	{
 		if((EmbeddedSound == null) && (URL == null))
 		{
-			FlxG.log("WARNING: FlxG.loadSound() requires either\nan embedded sound or a URL to work.");
+			FlxG.warn("FlxG.loadSound() requires either\nan embedded sound or a URL to work.");
 			return null;
 		}
 		var sound:FlxSound = sounds.recycle(FlxSound);
@@ -1309,7 +1366,7 @@ class FlxG
 		}
 		else
 		{
-			FlxG.log("Error removing camera, not part of game.");
+			FlxG.error("Removing camera, not part of game.");
 		}
 		
 		#if !flash
@@ -1646,6 +1703,10 @@ class FlxG
 		FlxG.scores = new Array();
 		
 		#if !FLX_NO_DEBUG
+		log = Reflect.makeVarArgs(_log);
+		warn = Reflect.makeVarArgs(_warn);
+		error = Reflect.makeVarArgs(_error);
+		notice = Reflect.makeVarArgs(_notice);
 		FlxG.visualDebug = false;
 		#end
 	}

--- a/src/org/flixel/FlxGame.hx
+++ b/src/org/flixel/FlxGame.hx
@@ -440,7 +440,7 @@ class FlxGame extends Sprite
 			
 			#if !FLX_NO_DEBUG
 			_debugger.vcr.recording();
-			FlxG.log("FLIXEL: starting new flixel gameplay record.");
+			FlxG.notice("Starting new flixel gameplay record.");
 			#end
 		}
 		else if (_replayRequested)

--- a/src/org/flixel/FlxObject.hx
+++ b/src/org/flixel/FlxObject.hx
@@ -528,7 +528,7 @@ class FlxObject extends FlxBasic
 	{
 		if(Path.nodes.length <= 0)
 		{
-			FlxG.log("WARNING: Paths need at least one node in them to be followed.");
+			FlxG.warn("Paths need at least one node in them to be followed.");
 			return;
 		}
 		

--- a/src/org/flixel/FlxSave.hx
+++ b/src/org/flixel/FlxSave.hx
@@ -79,7 +79,7 @@ class FlxSave
 		}
 		catch(e:Error)
 		{
-			FlxG.log("ERROR: There was a problem binding to\nthe shared object data from FlxSave.");
+			FlxG.error("There was a problem binding to\nthe shared object data from FlxSave.");
 			destroy();
 			return false;
 		}
@@ -184,9 +184,9 @@ class FlxSave
 		switch(Result)
 		{
 			case PENDING:
-				FlxG.log("FLIXEL: FlxSave is requesting extra storage space.");
+				FlxG.warn("FlxSave is requesting extra storage space.");
 			case ERROR:
-				FlxG.log("ERROR: There was a problem flushing\nthe shared object data from FlxSave.");
+				FlxG.error("There was a problem flushing\nthe shared object data from FlxSave.");
 			//default:
 		}
 		if (_onComplete != null)
@@ -208,7 +208,7 @@ class FlxSave
 	{
 		if(_sharedObject == null)
 		{
-			FlxG.log("FLIXEL: You must call FlxSave.bind()\nbefore you can read or write data.");
+			FlxG.warn("You must call FlxSave.bind()\nbefore you can read or write data.");
 			return false;
 		}
 		return true;

--- a/src/org/flixel/FlxSound.hx
+++ b/src/org/flixel/FlxSound.hx
@@ -571,7 +571,7 @@ class FlxSound extends FlxBasic
 	 */
 	private function gotID3(event:Event = null):Void
 	{
-		FlxG.log("got ID3 info!");
+		FlxG.notice("Got ID3 info.");
 		name = _sound.id3.songName;
 		artist = _sound.id3.artist;
 		_sound.removeEventListener(Event.ID3, gotID3);

--- a/src/org/flixel/FlxSprite.hx
+++ b/src/org/flixel/FlxSprite.hx
@@ -1131,7 +1131,7 @@ class FlxSprite extends FlxObject
 			return;
 		}
 		
-		FlxG.log("WARNING: No animation called \""+AnimName+"\"");
+		FlxG.warn("No animation called \""+AnimName+"\"");
 	}
 	
 	/**

--- a/src/org/flixel/FlxTypedGroup.hx
+++ b/src/org/flixel/FlxTypedGroup.hx
@@ -194,7 +194,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		if (Object == null)
 		{
-			FlxG.log("WARNING: Cannot add a `null` object to a FlxGroup.");
+			FlxG.warn("Cannot add a `null` object to a FlxGroup.");
 			return null;
 		}
 		

--- a/src/org/flixel/plugin/photonstorm/FlxColor.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxColor.hx
@@ -134,7 +134,7 @@ class FlxColor
 		var warmer:Int = FlxMath.wrapValue(Std.int(hsv.hue), opposite - threshold, 359);
 		var colder:Int = FlxMath.wrapValue(Std.int(hsv.hue), opposite + threshold, 359);
 		
-		FlxG.log("hue: " + hsv.hue + " opposite: " + opposite + " warmer: " + warmer + " colder: " + colder);
+		FlxG.notice("hue: " + hsv.hue + " opposite: " + opposite + " warmer: " + warmer + " colder: " + colder);
 		
 		//return { color1: color, color2: HSVtoRGB(warmer, 1.0, 1.0), color3: HSVtoRGB(colder, 1.0, 1.0), hue1: hsv.hue, hue2: warmer, hue3: colder }
 		
@@ -307,7 +307,7 @@ class FlxColor
 					result = getColor32(alpha, Std.int(v * 255), Std.int(p * 255), Std.int(q * 255));
 					
 				default:
-					FlxG.log("FlxColor Error: HSVtoRGB : Unknown color");
+					FlxG.error("FlxColor: HSVtoRGB : Unknown color");
 			}
 		}
 		
@@ -480,13 +480,13 @@ class FlxColor
 		//	Sanity checks
 		if (max > 255)
 		{
-			FlxG.log("FlxColor Warning: getRandomColor - max value too high");
+			FlxG.warn("FlxColor: getRandomColor - max value too high");
 			return getColor24(255, 255, 255);
 		}
 		
 		if (min > max)
 		{
-			FlxG.log("FlxColor Warning: getRandomColor - min value higher than max");
+			FlxG.warn("FlxColor: getRandomColor - min value higher than max");
 			return getColor24(255, 255, 255);
 		}
 		
@@ -502,13 +502,13 @@ class FlxColor
 		//	Sanity checks
 		if (max > 255)
 		{
-			FlxG.log("FlxColor Warning: getRandomColor - max value too high");
+			FlxG.warn("FlxColor: getRandomColor - max value too high");
 			return getColor24(255, 255, 255);
 		}
 		
 		if (min > max)
 		{
-			FlxG.log("FlxColor Warning: getRandomColor - min value higher than max");
+			FlxG.warn("FlxColor: getRandomColor - min value higher than max");
 			return getColor24(255, 255, 255);
 		}
 		

--- a/src/org/flixel/system/debug/Log.hx
+++ b/src/org/flixel/system/debug/Log.hx
@@ -6,6 +6,7 @@ import nme.geom.Rectangle;
 import nme.text.TextField;
 import nme.text.TextFormat;
 import org.flixel.FlxAssets;
+import org.flixel.FlxU;
 
 import org.flixel.system.FlxWindow;
 
@@ -15,6 +16,11 @@ import org.flixel.system.FlxWindow;
 class Log extends FlxWindow
 {
 	static public var MAX_LOG_LINES:Int = 200;
+	
+	static public var STYLE_NORMAL:LogStyle;
+	static public var STYLE_WARNING:LogStyle;
+	static public var STYLE_ERROR:LogStyle;
+	static public var STYLE_NOTICE:LogStyle;
 
 	private var _text:TextField;
 	private var _lines:Array<String>;
@@ -58,6 +64,11 @@ class Log extends FlxWindow
 		addChild(_text);
 		
 		_lines = new Array<String>();
+		
+		STYLE_NORMAL = new LogStyle();
+		STYLE_WARNING = new LogStyle("[WARNING] ", "FFFF00", 12, true, false, false, "Beep");
+		STYLE_ERROR = new LogStyle("[ERROR] ", "FF0000", 12, true, false, false, "Beep", true);
+		STYLE_NOTICE = new LogStyle("[NOTICE] ", "008000", 12, true);
 	}
 	
 	/**
@@ -71,20 +82,61 @@ class Log extends FlxWindow
 		}
 		_text = null;
 		_lines = null;
+		STYLE_NORMAL = null;
+		STYLE_WARNING = null;
+		STYLE_ERROR = null;
+		STYLE_NOTICE = null;
 		super.destroy();
 	}
 	
 	/**
 	 * Adds a new line to the log window.
-	 * @param Text		The line you want to add to the log window.
+	 * @param Data		The data being logged.
+	 * @param Style		The <code>LogStyle</code> to be used for the log
 	 */
-	public function add(Text:String):Void
+	public function add(Data:Array<Dynamic>, Style:LogStyle):Void
 	{
+		trace(Data);
+		if (Data == null) 
+			return;
+		
+		var l:Int = Data.length;
+		for (i in 0...l) {
+			if (Std.is(Data[i], Array))
+				Data[i] = FlxU.formatArray(Data[i]);
+			else 
+				Data[i] = Std.string(Data[i]);
+		}
+		
+		var text:String = Data.join(" ");
+
+		// Create the text and apply color and styles
+		var prefix:String = "<font size='" + Style.size + "' color='#" + Style.color + "'>";
+		var suffix:String = "</font>";
+		
+		if (Style.bold) {
+			prefix = "<b>" + prefix;
+			suffix = "</b>" + suffix;
+		}
+		if (Style.italic) {
+			prefix = "<i>" + prefix;
+			suffix = "</i>" + suffix;
+		}
+		if (Style.underlined) {
+			prefix = "<u>" + prefix;
+			suffix = "</u>" + suffix;
+		}
+		
+		text = prefix + Style.prefix + text + suffix;
+		
+		// Actually add it to the textfield
 		if (_lines.length <= 0)
 		{
 			_text.text = "";
 		}
-		_lines.push(Text);
+		
+		_lines.push(text);
+		
 		if(_lines.length > MAX_LOG_LINES)
 		{
 			_lines.shift();
@@ -93,11 +145,11 @@ class Log extends FlxWindow
 			{
 				newText += _lines[i]+"\n";
 			}
-			_text.text = newText;
+			_text.htmlText = newText;
 		}
 		else
 		{
-			_text.appendText(Text + "\n");
+			_text.htmlText += (text + "\n");
 		}
 		#if flash
 		_text.scrollV = Std.int(_text.maxScrollV);

--- a/src/org/flixel/system/debug/LogStyle.hx
+++ b/src/org/flixel/system/debug/LogStyle.hx
@@ -1,0 +1,80 @@
+package org.flixel.system.debug;
+
+/**
+ * A class that allows you to create a custom style
+ * for <code>FlxG.advancedLog()</code>. Also used 
+ * internally for the pre-defined styles.
+ */
+class LogStyle
+{
+	/**
+	 * A prefix which is always attached to the start of the logged data.
+	 * @default ""
+	 */
+	public var prefix:String;
+	/**
+	 * The text color.
+	 * @default "FFFFFF"
+	 */
+	public var color:String;
+	/**
+	 * The text size.
+	 * @default 12
+	 */
+	public var size:Int;
+	/**
+	 * Whether the text is bold or not.
+	 * @default false
+	 */
+	public var bold:Bool;
+	/**
+	 * Whether the text is italic or not.
+	 * @default false
+	 */
+	public var italic:Bool;
+	/**
+	 * Whether the text is underlined or not.
+	 * @default false
+	 */
+	public var underlined:Bool;
+	/**
+	 * A sound to be played when this <code>LogStyle</code> is used.
+	 * @default null
+	 */
+	public var errorSound:String;
+	/**
+	 * Whether the console should be forced to open when this <code>LogStyle</code> is used.
+	 * @default false
+	 */
+	public var openConsole:Bool;
+	/**
+	 * A callback function that is called when this <code>LogStyle</code> is used.
+	 * @default null
+	 */
+	public var callbackFunction:Dynamic;
+	
+	/**
+	 * Create a new <code>LogStyle</code> to be used in conjunction with <code>FlxG.advancedLog()</code>
+	 * @param	Prefix				A prefix which is always attached to the start of the logged data.
+	 * @param	Color				The text color.
+	 * @param	Size				The text size.
+	 * @param 	Bold				Whether the text is bold or not.
+	 * @param	Italic				Whether the text is italic or not.
+	 * @param	Underlined			Whether the text is underlined or not.
+	 * @param	ErrorSound			A sound to be played when this <code>LogStyle</code> is used.
+	 * @param	OpenConsole			Whether the console should be forced to open when this <code>LogStyle</code> is used.
+	 * @param	CallbackFunction	A callback function that is called when this <code>LogStyle</code> is used.
+	 */
+	public function new(Prefix:String = "", Color:String = "FFFFFF", Size:Int = 12, Bold:Bool = false, Italic:Bool = false, Underlined:Bool = false, ErrorSound:String = null, OpenConsole:Bool = false, CallbackFunction:Dynamic = null)
+	{
+		prefix = Prefix;
+		color = Color;
+		size = Size;
+		bold = Bold;
+		italic = Italic;
+		underlined = Underlined;
+		errorSound = ErrorSound;
+		openConsole = OpenConsole;
+		callbackFunction = CallbackFunction;
+	}
+}

--- a/src/org/flixel/system/debug/VCR.hx
+++ b/src/org/flixel/system/debug/VCR.hx
@@ -321,7 +321,7 @@ class VCR extends Sprite
 		_file = null;
 		if((fileContents == null) || (fileContents.length <= 0))
 		{
-			FlxG.log("ERROR: Empty flixel gameplay record.");
+			FlxG.error("Empty flixel gameplay record.");
 			return;
 		}
 		
@@ -352,7 +352,7 @@ class VCR extends Sprite
 		_file.removeEventListener(Event.COMPLETE, onOpenComplete);
 		_file.removeEventListener(IOErrorEvent.IO_ERROR, onOpenError);
 		_file = null;
-		FlxG.log("ERROR: Unable to open flixel gameplay record.");
+		FlxG.error("Unable to open flixel gameplay record.");
 		#end
 	}
 	
@@ -404,7 +404,7 @@ class VCR extends Sprite
 		_file.removeEventListener(Event.CANCEL,onSaveCancel);
 		_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
 		_file = null;
-		FlxG.log("FLIXEL: successfully saved flixel gameplay record.");
+		FlxG.notice("Successfully saved flixel gameplay record.");
 		#end
 	}
 	
@@ -433,7 +433,7 @@ class VCR extends Sprite
 		_file.removeEventListener(Event.CANCEL,onSaveCancel);
 		_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
 		_file = null;
-		FlxG.log("ERROR: problem saving flixel gameplay record.");
+		FlxG.error("Problem saving flixel gameplay record.");
 		#end
 	}
 	

--- a/src/org/flixel/system/input/FlxInputStates.hx
+++ b/src/org/flixel/system/input/FlxInputStates.hx
@@ -102,7 +102,7 @@ class FlxInputStates
 		}
 		else
 		{
-			FlxG.log("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
+			FlxG.error("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
 			return false;
 		}
 	}
@@ -120,7 +120,7 @@ class FlxInputStates
 		}
 		else
 		{
-			FlxG.log("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
+			FlxG.error("Invalid Key: `" + Key + "`. Note that function and numpad keys can only be used in flash and js.");
 			return false;
 		}
 	}


### PR DESCRIPTION
- You can now define a custom `LogStyle`
- Added `warn()`, `error()`, `notice()` and `advancedLog()` to `FlxG`
- `warn()`, `error()`, `notice()` and `log()` support a variable amount of
  paramaters. This means that to get an output of `"X: 500 Y: 250"`, you no
  longer need to seperate everything with plus signs (`log("X: " + this.x +
  " Y: " + this.y);`), instead you can just have seperate paramters:
  `log("X: ", this.x, "Y:", this.y);` which is more convenient and readable.
- Updated all the existing error and warning messages previously using
  `log()`

Note that the console code hasn't been updated, even though it uses a ton of logging. I will do that later when the `dev` and `texture_atlas` branches are merged, because that's where the most recent version of the console code is.
#361

Huge thanks to the [ideas over at flixel-community](https://github.com/FlixelCommunity/flixel/issues/89) regarding the enhancement of the logging system. 

I think two more sound effects should be included in core flixel, one to be used in conjunction with the `warn()` and one in conjunction with the `error()` log. Currently, they both use the `"Beep"` soundeffect, which works, but is not very appropriate.
