### PR TITLE
Fix neko crashing

### DIFF
--- a/src/org/flixel/plugin/photonstorm/FlxBar.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxBar.hx
@@ -973,6 +973,12 @@ class FlxBar extends FlxSprite
 	 */
 	private function get_percent():Float
 	{
+		#if neko
+		if (value == null) {
+            	    value = min;
+        	}
+        	#end
+
 		if (value > max)
 		{
 			return 100;


### PR DESCRIPTION
This workaround fixes neko crashing, a better solution would be to find out why value becomes null in the first place, but this workaround works.
