### PR TITLE
Console: Advanced logging, simplified create() etc

### DIFF
--- a/src/org/flixel/system/debug/Console.hx
+++ b/src/org/flixel/system/debug/Console.hx
@@ -120,13 +120,16 @@ class Console extends FlxWindow
 		_input.addEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
 		
 		// Install commands
+		#if !FLX_NO_DEBUG
 		var commands:ConsoleCommands = new ConsoleCommands(this);
+		#end
 	}
 	
 	private function onFocus(e:FocusEvent):Void
 	{
+		#if !FLX_NO_DEBUG
 		// Pause game
-		#if flash
+		#if flash 
 		if (autoPause)
 			FlxG._game.debugger.vcr.onPause();
 		#end
@@ -135,10 +138,12 @@ class Console extends FlxWindow
 		
 		if (_input.text == defaultText) 
 			_input.text = "";
+		#end
 	}
 	
 	private function onFocusLost(e:FocusEvent):Void
 	{
+		#if !FLX_NO_DEBUG
 		// Unpause game
 		#if flash
 		if (autoPause)
@@ -148,6 +153,7 @@ class Console extends FlxWindow
 		
 		if (_input.text == "") 
 			_input.text = defaultText;
+		#end
 	}
 	
 	private function onKeyPress(e:KeyboardEvent):Void
@@ -232,15 +238,16 @@ class Console extends FlxWindow
 		}
 		// In case the command doesn't exist
 		else {
-			FlxG.log("> Invalid command: '" + command + "'");
+			FlxG.error("Console: Invalid command: '" + command + "'");
 		}
 	}
 	
-	public function callFunction(obj:Dynamic, func:Dynamic, args:Array<Dynamic>):Void
+	public function callFunction(obj:Dynamic, func:Dynamic, args:Array<Dynamic>):Bool
 	{
 		try 
 		{
 			Reflect.callMethod(obj, func, args);
+			return true;
 		}
 		catch(e:ArgumentError)
 		{
@@ -262,10 +269,14 @@ class Console extends FlxWindow
 				// ...but not with too few
 				else 
 				{
-					FlxG.log("> Invalid number or parameters: " + expected + " expected, " + args.length + " passed");
-					return;
+					FlxG.error("Console: Invalid number or parameters: " + expected + " expected, " + args.length + " passed");
+					return false;
 				}
+				
+				return true;
 			}
+			
+			return false;
 		}
 	}
 	

--- a/src/org/flixel/system/debug/ConsoleCommands.hx
+++ b/src/org/flixel/system/debug/ConsoleCommands.hx
@@ -15,6 +15,7 @@ class ConsoleCommands
 	
 	public function new(console:Console):Void
 	{
+		#if !FLX_NO_DEBUG
 		_console = console;
 		
 		// Install commands
@@ -46,8 +47,11 @@ class ConsoleCommands
 		
 		// Registration
 		console.registerObject("FlxG", FlxG);
+		
+		#end
 	}
 	
