### PR TITLE
Fix null error bug with logging functions

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -1719,11 +1719,12 @@ class FlxG
 		
 		FlxG.mobile = false;
 		
-		#if !FLX_NO_DEBUG
 		log = Reflect.makeVarArgs(_log);
 		warn = Reflect.makeVarArgs(_warn);
 		error = Reflect.makeVarArgs(_error);
 		notice = Reflect.makeVarArgs(_notice);
+		
+		#if !FLX_NO_DEBUG
 		FlxG.visualDebug = false;
 		#end
 	}


### PR DESCRIPTION
The logging functions were null with `FLX_NO_DEBUG` which causes a crash when they are called with that conditional set.
