### PR TITLE
Option to redirect traces into the log window, closes #452

### DIFF
--- a/src/org/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/src/org/flixel/system/frontEnds/LogFrontEnd.hx
@@ -120,7 +120,7 @@ class LogFrontEnd
 	 * Whether everything you <code>trace()</code> is being redirected into the log window.
 	 * True by default.
 	 */
-	public var redirectTraces(default, set):Bool;
+	public var redirectTraces(default, set):Bool = false;
 	/**
 	 * Internal var used to undo the redirection of traces.
 	 */


### PR DESCRIPTION
Unfortunately, it doesn't seem like it's a good idea to `trace()` a warning indicating that traces are being redirceted, since this will create a textfield in the background when working with the flash target. This is unfortunate, because it might confuse people who don't want to use traces with the flixel debugger.