+	#if !FLX_NO_DEBUG
 	private function help(Command:String = ""):Void
 	{
 		if (Command == "") {
@@ -57,95 +61,77 @@ class ConsoleCommands
 			fs = "fullscreen,";
 			#end
 			
-			FlxG.log(">> System commands: log, clearLog, clearHistory, help, resetState, switchState, resetGame, " + fs + " watchMouse, visualDebug, pause, play, playMusic, bgColor, shake, create, set, call, close, listObjects, listFunctions, watch, unwatch");
+			cLog("System commands: \nlog, clearLog, clearHistory, help, resetState, switchState, resetGame, " + fs + " watchMouse, visualDebug, pause, play, playMusic, bgColor, shake, create, set, call, close, listObjects, listFunctions, watch, unwatch");
 		}
 		else {
-			FlxG.log(">> Help: " + Command + " <<");
+			cLog("help: " + Command);
 			
 			switch (Command) {
 				case "log":
-					FlxG.log("> log: Calls FlxG.log() with the text you enter");
-					FlxG.log("> log [Text]");
-				case "clearLog":
-				case "clear":
-					FlxG.log("> clearLog: {clear} Clears the log window");
-				case "clearHistory":
-					FlxG.log("> clearHistory: {ch} Clears the command history");
-				case "help":
-				case "h":
-					FlxG.log("> help: {h} Lists all system commands or provides more info on a specified command");
-					FlxG.log("> help (Command)");
-				case "resetState":
-				case "rs":
-					FlxG.log("> resetState: {rs} Calls FlxG.resetState()");
-				case "resetGame":
-				case "rg":
-					FlxG.log("> resetGame: {rg} Calls FlxG.resetGame()");
-				case "switchState":
-				case "ss":
-					FlxG.log("> switchState: {ss} Calls FlxG.switchState() with specified FlxState");
-					FlxG.log("> switchState [FlxState]");
+					cLog("log: Calls FlxG.log() with the text you enter");
+					cLog("log [Text]");
+				case "clearLog", "clear":
+					cLog("clearLog: {clear} Clears the log window");
+				case "clearHistory", "ch":
+					cLog("clearHistory: {ch} Clears the command history");
+				case "help", "h":
+					cLog("help: {h} Lists all system commands or provides more info on a specified command");
+					cLog("help (Command)");
+				case "resetState", "rs":
+					cLog("resetState: {rs} Calls FlxG.resetState()");
+				case "resetGame", "rg":
+					cLog("resetGame: {rg} Calls FlxG.resetGame()");
+				case "switchState", "ss":
+					cLog("switchState: {ss} Calls FlxG.switchState() with specified FlxState");
+					cLog("switchState [FlxState]");
 				#if flash
-				case "fullscreen":
-				case "fs":
-					FlxG.log("> fullscreen: {fs} Enables fullscreen mode");
+				case "fullscreen", "fs":
+					cLog("fullscreen: {fs} Enables fullscreen mode");
 				#end
-				case "watchMouse":
-				case "wm":	
-					FlxG.log("> watchMouse: {wm} Adds the x and y pos of the mosue to the watch window. Super useful for GUI-Building stuff.");
-				case "visualDebug":
-				case "vd":
-					FlxG.log("> visualDebug: {vd} Toggles visual debugging");
-				case "pause":
-				case "p":
-					FlxG.log("> pause: {p} Pauses / unpauses the game");
+				case "watchMouse", "wm":
+					cLog("watchMouse: {wm} Adds the x and y pos of the mosue to the watch window. Super useful for GUI-Building stuff.");
+				case "visualDebug", "vd":
+					cLog("visualDebug: {vd} Toggles visual debugging");
+				case "pause", "p":
+					cLog("pause: {p} Pauses / unpauses the game");
 				case "play":
-					FlxG.log("> play: Plays a sound");
-					FlxG.log("> play [Sound] (Volume = 1)");
-				case "playMusic":
-				case "pm":
-					FlxG.log("> playMusic: {pm} Sets up and plays a looping background soundtrack.");
-					FlxG.log("> playMusic [Music] (Volume = 1)");
-				case "bgColor":
-				case "bg":
-					FlxG.log("> bgColor: {bg} Changes the background color to a specified color. You can also pass the colors 'red, green, blue, pink, white,  and black'");
-					FlxG.log("> bgColor [Color]");
-				case "shake":
-				case "sh":
-					FlxG.log("> shake: {sh} Calls FlxG.shake()");
-					FlxG.log("> shake (Intensity = 0.05) (Duration = 0.5)");
-				case "close":
-				case "cl":
-					FlxG.log("> close: {cl} Close the debugger overlay");
-				case "create": 
-				case "cr":
-					FlxG.log("> create: {cr} Creates a new FlxObject and registers it - by default at the mouse position.");
-					FlxG.log("> create [FlxObject] (MousePos = true) (param0...paramX)");
+					cLog("play: Plays a sound");
+					cLog("play [Sound] (Volume = 1)");
+				case "playMusic", "pm":
+					cLog("playMusic: {pm} Sets up and plays a looping background soundtrack.");
+					cLog("playMusic [Music] (Volume = 1)");
+				case "bgColor", "bg":
+					cLog("bgColor: {bg} Changes the background color to a specified color. You can also pass the colors 'red, green, blue, pink, white,  and black'");
+					cLog("bgColor [Color]");
+				case "shake", "sh":
+					cLog("shake: {sh} Calls FlxG.shake()");
+					cLog("shake (Intensity = 0.05) (Duration = 0.5)");
+				case "close", "cl":
+					cLog("close: {cl} Close the debugger overlay");
+				case "create", "cr": 
+					cLog("create: {cr} Creates a new FlxObject and registers it - by default at the mouse position.");
+					cLog("create [FlxObject] (MousePos = true) (param0...paramX)");
 				case "set":
-					FlxG.log("> set: Changes a var within a previosuly registered object via FlxG.console.registerObject. Supports nesting (a field within an object within a registered object). Set a WatchName if you want to add the var to the watch window.");
-					FlxG.log("> set [Object.VariableName] [NewValue] (WatchName)");
+					cLog("set: Changes a var within a previosuly registered object via FlxG.console.registerObject(). Supports nesting (a field within an object within a registered object). Set a WatchName if you want to add the var to the watch window.");
+					cLog("set [Object.VariableName] [NewValue] (WatchName)");
 				case "call":
-					FlxG.log("> call: Calls a function previously registered via FlxG.console.registerFunction with a set of params (or a function of a registered object");
-					FlxG.log("> call [(Object.)Function] [param0...paramX]");
-				case "listObjects":
-				case "lo":
-					FlxG.log("> listObjects: {lo} Lists all the aliases of the objects registered");
-				case "listFunctions":
-				case "lf":
-					FlxG.log("> listFunctions: {lf} Lists all the aliases of the functions registered");
-				case "watch":
-				case "w":
-					FlxG.log("> watch: {w} Calls FlxG.watch()");
-					FlxG.log("> watch [Object.VariableName] (DisplayName)");
-				case "unwatch":
-				case "uw":
-					FlxG.log("> unwatch: {uw} Calls FlxG.unwatch()");
-					FlxG.log("> unwatch [Object(.VariableName)]");
+					cLog("call: Calls a function previously registered via FlxG.console.registerFunction() with a set of params (or a function of a registered object");
+					cLog("call [(Object.)Function] [param0...paramX]");
+				case "listObjects", "lo":
+					cLog("listObjects: {lo} Lists all the aliases of the objects registered");
+				case "listFunctions", "lf":
+					cLog("listFunctions: {lf} Lists all the aliases of the functions registered");
+				case "watch", "w":
+					cLog("watch: {w} Calls FlxG.watch()");
+					cLog("watch [Object.VariableName] (DisplayName)");
+				case "unwatch", "uw":
+					cLog("unwatch: {uw} Calls FlxG.unwatch()");
+					cLog("unwatch [Object(.VariableName)]");
 				default:
-					FlxG.log("> help: Couldn't find command '" + Command + "'");
+					cLog("help: Couldn't find command '" + Command + "'");
 			}
 			
-			FlxG.log("> {shortcut} [required param] (optional param)");
+			cLog("{shortcut} [required param] (optional param)");
 		}
 	}
 	
