### PR TITLE
Fixed FlxTextField.setFormat() to load font correctly

### DIFF
--- a/src/org/flixel/FlxTextField.hx
+++ b/src/org/flixel/FlxTextField.hx
@@ -116,7 +116,7 @@ class FlxTextField extends FlxText
 		{
 			Font = Assets.getFont(FlxAssets.defaultFont).fontName;
 		}
-		_format.font = Font;
+		_format.font = Assets.getFont(Font).fontName;
 		_format.size = Size;
 		_format.color = Color;
 		_format.align = convertTextAlignmentFromString(Alignment);


### PR DESCRIPTION
FlxTextField.setFormat() did not load fonts specifed by asset path correctly. I reported similar issue about FlxText.setFormat() some time ago. Probably someone forgot to make changes in FlxTextField :)
