### PR TITLE
Remove include.xml and improve .xml-template

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
 
 	<target name="Haxelib Package" depends="Run.n, Project Template">
 		<zip destfile="${PACKAGE_NAME}-${VERSION}.zip">
-			<zipfileset dir="" prefix="${PACKAGE_NAME}" includes="run.n,template.zip,CHANGELOG.txt,include.nmml" />
+			<zipfileset dir="" prefix="${PACKAGE_NAME}" includes="run.n,template.zip,CHANGELOG.txt" />
 			<zipfileset dir="src" prefix="${PACKAGE_NAME}" />
 		</zip>
 	</target>

--- a/include.xml
+++ b/include.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<project>
-	<app preloader="org.flixel.system.FlxPreloader" unless="html5" />
-	<set name="SWF_VERSION" value="11.2" />
-</project>

--- a/src/flixel/FlxGame.hx
+++ b/src/flixel/FlxGame.hx
@@ -417,7 +417,7 @@ class FlxGame extends Sprite
 	public inline function requestNewState(newState:FlxState):Void
 	{
 		_requestedState = newState;
-		#if(cpp && thread)
+		#if (cpp && FLX_THREADING)
 		_stateSwitchRequested = true;
 		#end
 	} 
@@ -470,7 +470,7 @@ class FlxGame extends Sprite
 		#end
 		_state.create();
 		
-		#if (cpp && thread) 
+		#if (cpp && FLX_THREADING) 
 		_stateSwitchRequested = false; 
 		#end
 	}
@@ -518,7 +518,7 @@ class FlxGame extends Sprite
 		//finally actually step through the game physics
 		FlxBasic._ACTIVECOUNT = 0;
 		
-		#if (cpp && thread)
+		#if (cpp && FLX_THREADING)
 		_threadSync.push(true);
 		#else
 		update();
@@ -532,7 +532,7 @@ class FlxGame extends Sprite
 		#end
 	}
 	
-	#if (cpp && thread)
+	#if (cpp && FLX_THREADING)
 	// push 'true' into this array to trigger an update. push 'false' to terminate update thread.
 	public var _stateSwitchRequested:Bool;
 	public var _threadSync:cpp.vm.Deque<Bool>;
@@ -687,7 +687,7 @@ class FlxGame extends Sprite
 		
 		FlxG.cameras.lock();
 		
-		#if (cpp && thread)
+		#if (cpp && FLX_THREADING)
 		// Only draw the state if a new state hasn't been requested
 		if (!_stateSwitchRequested)
 		#end 
@@ -790,7 +790,7 @@ class FlxGame extends Sprite
 			_requestedReset = false;
 		}
 		
-		#if (cpp && thread)
+		#if (cpp && FLX_THREADING)
 		_threadSync = new cpp.vm.Deque();
 		cpp.vm.Thread.create(threadedUpdate);
 		#end

--- a/template/${PROJECT_NAME}.xml.tpl
+++ b/template/${PROJECT_NAME}.xml.tpl
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project>
-	<app title="${PROJECT_NAME}" file="${PROJECT_NAME}" main="Main" version="0.0.1" company="Zaphod" />
+	<app title="${PROJECT_NAME}" file="${PROJECT_NAME}" main="Main" version="0.0.1" company="HaxeFlixel" />
 	
 	<window width="${WIDTH}" height="${HEIGHT}" fps="60" orientation="portrait" resizable="true" if="web" />
 	<window width="${WIDTH}" height="${HEIGHT}" fps="60" orientation="landscape" fullscreen="false" hardware="true" vsync="true" unless="web" />
  	
-	<set name="BUILD_DIR" value="export" />
+	<!--The flixel preloader gets stuck in Chrome, so it's disabled by default for now. 
+	Safe to use if you embed the swf into a html file!-->
+	<!--<app preloader="org.flixel.system.FlxPreloader" unless="html5" />-->
 	
-	<!--<setenv name="no_console" value="1" />-->
+	<!--The swf version should be at least 11.2 if you want to use the FLX_MOUSE_ADVANCED option-->
+	<set name="SWF_VERSION" value="11.2" />
+	
+	<set name="BUILD_DIR" value="export" />
 	
 	<classpath name="source" />
 	
@@ -46,21 +51,32 @@
 	
 	<icon name="assets/HaxeFlixel.svg" />
 	
+	
 	<haxelib name="openfl" />
 	<haxelib name="flixel"/>
 	
+	
+	<!--Enable experimental threading support for cpp targets-->
+	<!--<haxedef name="FLX_THREADING" />-->
+	
+	<!--Enable the flixel core recording system-->
+    <!--<haxedef name="FLX_RECORD" />-->
+	
+	<!--Enable right and middle click support for the mouse. Flash player version 11.2+, no HTML5 support -->
+	<!--<haxedef name="FLX_MOUSE_ADVANCED" />-->
+	
+	<!--Enables checks for antialiasing for sprite rendering on native targets. And could affect perfomance. -->
+	<!--<haxedef name="FLX_SPRITE_ANTIALIASING" />-->
+	
+	
     <!--Disable the Flixel core debugger-->
     <!--<haxedef name="FLX_NO_DEBUG" />-->
-	
-    <!--Enable the flixel core recording system-->
-    <!--<haxedef name="FLX_RECORD" />-->
 	
 	<!--Optimise inputs, be careful you will get null errors if you don't use conditionals in your game-->
     <!--<haxedef name="FLX_NO_MOUSE" if="mobile" />-->
     <!--<haxedef name="FLX_NO_KEYBOARD" if="mobile" />-->
     <!--<haxedef name="FLX_NO_TOUCH" if="desktop" />-->
     <!--<haxedef name="FLX_NO_JOYSTICK" />-->
-    <!--<haxedef name="thread" />-->
 	
 	<!--Disable the Flixel core sound tray-->
 	<!--<haxedef name="FLX_NO_SOUND_TRAY" />-->
@@ -68,11 +84,4 @@
 	<!--Disable the Flixel core focus lost screen-->
 	<!--<haxedef name="FLX_NO_FOCUS_LOST_SCREEN" />-->
 	
-	<!--Enable right and middle click support for the mouse. Requires flash player version 11.2 or higher. Doesn't work for HTML5. -->
-	<!--<haxedef name="FLX_MOUSE_ADVANCED" />-->
-	<!--<app swf-version="11.2" />-->
-	
-	<!--Enables checks for antialiasing for sprite rendering on native targets. And could affect perfomance. -->
-	<!--<haxedef name="FLX_SPRITE_ANTIALIASING" />-->
-
 </project>


### PR DESCRIPTION
- Includes a temp fix for #469 by disabling the flixel preloader by default for now.
- Removes the `include.xml` and moves its contents into the template xml.
- Renamed the `thread` flag to `FLX_THREADING` to follow the naming conventions
- Removed the `<setenv name="no_console" value="1" />` flag since it doesn't seem to do anything.
- Reorganized a few things and improved documentation.