@@ -153,13 +139,13 @@ class ConsoleCommands
 	{
 		_console.cmdHistory = new Array<String>();
 		FlxG._game._prefsSave.flush();
-		FlxG.log("> clearHistory: Command history cleared");
+		cLog("clearHistory: Command history cleared");
 	}
 	
 	private function resetState():Void
 	{
 		FlxG.resetState();
-		FlxG.log("> resetState: State has been reset");
+		cLog("resetState: State has been reset");
 		
 		#if flash
 		if (_console.autoPause) 
@@ -174,7 +160,7 @@ class ConsoleCommands
 			return;
 		
 		FlxG.switchState(instance);
-		FlxG.log("> switchState: New '" + ClassName + "' created");  
+		cLog("switchState: New '" + ClassName + "' created");  
 		
 		#if flash
 		if (_console.autoPause)
@@ -185,7 +171,7 @@ class ConsoleCommands
 	private function resetGame():Void
 	{
 		FlxG.resetGame();
-		FlxG.log("> resetGame: Game has been reset");
+		cLog("resetGame: Game has been reset");
 		
 		#if flash
 		if (_console.autoPause)
@@ -198,12 +184,12 @@ class ConsoleCommands
 		if (!watchingMouse) {
 			FlxG.watch(FlxG._game, "mouseX", "Mouse.x");
 			FlxG.watch(FlxG._game, "mouseY", "Mouse.y");
-			FlxG.log("> watchMouse: Mouse position added to watch window");
+			cLog("watchMouse: Mouse position added to watch window");
 		}
 		else {
 			FlxG.unwatch(FlxG._game, "mouseX");
 			FlxG.unwatch(FlxG._game, "mouseY");
-			FlxG.log("> watchMouse: Mouse position removed from watch window");
+			cLog("watchMouse: Mouse position removed from watch window");
 		}
 		
 		watchingMouse = !watchingMouse;
@@ -211,28 +197,24 @@ class ConsoleCommands
 	
 	private function visualDebug():Void
 	{		
-		#if !FLX_NO_DEBUG
 		FlxG.visualDebug = !FlxG.visualDebug;
 		
 		if (FlxG.visualDebug) 
-			FlxG.log("> visualDebug: Enbaled");
+			cLog("visualDebug: Enbaled");
 		else
-			FlxG.log("> visualDebug: Disabled");
-		#end
+			cLog("visualDebug: Disabled");
 	}
 	
 	private function pause():Void
 	{
-		#if !FLX_NO_DEBUG
 		if (FlxG._game.debugger.vcr.paused) {
 			FlxG._game.debugger.vcr.onPlay();
-			FlxG.log("> pause: Game unpaused");
+			cLog("pause: Game unpaused");
 		}
 		else {
 			FlxG._game.debugger.vcr.onPause();
-			FlxG.log("> pause: Game paused");
+			cLog("pause: Game paused");
 		}
-		#end
 	}
 	
 	private function bgColor(Color:Dynamic):Void
@@ -259,33 +241,31 @@ class ConsoleCommands
 		
 		if (!Math.isNaN(color)) {
 			FlxG.bgColor = color;
-			FlxG.log("> bgColor: Changed background color to '" + Color + "'");
+			cLog("bgColor: Changed background color to '" + Color + "'");
 		}
 		else 
-			FlxG.log("> bgColor: Invalid color '" + Color + "'");
+			cLog("bgColor: Invalid color '" + Color + "'");
 	}
 	
 	private function shake(Intensity:Float = 0.05, Duration:Float = 0.5):Void
 	{
 		if (Math.isNaN(Intensity)) {
-			FlxG.log("> shake: Intensity is not a number");
+			cLog("shake: Intensity is not a number");
 			return;
 		}
 		if (Math.isNaN(Duration)) {
-			FlxG.log("> shake: Duration is not a number");
+			cLog("shake: Duration is not a number");
 			return;
 		}
 		
 		FlxG.shake(Intensity, Duration);
-		FlxG.log("> shake: Shake started, Intensity: " + Intensity + " Duration: " + Duration);
+		cLog("shake: Shake started, Intensity: " + Intensity + " Duration: " + Duration);
 	}
 	
 	private function close():Void
 	{
-		#if !FLX_NO_DEBUG
 		FlxG._game._debugger.visible = false;
 		FlxG._game._debugger.hasMouse = false;
-		#end
 	}
 	
 	private function create(ClassName:String, MousePos:Bool = true, Params:Array<String> = null):Void
@@ -307,14 +287,14 @@ class ConsoleCommands
 		FlxG.state.add(instance);
 		
 		if (Params.length == 0)
-			FlxG.log("> create: New " + ClassName + " created at X = " + obj.x + " Y = " + obj.y);
+			cLog("create: New " + ClassName + " created at X = " + obj.x + " Y = " + obj.y);
 		else 
-			FlxG.log("> create: New " + ClassName + " created at X = " + obj.x + " Y = " + obj.y + " with params " + Params);
+			cLog("create: New " + ClassName + " created at X = " + obj.x + " Y = " + obj.y + " with params " + Params);
 			
 		_console.objectStack.push(instance);
 		_console.registerObject(Std.string(_console.objectStack.length), instance);
 		
-		FlxG.log("> create: " + ClassName + " registered as object '" + _console.objectStack.length);
+		cLog("create: " + ClassName + " registered as object '" + _console.objectStack.length);
 	}
 	
 	private function set(ObjectAndVariable:String, NewVariableValue:Dynamic, WatchName:String = null):Void
