### PR TITLE
Several improvements for DebuggerFrontEnd

### DIFF
--- a/src/flixel/system/FlxDebugger.hx
+++ b/src/flixel/system/FlxDebugger.hx
@@ -1,4 +1,5 @@
 package flixel.system;
+
 #if !FLX_NO_DEBUG
 
 import flash.display.Bitmap;
@@ -33,32 +34,32 @@ class FlxDebugger extends Sprite
 	/**
 	 * Debugger overlay layout preset: Wide but low windows at the bottom of the screen.
 	 */
-	inline static public var DEBUGGER_STANDARD:Int = 0;
+	inline static public var STANDARD:Int = 0;
 	
 	/**
 	 * Debugger overlay layout preset: Tiny windows in the screen corners.
 	 */
-	inline static public var DEBUGGER_MICRO:Int = 1;
+	inline static public var MICRO:Int = 1;
 	
 	/**
 	 * Debugger overlay layout preset: Large windows taking up bottom half of screen.
 	 */
-	inline static public var DEBUGGER_BIG:Int = 2;
+	inline static public var BIG:Int = 2;
 	
 	/**
 	 * Debugger overlay layout preset: Wide but low windows at the top of the screen.
 	 */
-	inline static public var DEBUGGER_TOP:Int = 3;
+	inline static public var TOP:Int = 3;
 	
 	/**
 	 * Debugger overlay layout preset: Large windows taking up left third of screen.
 	 */
-	inline static public var DEBUGGER_LEFT:Int = 4;
+	inline static public var LEFT:Int = 4;
 	
 	/**
 	 * Debugger overlay layout preset: Large windows taking up right third of screen.
 	 */
