### PR TITLE
Added FlxG.quickWatch() and renamed FlxString.formatHash() to FlxString....

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -439,7 +439,38 @@ class FlxG
 		#end
 	}
 	
-	public static var framerate(get_framerate, set_framerate):Int;
+	/**
+	 * Add or update a quickWatch entry to the watch list in the debugger.
+	 * Extremely useful when called in <code>update()</code> functions when there 
+	 * doesn't exist a variable for a value you want to watch - so you won't have to create one.
+	 * @param	Name		The name of the quickWatch entry, for example "mousePressed".
+	 * @param	NewValue	The new value for this entry, for example <code>FlxG.mouse.pressed()</code>.
+	 */
+	static public function quickWatch(Name:String, NewValue:Dynamic):Void
+	{
+		#if !FLX_NO_DEBUG
+		if ((_game != null) && (_game._debugger != null))
+		{
+			_game.debugger.watch.updateQuickWatch(Name, NewValue);
+		}
+		#end
+	}
+	
+	/**
+	 * Remove a quickWatch entry from the watch list of the debugger.
+	 * @param	Name	The name of the quickWatch entry you want to remove.
+	 */
+	static public function removeQuickWatch(Name:String):Void
+	{
+		#if !FLX_NO_DEBUG
+		if ((_game != null) && (_game._debugger != null))
+		{
+			_game.debugger.watch.remove(null, null, Name);
+		}
+		#end
+	}
+	
+	static public var framerate(get_framerate, set_framerate):Int;
 	
 	/**
 	 * How many times you want your game to update each second.

--- a/src/org/flixel/system/debug/ConsoleCommands.hx
+++ b/src/org/flixel/system/debug/ConsoleCommands.hx
@@ -413,12 +413,12 @@ class ConsoleCommands
 	
 	private function listObjects():Void
 	{
-		cLog("Objects registered: \n" + FlxString.formatHash(_console.registeredObjects)); 
+		cLog("Objects registered: \n" + FlxString.formatStringMap(_console.registeredObjects)); 
 	}
 	
 	private function listFunctions():Void
 	{
-		cLog("Functions registered: \n" + FlxString.formatHash(_console.registeredFunctions)); 
+		cLog("Functions registered: \n" + FlxString.formatStringMap(_console.registeredFunctions)); 
 	}
 	
 	private function watch(ObjectAndVariable:String, DisplayName:String = null):Void

--- a/src/org/flixel/system/debug/Log.hx
+++ b/src/org/flixel/system/debug/Log.hx
@@ -4,6 +4,7 @@ package org.flixel.system.debug;
 import flash.geom.Rectangle;
 import flash.text.TextField;
 import flash.text.TextFormat;
+import haxe.ds.StringMap;
 import openfl.Assets;
 import org.flixel.FlxAssets;
 import org.flixel.system.FlxDebugger;
@@ -90,12 +91,12 @@ class Log extends FlxWindow
 			
 		var texts:Array<String> = new Array<String>();
 		
-		// Format FlxPoints, Arrays or turn the Data entry into a String
+		// Format FlxPoints, Arrays, Maps or turn the Data entry into a String
 		for (i in 0...Data.length) {
 			if (Std.is(Data[i], FlxPoint)) 
 				texts[i] = FlxString.formatFlxPoint(Data[i], FlxDebugger.pointPrecision);
-			else if (Std.is(i, Array))
-				texts[i] = FlxString.formatArray(Data[i]); 
+			else if (Std.is(Data[i], StringMap))
+				texts[i] = FlxString.formatStringMap(Data[i]);
 			else 
 				texts[i] = Std.string(Data[i]);
 				

--- a/src/org/flixel/util/FlxString.hx
+++ b/src/org/flixel/util/FlxString.hx
@@ -1,4 +1,5 @@
 package org.flixel.util;
+import haxe.ds.StringMap.StringMap;
 
 /**
  * A class primarily containing functions related 
@@ -90,19 +91,19 @@ class FlxString
 	}
 
 	 /**
-	 * Generate a comma-seperated string representation of the keys in a Hash.
-	 * @param  AnyHash    A <code>Hash</code> object.
+	 * Generate a comma-seperated string representation of the keys of a <code>StringMap</code>.
+	 * @param  AnyMap    A <code>StringMap</code> object.
 	 * @return  A <code>String</code> formatted like this: <code>key1, key2, ..., keyX</code>
 	 */
-	inline static public function formatHash(AnyHash:Map<String, Dynamic>):String
+	inline static public function formatStringMap(AnyMap:Map<String,Dynamic>):String
 	{
 		var string:String = "";
-		for (key in AnyHash.keys()) {
+		for (key in AnyMap.keys()) {
 			string += Std.string(key);
 			string += ", ";
 		}
-		string = string.substring(0, string.length - 2);
-		return string;
+		
+		return string.substring(0, string.length - 2);
 	} 
 	
 	/**


### PR DESCRIPTION
...formatStringMap()

For debugging certain things, logging just isn't very suitable. If you log something in `update()`, the whole window gets flooded and you can't even tell if new logs are being added anymore when the log messages don't change. 
Watch is pretty much the solution to that - but it's really inconvenient when you don't have a var for the value you want to watch. `FlxG.quickWatch()` is basically a log in the watch window. You can push any value to it. It supports formatting `FlxPoint` and `StringMap` data types.  (also added StringMap support for `FlxG.log()`) It can't be edited and is displayed in green. `FlxG.removeQuickWatch()` gets rid of it.
