### PR TITLE
Improve framerate warnings and show debugger for FlxG.warn()

### DIFF
--- a/src/org/flixel/FlxG.hx
+++ b/src/org/flixel/FlxG.hx
@@ -525,7 +525,7 @@ class FlxG
 	{
 		if (Framerate < FlxG.flashFramerate)
 		{
-			FlxG.warn("You about to set game framerate less that flash framerate. It could stop your game from updating");
+			FlxG.warn("FlxG.framerate: The game's framerate shouldn't be smaller than the flash framerate, since it can stop your game from updating.");
 		}
 		
 		_game._step = Std.int(Math.abs(1000 / Framerate));
@@ -556,7 +556,7 @@ class FlxG
 	{
 		if (Framerate > FlxG.framerate)
 		{
-			FlxG.warn("You about to set flash framerate more than game framerate. It could stop your game from updating");
+			FlxG.warn("FlxG.flashFramerate: The game's framerate shouldn't be smaller than the flash framerate, since it can stop your game from updating.");
 		}
 		
 		_game._flashFramerate = Std.int(Math.abs(Framerate));

--- a/src/org/flixel/FlxGame.hx
+++ b/src/org/flixel/FlxGame.hx
@@ -193,7 +193,6 @@ class FlxGame extends Sprite
 	 * @param	Zoom			The default level of zoom for the game's cameras (e.g. 2 = all pixels are now drawn at 2x).  Default = 1.
 	 * @param	GameFramerate	How frequently the game should update (default is 60 times per second).
 	 * @param	FlashFramerate	Sets the actual display framerate for Flash player (default is 60 times per second).
-	 * @param	UseSystemCursor	Whether to use the default OS mouse pointer, or to use custom flixel ones.
 	 */
 	public function new(GameSizeX:Int, GameSizeY:Int, InitialState:Class<FlxState>, Zoom:Float = 1, GameFramerate:Int = 60, FlashFramerate:Int = 60)
 	{

--- a/src/org/flixel/system/debug/Log.hx
+++ b/src/org/flixel/system/debug/Log.hx
@@ -54,7 +54,7 @@ class Log extends FlxWindow
 		_lines = new Array<String>();
 		
 		STYLE_NORMAL = new LogStyle();
-		STYLE_WARNING = new LogStyle("[WARNING] ", "FFFF00", 12, true, false, false, "Beep");
+		STYLE_WARNING = new LogStyle("[WARNING] ", "FFFF00", 12, true, false, false, "Beep", true);
 		STYLE_ERROR = new LogStyle("[ERROR] ", "FF0000", 12, true, false, false, "Beep", true);
 		STYLE_NOTICE = new LogStyle("[NOTICE] ", "008000", 12, true);
 		STYLE_CONSOLE = new LogStyle("&#62; ", "0000ff", 12, true);


### PR DESCRIPTION
- Changed warning messages for the flash framerate being higher than the game framerate. It wasn't gramatically correct (should've been "you are about to", not "you about to"), and I also think it's good practice to always include the source of the error (like `FlxG.framerate` or `FlxG.flashFramerate`
- set `openDebugger` to true for the warning `LogStyle` - this prevents warnings from being unnoticed. However, this also means there isn't much which distuingishes errors from warnings. I think we need a clearer ruleset for when to use errors and when to use warnings.
- Removed the left-over documentation for the `UseSystemCursor` param in the constructor of `FlxGame` for now. It might be worth the re-introduce it at some point though.
