### PR TITLE
Fix for negative object width and height

### DIFF
--- a/src/org/flixel/FlxObject.hx
+++ b/src/org/flixel/FlxObject.hx
@@ -97,13 +97,13 @@ class FlxObject extends FlxBasic
 	 */
 	public var y:Float;
 	/**
-	 * The width of this object.
+	 * The width of this object's hitbox. For sprites, use offset to control the hitbox position.
 	 */
-	public var width:Float;
+	public var width(default, set_width):Float;
 	/**
-	 * The height of this object.
+	 * The height of this object's hitbox. For sprites, use offset to control the hitbox position.
 	 */
-	public var height:Float;
+	public var height(default, set_height):Float;
 
 	/**
 	 * Whether an object will move/alter position after a collision.
@@ -981,6 +981,32 @@ class FlxObject extends FlxBasic
 			allowCollisions = NONE;
 		}
 		return Solid;
+	}
+	
+	/**
+	 * @private
+	 */
+	private function set_width(Width:Float):Float
+	{
+		if (Width < 0) 
+			FlxG.warn("An object's width cannot be smaller than 0. Use offset for sprites to control the hitbox position!");
+		else
+			width = Width;
+			
+		return Width;
+	}
+	
+	/**
+	 * @private
+	 */
+	private function set_height(Height:Float):Float
+	{
+		if (Height < 0) 
+			FlxG.warn("An object's height cannot be smaller than 0. Use offset for sprites to control the hitbox position!");
+		else
+			height = Height;
+		
+		return Height;
 	}
 	
 	/**

--- a/src/org/flixel/FlxSprite.hx
+++ b/src/org/flixel/FlxSprite.hx
@@ -69,8 +69,8 @@ class FlxSprite extends FlxObject
 	 */
 	public var origin:FlxPoint;
 	/**
-	* If you changed the size of your sprite object after loading or making the graphic,
-	* you might need to offset the graphic away from the bound box to center it the way you want.
+	* Controls the position of the sprite's hitbox. Likely needs to be adjusted after
+	* changing a sprite's width or height.
 	*/
 	public var offset:FlxPoint;
 	


### PR DESCRIPTION
- Turned `width` and `height` of `FlxObject` into properties with warnings to
  ensure they can't be set to negative values, which breaks collision
  detection while still being drawn correctly in `visualDebug`, causing confusion
- Also improved the documentation of `width`, `height` and `offset` to be more
  beginner-friendly and informative

Originally, I wanted to prevent setting the values to 0 as well, but turns out that that's the default value when creating a new `FlxObject`. It's probably not a big deal you can do that, but I thought it shouldn't be possible since it's basically a workaround for setting `solid = false´ and doesn't really have any other use.

This fix was inspired by [this forum thread](http://www.haxeflixel.com/forum/help/does-player-can-crouch).
