### PR TITLE
Introduce FlxAngle, get rid of FlxPTMath

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -129,12 +129,6 @@ class FlxG
 	#end
 	
 	/**
-	 * Useful for rad-to-deg and deg-to-rad conversion.
-	 */
-	static public var DEG:Float = 180 / Math.PI;
-	static public var RAD:Float = Math.PI / 180;
-	
-	/**
 	 * Internal tracker for game object.
 	 */
 	static public var _game:FlxGame;

--- a/src/org/flixel/FlxObject.hx
+++ b/src/org/flixel/FlxObject.hx
@@ -2,6 +2,7 @@ package org.flixel;
 
 import flash.display.Graphics;
 import org.flixel.FlxBasic;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxColor;
 import org.flixel.util.FlxMath;
 import org.flixel.util.FlxPoint;
@@ -763,8 +764,8 @@ class FlxObject extends FlxBasic
 			}
 			else
 			{
-				pathAngle = FlxMath.getAngle(_point, node);
-				FlxMath.rotatePoint(0, pathSpeed, 0, 0, pathAngle, velocity);
+				pathAngle = FlxAngle.getAngle(_point, node);
+				FlxAngle.rotatePoint(0, pathSpeed, 0, 0, pathAngle, velocity);
 			}
 			
 			//then set object rotation if necessary

--- a/src/org/flixel/FlxSprite.hx
+++ b/src/org/flixel/FlxSprite.hx
@@ -14,6 +14,7 @@ import org.flixel.plugin.texturepacker.TexturePackerData;
 import org.flixel.system.FlxAnim;
 import org.flixel.system.layer.DrawStackItem;
 import org.flixel.system.layer.frames.FlxFrame;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxColor;
 import org.flixel.util.FlxArray;
 import org.flixel.util.FlxPoint;
@@ -329,7 +330,7 @@ class FlxSprite extends FlxObject
 		_flipped = Sprite.flipped;
 		bakedRotation = Sprite.bakedRotation;
 		_bitmapDataKey = Sprite.bitmapDataKey;
-		_textureData = Sprite.textureData;
+		_textureData = Sprite._textureData;
 		
 		width = frameWidth = Sprite.frameWidth;
 		height = frameHeight = Sprite.frameHeight;