@@ -336,24 +316,24 @@ class ConsoleCommands
 			else if (NewVariableValue == "true" || NewVariableValue == "1") 
 				NewVariableValue = true;
 			else {
-				FlxG.log("> set: '" + NewVariableValue + "' is not a valid value for Booelan '" + varName + "'");
+				FlxG.error("set: '" + NewVariableValue + "' is not a valid value for Booelan '" + varName + "'");
 				return;
 			}
 		}
 		// Prevent turning numbers into NaN
 		else if (Std.is(variable, Float) && Math.isNaN(Std.parseFloat(NewVariableValue))) {
-			FlxG.log("> set: '" + NewVariableValue + "' is not a valid value for number '" + varName + "'");
+			FlxG.error("set: '" + NewVariableValue + "' is not a valid value for number '" + varName + "'");
 			return;
 		}
 		// Prevent setting non "simple" typed properties
 		else if (!Std.is(variable, Float) && !Std.is(variable, Bool) && !Std.is(variable, String))
 		{
-			FlxG.log("> set: '" + varName + ":" + Std.string(variable) + "' is not of a simple type (number, bool or string)");
+			FlxG.error("set: '" + varName + ":" + Std.string(variable) + "' is not of a simple type (number, bool or string)");
 			return;
 		}
 		
 		Reflect.setProperty(object, varName, NewVariableValue);