-	inline static public var DEBUGGER_RIGHT:Int = 5;
+	inline static public var RIGHT:Int = 5;
 
 	/**
 	 * The amount of decimals FlxPoints are rounded to in log / watch.
@@ -109,8 +110,8 @@ class FlxDebugger extends Sprite
 	/**
 	 * Instantiates the debugger overlay.
 	 * 
-	 * @param Width		The width of the screen.
-	 * @param Height	The height of the screen.
+	 * @param 	Width	The width of the screen.
+	 * @param 	Height	The height of the screen.
 	 */
 	public function new(Width:Float, Height:Float)
 	{
@@ -165,7 +166,7 @@ class FlxDebugger extends Sprite
 		vis.y = 2;
 		addChild(vis);
 		
-		setLayout(DEBUGGER_STANDARD);
+		setLayout(STANDARD);
 		
 		//Should help with fake mouse focus type behavior
 		addEventListener(MouseEvent.MOUSE_OVER, onMouseOver);
@@ -223,9 +224,10 @@ class FlxDebugger extends Sprite
 	 * Mouse handler that helps with fake "mouse focus" type behavior.
 	 * @param	E	Flash mouse event.
 	 */
-	private function onMouseOver(E:MouseEvent = null):Void
+	private function onMouseOver(?E:MouseEvent):Void
 	{
 		hasMouse = true;
+		
 		#if !FLX_NO_MOUSE
 		Mouse.show();
 		#end
@@ -235,9 +237,10 @@ class FlxDebugger extends Sprite
 	 * Mouse handler that helps with fake "mouse focus" type behavior.
 	 * @param	E	Flash mouse event.
 	 */
-	private function onMouseOut(E:MouseEvent = null):Void
+	private function onMouseOut(?E:MouseEvent):Void
 	{
 		hasMouse = false;
+		
 		#if !FLX_NO_MOUSE
 		if (!FlxG.mouse.useSystemCursor && !FlxG._game._debugger.vcr.paused)
 			Mouse.hide();
@@ -245,8 +248,9 @@ class FlxDebugger extends Sprite
 	}
 	
 	/**
-	 * Rearrange the debugger windows using one of the constants specified in FlxG.
-	 * @param	Layout		The layout style for the debugger windows, e.g. <code>DEBUGGER_MICRO</code>.
+	 * Change the way the debugger's windows are laid out.
+	 * 
+	 * @param	Layout	The layout codes can be found in <code>FlxDebugger</code>, for example <code>FlxDebugger.MICRO</code>
 	 */
 	public function setLayout(Layout:Int):Void
 	{
@@ -256,13 +260,13 @@ class FlxDebugger extends Sprite
 	
 	/**
 	 * Forces the debugger windows to reset to the last specified layout.
-	 * The default layout is <code>DEBUGGER_STANDARD</code>.
+	 * The default layout is <code>STANDARD</code>.
 	 */
 	public function resetLayout():Void
 	{
 		switch(_layout)
 		{
-			case DEBUGGER_MICRO:
+			case MICRO:
 				log.resize(_screen.x / 4, 68);
 				log.reposition(0, _screen.y);
 				console.resize((_screen.x / 2) - _gutter * 4, 35);
@@ -270,7 +274,7 @@ class FlxDebugger extends Sprite
 				watch.resize(_screen.x / 4, 68);
 				watch.reposition(_screen.x,_screen.y);
 				perf.reposition(_screen.x, 0);
-			case DEBUGGER_BIG:
+			case BIG:
 				console.resize(_screen.x - _gutter * 2, 35);
 				console.reposition(_gutter, _screen.y);
 				log.resize((_screen.x - _gutter * 3) / 2, _screen.y / 2);
@@ -278,7 +282,7 @@ class FlxDebugger extends Sprite
 				watch.resize((_screen.x - _gutter * 3) / 2, _screen.y / 2);
 				watch.reposition(_screen.x, _screen.y - watch.height - console.height - _gutter * 1.5);
 				perf.reposition(_screen.x, 0);
-			case DEBUGGER_TOP:
+			case TOP:
 				console.resize(_screen.x - _gutter * 2, 35);
 				console.reposition(0,0);
 				log.resize((_screen.x - _gutter * 3) / 2, _screen.y / 4);
@@ -286,7 +290,7 @@ class FlxDebugger extends Sprite
 				watch.resize((_screen.x - _gutter * 3) / 2, _screen.y / 4);
 				watch.reposition(_screen.x,console.height + _gutter + 15);
 				perf.reposition(_screen.x,_screen.y);
-			case DEBUGGER_LEFT:
+			case LEFT:
 				console.resize(_screen.x - _gutter * 2, 35);
 				console.reposition(_gutter, _screen.y);
 				log.resize(_screen.x / 3, (_screen.y - 15 - _gutter * 2.5) / 2 - console.height / 2 - _gutter);
@@ -294,7 +298,7 @@ class FlxDebugger extends Sprite
 				watch.resize(_screen.x / 3, (_screen.y - 15 - _gutter * 2.5) / 2 - console.height / 2);
 				watch.reposition(0,log.y + log.height + _gutter);
 				perf.reposition(_screen.x,0);
-			case DEBUGGER_RIGHT:
+			case RIGHT:
 				console.resize(_screen.x - _gutter * 2, 35);
 				console.reposition(_gutter, _screen.y);
 				log.resize(_screen.x / 3, (_screen.y - 15 - _gutter * 2.5) / 2 - console.height / 2 - _gutter);
@@ -302,7 +306,7 @@ class FlxDebugger extends Sprite
 				watch.resize(_screen.x / 3, (_screen.y - 15 - _gutter * 2.5) / 2 - console.height / 2);
 				watch.reposition(_screen.x,log.y + log.height + _gutter);
 				perf.reposition(0,0);
-			case DEBUGGER_STANDARD:
+			case STANDARD:
 				console.resize(_screen.x - _gutter * 2, 35);
 				console.reposition(_gutter, _screen.y);
 				log.resize((_screen.x - _gutter * 3) / 2, _screen.y / 4);

--- a/src/flixel/system/debug/ConsoleCommands.hx
+++ b/src/flixel/system/debug/ConsoleCommands.hx
@@ -263,7 +263,7 @@ class ConsoleCommands
 	
 	private function close():Void
 	{
-		FlxG.debugger.hide();
+		FlxG.debugger.visible = false;
 	}
 	
 	private function create(ClassName:String, MousePos:Bool = true, Params:Array<String> = null):Void

--- a/src/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/src/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -1,116 +1,95 @@
 package flixel.system.frontEnds;
 
-import flixel.FlxG;
 import flixel.FlxBasic;
-import flash.display.Sprite;
-import flash.display.Graphics;
+import flixel.FlxG;
 
 class DebuggerFrontEnd
 {	
 	#if !FLX_NO_DEBUG
 	/**
-	 * Whether to show visual debug displays or not.
+	 * Whether to show visual debug displays or not. Doesn't exist in <code>FLX_NO_DEBUG</code> mode.
 	 * @default false
 	 */
-	public var visualDebug:Bool;
+	public var visualDebug:Bool = false;
 	#end
 	
 	#if !FLX_NO_KEYBOARD
 	/**
-	 * The key codes used to open the debugger. (via flash.ui.Keyboard)
+	 * The key codes used to open the debugger (via <code>flash.ui.Keyboard</code>). 
+	 * Doesn't exist in <code>FLX_NO_KEYBOARD</code> mode.
 	 * @default [192, 220]
 	 */
 	public var toggleKeys:Array<Int>;
 	#end
 	
+	/**
+	 * Used to instantiate this class and assign a value to <code>toggleKeys</code>
+	 */
 	public function new() 
 	{
 		#if !FLX_NO_KEYBOARD
 		toggleKeys = [192, 220];
 		#end
-		
+	}
+	
+	/**
+	 * Change the way the debugger's windows are laid out.
+	 * 
+	 * @param	Layout	The layout codes can be found in <code>FlxDebugger</code>, for example <code>FlxDebugger.MICRO</code>
+	 */
+	inline public function setLayout(Layout:Int):Void
+	{
 		#if !FLX_NO_DEBUG
-		visualDebug = false;
+		FlxG._game._debugger.setLayout(Layout);
 		#end
 	}
 	
+	/**
+	 * Just resets the debugger windows to whatever the last selected layout was (<code>STANDARD</code> by default).
+	 */
+	inline public function resetLayout():Void
+	{
+		#if !FLX_NO_DEBUG
+		FlxG._game._debugger.resetLayout();
+		#end
+	}
+	
+	/**
+	 * Whether the debugger is visible or not.
+	 * @default false
+	 */
+	public var visible(default, set):Bool = false;
+	
+	private function set_visible(Visible:Bool):Bool
+	{
+		#if !FLX_NO_DEBUG
+		FlxG._game._debuggerUp = Visible;
+		FlxG._game.debugger.visible = Visible;
+		#end
+		
+		return visible = Visible;
+	}
+	
 	#if !FLX_NO_DEBUG
-	inline public function drawDebugPlugins():Void
+	/**
+	 * You shouldn't need to call this. Used to Draw the debug graphics for any installed plugins.
+	 */
+	public function drawDebugPlugins():Void
 	{
 		var plugin:FlxBasic;
 		var pluginList:Array<FlxBasic> = FlxG.plugins.list;
 		var i:Int = 0;
 		var l:Int = pluginList.length;
+		
 		while(i < l)
 		{
 			plugin = pluginList[i++];
+			
 			if (plugin.exists && plugin.visible && !plugin.ignoreDrawDebug)
 			{
 				plugin.drawDebug();
 			}
 		}
-	}
-	#end
-	
-	/**
-	 * Toggles the flixel debugger, if it exists.
-	 */
-	public function toggle():Void
-	{
-		#if !FLX_NO_DEBUG
-		if ((FlxG._game != null) && (FlxG._game.debugger != null))
-		{
-			FlxG._game._debuggerUp = !FlxG._game.debugger.visible;
-			FlxG._game.debugger.visible = !FlxG._game.debugger.visible;
-		}
-		#end
-	}
-	
-	/**
-	 * Shows the flixel debugger, if it exists.
-	 */
-	public function show():Void
-	{
-		#if !FLX_NO_DEBUG
-		if ((FlxG._game != null) && (FlxG._game.debugger != null))
-		{
-			FlxG._game._debuggerUp = true;
-			FlxG._game.debugger.visible = true;
-		}
-		#end
-	}
-	
-	/**
-	 * Hides the flixel debugger, if it exists.
-	 */
-	public function hide():Void
-	{
-		#if !FLX_NO_DEBUG
-		if ((FlxG._game != null) && (FlxG._game.debugger != null))
-		{
-			FlxG._game._debuggerUp = false;
-			FlxG._game.debugger.visible = false;
-		}
-		#end
-	}
-	
-	#if !FLX_NO_DEBUG
-	/**
-	 * Change the way the debugger's windows are laid out.
-	 * 
-	 * @param	Layout		See the presets above (e.g. <code>DEBUGGER_MICRO</code>, etc).
-	 */
-	public function setLayout(Layout:Int):Void
-	{
-		FlxG._game._debugger.setLayout(Layout);
-	}
-	
-	/**
-	 * Just resets the debugger windows to whatever the last selected layout was (<code>DEBUGGER_STANDARD</code> by default).
-	 */
-	public function resetLayout():Void
-	{
-		FlxG._game._debugger.resetLayout();
 	}
 	#end
 }

--- a/src/flixel/system/input/FlxKeyboard.hx
+++ b/src/flixel/system/input/FlxKeyboard.hx
@@ -212,7 +212,7 @@ class FlxKeyboard extends FlxInputStates implements IFlxInput
 			#if !FLX_NO_DEBUG
 			if ((FlxG._game._debugger != null) && (FlxG.debugger.toggleKeys != null && Lambda.indexOf(FlxG.debugger.toggleKeys, c) != -1))
 			{
-				FlxG.debugger.toggle();
+				FlxG.debugger.visible = !FlxG.debugger.visible;
 				return;
 			}
 			#end


### PR DESCRIPTION
- turned `FlxG.debug.show()`, `FlxG.debug.hide()` and `FlxG.debug.toggle()` into a single property named `FlxG.debug.visible` which is a lot cleaner and makes more sense
- improved docs of `DebuggerFrontEnd` and `FlxDebugger`
- removed `DEBUGGER` prefix from debugger layouts as they are now located in `FlxDebugger` where this is obvious