@@ -532,7 +533,7 @@ class FlxSprite extends FlxObject
 				{
 					_matrix.identity();
 					_matrix.translate( -halfBrushWidth, -halfBrushHeight);
-					_matrix.rotate(bakedAngle * FlxG.RAD);
+					_matrix.rotate(bakedAngle * FlxAngle.RAD);
 					#if flash
 					_matrix.translate(max * column + midpointX, midpointY);
 					#else
@@ -859,7 +860,7 @@ class FlxSprite extends FlxObject
 				_matrix.scale(scale.x, scale.y);
 				if ((angle != 0) && (bakedRotation <= 0))
 				{
-					_matrix.rotate(angle * FlxG.RAD);
+					_matrix.rotate(angle * FlxAngle.RAD);
 				}
 				_matrix.translate(_point.x + origin.x, _point.y + origin.y);
 				camera.buffer.draw(framePixels, _matrix, null, blend, null, antialiasing);
@@ -886,7 +887,7 @@ class FlxSprite extends FlxObject
 			
 			if (!simpleRenderSprite())
 			{
-				radians = -(angle + _flxFrame.additionalAngle) * FlxG.RAD;
+				radians = -(angle + _flxFrame.additionalAngle) * FlxAngle.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 				
@@ -993,7 +994,7 @@ class FlxSprite extends FlxObject
 		_matrix.scale(Brush.scale.x, Brush.scale.y);
 		if (Brush.angle != 0)
 		{
-			_matrix.rotate(Brush.angle * FlxG.RAD);
+			_matrix.rotate(Brush.angle * FlxAngle.RAD);
 		}
 		_matrix.translate(X + Brush.origin.x, Y + Brush.origin.y);
 		var brushBlend:BlendMode = Brush.blend;

--- a/src/org/flixel/FlxTileblock.hx
+++ b/src/org/flixel/FlxTileblock.hx
@@ -1,6 +1,7 @@
 package org.flixel;
 
 import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxArray;
 import org.flixel.util.FlxRandom;
 
@@ -233,7 +234,7 @@ class FlxTileblock extends FlxSprite
 
 				if (!simpleRenderSprite ())
 				{
-					radians = angle * FlxG.RAD;
+					radians = angle * FlxAngle.RAD;
 					cos = Math.cos(radians);
 					sin = Math.sin(radians);
 					

--- a/src/org/flixel/addons/FlxSkewedSprite.hx
+++ b/src/org/flixel/addons/FlxSkewedSprite.hx
@@ -6,6 +6,7 @@ import org.flixel.FlxG;
 import org.flixel.FlxObject;
 import org.flixel.FlxSprite;
 import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxPoint;
 
 /**
@@ -142,14 +143,14 @@ class FlxSkewedSprite extends FlxSprite
 				_matrix.translate( -origin.x, -origin.y);
 				if ((angle != 0) && (bakedRotation <= 0))
 				{
-					_matrix.rotate(angle * FlxG.RAD);
+					_matrix.rotate(angle * FlxAngle.RAD);
 				}
 				_matrix.scale(scale.x, scale.y);
 				if (skew.x != 0 || skew.y != 0)
 				{
 					_skewMatrix.identity();
-					_skewMatrix.b = Math.tan(skew.y * FlxG.RAD);
-					_skewMatrix.c = Math.tan(skew.x * FlxG.RAD);
+					_skewMatrix.b = Math.tan(skew.y * FlxAngle.RAD);
+					_skewMatrix.c = Math.tan(skew.x * FlxAngle.RAD);
 					
 					_matrix.concat(_skewMatrix);
 				}
@@ -175,7 +176,7 @@ class FlxSkewedSprite extends FlxSprite
 			}
 			else
 			{
-				radians = -angle * FlxG.RAD;
+				radians = -angle * FlxAngle.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 				
@@ -207,8 +208,8 @@ class FlxSkewedSprite extends FlxSprite
 				if (skew.x != 0 || skew.y != 0)
 				{
 					_skewMatrix.identity();
-					_skewMatrix.b = Math.tan(-skew.x * FlxG.RAD);
-					_skewMatrix.c = Math.tan(-skew.y * FlxG.RAD);
+					_skewMatrix.b = Math.tan(-skew.x * FlxAngle.RAD);
+					_skewMatrix.c = Math.tan(-skew.y * FlxAngle.RAD);
 					
 					_matrix.concat(_skewMatrix);
 				}

--- a/src/org/flixel/addons/FlxSlider.hx
+++ b/src/org/flixel/addons/FlxSlider.hx
@@ -10,7 +10,6 @@ import org.flixel.plugin.photonstorm.FlxMouseControl;
 import org.flixel.util.FlxMath;
 import org.flixel.util.FlxPoint;
 import org.flixel.util.FlxRect;
-import org.flixel.plugin.photonstorm.FlxPTMath;
 
 /**
  * A slider GUI element for floats and integers. 

--- a/src/org/flixel/plugin/MouseInteractionMgr.hx
+++ b/src/org/flixel/plugin/MouseInteractionMgr.hx
@@ -5,6 +5,7 @@ import org.flixel.FlxBasic;
 import org.flixel.FlxCamera;
 import org.flixel.FlxG;
 import org.flixel.FlxGroup;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxPoint;
 import org.flixel.FlxSprite;
 import org.flixel.system.input.FlxTouch;
@@ -199,7 +200,7 @@ class MouseInteractionMgr extends FlxBasic
 			FlxG.mouse.getWorldPosition(camera, _point);
 			if (sprite.angle != 0)
 			{
-				FlxMath.rotatePoint(_point.x, _point.y, sprite.x + sprite.origin.x, sprite.y + sprite.origin.y, -180 + sprite.angle, _point);	
+				FlxAngle.rotatePoint(_point.x, _point.y, sprite.x + sprite.origin.x, sprite.y + sprite.origin.y, -180 + sprite.angle, _point);	
 			}
 			if (sprite.overlapsPoint(_point, true, camera))
 			{
@@ -221,7 +222,7 @@ class MouseInteractionMgr extends FlxBasic
 				touch.getWorldPosition(camera, _point);
 				if (sprite.angle != 0)
 				{
-					FlxMath.rotatePoint(_point.x, _point.y, sprite.x + sprite.origin.x, sprite.y + sprite.origin.y, -180 + sprite.angle, _point);	
+					FlxAngle.rotatePoint(_point.x, _point.y, sprite.x + sprite.origin.x, sprite.y + sprite.origin.y, -180 + sprite.angle, _point);	
 				}
 				if (sprite.overlapsPoint(_point, true, camera))
 				{

--- a/src/org/flixel/plugin/photonstorm/FlxBar.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxBar.hx
@@ -22,6 +22,7 @@ import flash.geom.Rectangle;
 import org.flixel.FlxG;
 import org.flixel.FlxSprite;
 import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxPoint;
 import org.flixel.util.FlxColor;
 
@@ -1088,7 +1089,7 @@ class FlxBar extends FlxSprite
 
 			if (!simpleRenderSprite())
 			{
-				var radians:Float = -angle * FlxG.RAD;
+				var radians:Float = -angle * FlxAngle.RAD;
 				var cos:Float = Math.cos(radians);
 				var sin:Float = Math.sin(radians);
 				

--- a/src/org/flixel/plugin/photonstorm/FlxBitmapFont.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxBitmapFont.hx
@@ -22,6 +22,7 @@ import org.flixel.FlxBasic;
 import org.flixel.FlxG;
 import org.flixel.FlxSprite;
 import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
 
 class FlxBitmapFont extends FlxSprite
 {
@@ -359,7 +360,7 @@ class FlxBitmapFont extends FlxSprite
 
 			if (!simpleRenderSprite ())
 			{
-				radians = angle * FlxG.RAD;
+				radians = angle * FlxAngle.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 				

--- a/src/org/flixel/plugin/photonstorm/FlxControlHandler.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxControlHandler.hx
@@ -22,6 +22,7 @@ import flash.geom.Rectangle;
 import flash.Lib;
 import org.flixel.FlxG;
 import org.flixel.FlxObject;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxPoint;
 import org.flixel.FlxSound;
 import org.flixel.FlxSprite;
@@ -839,7 +840,7 @@ class FlxControlHandler
 			// TODO - Not quite there yet given the way Flixel can rotate to any valid int angle!
 			if (enforceAngleLimits)
 			{
-				//entity.angle = FlxMath.angleLimit(entity.angle, minAngle, maxAngle);
+				//entity.angle = FlxAngle.angleLimit(entity.angle, minAngle, maxAngle);
 			}
 		}
 		
@@ -866,7 +867,7 @@ class FlxControlHandler
 			// TODO - Not quite there yet given the way Flixel can rotate to any valid int angle!
 			if (enforceAngleLimits)
 			{
-				//entity.angle = FlxMath.angleLimit(entity.angle, minAngle, maxAngle);
+				//entity.angle = FlxAngle.angleLimit(entity.angle, minAngle, maxAngle);
 			}
 		}
 		

--- a/src/org/flixel/plugin/photonstorm/FlxGradient.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxGradient.hx
@@ -19,7 +19,7 @@ import flash.geom.Rectangle;
 import org.flixel.FlxG;
 import org.flixel.FlxSprite;
 import org.flixel.util.FlxColor;
-
+import org.flixel.util.FlxAngle;
 import flash.display.Bitmap;
 import flash.geom.Matrix;
 import flash.display.BitmapData;
@@ -33,15 +33,12 @@ import flash.display.InterpolationMethod;
  */
 class FlxGradient
 {
-	
-	public function new() { }
-	
 	public static function createGradientMatrix(width:Int, height:Int, colors:Array<Int>, chunkSize:Int = 1, rotation:Int = 90):GradientMatrix
 	{
 		var gradientMatrix:Matrix = new Matrix();
 		
 		//	Rotation (in radians) that the gradient is rotated
-		var rot:Float = FlxPTMath.asRadians(rotation);
+		var rot:Float = FlxAngle.asRadians(rotation);
 		
 		//	Last 2 values = horizontal and vertical shift (in pixels)
 		if (chunkSize == 1)

--- a/src/org/flixel/plugin/photonstorm/FlxPTColor.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxPTColor.hx
@@ -18,6 +18,7 @@ package org.flixel.plugin.photonstorm;
 import flash.errors.Error;
 import org.flixel.FlxG;
 import org.flixel.util.FlxColor;
+import org.flixel.util.FlxMath;
 
 /**
  * <code>FlxColor</code> is a set of fast color manipulation and color harmony methods.<br />
@@ -57,7 +58,7 @@ class FlxPTColor
 	{
 		var hsv:HSV = RGBtoHSV(color);
 		
-		var opposite:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), 180, 359);
+		var opposite:Int = FlxMath.wrapValue(Std.int(hsv.hue), 180, 359);
 		
 		return HSVtoRGB(opposite, 1.0, 1.0);
 	}
@@ -81,8 +82,8 @@ class FlxPTColor
 			throw "FlxColor Warning: Invalid threshold given to getAnalogousHarmony()";
 		}
 		
-		var warmer:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), 359 - threshold, 359);
-		var colder:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), threshold, 359);
+		var warmer:Int = FlxMath.wrapValue(Std.int(hsv.hue), 359 - threshold, 359);
+		var colder:Int = FlxMath.wrapValue(Std.int(hsv.hue), threshold, 359);
 		
 		return { color1: color, color2: HSVtoRGB(warmer, 1.0, 1.0), color3: HSVtoRGB(colder, 1.0, 1.0), hue1: Std.int(hsv.hue), hue2: warmer, hue3: colder };
 	}
@@ -106,10 +107,10 @@ class FlxPTColor
 			throw "FlxColor Warning: Invalid threshold given to getSplitComplementHarmony()";
 		}
 		
-		var opposite:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), 180, 359);
+		var opposite:Int = FlxMath.wrapValue(Std.int(hsv.hue), 180, 359);
 		
-		var warmer:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), opposite - threshold, 359);
-		var colder:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), opposite + threshold, 359);
+		var warmer:Int = FlxMath.wrapValue(Std.int(hsv.hue), opposite - threshold, 359);
+		var colder:Int = FlxMath.wrapValue(Std.int(hsv.hue), opposite + threshold, 359);
 		
 		FlxG.notice("hue: " + hsv.hue + " opposite: " + opposite + " warmer: " + warmer + " colder: " + colder);
 		
@@ -131,8 +132,8 @@ class FlxPTColor
 	{
 		var hsv:HSV = RGBtoHSV(color);
 		
-		var triadic1:Int = FlxPTMath.wrapValue(Std.int(hsv.hue), 120, 359);
-		var triadic2:Int = FlxPTMath.wrapValue(triadic1, 120, 359);
+		var triadic1:Int = FlxMath.wrapValue(Std.int(hsv.hue), 120, 359);
+		var triadic2:Int = FlxMath.wrapValue(triadic1, 120, 359);
 		
 		return { color1: color, color2: HSVtoRGB(triadic1, 1.0, 1.0), color3: HSVtoRGB(triadic2, 1.0, 1.0) };
 	}

--- a/src/org/flixel/plugin/photonstorm/FlxVelocity.hx
+++ b/src/org/flixel/plugin/photonstorm/FlxVelocity.hx
@@ -18,6 +18,7 @@ package org.flixel.plugin.photonstorm;
 
 import org.flixel.FlxG;
 import org.flixel.FlxObject;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxPoint;
 import org.flixel.FlxSprite;
 import org.flixel.system.input.FlxTouch;
@@ -319,7 +320,7 @@ class FlxVelocity
 		
 		if (asDegrees)
 		{
-			return FlxMath.asDegrees(Math.atan2(dy, dx));
+			return FlxAngle.asDegrees(Math.atan2(dy, dx));
 		}
 		else
 		{
@@ -344,7 +345,7 @@ class FlxVelocity
 		
 		if (asDegrees)
 		{
-			return FlxMath.asDegrees(Math.atan2(dy, dx));
+			return FlxAngle.asDegrees(Math.atan2(dy, dx));
 		}
 		else
 		{
@@ -362,7 +363,7 @@ class FlxVelocity
 	 */
 	public static function velocityFromAngle(angle:Int, speed:Int):FlxPoint
 	{
-		var a:Float = FlxMath.asRadians(angle);
+		var a:Float = FlxAngle.asRadians(angle);
 		
 		var result:FlxPoint = new FlxPoint();
 		
@@ -386,19 +387,19 @@ class FlxVelocity
 		
 		if (parent.facing == FlxObject.LEFT)
 		{
-			a = FlxMath.asRadians(180);
+			a = FlxAngle.asRadians(180);
 		}
 		else if (parent.facing == FlxObject.RIGHT)
 		{
-			a = FlxMath.asRadians(0);
+			a = FlxAngle.asRadians(0);
 		}
 		else if (parent.facing == FlxObject.UP)
 		{
-			a = FlxMath.asRadians( -90);
+			a = FlxAngle.asRadians( -90);
 		}
 		else if (parent.facing == FlxObject.DOWN)
 		{
-			a = FlxMath.asRadians(90);
+			a = FlxAngle.asRadians(90);
 		}
 		
 		var result:FlxPoint = new FlxPoint();
@@ -433,7 +434,7 @@ class FlxVelocity
 		
 		if (asDegrees)
 		{
-			return FlxMath.asDegrees(Math.atan2(dy, dx));
+			return FlxAngle.asDegrees(Math.atan2(dy, dx));
 		}
 		else
 		{
@@ -463,7 +464,7 @@ class FlxVelocity
 		
 		if (asDegrees)
 		{
-			return FlxMath.asDegrees(Math.atan2(dy, dx));
+			return FlxAngle.asDegrees(Math.atan2(dy, dx));
 		}
 		else
 		{

--- a/src/org/flixel/plugin/photonstorm/fx/GlitchFX.hx
+++ b/src/org/flixel/plugin/photonstorm/fx/GlitchFX.hx
@@ -17,6 +17,7 @@ import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
 import org.flixel.FlxSprite;
+import org.flixel.util.FlxAngle;
 
 /**
  * Creates a static / glitch / monitor-corruption style effect on an FlxSprite
@@ -370,7 +371,7 @@ class GlitchSprite extends FlxSprite
 
 			if (!simpleRenderSprite ())
 			{
-				radians = angle * FlxG.RAD;
+				radians = angle * FlxAngle.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 

--- a/src/org/flixel/plugin/photonstorm/fx/StarfieldFX.hx
+++ b/src/org/flixel/plugin/photonstorm/fx/StarfieldFX.hx
@@ -20,6 +20,7 @@ import org.flixel.FlxSprite;
 import org.flixel.plugin.photonstorm.FlxColor;
 import org.flixel.plugin.photonstorm.FlxGradient;
 import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxColor;
 import org.flixel.util.FlxMisc;
 
@@ -484,7 +485,7 @@ class StarSprite extends FlxSprite
 
 			if (!simpleRenderSprite ())
 			{
-				radians = angle * FlxG.RAD;
+				radians = angle * FlxAngle.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 				

--- a/src/org/flixel/plugin/pxText/FlxBitmapTextField.hx
+++ b/src/org/flixel/plugin/pxText/FlxBitmapTextField.hx
@@ -5,6 +5,7 @@ import org.flixel.FlxCamera;
 import org.flixel.FlxG;
 import org.flixel.FlxSprite;
 import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
 
 /**
  * Extends <code>FlxSprite</code> to support rendering text.
@@ -255,7 +256,7 @@ class FlxBitmapTextField extends FlxSprite
 
 			if (!simpleRenderSprite ())
 			{
-				radians = angle * FlxG.RAD;
+				radians = angle * FlxAngle.RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
 				

--- a/src/org/flixel/system/layer/frames/FlxFrame.hx
+++ b/src/org/flixel/system/layer/frames/FlxFrame.hx
@@ -6,6 +6,7 @@ import flash.geom.Point;
 import flash.geom.Rectangle;
 import org.flixel.FlxG;
 import org.flixel.system.layer.TileSheetData;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxColor;
 import org.flixel.util.FlxPoint;
 
@@ -71,7 +72,7 @@ class FlxFrame
 			
 			MATRIX.identity();
 			MATRIX.translate( -0.5 * frame.width, -0.5 * frame.height);
-			MATRIX.rotate(-90.0 * FlxG.RAD);
+			MATRIX.rotate(-90.0 * FlxAngle.RAD);
 			MATRIX.translate(offset.x + 0.5 * frame.height, offset.y + 0.5 * frame.width);
 			
 			_bitmapData.draw(temp, MATRIX);

--- a/src/org/flixel/system/layer/frames/TexturePackerFrame.hx
+++ b/src/org/flixel/system/layer/frames/TexturePackerFrame.hx
@@ -4,6 +4,7 @@ import flash.display.BitmapData;
 import flash.geom.Matrix;
 import flash.geom.Rectangle;
 import org.flixel.plugin.texturepacker.TexturePackerTileSheetData;
+import org.flixel.util.FlxAngle;
 import org.flixel.util.FlxColor;
 
 class TexturePackerFrame extends FlxFrame
@@ -42,7 +43,7 @@ class TexturePackerFrame extends FlxFrame
 			// TODO: fix this for non-square sprites
 			MATRIX.identity();
 			MATRIX.translate(-sourceSize.x * 0.5, -sourceSize.y * 0.5);
-			MATRIX.rotate(-90.0 * FlxG.RAD);
+			MATRIX.rotate(-90.0 * FlxAngle.RAD);
 			MATRIX.translate(sourceSize.x * 0.5, sourceSize.y * 0.5);
 			MATRIX.translate(offset.x, offset.y);
 			

--- a/src/org/flixel/util/FlxMath.hx
+++ b/src/org/flixel/util/FlxMath.hx
@@ -82,146 +82,6 @@ class FlxMath
 	}
 	
 	/**
-	 * Rotates a point in 2D space around another point by the given angle.
-	 * @param	X		The X coordinate of the point you want to rotate.
-	 * @param	Y		The Y coordinate of the point you want to rotate.
-	 * @param	PivotX	The X coordinate of the point you want to rotate around.
-	 * @param	PivotY	The Y coordinate of the point you want to rotate around.
-	 * @param	Angle	Rotate the point by this many degrees.
-	 * @param	Point	Optional <code>FlxPoint</code> to store the results in.
-	 * @return	A <code>FlxPoint</code> containing the coordinates of the rotated point.
-	 */
-	inline static public function rotatePoint(X:Float, Y:Float, PivotX:Float, PivotY:Float, Angle:Float, point:FlxPoint = null):FlxPoint
-	{
-		var sin:Float = 0;
-		var cos:Float = 0;
-		var radians:Float = Angle * -0.017453293;
-		while (radians < -3.14159265)
-		{
-			radians += 6.28318531;
-		}
-		while (radians >  3.14159265)
-		{
-			radians = radians - 6.28318531;
-		}
-		
-		if (radians < 0)
-		{
-			sin = 1.27323954 * radians + .405284735 * radians * radians;
-			if (sin < 0)
-			{
-				sin = .225 * (sin *-sin - sin) + sin;
-			}
-			else
-			{
-				sin = .225 * (sin * sin - sin) + sin;
-			}
-		}
-		else
-		{
-			sin = 1.27323954 * radians - 0.405284735 * radians * radians;
-			if (sin < 0)
-			{
-				sin = .225 * (sin *-sin - sin) + sin;
-			}
-			else
-			{
-				sin = .225 * (sin * sin - sin) + sin;
-			}
-		}
-		
-		radians += 1.57079632;
-		if (radians >  3.14159265)
-		{
-			radians = radians - 6.28318531;
-		}
-		if (radians < 0)
-		{
-			cos = 1.27323954 * radians + 0.405284735 * radians * radians;
-			if (cos < 0)
-			{
-				cos = .225 * (cos *-cos - cos) + cos;
-			}
-			else
-			{
-				cos = .225 * (cos * cos - cos) + cos;
-			}
-		}
-		else
-		{
-			cos = 1.27323954 * radians - 0.405284735 * radians * radians;
-			if (cos < 0)
-			{
-				cos = .225 * (cos *-cos - cos) + cos;
-			}
-			else
-			{
-				cos = .225 * (cos * cos - cos) + cos;
-			}
-		}
-		
-		var dx:Float = X - PivotX;
-		// TODO: Uncomment this line if there will be problems
-		//var dy:Float = PivotY + Y; //Y axis is inverted in flash, normally this would be a subtract operation
-		var dy:Float = Y - PivotY;
-		if (point == null)
-		{
-			point = new FlxPoint();
-		}
-		point.x = PivotX + cos * dx - sin * dy;
-		point.y = PivotY - sin * dx - cos * dy;
-		return point;
-	}
-	
-	/**
-	 * Calculates the angle between two points.  0 degrees points straight up.
-	 * @param	Point1		The X coordinate of the point.
-	 * @param	Point2		The Y coordinate of the point.
-	 * @return	The angle in degrees, between -180 and 180.
-	 */
-	inline static public function getAngle(Point1:FlxPoint, Point2:FlxPoint):Float
-	{
-		var x:Float = Point2.x - Point1.x;
-		var y:Float = Point2.y - Point1.y;
-		var angle:Float = 0;
-		if ((x != 0) || (y != 0))
-		{
-			var c1:Float = 3.14159265 * 0.25;
-			var c2:Float = 3 * c1;
-			var ay:Float = (y < 0) ? -y : y;
-			if (x >= 0)
-			{
-				angle = c1 - c1 * ((x - ay) / (x + ay));
-			}
-			else
-			{
-				angle = c2 - c1 * ((x + ay) / (ay - x));
-			}
-			angle = ((y < 0)? -angle:angle) * 57.2957796;
-			if (angle > 90)
-			{
-				angle = angle - 270;
-			}
-			else
-			{
-				angle += 90;
-			}
-		}
-		
-		return angle;
-	}
-	
-	/**
-	 * Transforms degrees to radians
-	 * @param 	degrees		Angle in degrees (0 - 360).
-	 * @return	The andgle in radians.
-	 */
-	inline static public function degreesToRadians(degrees:Float):Float 
-	{
-		return degrees * FlxG.RAD;
-	}
-	
-	/**
 	 * Calculate the distance between two points.
 	 * @param 	Point1		A <code>FlxPoint</code> object referring to the first location.
 	 * @param 	Point2		A <code>FlxPoint</code> object referring to the second location.
@@ -382,12 +242,69 @@ class FlxMath
 	}
 	
 	/**
+	 * Adds the given amount to the value, but never lets the value go over the specified maximum
+	 * 
+	 * @param 	value 	The value to add the amount to
+	 * @param 	amount 	The amount to add to the value
+	 * @param 	max 	The maximum the value is allowed to be
+	 * @return The new value
+	 */
+	static public function maxAdd(value:Int, amount:Int, max:Int):Int
+	{
+		value += amount;
+		
+		if (value > max)
+		{
+			value = max;
+		}
+		
+		return value;
+	}
+	
+	/**
+	 * Adds value to amount and ensures that the result always stays between 0 and max, by wrapping the value around.
+	 * Values must be positive integers, and are passed through <code>Math.abs</code>
+	 * 
+	 * @param 	value 	The value to add the amount to
+	 * @param 	amount 	The amount to add to the value
+	 * @param 	max 	The maximum the value is allowed to be
+	 * @return The wrapped value
+	 */
+	static public function wrapValue(value:Int, amount:Int, max:Int):Int
+	{
+		var diff:Int;
+
+		value = Std.int(Math.abs(value));
+		amount = Std.int(Math.abs(amount));
+		max = Std.int(Math.abs(max));
+		
+		diff = (value + amount) % max;
+		
+		return diff;
+	}
+	
+	/**
+	 * Finds the dot product value of two vectors
+	 * 
+	 * @param	ax		Vector X
+	 * @param	ay		Vector Y
+	 * @param	bx		Vector X
+	 * @param	by		Vector Y
+	 * 
+	 * @return	Result of the dot product
+	 */
+	inline static public function dotProduct(ax:Float, ay:Float, bx:Float, by:Float):Float
+	{
+		return ax * bx + ay * by;
+	}
+	
+	/**
 	 * Finds the length of the given vector
 	 * 
 	 * @param	dx
 	 * @param	dy
 	 * 
-	 * @return
+	 * @return The length
 	 */
 	inline static public function vectorLength(dx:Float, dy:Float):Float
 	{


### PR DESCRIPTION
- added a new `FlxAngle` class contaning a bunch of functions from `FlxMath` & `FlxPTMath` related to angle calculations in some way. Moved `RAD` and `DEG` over from `FlxG` (didn't really belong there).
- moved the remaining functions in `FlxPTMath` to `FlxMath`:
  - `maxAdd()`
  - `wrapValue()`
  - `dotProduct()`
- also removed `FlxMath.degreesToRadians()` (not really needed anymore due to `FlxAngle.asDegrees()` and `FlxAngle.asRadians()` - same for vars in `FlxPTMath` that were equivalent to `DEG` and `RAD` - this made it possible to get rid of `FlxPTMath` entirely, which is good because of possible naming confusions