-		FlxG.log("> set: " + Std.string(object) + "." + varName + " is now " + NewVariableValue);
+		cLog("set: " + Std.string(object) + "." + varName + " is now " + NewVariableValue);
 		
 		if (WatchName != null) 
 			FlxG.watch(object, varName, WatchName);
@@ -376,7 +356,7 @@ class ConsoleCommands
 			
 			if (!Reflect.isObject(object)) 
 			{
-				FlxG.log("> call: '" + Std.string(object) + "' is not a valid Object to call function from");
+				FlxG.error("call: '" + Std.string(object) + "' is not a valid Object to call function from");
 				return;
 			}
 			
@@ -389,7 +369,7 @@ class ConsoleCommands
 				tempVarName = searchArr[i];
 				if (!Reflect.hasField(tempObj, tempVarName)) 
 				{
-					FlxG.log("> call: " + Std.string(tempObj) + " does not have a field '" + tempVarName + "' to call function from");
+					FlxG.error("call: " + Std.string(tempObj) + " does not have a field '" + tempVarName + "' to call function from");
 					return;
 				}
 				
@@ -400,34 +380,32 @@ class ConsoleCommands
 			
 			if (func == null)
 			{
-				FlxG.log("> call: " + Std.string(tempObj) + " does not have a method '" + searchArr[l] + "' to call");
+				FlxG.error("call: " + Std.string(tempObj) + " does not have a method '" + searchArr[l] + "' to call");
 				return;
 			}
 		}
 		
 		if (Reflect.isFunction(func)) {
-			_console.callFunction(null, func, Params);
+			var success:Bool = _console.callFunction(null, func, Params);
 			
-			if (Params.length == 0) 
-				FlxG.log("> call: Called '" + FunctionAlias + "'");
-			else 
-				FlxG.log("> call: Called '" + FunctionAlias + "' with params " + Params);
+			if (Params.length == 0 && success) 
+				cLog("call: Called '" + FunctionAlias + "'");
+			else if (success)
+				cLog("call: Called '" + FunctionAlias + "' with params " + Params);
 		}
 		else {
-			FlxG.log("> call: '" + FunctionAlias + "' is not a valid function");
+			FlxG.error("call: '" + FunctionAlias + "' is not a valid function");
 		}
 	}
 	
 	private function listObjects():Void
 	{
-		FlxG.log(">> Objects registered <<"); 
-		listHash(_console.registeredObjects);
+		cLog("Objects registered: \n" + hashToString(_console.registeredObjects)); 
 	}
 	
 	private function listFunctions():Void
 	{
-		FlxG.log(">> Functions registered <<"); 
-		listHash(_console.registeredFunctions);
+		cLog("Functions registered: \n" + hashToString(_console.registeredFunctions)); 
 	}
 	
 	private function watch(ObjectAndVariable:String, DisplayName:String = null):Void
@@ -469,21 +447,21 @@ class ConsoleCommands
 			
 		var obj:Dynamic = Type.resolveClass(ClassName);
 		if (!Reflect.isObject(obj)) {
-			FlxG.log("> " + CommandName + ": '" + ClassName + "' is not a valid class name. Try passing the full class path. Also make sure the class is being compiled.");
+			FlxG.error(CommandName + ": '" + ClassName + "' is not a valid class name. Try passing the full class path. Also make sure the class is being compiled.");
 			return null;
 		}
 		
 		var instance:Dynamic = Type.createInstance(obj, Params);
 		
 		if (!Std.is(instance, _Type)) {
-			FlxG.log("> " + CommandName + ": '" + ClassName + "' is not a " + Type.getClassName(_Type));
+			FlxG.error(CommandName + ": '" + ClassName + "' is not a " + Type.getClassName(_Type));
 			return null;
 		}
 		
 		return instance;
 	}
 	
-	private function listHash(hash:Hash<Dynamic>) 
+	private function hashToString(hash:Hash<Dynamic>):String
 	{
 		var output:String = "";
 		
@@ -493,7 +471,7 @@ class ConsoleCommands
 		}
 		output = output.substring(0, output.length - 2);
 		
-		FlxG.log(output);
+		return output;
 	}
 	
 	private function resolveObjecAndVariable(ObjectAndVariable:String, CommandName:String):Array<Dynamic>
