### PR TITLE
FlxSlider refactor

### DIFF
--- a/src/org/flixel/addons/FlxSlider.hx
+++ b/src/org/flixel/addons/FlxSlider.hx
@@ -170,7 +170,7 @@ class FlxSlider extends FlxSpriteGroup
 			FlxG.addPlugin(new FlxMouseControl());
 			
 		// Attempt to create the slider
-		if (!Reflect.hasField(object, varString)) 
+		if (Reflect.field(object, varString) == null) 
 		{
 			FlxG.error("Could not create FlxSlider -", "'" + varString + "'" , "is not a valid field of", "'" + object + "'");
 			kill();
@@ -283,7 +283,7 @@ class FlxSlider extends FlxSpriteGroup
 	private function updateValue():Void
 	{
 		if (callbackFunction == null) {
-			if (Reflect.hasField(object, varString))
+			if (Reflect.field(object, varString) != null)
 				Reflect.setProperty(object, varString, relativePos * maxValue);
 		}
 		else if (lastPos != relativePos) {


### PR DESCRIPTION
Resubmit of #406 because of a merge conflict.
- removed `rightBorder` and `leftBorder` sprites
- update the `handle` position when the variable value is changed from outside (if no callback was set) resolving #402
- added `setCallback()`
- removed `Callback` param from constructor and added a bunch of others
- proper nulling of objects in `destroy()`
- make use of `FlxMath` for hovering logic
- changes to `createSlider()` make it easier to position sliders, their origin is now at 0,0 due to using `offset`
- added `clickable` and `hoverAlpha` vars
- use `FlxU.roundDecimal()` and drop the `round()` function 

Probably forgot a few more things. Essentially a refactor of the class.