@@ -502,7 +480,7 @@ class ConsoleCommands
 		
 		// In case there's not dot in the string
 		if (searchArr[0].length == ObjectAndVariable.length) {
-			FlxG.log("> " + CommandName + ": '" + ObjectAndVariable + "' does not refer to an object's field");
+			FlxG.error(CommandName + ": '" + ObjectAndVariable + "' does not refer to an object's field");
 			return null;
 		}
 		
@@ -510,7 +488,7 @@ class ConsoleCommands
 		var variableName:String = searchArr.join(".");
 		
 		if (!Reflect.isObject(object)) {
-			FlxG.log("> " + CommandName + ": '" + Std.string(object) + "' is not a valid Object");
+			FlxG.error(CommandName + ": '" + Std.string(object) + "' is not a valid Object");
 			return null;
 		}
 		
@@ -523,7 +501,7 @@ class ConsoleCommands
 			tempVarName = searchArr[i];
 			if (!Reflect.hasField(tempObj, tempVarName)) 
 			{
-				FlxG.log("> " + CommandName + ": " + Std.string(tempObj) + " does not have a field '" + tempVarName + "'");
+				FlxG.error(CommandName + ": " + Std.string(tempObj) + " does not have a field '" + tempVarName + "'");
 				return null;
 			}
 			
@@ -535,4 +513,10 @@ class ConsoleCommands
 		
 		return [tempObj, tempVarName];
 	}
+	
+	private function cLog(Text:Dynamic):Void
+	{
+		FlxG.advancedLog([Text], Log.STYLE_CONSOLE);
+	}
+	#end
 }

--- a/src/org/flixel/system/debug/Log.hx
+++ b/src/org/flixel/system/debug/Log.hx
@@ -21,6 +21,7 @@ class Log extends FlxWindow
 	static public var STYLE_WARNING:LogStyle;
 	static public var STYLE_ERROR:LogStyle;
 	static public var STYLE_NOTICE:LogStyle;
+	static public var STYLE_CONSOLE:LogStyle;
 
 	private var _text:TextField;
 	private var _lines:Array<String>;
@@ -69,6 +70,7 @@ class Log extends FlxWindow
 		STYLE_WARNING = new LogStyle("[WARNING] ", "FFFF00", 12, true, false, false, "Beep");
 		STYLE_ERROR = new LogStyle("[ERROR] ", "FF0000", 12, true, false, false, "Beep", true);
 		STYLE_NOTICE = new LogStyle("[NOTICE] ", "008000", 12, true);
+		STYLE_CONSOLE = new LogStyle("&#62; ", "0000ff", 12, true);
 	}
 	
 	/**
@@ -86,6 +88,7 @@ class Log extends FlxWindow
 		STYLE_WARNING = null;
 		STYLE_ERROR = null;
 		STYLE_NOTICE = null;
+		STYLE_CONSOLE = null;
 		super.destroy();
 	}
 	
@@ -96,7 +99,6 @@ class Log extends FlxWindow
 	 */
 	public function add(Data:Array<Dynamic>, Style:LogStyle):Void
 	{
-		trace(Data);
 		if (Data == null) 
 			return;
 		
@@ -116,15 +118,15 @@ class Log extends FlxWindow
 		
 		if (Style.bold) {
 			prefix = "<b>" + prefix;
-			suffix = "</b>" + suffix;
+			suffix = suffix + "</b>";
 		}
 		if (Style.italic) {
 			prefix = "<i>" + prefix;
-			suffix = "</i>" + suffix;
+			suffix = suffix + "</i>";
 		}
 		if (Style.underlined) {
 			prefix = "<u>" + prefix;
-			suffix = "</u>" + suffix;
+			suffix = suffix + "</u>";
 		}
 		
 		text = prefix + Style.prefix + text + suffix;

--- a/src/org/flixel/system/debug/WatchEntry.hx
+++ b/src/org/flixel/system/debug/WatchEntry.hx
@@ -74,7 +74,7 @@ class WatchEntry
 			tempVarName = tempArr[i];
 			if (!Reflect.hasField(tempObj, tempVarName)) 
 			{
-				FlxG.log("> Watch: " + Std.string(tempObj) + " does not have a field '" + tempVarName + "'");
+				FlxG.error("Watch: " + Std.string(tempObj) + " does not have a field '" + tempVarName + "'");
 				tempVarName = null;
 				break;
 			}


### PR DESCRIPTION
It seems like it's possible to call methods via `Reflect.callMethod()`
without specifying their object (and passing `null` instead), which
simplifies the process of registering a function as well as the `call()`
logic.
