### PR TITLE
Cleanup for flixel.effects

### DIFF
--- a/src/flixel/addons/tile/FlxCaveGenerator.hx
+++ b/src/flixel/addons/tile/FlxCaveGenerator.hx
@@ -7,9 +7,6 @@ package flixel.addons.tile;
  */
 class FlxCaveGenerator
 {
-	private var _numTilesCols:Int;
-	private var _numTilesRows:Int;
-	
 	/**
 	 * How many times do you want to "smooth" the cave.
 	 * The higher number the smoother.
@@ -22,31 +19,32 @@ class FlxCaveGenerator
 	 */
 	public static var initWallRatio:Float = 0.5;
 	
+	private var _numTilesCols:Int;
+	private var _numTilesRows:Int;
+	
 	/**
-	 * 
-	 * @param	nCols	Number of columns in the cave tilemap
-	 * @param	nRows	Number of rows in the cave tilemap
+	 * @param	Columns		Number of columns in the cave tilemap
+	 * @param	Rows		Number of rows in the cave tilemap
 	 */
-	public function new(nCols:Int = 10, nRows:Int = 10) 
+	public function new(Columns:Int = 10, Rows:Int = 10) 
 	{
-		_numTilesCols = nCols;
-		_numTilesRows = nRows;
+		_numTilesCols = Columns;
+		_numTilesRows = Rows;
 	}
 	
 	/**
-	 * @param 	mat		A matrix of data
-	 * 
-	 * @return 	A string that is usuable for FlxTileMap.loadMap(...)
+	 * @param 	Matrix		A matrix of data
+	 * @return 	A string that is usuable for <code>FlxTileMap.loadMap()</code>
 	 */
-	static public function convertMatrixToStr(mat:Array<Array<Int>>):String
+	static public function convertMatrixToStr(Matrix:Array<Array<Int>>):String
 	{
 		var mapString:String = "";
 		
-		for (y in 0...(mat.length))
+		for (y in 0...(Matrix.length))
 		{
-			for (x in 0...(mat[y].length))
+			for (x in 0...(Matrix[y].length))
 			{
-				mapString += Std.string(mat[y][x]) + ",";
+				mapString += Std.string(Matrix[y][x]) + ",";
 			}
 			
 			mapString += "\n";
@@ -57,19 +55,20 @@ class FlxCaveGenerator
 	
 	/**
 	 * 
-	 * @param	rows 	Number of rows for the matrix
-	 * @param	cols	Number of cols for the matrix
-	 * 
-	 * @return Spits out a matrix that is cols x rows, zero initiated
+	 * @param	Rows		Number of rows for the matrix
+	 * @param	Columns 	Number of cols for the matrix
+	 * @return 	Spits out a matrix that is cols x rows, zero initiated
 	 */
-	private function genInitMatrix(rows:Int, cols:Int):Array<Array<Int>>
+	private function genInitMatrix(Rows:Int, Columns:Int):Array<Array<Int>>
 	{
 		// Build array of 1s
 		var mat:Array<Array<Int>> = new Array<Array<Int>>();
-		for (y in 0...(rows))
+		
+		for (y in 0...(Rows))
 		{
 			mat.push(new Array<Int>());
-			for (x in 0...(cols)) 
+			
+			for (x in 0...(Columns)) 
 			{
 				mat[y].push(0);
 			}
@@ -79,27 +78,31 @@ class FlxCaveGenerator
 	}
 	
 	/**
-	 * 
-	 * @param	mat		Matrix of data (0=empty, 1 = wall)
-	 * @param	xPos	Column we are examining
-	 * @param	yPos	Row we are exampining
-	 * @param	dist	Radius of how far to check for neighbors
-	 * 
+	 * @param	Matrix		Matrix of data (0 = empty, 1 = wall)
+	 * @param	PosX		Column we are examining
+	 * @param	PosY		Row we are exampining
+	 * @param	Distance	Radius of how far to check for neighbors
 	 * @return	Number of walls around the target, including itself
 	 */
-	private function countNumWallsNeighbors(mat:Array<Array<Int>>, xPos:Int, yPos:Int, dist:Int = 1):Int
+	private function countNumWallsNeighbors(Matrix:Array<Array<Int>>, PosX:Int, PosY:Int, Distance:Int = 1):Int
 	{
 		var count:Int = 0;
 		
-		for (y in (-dist)...(dist + 1))
+		for (y in ( -Distance)...(Distance + 1))
 		{
-			for (x in (-dist)...(dist + 1))
+			for (x in ( -Distance)...(Distance + 1))
 			{
 				// Boundary
-				if ((xPos + x < 0) || (xPos + x > _numTilesCols - 1) || (yPos + y < 0) || (yPos + y > _numTilesRows - 1)) continue;
+				if ((PosX + x < 0) || (PosX + x > _numTilesCols - 1) || (PosY + y < 0) || (PosY + y > _numTilesRows - 1))
+				{
+					continue;
+				}
 				
 				// Neighbor is non-wall
-				if (mat[yPos + y][xPos + x] != 0) ++count;
+				if (Matrix[PosY + y][PosX + x] != 0) 
+				{
+					count++;
+				}
 			}
 		}
 		
@@ -109,31 +112,37 @@ class FlxCaveGenerator
 	/**
 	 * Use the 4-5 rule to smooth cells
 	 */
-	private function runCelluarAutomata(inMat:Array<Array<Int>>, outMat:Array<Array<Int>>):Void
+	private function runCelluarAutomata(InMatrix:Array<Array<Int>>, OutMatrix:Array<Array<Int>>):Void
 	{
-		var numRows:Int = inMat.length;
-		var numCols:Int = inMat[0].length;
+		var numRows:Int = InMatrix.length;
+		var numCols:Int = InMatrix[0].length;
 		
 		for (y in 0...(numRows))
 		{
 			for (x in 0...(numCols))
 			{
-				var numWalls:Int = countNumWallsNeighbors(inMat, x, y, 1);
+				var numWalls:Int = countNumWallsNeighbors(InMatrix, x, y, 1);
 				
-				if (numWalls >= 5) outMat[y][x] = 1;
-				else outMat[y][x] = 0;
+				if (numWalls >= 5) 
+				{
+					OutMatrix[y][x] = 1;
+				}
+				else 
+				{
+					OutMatrix[y][x] = 0;
+				}
 			}
 		}
 	}
 	
 	/**
-	 * 
 	 * @return Returns a matrix of a cave!
 	 */
 	public function generateCaveLevel():Array<Array<Int>>
 	{
 		// Initialize random array
 		var mat:Array<Array<Int>> = genInitMatrix(_numTilesRows, _numTilesCols);
+		
 		for (y in 0...(_numTilesRows))
 		{
 			for (x in 0...(_numTilesCols)) 

--- a/src/flixel/effects/FlxSpecialFX.hx
+++ b/src/flixel/effects/FlxSpecialFX.hx
@@ -44,6 +44,7 @@ class FlxSpecialFX extends FlxBasic
 	{
 		var temp:StarfieldFX = new StarfieldFX();
 		members.set(temp, temp);
+
 		return temp;
 	}
 	
@@ -52,13 +53,13 @@ class FlxSpecialFX extends FlxBasic
 	/**
 	 * Starts the given FX Plugin running
 	 * 
-	 * @param	source	A reference to the FX Plugin you wish to run. If null it will start all currently added FX Plugins
+	 * @param	Effect	A reference to the FX Plugin you wish to run. If null it will start all currently added FX Plugins
 	 */
-	public static function startFX(source:BaseFX = null):Void
+	public static function startFX(Effect:BaseFX = null):Void
 	{
-		if (source != null)
+		if (Effect != null)
 		{
-			members.get(source).active = true;
+			members.get(Effect).active = true;
 		}
 		else
 		{
@@ -72,13 +73,13 @@ class FlxSpecialFX extends FlxBasic
 	/**
 	 * Stops the given FX Plugin running
 	 * 
-	 * @param	source	A reference to the FX Plugin you wish to stop. If null it will stop all currently added FX Plugins
+	 * @param	Effect	A reference to the FX Plugin you wish to stop. If null it will stop all currently added FX Plugins
 	 */
-	public static function stopFX(source:BaseFX = null):Void
+	public static function stopFX(Effect:BaseFX = null):Void
 	{
-		if (source != null)
+		if (Effect != null)
 		{
-			members.get(source).active = false;
+			members.get(Effect).active = false;
 		}
 		else
 		{
@@ -92,14 +93,14 @@ class FlxSpecialFX extends FlxBasic
 	/**
 	 * Returns the active state of the given FX Plugin running
 	 * 
-	 * @param	source	A reference to the FX Plugin you wish to run. If null it will start all currently added FX Plugins
+	 * @param	Effect	A reference to the FX Plugin you wish to run. If null it will start all currently added FX Plugins
 	 * @return	Boolean	true if the FX Plugin is active, false if not
 	 */
-	public static function isActive(source:BaseFX):Bool
+	public static function isActive(Effect:BaseFX):Bool
 	{
-		if (members.exists(source))
+		if (members.exists(Effect))
 		{
-			return members.get(source).active;
+			return members.get(Effect).active;
 		}
 		
 		return false;
@@ -127,15 +128,16 @@ class FlxSpecialFX extends FlxBasic
 	/**
 	 * Removes a FX Plugin from the Special FX Handler
 	 * 
-	 * @param	source	The FX Plugin to remove
+	 * @param	Effect	The FX Plugin to remove
 	 * @return	Boolean	true if the plugin was removed, otherwise false.
 	 */
-	public static function remove(source:BaseFX):Bool
+	public static function remove(Effect:BaseFX):Bool
 	{
-		if (members.exists(source))
+		if (members.exists(Effect))
 		{
-			members.get(source).destroy();
-			members.remove(source);
+			members.get(Effect).destroy();
+			members.remove(Effect);
+			
 			return true;
 		}
 		
@@ -143,8 +145,8 @@ class FlxSpecialFX extends FlxBasic
 	}
 	
 	/**
-	 * Removes all FX Plugins<br>
-	 * This is called automatically if the plugin is destroyed, but should be called manually by you if you change States
+	 * Removes all FX Plugins. This is called automatically if the plugin is destroyed, 
+	 * but should be called manually by you if you change states.
 	 */
 	public static function clear():Void
 	{

--- a/src/flixel/effects/FlxTrail.hx
+++ b/src/flixel/effects/FlxTrail.hx
@@ -1,7 +1,7 @@
 package flixel.effects;
 
 import flixel.FlxSprite;
-import flixel.group.FlxTypedGroup;
+import flixel.group.FlxSpriteGroup;
 import flixel.util.FlxPoint;
 
 /**
@@ -12,112 +12,109 @@ import flixel.util.FlxPoint;
  * 
  * @author Gama11
  */
-class FlxTrail extends FlxTypedGroup<FlxSprite>
+class FlxTrail extends FlxSpriteGroup
 {		
 	/**
-	 *  Stores the FlxSprite the trail is attached to.
+	 * Stores the FlxSprite the trail is attached to.
 	 */
 	public var sprite:FlxSprite;
 	/**
-	 *  How often to update the trail.
+	 * How often to update the trail.
 	 */
 	public var delay:Int;
 	/**
-	 *  Whether to check for X changes or not.
+	 * Whether to check for X changes or not.
 	 */
 	public var xEnabled:Bool = true;
 	/**
-	 *  Whether to check for Y changes or not.
+	 * Whether to check for Y changes or not.
 	 */
 	public var yEnabled:Bool = true;
 	/**
-	 *  Whether to check for angle changes or not.
+	 * Whether to check for angle changes or not.
 	 */
 	public var rotationsEnabled:Bool = true;
 	/**
-	 *  Whether to check for scale changes or not.
+	 * Whether to check for scale changes or not.
 	 */
 	public var scalesEnabled:Bool = true;
 	/**
 	 * Whether to check for frame changes of the "parent" FlxSprite or not.
 	 */
 	public var framesEnabled:Bool = true;
-	/**
-	 * Determines whether trailsprites are solid or not. False by default.
-	 */
-	public var solid(default, set_solid):Bool = false;
+	
 	/**
 	 *  Counts the frames passed.
 	 */
-	private var counter:Int = 0;
+	private var _counter:Int = 0;
 	/**
 	 *  How long is the trail?
 	 */
-	private var trailLength:Int = 0;
+	private var _trailLength:Int = 0;
 	/**
 	 *  Stores the trailsprite image.
 	 */
-	private var image:Dynamic;
+	private var _image:Dynamic;
 	/**
 	 *  The alpha value for the next trailsprite.
 	 */
-	private var transp:Float = 1;
+	private var _transp:Float = 1;
 	/**
 	 *  How much lower the alpha value of the next trailsprite is.
 	 */
-	private var difference:Float;
+	private var _difference:Float;
 	/**
 	 *  Stores the sprites recent positions.
 	 */
-	private var recentPositions:Array<FlxPoint>;
+	private var _recentPositions:Array<FlxPoint>;
 	/**
 	 *  Stores the sprites recent angles.
 	 */
-	private var recentAngles:Array<Float>;
+	private var _recentAngles:Array<Float>;
 	/**
 	 *  Stores the sprites recent scale.
 	 */
-	private var recentScales:Array<FlxPoint>;
+	private var _recentScales:Array<FlxPoint>;
 	/**
 	 *  Stores the sprites recent frame.
 	 */
-	private var recentFrames:Array<Int>;
+	private var _recentFrames:Array<Int>;
 	/**
 	 *  Stores the sprites recent facing.
 	 */
-	private var recentFacings:Array<Int>;
+	private var _recentFacings:Array<Int>;
 	/**
 	 *  Stores the sprite origin (rotation axis)
 	 */
-	private var spriteOrigin:FlxPoint;
+	private var _spriteOrigin:FlxPoint;
 	
 	/**
 	 * Creates a new <code>FlxTrail</code> effect for a specific FlxSprite.
 	 * 
 	 * @param	Sprite		The FlxSprite the trail is attached to.
-	 * @param  Image    The image to ues for the trailsprites. Optional, uses the sprite's graphic if null.
+	 * @param  	Image   	The image to ues for the trailsprites. Optional, uses the sprite's graphic if null.
 	 * @param	Length		The amount of trailsprites to create. 
 	 * @param	Delay		How often to update the trail. 0 updates every frame.
 	 * @param	Alpha		The alpha value for the very first trailsprite.
 	 * @param	Diff		How much lower the alpha of the next trailsprite is.
 	 */
-	public function new(Sprite:FlxSprite, Image:Dynamic = null, Length:Int = 10, Delay:Int = 3, Alpha:Float = 0.4, Diff:Float = 0.05):Void
+	public function new(Sprite:FlxSprite, ?Image:Dynamic, Length:Int = 10, Delay:Int = 3, Alpha:Float = 0.4, Diff:Float = 0.05):Void
 	{
 		super();
 
-		recentAngles = new Array<Float>();
-		recentPositions = new Array<FlxPoint>();
-		recentScales = new Array<FlxPoint>();
-		recentFrames = new Array<Int>();
-		recentFacings = new Array<Int>();
-		spriteOrigin = Sprite.origin;
+		_recentAngles = new Array<Float>();
+		_recentPositions = new Array<FlxPoint>();
+		_recentScales = new Array<FlxPoint>();
+		_recentFrames = new Array<Int>();
+		_recentFacings = new Array<Int>();
+		_spriteOrigin = Sprite.origin;
 
 		// Sync the vars 
 		sprite = Sprite;
 		delay = Delay;
-		image = Image;
-		transp = Alpha;
-		difference = Diff;
+		_image = Image;
+		_transp = Alpha;
+		_difference = Diff;
 
 		// Create the initial trailsprites
 		increaseLength(Length);
@@ -126,15 +123,15 @@ class FlxTrail extends FlxTypedGroup<FlxSprite>
 	
 	override public function destroy():Void
 	{
-		recentAngles = null;
-		recentPositions = null;
-		recentScales = null;
-		recentFrames = null;
-		recentFacings = null;
-		spriteOrigin = null;
+		_recentAngles = null;
+		_recentPositions = null;
+		_recentScales = null;
+		_recentFrames = null;
+		_recentFacings = null;
+		_spriteOrigin = null;
 
 		sprite = null;
-		image = null;
+		_image = null;
 		
 		super.destroy();
 	}
@@ -146,68 +143,93 @@ class FlxTrail extends FlxTypedGroup<FlxSprite>
 	override public function update():Void
 	{
 		// Count the frames
-		counter++;
+		_counter++;
 
 		// Update the trail in case the intervall and there actually is one.
-		if (counter >= delay && trailLength >= 1)
+		if (_counter >= delay && _trailLength >= 1)
 		{
-			counter = 0;
+			_counter = 0;
 
 			// Push the current position into the positons array and drop one.
 			var spritePosition:FlxPoint = new FlxPoint(sprite.x - sprite.offset.x, sprite.y - sprite.offset.y);
-			recentPositions.unshift(spritePosition);
-			if (recentPositions.length > trailLength) recentPositions.pop();
+			_recentPositions.unshift(spritePosition);
+			
+			if (_recentPositions.length > _trailLength) 
+			{
+				_recentPositions.pop();
+			}
 
 			// Also do the same thing for the Sprites angle if rotationsEnabled 
 			if (rotationsEnabled) 
 			{
 				var spriteAngle:Float = sprite.angle;
-				recentAngles.unshift(spriteAngle);
-				if (recentAngles.length > trailLength) recentAngles.pop();
+				_recentAngles.unshift(spriteAngle);
+				
+				if (_recentAngles.length > _trailLength) 
+				{
+					_recentAngles.pop();
+				}
 			}
 			
 			// Again the same thing for Sprites scales if scalesEnabled
 			if (scalesEnabled)
 			{
 				var spriteScale:FlxPoint = sprite.scale;
-				recentScales.unshift(spriteScale);
-				if (recentScales.length > trailLength) recentScales.pop();
+				_recentScales.unshift(spriteScale);
+				
+				if (_recentScales.length > _trailLength) 
+				{
+					_recentScales.pop();
+				}
 			}
 			
 			// Again the same thing for Sprites frames if framesEnabled
-			if (framesEnabled && image == null) 
+			if (framesEnabled && _image == null) 
 			{
 				var spriteFrame:Int = sprite.frame;
-				recentFrames.unshift(spriteFrame);
-				if (recentFrames.length > trailLength) recentFrames.pop();
+				_recentFrames.unshift(spriteFrame);
+				
+				if (_recentFrames.length > _trailLength) 
+				{
+					_recentFrames.pop();
+				}
 				
 				var spriteFacing:Int = sprite.facing;
-				recentFacings.unshift(spriteFacing);
-				if (recentFacings.length > trailLength) recentFacings.pop();
+				_recentFacings.unshift(spriteFacing);
+				
+				if (_recentFacings.length > _trailLength) 
+				{
+					_recentFacings.pop();
+				}
 			}
 
 			// Now we need to update the all the Trailsprites' values
 			var trailSprite:FlxSprite;
-			for (i in 0 ... recentPositions.length) 
+			
+			for (i in 0..._recentPositions.length) 
 			{
 				trailSprite = members[i];
-				trailSprite.x = recentPositions[i].x;
-				trailSprite.y = recentPositions[i].y;
+				trailSprite.x = _recentPositions[i].x;
+				trailSprite.y = _recentPositions[i].y;
+				
 				// And the angle...
 				if (rotationsEnabled) 
 				{
-					trailSprite.angle = recentAngles[i];
-					trailSprite.origin = spriteOrigin;
+					trailSprite.angle = _recentAngles[i];
+					trailSprite.origin = _spriteOrigin;
 				}
 				
 				// the scale...
-				if (scalesEnabled) trailSprite.scale = recentScales[i];
+				if (scalesEnabled) 
+				{
+					trailSprite.scale = _recentScales[i];
+				}
 				
 				// and frame...
-				if (framesEnabled && image == null) 
+				if (framesEnabled && _image == null) 
 				{
-					trailSprite.frame = recentFrames[i];
-					trailSprite.facing = recentFacings[i];
+					trailSprite.frame = _recentFrames[i];
+					trailSprite.facing = _recentFacings[i];
 				}
 
 				// Is the trailsprite even visible?
@@ -220,45 +242,60 @@ class FlxTrail extends FlxTypedGroup<FlxSprite>
 
 	public function resetTrail():Void
 	{
-		recentPositions.splice(0, recentPositions.length);
-		recentAngles.splice(0, recentAngles.length);
-		recentScales.splice(0, recentScales.length);
-		recentFrames.splice(0, recentFrames.length);
-		recentFacings.splice(0, recentFacings.length);
+		_recentPositions.splice(0, _recentPositions.length);
+		_recentAngles.splice(0, _recentAngles.length);
+		_recentScales.splice(0, _recentScales.length);
+		_recentFrames.splice(0, _recentFrames.length);
+		_recentFacings.splice(0, _recentFacings.length);
+		
 		for (i in 0...members.length) 
 		{
 			if (members[i] != null)
+			{
 				members[i].exists = false;
+			}
 		}
 	}
 
 	/**
 	 * A function to add a specific number of sprites to the trail to increase its length.
 	 *
-	 * @param 	amount	The amount of sprites to add to the trail.
+	 * @param 	Amount	The amount of sprites to add to the trail.
 	 */
-	public function increaseLength(amount:Int):Void
+	public function increaseLength(Amount:Int):Void
 	{
 		// Can't create less than 1 sprite obviously
-		if (amount <= 0) return;
+		if (Amount <= 0) 
+		{
+			return;
+		}
 
-		trailLength += amount;
+		_trailLength += Amount;
 
 		// Create the trail sprites
-		for (i in 0...amount)
+		for (i in 0...Amount)
 		{
 			var trailSprite:FlxSprite = new FlxSprite(0, 0);
 			trailSprite.exists = false;
 			
-			if (image == null) trailSprite.loadFromSprite(sprite);
-			else trailSprite.loadGraphic(image);
+			if (_image == null) 
+			{
+				trailSprite.loadFromSprite(sprite);
+			}
+			else 
+			{
+				trailSprite.loadGraphic(_image);
+			}
 			
 			add(trailSprite);
-			trailSprite.alpha = transp;
-			transp -= difference;
+			trailSprite.alpha = _transp;
+			_transp -= _difference;
 			trailSprite.solid = solid;
-
-			if (trailSprite.alpha <= 0) trailSprite.kill();
+			
+			if (trailSprite.alpha <= 0) 
+			{
+				trailSprite.kill();
+			}
 		}	
 	}
 
@@ -269,9 +306,9 @@ class FlxTrail extends FlxTypedGroup<FlxSprite>
 	 */
 	public function changeGraphic(Image:Dynamic):Void
 	{
-		image = Image;
+		_image = Image;
 		
-		for (i in 0...trailLength)
+		for (i in 0..._trailLength)
 		{
 			members[i].loadGraphic(Image);
 		}	
@@ -293,13 +330,18 @@ class FlxTrail extends FlxTypedGroup<FlxSprite>
 		scalesEnabled = Scale;
 	}
 	
-	private function set_solid(value:Bool):Bool
+	/**
+	 * Determines whether trailsprites are solid or not. False by default.
+	 */
+	public var solid(default, set):Bool = false;
+	
+	private function set_solid(Value:Bool):Bool
 	{
-		for (i in 0...trailLength)
+		for (i in 0..._trailLength)
 		{
-			members[i].solid = value; 
+			members[i].solid = Value; 
 		}
-		solid = value;
-		return value;
+		
+		return solid = Value;
 	}
 }

--- a/src/flixel/effects/fx/BaseFX.hx
+++ b/src/flixel/effects/fx/BaseFX.hx
@@ -17,7 +17,6 @@ class BaseFX
 	 * Set to false to stop this effect being updated by the FlxSpecialFX Plugin. Set to true to enable.
 	 */
 	public var active:Bool;
-	
 	/**
 	 * The FlxSprite into which the effect is drawn. Add this to your FlxState / FlxGroup to display the effect.
 	 */
@@ -27,47 +26,47 @@ class BaseFX
 	/**
 	 * A scratch bitmapData used to build-up the effect before passing to sprite.pixels
 	 */
-	var canvas:BitmapData;
+	public var canvas:BitmapData;
 	
 	/**
 	 * TODO A snapshot of the sprite background before the effect is applied
 	 */
-	var back:BitmapData;
+	public var back:BitmapData;
 	#end
 	
-	var image:BitmapData;
-	var sourceRef:FlxSprite;
-	var updateFromSource:Bool;
-	var clsRect:Rectangle;
-	var clsPoint:Point;
-	var clsColor:Int;
+	private var _image:BitmapData;
+	private var _sourceRef:FlxSprite;
+	private var _updateFromSource:Bool;
+	private var _clsRect:Rectangle;
+	private var _clsPoint:Point;
+	private var _clsColor:Int;
+
+	// For staggered drawing updates
+	private var _updateLimit:Int;
+	private var _lastUpdate:Int;
+	private var _ready:Bool;
 	
-	//	For staggered drawing updates
-	var updateLimit:Int;
-	var lastUpdate:Int;
-	var ready:Bool;
-	
-	var copyRect:Rectangle;
-	var copyPoint:Point;
+	private var _copyRect:Rectangle;
+	private var _copyPoint:Point;
 	
 	public function new() 
 	{
-		updateLimit = 0;
-		lastUpdate = 0;
-		ready = false;
+		_updateLimit = 0;
+		_lastUpdate = 0;
+		_ready = false;
 		active = false;
 	}
 	
 	/**
 	 * Starts the effect runnning
 	 * 
-	 * @param	delay	How many "game updates" should pass between each update? If your game runs at 30fps a value of 0 means it will do 30 updates per second. A value of 1 means it will do 15 updates per second, etc.
+	 * @param	Delay	How many "game updates" should pass between each update? If your game runs at 30fps a value of 0 means it will do 30 updates per second. A value of 1 means it will do 15 updates per second, etc.
 	 */
-	public function start(delay:Int = 0):Void
+	public function start(Delay:Int = 0):Void
 	{
-		updateLimit = delay;
-		lastUpdate = 0;
-		ready = true;
+		_updateLimit = Delay;
+		_lastUpdate = 0;
+		_ready = true;
 	}
 	
 	/**
@@ -76,7 +75,7 @@ class BaseFX
 	 */
 	public function stop():Void
 	{
-		ready = false;
+		_ready = false;
 	}
 	
 	public function draw():Void
@@ -103,13 +102,12 @@ class BaseFX
 		}
 		#end
 		
-		if (image != null)
+		if (_image != null)
 		{
-			image.dispose();
+			_image.dispose();
 		}
 		
-		sourceRef = null;
+		_sourceRef = null;
 		active = false;
-	}
-	
+	}	
 }

--- a/src/flixel/effects/fx/GlitchFX.hx
+++ b/src/flixel/effects/fx/GlitchFX.hx
@@ -17,32 +17,32 @@ import flixel.util.FlxAngle;
  */
 class GlitchFX extends BaseFX
 {
-	private var glitchSize:Int;
-	private var glitchSkip:Int;
+	private var _glitchSize:Int;
+	private var _glitchSkip:Int;
 	
 	public function new() 
 	{
 		super();
 	}
 	
-	public function createFromFlxSprite(source:FlxSprite, maxGlitch:Int, maxSkip:Int, autoUpdate:Bool = false, backgroundColor:Int = 0x0):FlxSprite
+	public function createFromFlxSprite(Source:FlxSprite, MaxGlitch:Int, MaxSkip:Int, AutoUpdate:Bool = false, BackgroundColor:Int = 0x0):FlxSprite
 	{
 		#if flash
-		sprite = new FlxSprite(source.x, source.y).makeGraphic(Std.int(source.width + maxGlitch), Std.int(source.height), backgroundColor);
-		canvas = new BitmapData(Std.int(sprite.width), Std.int(sprite.height), true, backgroundColor);
-		image = source.pixels;
+		sprite = new FlxSprite(Source.x, Source.y).makeGraphic(Std.int(Source.width + MaxGlitch), Std.int(Source.height), BackgroundColor);
+		canvas = new BitmapData(Std.int(sprite.width), Std.int(sprite.height), true, BackgroundColor);
+		image = Source.pixels;
 		#else
-		sprite = new GlitchSprite(source, maxGlitch, maxSkip, backgroundColor);
+		sprite = new GlitchSprite(Source, MaxGlitch, MaxSkip, BackgroundColor);
 		#end
 		
-		sourceRef = source;
+		sourceRef = Source;
 		
-		updateFromSource = autoUpdate;
+		updateFromSource = AutoUpdate;
 		
-		glitchSize = maxGlitch;
-		glitchSkip = maxSkip;
+		_glitchSize = MaxGlitch;
+		_glitchSkip = MaxSkip;
 		
-		clsColor = backgroundColor;
+		clsColor = BackgroundColor;
 		
 		copyPoint = new Point(0, 0);
 		
@@ -52,21 +52,22 @@ class GlitchFX extends BaseFX
 		#end
 		
 		active = true;
+		
 		return sprite;
 	}
 	
-	public function changeGlitchValues(maxGlitch:Int, maxSkip:Int):Void
+	public function changeGlitchValues(MaxGlitch:Int, MaxSkip:Int):Void
 	{
-		glitchSize = maxGlitch;
-		glitchSkip = maxSkip;
+		glitchSize = MaxGlitch;
+		glitchSkip = MaxSkip;
 		
 		#if !flash
 		if (sprite != null && sourceRef != null)
 		{
 			var glitch:GlitchSprite = cast(sprite, GlitchSprite);
-			glitch.frameWidth = Std.int(sourceRef.frameWidth + maxGlitch);
-			glitch.maxGlitch = maxGlitch;
-			glitch.glitchSkip = maxSkip;
+			glitch.frameWidth = Std.int(sourceRef.frameWidth + MaxGlitch);
+			glitch.maxGlitch = MaxGlitch;
+			glitch.glitchSkip = MaxSkip;
 		}
 		#end
 	}
@@ -122,407 +123,6 @@ class GlitchFX extends BaseFX
 			lastUpdate = 0;
 		}
 	}
-	
-}
-
-#if !flash
-class GlitchSprite extends FlxSprite
-{
-	/**
-	 * Information about each line in glitched sprite
-	 */
-	public var imageLines:Array<ImageLine>;
-	
-	private var _sourceSprite:FlxSprite;
-	
-	/**
-	 * link to source image tilesheet data
-	 */
-	private var _imageTileSheetData:TileSheetData;
-	
-	/**
-	 * storage for each frame's lines tile IDs
-	 */
-	private var _imageTileIDs:Map<Int, Array<Int>>;
-	
-	private var _bgRed:Float;
-	private var _bgGreen:Float;
-	private var _bgBlue:Float;
-	private var _bgAlpha:Float;
-	
-	public var maxGlitch:Float;
-	public var glitchSkip:Float;
-	
-	public var sourceFrame:Int;
-	
-	public function new(Source:FlxSprite, MaxGlitch:Int, GlitchSkip:Int, BgColor:Int)
-	{
-		super();
-		
-		_sourceSprite = Source;
-		sourceFrame = -1;
-		
-		this.maxGlitch = MaxGlitch;
-		this.glitchSkip = GlitchSkip;
-		
-		_imageTileIDs = new Map<Int, Array<Int>>();
-		imageLines = new Array<ImageLine>();
-		
-		makeGraphic(1, 1, FlxColor.WHITE);
-		
-		_frameID = _framesData.frameIDs[0];
-		_tileSheetData.isColored = true;
-		
-		var rgba:RGBA = FlxColor.getRGB(BgColor);
-		_bgRed = rgba.red / 255;
-		_bgGreen = rgba.green / 255;
-		_bgBlue = rgba.blue / 255;
-		_bgAlpha = rgba.alpha / 255;
-		
-		this.x = _sourceSprite.x;
-		this.y = _sourceSprite.y;
-	}
-	
-	public function updateFromSourceSprite():Void
-	{
-		if (_sourceSprite.pixels != _imageTileSheetData.tileSheet.nmeBitmap)
-		{
-			updateTileSheet();
-		}
-		else
-		{
-			updateLineIDs();
-		}
-	}
-	
-	private function updateLineIDs():Void
-	{
-		if (sourceFrame != _sourceSprite.frame)
-		{
-			var sourceFrameHeight:Int = _sourceSprite.frameHeight;
-			var halfFrameWidth:Float = _sourceSprite.frameWidth * 0.5;
-			
-			sourceFrame = _sourceSprite.frame;
-			var frameLines:Array<Int> = _imageTileIDs.get(sourceFrame);
-			var halfFrameHeight:Float = sourceFrameHeight * 0.5;
-			
-			var imageLine:ImageLine;
-			
-			for (i in 0...(sourceFrameHeight))
-			{
-				imageLine = imageLines[i];
-				if (imageLine == null)
-				{
-					imageLines[i] = { x: 0, y: i + 0.5, tileID: frameLines[i] };
-				}
-				else
-				{
-					imageLine.x = halfFrameWidth;
-					imageLine.y = i - sourceFrameHeight + 0.5;
-					imageLine.tileID = frameLines[i];
-				}
-			}
-			
-			if (imageLines.length > _sourceSprite.frameHeight)
-			{
-				imageLines.splice(_sourceSprite.frameHeight, (imageLines.length - _sourceSprite.frameHeight));
-			}
-		}
-	}
-	
-	public function updateLinePositions():Void
-	{
-		var sourceFrameHeight:Int = _sourceSprite.frameHeight;
-		
-		var rndSkip:Int = 1 + Std.int(Math.random() * glitchSkip);
-		var y:Int = 0;
-		var rndX:Float = 0;
-		
-		for (i in 0...(sourceFrameHeight))
-		{
-			if (i == y)
-			{
-				rndX = Std.int(Math.random() * maxGlitch);
-				y += rndSkip;
-			}
-			
-			imageLines[i].x = rndX;
-		}
-	}
-	
-	override public function destroy():Void 
-	{
-		super.destroy();
-		
-		imageLines = null;
-		_sourceSprite = null;
-		_imageTileSheetData = null;
-		_imageTileIDs = null;
-	}
-	
-	override public function set_color(Color:Int):Int 
-	{
-		var col = super.set_color(Color);
-		
-		if (_color < 0xffffff)
-		{
-			if (_imageTileSheetData != null)
-			{
-				_imageTileSheetData.isColored = true;
-			}
-		}
-		
-		return col;
-	}
-	
-	override public function draw():Void
-	{
-		if(_flickerTimer != 0)
-		{
-			_flicker = !_flicker;
-			if (_flicker)
-			{
-				return;
-			}
-		}
-		
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		var camera:FlxCamera;
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		
-		var currDrawData:Array<Float>;
-		var currIndex:Int;
-		
-		var radians:Float;
-		var cos:Float;
-		var sin:Float;
-		
-		var halfWidth:Float = frameWidth * 0.5;
-		var halfHeight:Float = frameHeight * 0.5;
-		
-		var lineDef:ImageLine;
-		
-		var lineRed:Float = 1;
-		var lineGreen:Float = 1;
-		var lineBlue:Float = 1;
-		
-		if (_color < 0xffffff)
-		{
-			lineRed = _red;
-			lineGreen = _green;
-			lineBlue = _blue;
-		}
-		
-		var onCamRed:Float;
-		var onCamGreen:Float;
-		var onCamBlue:Float;
-		
-		while (i < l)
-		{
-			camera = cameras[i++];
-			
-			if (!onScreenSprite(camera) || !camera.visible || !camera.exists)
-			{
-				continue;
-			}
-			
-			var onCamRed:Float = lineRed;
-			var onCamGreen:Float = lineGreen;
-			var onCamBlue:Float = lineBlue;
-			
-			if (camera.isColored())
-			{
-				onCamRed = camera.red;
-				onCamGreen = camera.green;
-				onCamBlue = camera.blue;
-			}
-			
-			var useColor:Bool = (_imageTileSheetData.isColored || camera.isColored());
-			
-			currDrawData = _tileSheetData.drawData[camera.ID];
-			currIndex = _tileSheetData.positionData[camera.ID];
-			
-			_point.x = (x - (camera.scroll.x * scrollFactor.x) - (offset.x)) + origin.x;
-			_point.y = (y - (camera.scroll.y * scrollFactor.y) - (offset.y)) + origin.y;
-
-			var csx : Float = 1;
-			var ssy : Float = 0;
-			var ssx : Float = 0;
-			var csy : Float = 1;
-			var x1 : Float = 0;
-			var y1 : Float = 0;
-
-			if (!simpleRenderSprite ())
-			{
-				radians = angle * FlxAngle.TO_RAD;
-				cos = Math.cos(radians);
-				sin = Math.sin(radians);
-
-				csx = cos * scale.x;
-				ssy = sin * scale.y;
-				ssx = sin * scale.x;
-				csy = cos * scale.y;
-				x1 = halfWidth;
-				y1 = halfHeight;
-			}
-
-			_point.x += halfWidth;
-			_point.y += halfHeight;
-			
-			// draw background
-			if (_bgAlpha > 0)
-			{
-				currDrawData[currIndex++] = _point.x;
-				currDrawData[currIndex++] = _point.y;
-				
-				currDrawData[currIndex++] = _frameID;
-				
-				currDrawData[currIndex++] = csx * frameWidth;
-				currDrawData[currIndex++] = -ssy * frameHeight;
-				currDrawData[currIndex++] = ssx * frameWidth;
-				currDrawData[currIndex++] = csy * frameHeight;
-				
-				if (camera.isColored())
-				{
-					currDrawData[currIndex++] = _bgRed * camera.red;
-					currDrawData[currIndex++] = _bgGreen * camera.green;
-					currDrawData[currIndex++] = _bgBlue * camera.blue;
-				}
-				else
-				{
-					currDrawData[currIndex++] = _bgRed;
-					currDrawData[currIndex++] = _bgGreen;
-					currDrawData[currIndex++] = _bgBlue;
-				}
-				
-				currDrawData[currIndex++] = _bgAlpha * alpha;
-				_tileSheetData.positionData[camera.ID] = currIndex;
-			}
-
-			// draw lines
-			currDrawData = _imageTileSheetData.drawData[camera.ID];
-			currIndex = _imageTileSheetData.positionData[camera.ID];
-
-			for (j in 0...(imageLines.length))
-			{
-				lineDef = imageLines[j];
-				
-				var localX:Float = lineDef.x - x1;
-				var localY:Float = lineDef.y - y1;
-				
-				var relativeX:Float = (localX * csx - localY * ssy);
-				var relativeY:Float = (localX * ssx + localY * csy);
-				
-				currDrawData[currIndex++] = _point.x + relativeX;
-				currDrawData[currIndex++] = _point.y + relativeY;
-				
-				currDrawData[currIndex++] = lineDef.tileID;
-				
-				currDrawData[currIndex++] = csx;
-				currDrawData[currIndex++] = -ssy;
-				currDrawData[currIndex++] = ssx;
-				currDrawData[currIndex++] = csy;
-				
-				if (useColor)
-				{
-					currDrawData[currIndex++] = onCamRed;
-					currDrawData[currIndex++] = onCamGreen;
-					currDrawData[currIndex++] = onCamBlue;
-				}
-				
-				currDrawData[currIndex++] = alpha;
-			}
-			_imageTileSheetData.positionData[camera.ID] = currIndex;
-			
-			FlxBasic._VISIBLECOUNT++;
-		} 
-	}
-	
-	public function swapTileSheets():Void
-	{
-		/*if (_tileSheetData != null && _imageTileSheetData != null)
-		{
-			var bgIndex:Int = TileSheetManager.getTileSheetIndex(_tileSheetData);
-			var imgIndex:Int = TileSheetManager.getTileSheetIndex(_imageTileSheetData);
-			
-			if (bgIndex > imgIndex)
-			{
-				TileSheetManager.swapTileSheets(bgIndex, imgIndex);
-			}
-		}*/
-	}
-	
-	public function updateTileSheet():Void 
-	{
-		/*
-		if (_tileSheetData == null)
-		{
-			if (_pixels != null)
-			{
-				_tileSheetData = TileSheetManager.addTileSheet(_pixels);
-				_tileSheetData.antialiasing = antialiasing;
-				_tileSheetData.isTilemap = false;
-				_framesData = _tileSheetData.getSpriteSheetFrames(1, 1);
-			}
-		}
-		
-		if (_sourceSprite != null)
-		{
-			this.width = _sourceSprite.width + maxGlitch;
-			this.height = _sourceSprite.height;
-			
-			this.frameWidth = Std.int(this.width);
-			this.frameHeight = Std.int(this.height);
-			
-			_imageTileSheetData = TileSheetManager.addTileSheet(_sourceSprite.pixels);
-			
-			var frameLines:Array<Int>;
-			var frameX:Int = 0;
-			var frameY:Int = 0;
-			var sourceFrameWidth:Int = _sourceSprite.frameWidth;
-			var sourceFrameHeight:Int = _sourceSprite.frameHeight;
-			
-			var sourcePixelsWidth:Int = _sourceSprite.pixels.width;
-			var sourcePixelsHeight:Int = _sourceSprite.pixels.height;
-			
-			var sourceRect:Rectangle;
-			var tileID:Int;
-			
-			for (i in 0...(_sourceSprite.frames))
-			{
-				frameX = (sourceFrameWidth + 1) * i;
-				if (((frameX + sourceFrameWidth) >= sourcePixelsWidth) && (i != 0))
-				{
-					frameX = 0;
-					frameY += sourceFrameHeight;
-				}
-				
-				if (((frameY + sourceFrameHeight) <= sourcePixelsHeight))
-				{
-					frameLines = [];
-					
-					for (j in 0...(sourceFrameHeight))
-					{
-						sourceRect = new Rectangle(frameX, frameY + j, sourceFrameWidth, 1);
-						tileID = _imageTileSheetData.addTileRect(sourceRect);
-						frameLines.push(tileID);
-					}
-					
-					_imageTileIDs.set(i, frameLines);
-				}
-			}
-			
-			updateLineIDs();
-		}
-		
-		swapTileSheets();
-		*/
-	}
-	
 }
 
 typedef ImageLine = {

--- a/src/flixel/effects/fx/GlitchSprite.hx
+++ b/src/flixel/effects/fx/GlitchSprite.hx
@@ -1,0 +1,403 @@
+package flixel.effects.fx;
+
+import flixel.FlxSprite;
+
+#if !flash
+class GlitchSprite extends FlxSprite
+{
+	/**
+	 * Information about each line in glitched sprite
+	 */
+	public var imageLines:Array<ImageLine>;
+	
+	private var _sourceSprite:FlxSprite;
+	
+	/**
+	 * link to source image tilesheet data
+	 */
+	private var _imageTileSheetData:TileSheetData;
+	
+	/**
+	 * storage for each frame's lines tile IDs
+	 */
+	private var _imageTileIDs:Map<Int, Array<Int>>;
+	
+	private var _bgRed:Float;
+	private var _bgGreen:Float;
+	private var _bgBlue:Float;
+	private var _bgAlpha:Float;
+	
+	public var maxGlitch:Float;
+	public var glitchSkip:Float;
+	
+	public var sourceFrame:Int;
+	
+	public function new(Source:FlxSprite, MaxGlitch:Int, GlitchSkip:Int, BgColor:Int)
+	{
+		super();
+		
+		_sourceSprite = Source;
+		sourceFrame = -1;
+		
+		this.maxGlitch = MaxGlitch;
+		this.glitchSkip = GlitchSkip;
+		
+		_imageTileIDs = new Map<Int, Array<Int>>();
+		imageLines = new Array<ImageLine>();
+		
+		makeGraphic(1, 1, FlxColor.WHITE);
+		
+		_frameID = _framesData.frameIDs[0];
+		_tileSheetData.isColored = true;
+		
+		var rgba:RGBA = FlxColor.getRGB(BgColor);
+		_bgRed = rgba.red / 255;
+		_bgGreen = rgba.green / 255;
+		_bgBlue = rgba.blue / 255;
+		_bgAlpha = rgba.alpha / 255;
+		
+		this.x = _sourceSprite.x;
+		this.y = _sourceSprite.y;
+	}
+	
+	public function updateFromSourceSprite():Void
+	{
+		if (_sourceSprite.pixels != _imageTileSheetData.tileSheet.nmeBitmap)
+		{
+			updateTileSheet();
+		}
+		else
+		{
+			updateLineIDs();
+		}
+	}
+	
+	private function updateLineIDs():Void
+	{
+		if (sourceFrame != _sourceSprite.frame)
+		{
+			var sourceFrameHeight:Int = _sourceSprite.frameHeight;
+			var halfFrameWidth:Float = _sourceSprite.frameWidth * 0.5;
+			
+			sourceFrame = _sourceSprite.frame;
+			var frameLines:Array<Int> = _imageTileIDs.get(sourceFrame);
+			var halfFrameHeight:Float = sourceFrameHeight * 0.5;
+			
+			var imageLine:ImageLine;
+			
+			for (i in 0...(sourceFrameHeight))
+			{
+				imageLine = imageLines[i];
+				if (imageLine == null)
+				{
+					imageLines[i] = { x: 0, y: i + 0.5, tileID: frameLines[i] };
+				}
+				else
+				{
+					imageLine.x = halfFrameWidth;
+					imageLine.y = i - sourceFrameHeight + 0.5;
+					imageLine.tileID = frameLines[i];
+				}
+			}
+			
+			if (imageLines.length > _sourceSprite.frameHeight)
+			{
+				imageLines.splice(_sourceSprite.frameHeight, (imageLines.length - _sourceSprite.frameHeight));
+			}
+		}
+	}
+	
+	public function updateLinePositions():Void
+	{
+		var sourceFrameHeight:Int = _sourceSprite.frameHeight;
+		
+		var rndSkip:Int = 1 + Std.int(Math.random() * glitchSkip);
+		var y:Int = 0;
+		var rndX:Float = 0;
+		
+		for (i in 0...(sourceFrameHeight))
+		{
+			if (i == y)
+			{
+				rndX = Std.int(Math.random() * maxGlitch);
+				y += rndSkip;
+			}
+			
+			imageLines[i].x = rndX;
+		}
+	}
+	
+	override public function destroy():Void 
+	{
+		super.destroy();
+		
+		imageLines = null;
+		_sourceSprite = null;
+		_imageTileSheetData = null;
+		_imageTileIDs = null;
+	}
+	
+	override public function set_color(Color:Int):Int 
+	{
+		var col = super.set_color(Color);
+		
+		if (_color < 0xffffff)
+		{
+			if (_imageTileSheetData != null)
+			{
+				_imageTileSheetData.isColored = true;
+			}
+		}
+		
+		return col;
+	}
+	
+	override public function draw():Void
+	{
+		if(_flickerTimer != 0)
+		{
+			_flicker = !_flicker;
+			if (_flicker)
+			{
+				return;
+			}
+		}
+		
+		if (cameras == null)
+		{
+			cameras = FlxG.cameras.list;
+		}
+		var camera:FlxCamera;
+		var i:Int = 0;
+		var l:Int = cameras.length;
+		
+		var currDrawData:Array<Float>;
+		var currIndex:Int;
+		
+		var radians:Float;
+		var cos:Float;
+		var sin:Float;
+		
+		var halfWidth:Float = frameWidth * 0.5;
+		var halfHeight:Float = frameHeight * 0.5;
+		
+		var lineDef:ImageLine;
+		
+		var lineRed:Float = 1;
+		var lineGreen:Float = 1;
+		var lineBlue:Float = 1;
+		
+		if (_color < 0xffffff)
+		{
+			lineRed = _red;
+			lineGreen = _green;
+			lineBlue = _blue;
+		}
+		
+		var onCamRed:Float;
+		var onCamGreen:Float;
+		var onCamBlue:Float;
+		
+		while (i < l)
+		{
+			camera = cameras[i++];
+			
+			if (!onScreenSprite(camera) || !camera.visible || !camera.exists)
+			{
+				continue;
+			}
+			
+			var onCamRed:Float = lineRed;
+			var onCamGreen:Float = lineGreen;
+			var onCamBlue:Float = lineBlue;
+			
+			if (camera.isColored())
+			{
+				onCamRed = camera.red;
+				onCamGreen = camera.green;
+				onCamBlue = camera.blue;
+			}
+			
+			var useColor:Bool = (_imageTileSheetData.isColored || camera.isColored());
+			
+			currDrawData = _tileSheetData.drawData[camera.ID];
+			currIndex = _tileSheetData.positionData[camera.ID];
+			
+			_point.x = (x - (camera.scroll.x * scrollFactor.x) - (offset.x)) + origin.x;
+			_point.y = (y - (camera.scroll.y * scrollFactor.y) - (offset.y)) + origin.y;
+
+			var csx : Float = 1;
+			var ssy : Float = 0;
+			var ssx : Float = 0;
+			var csy : Float = 1;
+			var x1 : Float = 0;
+			var y1 : Float = 0;
+
+			if (!simpleRenderSprite ())
+			{
+				radians = angle * FlxAngle.TO_RAD;
+				cos = Math.cos(radians);
+				sin = Math.sin(radians);
+
+				csx = cos * scale.x;
+				ssy = sin * scale.y;
+				ssx = sin * scale.x;
+				csy = cos * scale.y;
+				x1 = halfWidth;
+				y1 = halfHeight;
+			}
+
+			_point.x += halfWidth;
+			_point.y += halfHeight;
+			
+			// draw background
+			if (_bgAlpha > 0)
+			{
+				currDrawData[currIndex++] = _point.x;
+				currDrawData[currIndex++] = _point.y;
+				
+				currDrawData[currIndex++] = _frameID;
+				
+				currDrawData[currIndex++] = csx * frameWidth;
+				currDrawData[currIndex++] = -ssy * frameHeight;
+				currDrawData[currIndex++] = ssx * frameWidth;
+				currDrawData[currIndex++] = csy * frameHeight;
+				
+				if (camera.isColored())
+				{
+					currDrawData[currIndex++] = _bgRed * camera.red;
+					currDrawData[currIndex++] = _bgGreen * camera.green;
+					currDrawData[currIndex++] = _bgBlue * camera.blue;
+				}
+				else
+				{
+					currDrawData[currIndex++] = _bgRed;
+					currDrawData[currIndex++] = _bgGreen;
+					currDrawData[currIndex++] = _bgBlue;
+				}
+				
+				currDrawData[currIndex++] = _bgAlpha * alpha;
+				_tileSheetData.positionData[camera.ID] = currIndex;
+			}
+
+			// draw lines
+			currDrawData = _imageTileSheetData.drawData[camera.ID];
+			currIndex = _imageTileSheetData.positionData[camera.ID];
+
+			for (j in 0...(imageLines.length))
+			{
+				lineDef = imageLines[j];
+				
+				var localX:Float = lineDef.x - x1;
+				var localY:Float = lineDef.y - y1;
+				
+				var relativeX:Float = (localX * csx - localY * ssy);
+				var relativeY:Float = (localX * ssx + localY * csy);
+				
+				currDrawData[currIndex++] = _point.x + relativeX;
+				currDrawData[currIndex++] = _point.y + relativeY;
+				
+				currDrawData[currIndex++] = lineDef.tileID;
+				
+				currDrawData[currIndex++] = csx;
+				currDrawData[currIndex++] = -ssy;
+				currDrawData[currIndex++] = ssx;
+				currDrawData[currIndex++] = csy;
+				
+				if (useColor)
+				{
+					currDrawData[currIndex++] = onCamRed;
+					currDrawData[currIndex++] = onCamGreen;
+					currDrawData[currIndex++] = onCamBlue;
+				}
+				
+				currDrawData[currIndex++] = alpha;
+			}
+			_imageTileSheetData.positionData[camera.ID] = currIndex;
+			
+			FlxBasic._VISIBLECOUNT++;
+		} 
+	}
+	
+	public function swapTileSheets():Void
+	{
+		/*if (_tileSheetData != null && _imageTileSheetData != null)
+		{
+			var bgIndex:Int = TileSheetManager.getTileSheetIndex(_tileSheetData);
+			var imgIndex:Int = TileSheetManager.getTileSheetIndex(_imageTileSheetData);
+			
+			if (bgIndex > imgIndex)
+			{
+				TileSheetManager.swapTileSheets(bgIndex, imgIndex);
+			}
+		}*/
+	}
+	
+	public function updateTileSheet():Void 
+	{
+		/*
+		if (_tileSheetData == null)
+		{
+			if (_pixels != null)
+			{
+				_tileSheetData = TileSheetManager.addTileSheet(_pixels);
+				_tileSheetData.antialiasing = antialiasing;
+				_tileSheetData.isTilemap = false;
+				_framesData = _tileSheetData.getSpriteSheetFrames(1, 1);
+			}
+		}
+		
+		if (_sourceSprite != null)
+		{
+			this.width = _sourceSprite.width + maxGlitch;
+			this.height = _sourceSprite.height;
+			
+			this.frameWidth = Std.int(this.width);
+			this.frameHeight = Std.int(this.height);
+			
+			_imageTileSheetData = TileSheetManager.addTileSheet(_sourceSprite.pixels);
+			
+			var frameLines:Array<Int>;
+			var frameX:Int = 0;
+			var frameY:Int = 0;
+			var sourceFrameWidth:Int = _sourceSprite.frameWidth;
+			var sourceFrameHeight:Int = _sourceSprite.frameHeight;
+			
+			var sourcePixelsWidth:Int = _sourceSprite.pixels.width;
+			var sourcePixelsHeight:Int = _sourceSprite.pixels.height;
+			
+			var sourceRect:Rectangle;
+			var tileID:Int;
+			
+			for (i in 0...(_sourceSprite.frames))
+			{
+				frameX = (sourceFrameWidth + 1) * i;
+				if (((frameX + sourceFrameWidth) >= sourcePixelsWidth) && (i != 0))
+				{
+					frameX = 0;
+					frameY += sourceFrameHeight;
+				}
+				
+				if (((frameY + sourceFrameHeight) <= sourcePixelsHeight))
+				{
+					frameLines = [];
+					
+					for (j in 0...(sourceFrameHeight))
+					{
+						sourceRect = new Rectangle(frameX, frameY + j, sourceFrameWidth, 1);
+						tileID = _imageTileSheetData.addTileRect(sourceRect);
+						frameLines.push(tileID);
+					}
+					
+					_imageTileIDs.set(i, frameLines);
+				}
+			}
+			
+			updateLineIDs();
+		}
+		
+		swapTileSheets();
+		*/
+	}
+}
+#end

--- a/src/flixel/effects/fx/StarObject.hx
+++ b/src/flixel/effects/fx/StarObject.hx
@@ -1,0 +1,14 @@
+package flixel.effects.fx;
+
+class StarObject 
+{
+	public var index:Int;
+	public var x:Int;
+	public var y:Int;
+	public var d:Float;
+	public var speed:Float;
+	public var r:Float;
+	public var alpha:Float;
+	
+	public function new() {  }
+}

--- a/src/flixel/effects/fx/StarSprite.hx
+++ b/src/flixel/effects/fx/StarSprite.hx
@@ -1,0 +1,231 @@
+package flixel.effects.fx;
+
+import flixel.FlxSprite;
+import flixel.system.layer.DrawStackItem;
+import flixel.util.FlxAngle;
+import flixel.util.FlxColor;
+
+#if !flash
+class StarSprite extends FlxSprite
+{
+	
+	/**
+	 * Information about stars positions and colors
+	 */
+	public var starData:Array<StarDef>;
+	
+	/**
+	 * Starfield's background
+	 */
+	public var bgRed:Float;
+	public var bgGreen:Float;
+	public var bgBlue:Float;
+	public var bgAlpha:Float;
+	
+	public var halfWidth:Float;
+	public var halfHeight:Float;
+	
+	public function new(X:Float = 0, Y:Float = 0, Width:Int = 1, Height:Int = 1, ?bgColor:Int)
+	{
+		super(X, Y);
+		
+		makeGraphic(1, 1, FlxColor.WHITE);
+		
+		setBackgroundColor(bgColor);
+		
+		width = Width;
+		height = Height;
+		
+		halfWidth = 0.5 * Width;
+		halfHeight = 0.5 * Height;
+		
+		starData = new Array<StarDef>();
+	}
+	
+	public function setBackgroundColor(bgColor:Int):Void
+	{
+		var rgba:RGBA = FlxColor.getRGB(bgColor);
+		bgRed = rgba.red / 255;
+		bgGreen = rgba.green / 255;
+		bgBlue = rgba.blue / 255;
+		bgAlpha = rgba.alpha / 255;
+	}
+	
+	override public function destroy():Void 
+	{
+		starData = null;
+		super.destroy();
+	}
+	
+	override public function draw():Void 
+	{
+		if (_atlas == null)
+		{
+			return;
+		}
+		
+		if (_flickerTimer != 0)
+		{
+			_flicker = !_flicker;
+			if (_flicker)
+			{
+				return;
+			}
+		}
+		
+		if (cameras == null)
+		{
+			cameras = FlxG.cameras.list;
+		}
+		var camera:FlxCamera;
+		var i:Int = 0;
+		var l:Int = cameras.length;
+		
+		var currDrawData:Array<Float>;
+		var currIndex:Int;
+		var drawItem:DrawStackItem;
+		
+		var radians:Float;
+		var cos:Float;
+		var sin:Float;
+		
+		var starRed:Float;
+		var starGreen:Float;
+		var starBlue:Float;
+		
+		var starDef:StarDef;
+		
+		while (i < l)
+		{
+			camera = cameras[i++];
+			if (!onScreenSprite(camera) || !camera.visible || !camera.exists)
+			{
+				continue;
+			}
+			
+			#if !js
+			drawItem = camera.getDrawStackItem(_atlas, true, _blendInt, antialiasing);
+			#else
+			drawItem = camera.getDrawStackItem(_atlas, true);
+			#end
+			
+			currDrawData = drawItem.drawData;
+			currIndex = drawItem.position;
+			
+			_point.x = (x - (camera.scroll.x * scrollFactor.x) - (offset.x));
+			_point.y = (y - (camera.scroll.y * scrollFactor.y) - (offset.y));
+			
+			#if js
+			_point.x = Math.floor(_point.x);
+			_point.y = Math.floor(_point.y);
+			#end
+
+			var csx:Float = 1;
+			var ssy:Float = 0;
+			var ssx:Float = 0;
+			var csy:Float = 1;
+			var x1 : Float = 0.5; // yes, 0.5
+			var y1 : Float = 0.5; // yes, 0.5
+
+			if (!simpleRenderSprite ())
+			{
+				radians = angle * FlxAngle.TO_RAD;
+				cos = Math.cos(radians);
+				sin = Math.sin(radians);
+				
+				csx = cos * scale.x;
+				ssy = sin * scale.y;
+				ssx = sin * scale.x;
+				csy = cos * scale.y;
+				x1 = 0.0; // yes, zero
+				y1 = 0.0; // yes, zero
+			}
+
+			_point.x += halfWidth;
+			_point.y += halfHeight;
+			
+			// draw background
+			currDrawData[currIndex++] = _point.x;
+			currDrawData[currIndex++] = _point.y;
+			
+			currDrawData[currIndex++] = _flxFrame.tileID;
+			
+			currDrawData[currIndex++] = csx * width;
+			currDrawData[currIndex++] = ssx * width;
+			currDrawData[currIndex++] = -ssy * height;
+			currDrawData[currIndex++] = csy * height;
+			
+			#if !js
+			currDrawData[currIndex++] = bgRed;
+			currDrawData[currIndex++] = bgGreen;
+			currDrawData[currIndex++] = bgBlue;
+			#end
+			
+			currDrawData[currIndex++] = bgAlpha * alpha;
+
+			// draw stars
+			for (j in 0...(starData.length))
+			{
+				starDef = starData[j];
+				
+				var localX:Float = starDef.x;
+				var localY:Float = starDef.y;
+				
+				var relativeX:Float = (localX * csx - localY * ssy);
+				var relativeY:Float = (localX * ssx + localY * csy);
+				
+				currDrawData[currIndex++] = _point.x + relativeX + x1;
+				currDrawData[currIndex++] = _point.y + relativeY + y1;
+				
+				currDrawData[currIndex++] = _flxFrame.tileID;
+				
+				currDrawData[currIndex++] = csx;
+				currDrawData[currIndex++] = ssx;
+				currDrawData[currIndex++] = -ssy;
+				currDrawData[currIndex++] = csy;
+			
+				starRed = starDef.red;
+				starGreen = starDef.green;
+				starBlue = starDef.blue;
+				
+			#if !js
+				if (_color < 0xffffff)
+				{
+					starRed *= _red;
+					starGreen *= _green;
+					starBlue *= _blue;
+				}
+				
+				currDrawData[currIndex++] = starRed;
+				currDrawData[currIndex++] = starGreen;
+				currDrawData[currIndex++] = starBlue;
+			#end
+				
+				currDrawData[currIndex++] = alpha * starDef.alpha;
+			}
+			
+			drawItem.position = currIndex;
+
+			FlxBasic._VISIBLECOUNT++;
+		}
+	}
+	
+	override public function updateFrameData():Void
+	{
+		if (_node != null && frameWidth >= 1 && frameHeight >= 1)
+		{
+			_framesData = _node.getSpriteSheetFrames(Std.int(frameWidth), Std.int(frameHeight));
+			_flxFrame = _framesData.frames[0];
+		}
+	}
+}
+
+typedef StarDef = {
+	var x:Float;
+	var y:Float;
+	var red:Float;
+	var green:Float;
+	var blue:Float;
+	var alpha:Float;
+}
+#end

--- a/src/flixel/effects/fx/StarfieldFX.hx
+++ b/src/flixel/effects/fx/StarfieldFX.hx
@@ -3,6 +3,7 @@ package flixel.effects.fx;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
+import flixel.FlxSprite;
 import flixel.util.FlxAngle;
 import flixel.util.FlxColor;
 import flixel.util.FlxGradient;
@@ -17,38 +18,35 @@ import flixel.system.layer.DrawStackItem;
  */
 class StarfieldFX extends BaseFX
 {
+	inline static public var STARFIELD_TYPE_2D:Int = 1;
+	inline static public var STARFIELD_TYPE_3D:Int = 2;
+	
 	/**
 	 * In a 3D starfield this controls the X coordinate the stars emit from, can be updated in real-time!
 	 */
 	public var centerX:Int;
-	
 	/**
 	 * In a 3D starfield this controls the Y coordinate the stars emit from, can be updated in real-time!
 	 */
 	public var centerY:Int;
-	
 	/**
 	 * How much to shift on the X axis every update. Negative values move towards the left, positiive to the right. 2D Starfield only. Can also be set via setStarSpeed()
 	 */
 	public var starXOffset:Float;
-	
 	/**
 	 * How much to shift on the Y axis every update. Negative values move up, positiive values move down. 2D Starfield only. Can also be set via setStarSpeed()
 	 */
 	public var starYOffset:Float;
 	
-	private var stars:Array<StarObject>;
-	private var starfieldType:Int;
+	private var _stars:Array<StarObject>;
+	private var _starfieldType:Int;
 	
-	private var backgroundColor:Int;
+	private var _backgroundColor:Int;
 	
-	private var updateSpeed:Int;
-	private var tick:Int;
+	private var _updateSpeed:Int;
+	private var _tick:Int;
 	
-	private var depthColours:Array<Int>;
-	
-	public static inline var STARFIELD_TYPE_2D:Int = 1;
-	public static inline var STARFIELD_TYPE_3D:Int = 2;
+	private var _depthColours:Array<Int>;
 	
 	public function new() 
 	{
@@ -56,52 +54,52 @@ class StarfieldFX extends BaseFX
 		
 		starXOffset = -1;
 		starYOffset = 0;
-		backgroundColor = FlxColor.BLACK;
+		_backgroundColor = FlxColor.BLACK;
 	}
 	
 	/**
 	 * Create a new StarField
 	 * 
-	 * @param	x				X coordinate of the starfield sprite
-	 * @param	y				Y coordinate of the starfield sprite
-	 * @param	width			The width of the starfield
-	 * @param	height			The height of the starfield
-	 * @param	quantity		The number of stars in the starfield (default 200)
-	 * @param	type			Type of starfield. Either STARFIELD_TYPE_2D (default, stars move horizontally) or STARFIELD_TYPE_3D (stars flow out from the center)
-	 * @param	updateInterval	How many ms should pass before the next starfield update (default 20)
+	 * @param	X				X coordinate of the starfield sprite
+	 * @param	Y				Y coordinate of the starfield sprite
+	 * @param	Width			The width of the starfield
+	 * @param	Height			The height of the starfield
+	 * @param	Quantity		The number of stars in the starfield (default 200)
+	 * @param	FieldType		Type of starfield. Either STARFIELD_TYPE_2D (default, stars move horizontally) or STARFIELD_TYPE_3D (stars flow out from the center)
+	 * @param	UpdateInterval	How many ms should pass before the next starfield update (default 20)
 	 */
-	public function create(x:Int, y:Int, width:Int, height:Int, quantity:Int = 200, type:Int = 1, updateInterval:Int = 20):FlxSprite
+	public function create(X:Int, Y:Int, Width:Int, Height:Int, Quantity:Int = 200, FieldType:Int = 1, UpdateInterval:Int = 20):FlxSprite
 	{
 		#if flash
-		sprite = new FlxSprite(x, y).makeGraphic(width, height, backgroundColor);
-		canvas = new BitmapData(Std.int(sprite.width), Std.int(sprite.height), true, backgroundColor);
+		sprite = new FlxSprite(X, Y).makeGraphic(Width, Height, _backgroundColor);
+		canvas = new BitmapData(Std.int(sprite.width), Std.int(sprite.height), true, _backgroundColor);
 		#else
-		sprite = new StarSprite(x, y, width, height, backgroundColor);
+		sprite = new StarSprite(X, Y, Width, Height, _backgroundColor);
 		var starDefs:Array<StarDef> = cast(sprite, StarSprite).starData;
 		#end
-		starfieldType = type;
-		updateSpeed = speed;
+		_starfieldType = FieldType;
+		_updateSpeed = speed;
 		
 		//	Stars come from the middle of the starfield in 3D mode
-		centerX = width >> 1;
-		centerY = height >> 1;
+		centerX = Width >> 1;
+		centerY = Height >> 1;
 		
-		clsRect = new Rectangle(0, 0, width, height);
-		clsPoint = new Point();
-		clsColor = backgroundColor;
+		_clsRect = new Rectangle(0, 0, Width, Height);
+		_clsPoint = new Point();
+		_clsColor = _backgroundColor;
 		
-		stars = new Array<StarObject>();
+		_stars = new Array<StarObject>();
 		
-		for (i in 0...(quantity))
+		for (i in 0...(Quantity))
 		{
 			var star:StarObject = new StarObject();
 			
 			star.index = i;
-			star.x = Std.int(Math.random() * width);
-			star.y = Std.int(Math.random() * height);
+			star.x = Std.int(Math.random() * Width);
+			star.y = Std.int(Math.random() * Height);
 			star.d = 1;
 			
-			if (type == STARFIELD_TYPE_2D)
+			if (FieldType == STARFIELD_TYPE_2D)
 			{
 				star.speed = 1 + Std.int(Math.random() * 5);
 			}
@@ -113,41 +111,40 @@ class StarfieldFX extends BaseFX
 			star.r = Math.random() * Math.PI * 2;
 			star.alpha = 0;
 			
-			stars.push(star);
+			_stars.push(star);
 			
 			#if !flash
 			starDefs.push( { x: 0, y: 0, red: 0, green: 0, blue: 0, alpha: 0 } );
 			#end
 		}
 		
-		//	Colours array
-		if (type == STARFIELD_TYPE_2D)
+		// Colours array
+		if (FieldType == STARFIELD_TYPE_2D)
 		{
-			depthColours = FlxGradient.createGradientArray(1, 5, [0xff585858, 0xffF4F4F4]);
+			_depthColours = FlxGradient.createGradientArray(1, 5, [0xff585858, 0xffF4F4F4]);
 		}
 		else
 		{
-			depthColours = FlxGradient.createGradientArray(1, 300, [0xff292929, 0xffffffff]);
+			_depthColours = FlxGradient.createGradientArray(1, 300, [0xff292929, 0xffffffff]);
 		}
 		
 		active = true;
+		
 		return sprite;
 	}
 	
 	/**
-	 * Change the background color in the format 0xAARRGGBB of the starfield.<br />
+	 * Change the background color in the format 0xAARRGGBB of the starfield.
 	 * Supports alpha, so if you want a transparent background just pass 0x00 as the color.
-	 * 
-	 * @param	backgroundColor
 	 */
-	public function setBackgroundColor(backgroundColor:Int):Void
+	public function setBackgroundColor(BackgroundColor:Int):Void
 	{
-		clsColor = backgroundColor;
+		_clsColor = BackgroundColor;
 		
 		#if !flash
 		if (sprite != null)
 		{
-			cast(sprite, StarSprite).setBackgroundColor(backgroundColor);
+			cast(sprite, StarSprite).setBackgroundColor(BackgroundColor);
 		}
 		#end
 	}
@@ -155,52 +152,53 @@ class StarfieldFX extends BaseFX
 	/**
 	 * Change the number of layers (depth) and colors used for each layer of the starfield. Change happens immediately.
 	 * 
-	 * @param	depth			Number of depths (for a 2D starfield the default is 5)
-	 * @param	lowestColor		The color given to the stars furthest away from the camera (i.e. the slowest stars), typically the darker colour
-	 * @param	highestColor	The color given to the stars cloest to the camera (i.e. the fastest stars), typically the brighter colour
+	 * @param	Depth			Number of depths (for a 2D starfield the default is 5)
+	 * @param	LowestColor		The color given to the stars furthest away from the camera (i.e. the slowest stars), typically the darker colour
+	 * @param	HighestColor	The color given to the stars cloest to the camera (i.e. the fastest stars), typically the brighter colour
 	 */
-	public function setStarDepthColors(depth:Int, lowestColor:Int = 0xff585858, highestColor:Int = 0xffF4F4F4):Void
+	public function setStarDepthColors(Depth:Int, LowestColor:Int = 0xff585858, HighestColor:Int = 0xffF4F4F4):Void
 	{
-		//	Depth is the same, we just need to update the gradient then
-		depthColours = FlxGradient.createGradientArray(1, depth, [lowestColor, highestColor]);
+		// Depth is the same, we just need to update the gradient then
+		_depthColours = FlxGradient.createGradientArray(1, Depth, [LowestColor, HighestColor]);
 		
-		//	Run through the stars array, making sure the depths are all within range
-		for (star in stars)
+		// Run through the stars array, making sure the depths are all within range
+		for (star in _stars)
 		{
-			star.speed = 1 + Std.int(Math.random() * depth);
+			star.speed = 1 + Std.int(Math.random() * Depth);
 		}
 	}
 	
 	/**
-	 * Sets the direction and speed of the 2D starfield (doesn't apply to 3D)<br />
+	 * Sets the direction and speed of the 2D starfield (doesn't apply to 3D)
 	 * You can combine both X and Y together to make the stars move on a diagnol
 	 * 
-	 * @param	xShift	How much to shift on the X axis every update. Negative values move towards the left, positiive to the right
-	 * @param	yShift	How much to shift on the Y axis every update. Negative values move up, positiive values move down
+	 * @param	ShiftX	How much to shift on the X axis every update. Negative values move towards the left, positiive to the right
+	 * @param	ShiftY	How much to shift on the Y axis every update. Negative values move up, positiive values move down
 	 */
-	public function setStarSpeed(xShift:Float, yShift:Float):Void
+	public function setStarSpeed(ShiftX:Float, ShiftY:Float):Void
 	{
-		starXOffset = xShift;
-		starYOffset = yShift;
+		starXOffset = ShiftX;
+		starYOffset = ShiftY;
 	}
 	
-	public var speed(get_speed, set_speed):Int;
+	public var speed(get, set):Int;
 	
 	/**
 	 * The current update speed
 	 */
 	private function get_speed():Int
 	{
-		return updateSpeed;
+		return _updateSpeed;
 	}
 	
 	/**
 	 * Change the tick interval on which the update runs. By default the starfield updates once every 20ms. Set to zero to disable totally.
 	 */
-	private function set_speed(newSpeed:Int):Int
+	private function set_speed(NewSpeed:Int):Int
 	{
-		updateSpeed = newSpeed;
-		return newSpeed;
+		_updateSpeed = NewSpeed;
+		
+		return NewSpeed;
 	}
 	
 	private function update2DStarfield():Void
@@ -212,16 +210,16 @@ class StarfieldFX extends BaseFX
 		
 		var star:StarObject;
 		
-		for (i in 0...(stars.length))
+		for (i in 0...(_stars.length))
 		{
-			star = stars[i];
+			star = _stars[i];
 			star.x += Math.floor(starXOffset * star.speed);
 			star.y += Math.floor(starYOffset * star.speed);
 			
 			#if flash
-			canvas.setPixel32(star.x, star.y, depthColours[Std.int(star.speed - 1)]);
+			canvas.setPixel32(star.x, star.y, _depthColours[Std.int(star.speed - 1)]);
 			#else
-			var starColor:Int = depthColours[Std.int(star.speed - 1)];
+			var starColor:Int = _depthColours[Std.int(star.speed - 1)];
 			var rgba:RGBA = FlxColor.getRGB(starColor);
 			
 			var starDef:StarDef = starArray[i];
@@ -265,9 +263,9 @@ class StarfieldFX extends BaseFX
 		
 		var star:StarObject;
 		
-		for (i in 0...(stars.length))
+		for (i in 0...(_stars.length))
 		{
-			star = stars[i];
+			star = _stars[i];
 			star.d *= 1.1;
 			star.x = Math.floor(centerX + ((Math.cos(star.r) * star.d) * star.speed));
 			star.y = Math.floor(centerY + ((Math.sin(star.r) * star.d) * star.speed));
@@ -292,7 +290,7 @@ class StarfieldFX extends BaseFX
 			starDef.blue = rgba.blue / 255;
 			starDef.alpha = rgba.alpha / 255;
 			#end
-			//canvas.setPixel32(star.x, star.y, FlxColor.getColor32(255, star.alpha, star.alpha, star.alpha));
+			// canvas.setPixel32(star.x, star.y, FlxColor.getColor32(255, star.alpha, star.alpha, star.alpha));
 			
 			if (star.x < 0 || star.x > sprite.width || star.y < 0 || star.y > sprite.height)
 			{
@@ -303,7 +301,7 @@ class StarfieldFX extends BaseFX
 				star.speed = Math.random();
 				star.alpha = 0;
 				
-				stars[star.index] = star;
+				_stars[star.index] = star;
 				
 				#if !flash
 				starDef.alpha = 0;
@@ -319,14 +317,14 @@ class StarfieldFX extends BaseFX
 	
 	override public function draw():Void
 	{
-		if (FlxMisc.getTicks() > tick)
+		if (FlxMisc.getTicks() > _tick)
 		{
 			#if flash
 			canvas.lock();
-			canvas.fillRect(clsRect, clsColor);
+			canvas.fillRect(_clsRect, _clsColor);
 			#end
 			
-			if (starfieldType == STARFIELD_TYPE_2D)
+			if (_starfieldType == STARFIELD_TYPE_2D)
 			{
 				update2DStarfield();
 			}
@@ -340,249 +338,10 @@ class StarfieldFX extends BaseFX
 			sprite.pixels = canvas;
 			#end
 			
-			if (updateSpeed > 0)
+			if (_updateSpeed > 0)
 			{
-				tick = FlxMisc.getTicks() + updateSpeed;
+				_tick = FlxMisc.getTicks() + _updateSpeed;
 			}
 		}
 	}
-	
-}
-
-#if !flash
-class StarSprite extends FlxSprite
-{
-	
-	/**
-	 * Information about stars positions and colors
-	 */
-	public var starData:Array<StarDef>;
-	
-	/**
-	 * Starfield's background
-	 */
-	public var bgRed:Float;
-	public var bgGreen:Float;
-	public var bgBlue:Float;
-	public var bgAlpha:Float;
-	
-	public var halfWidth:Float;
-	public var halfHeight:Float;
-	
-	public function new(X:Float = 0, Y:Float = 0, Width:Int = 1, Height:Int = 1, ?bgColor:Int)
-	{
-		super(X, Y);
-		
-		makeGraphic(1, 1, FlxColor.WHITE);
-		
-		setBackgroundColor(bgColor);
-		
-		width = Width;
-		height = Height;
-		
-		halfWidth = 0.5 * Width;
-		halfHeight = 0.5 * Height;
-		
-		starData = new Array<StarDef>();
-	}
-	
-	public function setBackgroundColor(bgColor:Int):Void
-	{
-		var rgba:RGBA = FlxColor.getRGB(bgColor);
-		bgRed = rgba.red / 255;
-		bgGreen = rgba.green / 255;
-		bgBlue = rgba.blue / 255;
-		bgAlpha = rgba.alpha / 255;
-	}
-	
-	override public function destroy():Void 
-	{
-		starData = null;
-		super.destroy();
-	}
-	
-	override public function draw():Void 
-	{
-		if (_atlas == null)
-		{
-			return;
-		}
-		
-		if (_flickerTimer != 0)
-		{
-			_flicker = !_flicker;
-			if (_flicker)
-			{
-				return;
-			}
-		}
-		
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		var camera:FlxCamera;
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		
-		var currDrawData:Array<Float>;
-		var currIndex:Int;
-		var drawItem:DrawStackItem;
-		
-		var radians:Float;
-		var cos:Float;
-		var sin:Float;
-		
-		var starRed:Float;
-		var starGreen:Float;
-		var starBlue:Float;
-		
-		var starDef:StarDef;
-		
-		while (i < l)
-		{
-			camera = cameras[i++];
-			if (!onScreenSprite(camera) || !camera.visible || !camera.exists)
-			{
-				continue;
-			}
-			
-			#if !js
-			drawItem = camera.getDrawStackItem(_atlas, true, _blendInt, antialiasing);
-			#else
-			drawItem = camera.getDrawStackItem(_atlas, true);
-			#end
-			
-			currDrawData = drawItem.drawData;
-			currIndex = drawItem.position;
-			
-			_point.x = (x - (camera.scroll.x * scrollFactor.x) - (offset.x));
-			_point.y = (y - (camera.scroll.y * scrollFactor.y) - (offset.y));
-			
-			#if js
-			_point.x = Math.floor(_point.x);
-			_point.y = Math.floor(_point.y);
-			#end
-
-			var csx:Float = 1;
-			var ssy:Float = 0;
-			var ssx:Float = 0;
-			var csy:Float = 1;
-			var x1 : Float = 0.5; // yes, 0.5
-			var y1 : Float = 0.5; // yes, 0.5
-
-			if (!simpleRenderSprite ())
-			{
-				radians = angle * FlxAngle.TO_RAD;
-				cos = Math.cos(radians);
-				sin = Math.sin(radians);
-				
-				csx = cos * scale.x;
-				ssy = sin * scale.y;
-				ssx = sin * scale.x;
-				csy = cos * scale.y;
-				x1 = 0.0; // yes, zero
-				y1 = 0.0; // yes, zero
-			}
-
-			_point.x += halfWidth;
-			_point.y += halfHeight;
-			
-			// draw background
-			currDrawData[currIndex++] = _point.x;
-			currDrawData[currIndex++] = _point.y;
-			
-			currDrawData[currIndex++] = _flxFrame.tileID;
-			
-			currDrawData[currIndex++] = csx * width;
-			currDrawData[currIndex++] = ssx * width;
-			currDrawData[currIndex++] = -ssy * height;
-			currDrawData[currIndex++] = csy * height;
-			
-			#if !js
-			currDrawData[currIndex++] = bgRed;
-			currDrawData[currIndex++] = bgGreen;
-			currDrawData[currIndex++] = bgBlue;
-			#end
-			
-			currDrawData[currIndex++] = bgAlpha * alpha;
-
-			// draw stars
-			for (j in 0...(starData.length))
-			{
-				starDef = starData[j];
-				
-				var localX:Float = starDef.x;
-				var localY:Float = starDef.y;
-				
-				var relativeX:Float = (localX * csx - localY * ssy);
-				var relativeY:Float = (localX * ssx + localY * csy);
-				
-				currDrawData[currIndex++] = _point.x + relativeX + x1;
-				currDrawData[currIndex++] = _point.y + relativeY + y1;
-				
-				currDrawData[currIndex++] = _flxFrame.tileID;
-				
-				currDrawData[currIndex++] = csx;
-				currDrawData[currIndex++] = ssx;
-				currDrawData[currIndex++] = -ssy;
-				currDrawData[currIndex++] = csy;
-			
-				starRed = starDef.red;
-				starGreen = starDef.green;
-				starBlue = starDef.blue;
-				
-			#if !js
-				if (_color < 0xffffff)
-				{
-					starRed *= _red;
-					starGreen *= _green;
-					starBlue *= _blue;
-				}
-				
-				currDrawData[currIndex++] = starRed;
-				currDrawData[currIndex++] = starGreen;
-				currDrawData[currIndex++] = starBlue;
-			#end
-				
-				currDrawData[currIndex++] = alpha * starDef.alpha;
-			}
-			
-			drawItem.position = currIndex;
-
-			FlxBasic._VISIBLECOUNT++;
-		}
-	}
-	
-	override public function updateFrameData():Void
-	{
-		if (_node != null && frameWidth >= 1 && frameHeight >= 1)
-		{
-			_framesData = _node.getSpriteSheetFrames(Std.int(frameWidth), Std.int(frameHeight));
-			_flxFrame = _framesData.frames[0];
-		}
-	}
-}
-
-typedef StarDef = {
-	var x:Float;
-	var y:Float;
-	var red:Float;
-	var green:Float;
-	var blue:Float;
-	var alpha:Float;
-}
-#end
-
-class StarObject 
-{
-	public var index:Int;
-	public var x:Int;
-	public var y:Int;
-	public var d:Float;
-	public var speed:Float;
-	public var r:Float;
-	public var alpha:Float;
-	
-	public function new() {  }
 }

--- a/src/flixel/effects/particles/FlxEmitter.hx
+++ b/src/flixel/effects/particles/FlxEmitter.hx
@@ -1,7 +1,25 @@
 package flixel.effects.particles;
 
+/**
+ * <code>FlxEmitter</code> is a lightweight particle emitter.
+ * It can be used for one-time explosions or for
+ * continuous fx like rain and fire.  <code>FlxEmitter</code>
+ * is not optimized or anything; all it does is launch
+ * <code>FlxParticle</code> objects out at set intervals
+ * by setting their positions and velocities accordingly.
+ * It is easy to use and relatively efficient,
+ * relying on <code>FlxGroup</code>'s RECYCLE POWERS.
+ */
 class FlxEmitter extends FlxTypedEmitter<FlxParticle>
 {
+	/**
+	 * Creates a new <code>FlxEmitter</code> object at a specific position.
+	 * Does NOT automatically generate or attach particles!
+	 * 
+	 * @param	X		The X position of the emitter.
+	 * @param	Y		The Y position of the emitter.
+	 * @param	Size	Optional, specifies a maximum capacity for this emitter.
+	 */
 	public function new(X:Float = 0, Y:Float = 0, Size:Int = 0)
 	{
 		super(X, Y, Size);

--- a/src/flixel/effects/particles/FlxEmitterExt.hx
+++ b/src/flixel/effects/particles/FlxEmitterExt.hx
@@ -1,7 +1,21 @@
 package flixel.effects.particles;
 
+/**
+ * Extended <code>FlxEmitter</code> that emits particles in a circle (instead of a square).
+ * It also provides a new function setMotion to control particle behavior even more.
+ * This was inspired by the way Chevy Ray Johnston implemented his particle emitter in Flashpunk.
+ * @author Dirk Bunk
+ */
 class FlxEmitterExt extends FlxTypedEmitterExt<FlxParticle>
 {
+	/**
+	 * Creates a new <code>FlxEmitterExt</code> object at a specific position.
+	 * Does NOT automatically generate or attach particles!
+	 * 
+	 * @param	X		The X position of the emitter.
+	 * @param	Y		The Y position of the emitter.
+	 * @param	Size	Optional, specifies a maximum capacity for this emitter.
+	 */
 	public function new(X:Float = 0, Y:Float = 0, Size:Int = 0)
 	{
 		super(X, Y, Size);

--- a/src/flixel/effects/particles/FlxParticle.hx
+++ b/src/flixel/effects/particles/FlxParticle.hx
@@ -1,5 +1,7 @@
 package flixel.effects.particles;
 
+import flixel.FlxSprite;
+
 /**
  * This is a simple particle class that extends the default behavior
  * of <code>FlxSprite</code> to have slightly more specialized behavior
@@ -16,90 +18,75 @@ class FlxParticle extends FlxSprite
 	 * could get recycled before its lifespan is up.
 	 */
 	public var lifespan:Float;
-	
 	/**
 	 * Determines how quickly the particles come to rest on the ground.
 	 * Only used if the particle has gravity-like acceleration applied.
 	 * @default 500
 	 */
 	public var friction:Float;
-	
 	/**
 	 * If this is set to true, particles will slowly fade away by
 	 * decreasing their alpha value based on their lifespan.
 	*/
 	public var useFading:Bool = false;
-
 	/**
 	 * If this is set to true, particles will slowly decrease in scale
 	 * based on their lifespan.
 	 * WARNING: This severely impacts performance on flash target.
 	*/
 	public var useScaling:Bool = false;
-	
 	/**
 	 * If this is set to true, particles will change their color
 	 * based on their lifespan and start and range color components values.
 	 */
 	public var useColoring:Bool = false;
-	
 	/**
 	 * Helper variable for fading, scaling and coloring particle.
 	 */
 	public var maxLifespan:Float;
-	
 	/**
 	 * Start value for particle's alpha
 	 */
 	public var startAlpha:Float;
-	
 	/**
 	 * Range of alpha change during particle's life
 	 */
 	public var rangeAlpha:Float;
-	
 	/**
 	 * Start value for particle's scale.x and scale.y
 	 */
 	public var startScale:Float;
-	
 	/**
 	 * Range of scale change during particle's life
 	 */
 	public var rangeScale:Float;
-	
 	/**
 	 * Start value for particle's red color component
 	 */
 	public var startRed:Float;
-	
 	/**
 	 * Start value for particle's green color component
 	 */
 	public var startGreen:Float;
-	
 	/**
 	 * Start value for particle's blue color component
 	 */
 	public var startBlue:Float;
-	
 	/**
 	 * Range of red color component change during particle's life
 	 */
 	public var rangeRed:Float;
-	
 	/**
 	 * Range of green color component change during particle's life
 	 */
 	public var rangeGreen:Float;
-	
 	/**
 	 * Range of blue color component change during particle's life
 	 */
 	public var rangeBlue:Float;
 	
 	/**
-	 * Instantiate a new particle.  Like <code>FlxSprite</code>, all meaningful creation
+	 * Instantiate a new particle. Like <code>FlxSprite</code>, all meaningful creation
 	 * happens during <code>loadGraphic()</code> or <code>makeGraphic()</code> or whatever.
 	 */
 	public function new()
@@ -121,6 +108,7 @@ class FlxParticle extends FlxSprite
 		if (_flickerTimer > 0)
 		{
 			_flickerTimer -= FlxG.elapsed;
+			
 			if(_flickerTimer <= 0)
 			{
 				_flickerTimer = 0;
@@ -131,7 +119,7 @@ class FlxParticle extends FlxSprite
 		last.x = x;
 		last.y = y;
 		
-		//lifespan behavior
+		// Lifespan behavior
 		if (lifespan > 0)
 		{
 			lifespan -= FlxG.elapsed;
@@ -164,7 +152,7 @@ class FlxParticle extends FlxSprite
 				color = Std.int(255 * redComp) << 16 | Std.int(255 * greenComp) << 8 | Std.int(255 * blueComp);
 			}
 			
-			//simpler bounce/spin behavior for now
+			// Simpler bounce/spin behavior for now
 			if (touching != 0)
 			{
 				if (angularVelocity != 0)
@@ -172,7 +160,8 @@ class FlxParticle extends FlxSprite
 					angularVelocity = -angularVelocity;
 				}
 			}
-			if (acceleration.y > 0) //special behavior for particles with gravity
+			// Special behavior for particles with gravity
+			if (acceleration.y > 0)
 			{
 				if ((touching & FlxObject.FLOOR) != 0)
 				{

--- a/src/flixel/effects/particles/FlxTypedEmitter.hx
+++ b/src/flixel/effects/particles/FlxTypedEmitter.hx
@@ -2,12 +2,13 @@ package flixel.effects.particles;
 
 import flash.display.Bitmap;
 import flash.display.BlendMode;
+import flixel.FlxObject;
 import flixel.util.FlxRandom;
 import flixel.util.FlxPoint;
 import flixel.group.FlxTypedGroup;
 
 /**
- * <code>FlxEmitter</code> is a lightweight particle emitter.
+ * <code>FlxTypedEmitter</code> is a lightweight particle emitter.
  * It can be used for one-time explosions or for
  * continuous fx like rain and fire.  <code>FlxEmitter</code>
  * is not optimized or anything; all it does is launch
@@ -58,9 +59,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	 * How often a particle is emitted (if emitter is started with Explode == false).
 	 */
 	public var frequency:Float;
-	
 	public var life:Bounds<Float>;
-	
 	/**
 	 * Sets start scale range (when particle emits)
 	 */
@@ -69,53 +68,43 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	 * Sets end scale range (when particle dies)
 	 */
 	public var endScale:Bounds<Float>;
-	
 	/**
 	 * Sets start alpha range (when particle emits)
 	 */
 	public var startAlpha:Bounds<Float>;
-	
 	/**
 	 * Sets end alpha range (when particle emits)
 	 */
 	public var endAlpha:Bounds<Float>;
-	
 	/**
 	 * Sets start red color component range (when particle emits)
 	 */
 	public var startRed:Bounds<Float>;
-	
 	/**
 	 * Sets start green color component range (when particle emits)
 	 */
 	public var startGreen:Bounds<Float>;
-	
 	/**
 	 * Sets start blue color component range (when particle emits)
 	 */
 	public var startBlue:Bounds<Float>;
-	
 	/**
 	 * Sets end red color component range (when particle emits)
 	 */
 	public var endRed:Bounds<Float>;
-	
 	/**
 	 * Sets end green color component range (when particle emits)
 	 */
 	public var endGreen:Bounds<Float>;
-	
 	/**
 	 * Sets end blue color component range (when particle emits)
 	 */
 	public var endBlue:Bounds<Float>;
-	
 	/**
 	 * Sets particle's blend mode. null by default.
 	 * Warning: expensive on flash target
 	 */
 	public var blend:BlendMode;
-	
 	/**
 	 * How much each particle should bounce.  1 = full bounce, 0 = no bounce.
 	 */
@@ -123,6 +112,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	/**
 	 * Internal variable for tracking the class to create when generating particles.
 	 */
+	
 	private var _particleClass:Class<T>;
 	/**
 	 * Internal helper for deciding how many particles to launch.
@@ -150,8 +140,9 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	private var _waitForKill:Bool = false;
 	
 	/**
-	 * Creates a new <code>FlxEmitter</code> object at a specific position.
+	 * Creates a new <code>FlxTypedEmitter</code> object at a specific position.
 	 * Does NOT automatically generate or attach particles!
+	 * 
 	 * @param	X		The X position of the emitter.
 	 * @param	Y		The Y position of the emitter.
 	 * @param	Size	Optional, specifies a maximum capacity for this emitter.
@@ -175,6 +166,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 		endRed = new Bounds<Float>(1.0, 1.0);
 		endGreen = new Bounds<Float>(1.0, 1.0);
 		endBlue = new Bounds<Float>(1.0, 1.0);
+		
 		blend = null;
 		acceleration = new FlxPoint(0, 0);
 		_particleClass = cast FlxParticle;
@@ -216,11 +208,13 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 		particleDrag = null;
 		_particleClass = null;
 		_point = null;
+		
 		super.destroy();
 	}
 	
 	/**
 	 * This function generates a new array of particle sprites to attach to the emitter.
+	 * 
 	 * @param	Graphics		If you opted to not pre-configure an array of FlxParticle objects, you can simply pass in a particle image or sprite sheet.
 	 * @param	Quantity		The number of particles to generate when using the "create from image" option.
 	 * @param	BakedRotations	How many frames of baked rotation to use (boosts performance).  Set to zero to not use baked rotations.
@@ -233,6 +227,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	{
 		maxSize = Quantity;
 		var totalFrames:Int = 1;
+		
 		if (Multiple)
 		{ 
 			var sprite:FlxSprite = new FlxSprite();
@@ -244,12 +239,15 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 		var randomFrame:Int;
 		var particle:FlxParticle;
 		var i:Int = 0;
+		
 		while (i < Quantity)
 		{
 			particle = Type.createInstance(_particleClass, []);
+			
 			if (Multiple)
 			{
 				randomFrame = Std.int(FlxRandom.float() * totalFrames); 
+				
 				if (BakedRotations > 0)
 				{
 					#if flash
@@ -280,7 +278,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 					particle.loadGraphic(Graphics);
 				}
 			}
-			if(Collide > 0)
+			if (Collide > 0)
 			{
 				particle.width *= Collide;
 				particle.height *= Collide;
@@ -290,6 +288,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 			{
 				particle.allowCollisions = FlxObject.NONE;
 			}
+			
 			particle.exists = false;
 			add(particle);
 			i++;
@@ -310,15 +309,18 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 				_waitForKill = true;
 				var i:Int = 0;
 				var l:Int = _quantity;
+				
 				if ((l <= 0) || (l > length))
 				{
 					l = length;
 				}
+				
 				while(i < l)
 				{
 					emitParticle();
 					i++;
 				}
+				
 				_quantity = 0;
 			}
 			else
@@ -327,6 +329,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 				if (frequency <= 0)
 				{
 					emitParticle();
+					
 					if((_quantity > 0) && (++_counter >= _quantity))
 					{
 						on = false;
@@ -337,10 +340,12 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 				else
 				{
 					_timer += FlxG.elapsed;
+					
 					while (_timer > frequency)
 					{
 						_timer -= frequency;
 						emitParticle();
+						
 						if ((_quantity > 0) && (++_counter >= _quantity))
 						{
 							on = false;
@@ -354,6 +359,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 		else if (_waitForKill)
 		{
 			_timer += FlxG.elapsed;
+			
 			if ((life.max > 0) && (_timer > life.max))
 			{
 				kill();
@@ -371,15 +377,16 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	{
 		on = false;
 		_waitForKill = false;
+		
 		super.kill();
 	}
 	
 	/**
 	 * Call this function to start emitting particles.
-	 * @param	Explode		Whether the particles should all burst out at once.
-	 * @param	Lifespan	How long each particle lives once emitted. 0 = forever.
-	 * @param	Frequency	Ignored if Explode is set to true. Frequency is how often to emit a particle. 0 = never emit, 0.1 = 1 particle every 0.1 seconds, 5 = 1 particle every 5 seconds.
-	 * @param	Quantity	How many particles to launch. 0 = "all of the particles".
+	 * @param	Explode			Whether the particles should all burst out at once.
+	 * @param	Lifespan		How long each particle lives once emitted. 0 = forever.
+	 * @param	Frequency		Ignored if Explode is set to true. Frequency is how often to emit a particle. 0 = never emit, 0.1 = 1 particle every 0.1 seconds, 5 = 1 particle every 5 seconds.
+	 * @param	Quantity		How many particles to launch. 0 = "all of the particles".
 	 * @param	LifespanRange	Max amount to add to the particle's lifespan. Leave it to default (zero), if you want to make particle "live" forever (plus you should set Lifespan parameter to zero too).
 	 */
 	public function start(Explode:Bool = true, Lifespan:Float = 0, Frequency:Float = 0.1, Quantity:Int = 0, LifespanRange:Float = 0):Void
@@ -446,7 +453,8 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 			particle.useFading = false;
 			particle.rangeAlpha = 0;
 		}
-		// particle color settings
+		
+		// Particle color settings
 		var startRedComp:Float = particle.startRed = startRed.min;
 		var startGreenComp:Float = particle.startGreen = startGreen.min;
 		var startBlueComp:Float = particle.startBlue = startBlue.min;
@@ -488,11 +496,12 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 		particle.rangeBlue = endBlueComp - startBlueComp;
 		
 		particle.useColoring = false;
+		
 		if (particle.rangeRed != 0 || particle.rangeGreen != 0 || particle.rangeBlue != 0)
 		{
 			particle.useColoring = true;
 		}
-		// end of particle color settings
+		// End of particle color settings
 		if (startScale.min != startScale.max)
 		{
 			particle.startScale = startScale.min + FlxRandom.float() * (startScale.max - startScale.min);
@@ -559,6 +568,7 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	
 	/**
 	 * A more compact way of setting the width and height of the emitter.
+	 * 
 	 * @param	Width	The desired width of the emitter (particles are spawned randomly within these dimensions).
 	 * @param	Height	The desired height of the emitter.
 	 */
@@ -570,13 +580,16 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	
 	/**
 	 * A more compact way of setting the X velocity range of the emitter.
+	 * 
 	 * @param	Min		The minimum value for this range.
 	 * @param	Max		The maximum value for this range.
 	 */
 	public function setXSpeed(Min:Float = 0, Max:Float = 0):Void
 	{
 		if (Max < Min)
+		{
 			Max = Min;
+		}
 		
 		xVelocity.min = Min;
 		xVelocity.max = Max;
@@ -584,13 +597,16 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	
 	/**
 	 * A more compact way of setting the Y velocity range of the emitter.
+	 * 
 	 * @param	Min		The minimum value for this range.
 	 * @param	Max		The maximum value for this range.
 	 */
 	public function setYSpeed(Min:Float = 0, Max:Float = 0):Void
 	{
 		if (Max < Min)
+		{
 			Max = Min;
+		}
 			
 		yVelocity.min = Min;
 		yVelocity.max = Max;
@@ -598,13 +614,16 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	
 	/**
 	 * A more compact way of setting the angular velocity constraints of the emitter.
+	 * 
 	 * @param	Min		The minimum value for this range.
 	 * @param	Max		The maximum value for this range.
 	 */
 	public function setRotation(Min:Float = 0, Max:Float = 0):Void
 	{
 		if (Max < Min)
+		{
 			Max = Min;
+		}
 		
 		rotation.min = Min;
 		rotation.max = Max;
@@ -612,70 +631,85 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	
 	/**
 	 * A more compact way of setting the scale constraints of the emitter.
-	 * @param	startMin	The minimum value for particle scale at the start (emission).
-	 * @param	startMax	The maximum value for particle scale at the start (emission).
-	 * @param	endMin		The minimum value for particle scale at the end (death).
-	 * @param	endMax		The maximum value for particle scale at the end (death).
+	 * 
+	 * @param	StartMin	The minimum value for particle scale at the start (emission).
+	 * @param	StartMax	The maximum value for particle scale at the start (emission).
+	 * @param	EndMin		The minimum value for particle scale at the end (death).
+	 * @param	EndMax		The maximum value for particle scale at the end (death).
 	 */
-	public function setScale(startMin:Float = 1, startMax:Float = 1, endMin:Float = 1, endMax:Float = 1):Void
+	public function setScale(StartMin:Float = 1, StartMax:Float = 1, EndMin:Float = 1, EndMax:Float = 1):Void
 	{
-		if (startMax < startMin)	
-			startMax = startMin;
+		if (StartMax < StartMin)
+		{
+			StartMax = StartMin;
+		}
 		
-		if (endMax < endMin)		
-			endMax = endMin;
+		if (EndMax < EndMin)
+		{
+			EndMax = EndMin;
+		}
 		
-		startScale.min = startMin;
-		startScale.max = startMax;
-		endScale.min = endMin;
-		endScale.max = endMax;
+		startScale.min = StartMin;
+		startScale.max = StartMax;
+		endScale.min = EndMin;
+		endScale.max = EndMax;
 	}
 	
 	/**
 	 * A more compact way of setting the alpha constraints of the emitter.
-	 * @param	startMin	The minimum value for particle alpha at the start (emission).
-	 * @param	startMax	The maximum value for particle alpha at the start (emission).
-	 * @param	endMin		The minimum value for particle alpha at the end (death).
-	 * @param	endMax		The maximum value for particle alpha at the end (death).
+	 * 
+	 * @param	StartMin	The minimum value for particle alpha at the start (emission).
+	 * @param	StartMax	The maximum value for particle alpha at the start (emission).
+	 * @param	EndMin		The minimum value for particle alpha at the end (death).
+	 * @param	EndMax		The maximum value for particle alpha at the end (death).
 	 */
-	public function setAlpha(startMin:Float = 1.0, startMax:Float = 1.0, endMin:Float = 1.0, endMax:Float = 1.0):Void
+	public function setAlpha(StartMin:Float = 1, StartMax:Float = 1, EndMin:Float = 1, EndMax:Float = 1):Void
 	{
-		if (startMin < 0)
-			startMin = 0;
+		if (StartMin < 0)
+		{
+			StartMin = 0;
+		}
 		
-		if (startMax < startMin)
-			startMax = startMin;
+		if (StartMax < StartMin)
+		{
+			StartMax = StartMin;
+		}
 		
-		if (endMin < 0)
-			endMin = 0;
+		if (EndMin < 0)
+		{
+			EndMin = 0;
+		}
 		
-		if (endMax < endMin)
-			endMax = endMin;
+		if (EndMax < EndMin)
+		{
+			EndMax = EndMin;
+		}
 		
-		startAlpha.min = startMin;
-		startAlpha.max = startMax;
-		endAlpha.min = endMin;
-		endAlpha.max = endMax;
+		startAlpha.min = StartMin;
+		startAlpha.max = StartMax;
+		endAlpha.min = EndMin;
+		endAlpha.max = EndMax;
 	}
 	
 	/**
 	 * A more compact way of setting the color constraints of the emitter.
 	 * But it's not so flexible as setting values of each color bounds objects.
-	 * @param	start		The start particles color at the start (emission).
-	 * @param	endMin		The end particles color at the end (death).
+	 * 
+	 * @param	Start		The start particles color at the start (emission).
+	 * @param	EndMin		The end particles color at the end (death).
 	 */
-	public function setColor(start:Int = 0xffffff, end:Int = 0xffffff):Void
+	public function setColor(Start:Int = 0xffffff, End:Int = 0xffffff):Void
 	{
-		start &= 0xffffff;
-		end &= 0xffffff;
+		Start &= 0xffffff;
+		End &= 0xffffff;
 		
-		var startRedComp:Float = (start >> 16 & 0xFF) / 255;
-		var startGreenComp:Float = (start >> 8 & 0xFF) / 255;
-		var startBlueComp:Float = (start & 0xFF) / 255;
+		var startRedComp:Float = (Start >> 16 & 0xFF) / 255;
+		var startGreenComp:Float = (Start >> 8 & 0xFF) / 255;
+		var startBlueComp:Float = (Start & 0xFF) / 255;
 		
-		var endRedComp:Float = (end >> 16 & 0xFF) / 255;
-		var endGreenComp:Float = (end >> 8 & 0xFF) / 255;
-		var endBlueComp:Float = (end & 0xFF) / 255;
+		var endRedComp:Float = (End >> 16 & 0xFF) / 255;
+		var endGreenComp:Float = (End >> 8 & 0xFF) / 255;
+		var endBlueComp:Float = (End & 0xFF) / 255;
 		
 		startRed.min = startRed.max = startRedComp;
 		startGreen.min = startGreen.max = startGreenComp;
@@ -688,11 +722,13 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	
 	/**
 	 * Change the emitter's midpoint to match the midpoint of a <code>FlxObject</code>.
+	 * 
 	 * @param	Object		The <code>FlxObject</code> that you want to sync up with.
 	 */
 	public function at(Object:FlxObject):Void
 	{
 		Object.getMidpoint(_point);
+		
 		x = _point.x - (Std.int(width) >> 1);
 		y = _point.y - (Std.int(height) >> 1);
 	}
@@ -701,143 +737,137 @@ class FlxTypedEmitter<T:FlxParticle> extends FlxTypedGroup<FlxParticle>
 	 * Set your own particle class type here. The custom class must extend <code>FlxParticle</code>.
 	 * Default is <code>FlxParticle</code>.
 	 */
-	public var particleClass(get_particleClass, set_particleClass):Class<T>;
+	public var particleClass(get, set):Class<T>;
 	
 	private function get_particleClass():Class<T> 
 	{
 		return _particleClass;
 	}
 	
-	private function set_particleClass(value:Class<T>):Class<T> 
+	private function set_particleClass(Value:Class<T>):Class<T> 
 	{
-		return _particleClass = value;
+		return _particleClass = Value;
 	}
 	
 	/**
 	 * The width of the emitter.  Particles can be randomly generated from anywhere within this box.
 	 */
-	public var width(get_width, set_width):Float;
+	public var width(get, set):Float;
 	
 	private function get_width():Float
 	{
 		return xPosition.max;
 	}
 	
-	private function set_width(value:Float):Float
+	private function set_width(Value:Float):Float
 	{
-		xPosition.max = value;
-		return value;
+		return xPosition.max = Value;
 	}
 	
 	/**
 	 * The height of the emitter.  Particles can be randomly generated from anywhere within this box.
 	 */
-	public var height(get_height, set_height):Float;
+	public var height(get, set):Float;
 	
 	private function get_height():Float
 	{
 		return yPosition.max;
 	}
 	
-	private function set_height(value:Float):Float
+	private function set_height(Value:Float):Float
 	{
-		yPosition.max = value;
-		return value;
+		return yPosition.max = Value;
 	}
 	
-	public var x(get_x, set_x):Float;
+	public var x(get, set):Float;
 	
 	private function get_x():Float
 	{
 		return xPosition.min;
 	}
 	
-	private function set_x(value:Float):Float
+	private function set_x(Value:Float):Float
 	{
-		xPosition.min = value;
-		return value;
+		return xPosition.min = Value;
 	}
 	
-	public var y(get_y, set_y):Float;
+	public var y(get, set):Float;
 	
 	private function get_y():Float
 	{
 		return yPosition.min;
 	}
 	
-	private function set_y(value:Float):Float
+	private function set_y(Value:Float):Float
 	{
-		yPosition.min = value;
-		return value;
+		return yPosition.min = Value;
 	}
 	
 	/**
 	 * Sets the <code>acceleration.y</code> member of each particle to this value on launch.
 	 */
-	public var gravity(get_gravity, set_gravity):Float;
+	public var gravity(get, set):Float;
 	
 	private function get_gravity():Float
 	{
 		return acceleration.y;
 	}
 	
-	private function set_gravity(value:Float):Float
+	private function set_gravity(Value:Float):Float
 	{
-		acceleration.y = value;
-		return value;
+		return acceleration.y = Value;
 	}
 	
 	/**
 	 * The minimum possible angular velocity of a particle. The default value is -360.
 	 * NOTE: rotating particles are more expensive to draw than non-rotating ones!
 	 */
-	public var minRotation(get_minRotation, set_minRotation):Float;
+	public var minRotation(get, set):Float;
 	
 	private function get_minRotation():Float
 	{
 		return rotation.min;
 	}
 	
-	private function set_minRotation(value:Float):Float
+	private function set_minRotation(Value:Float):Float
 	{
-		rotation.min = value;
-		return value;
+		return rotation.min = Value;
 	}
 	
 	/**
 	 * The maximum possible angular velocity of a particle. The default value is 360.
 	 * NOTE: rotating particles are more expensive to draw than non-rotating ones!
 	 */
-	public var maxRotation(get_maxRotation, set_maxRotation):Float;
+	public var maxRotation(get, set):Float;
 	
 	private function get_maxRotation():Float
 	{
 		return rotation.max;
 	}
 	
-	private function set_maxRotation(value:Float):Float
+	private function set_maxRotation(Value:Float):Float
 	{
-		rotation.max = value;
-		return value;
+		return rotation.max = Value;
 	}
 	
 	/**
 	 * How long each particle lives once it is emitted.
 	 * Set lifespan to 'zero' for particles to live forever.
 	 */
-	public var lifespan(get_lifespan, set_lifespan):Float;
+	public var lifespan(get, set):Float;
 	
 	private function get_lifespan():Float
 	{
 		return life.min;
 	}
 	
-	private function set_lifespan(value:Float):Float
+	private function set_lifespan(Value:Float):Float
 	{
 		var dl:Float = life.max - life.min;
-		life.min = value;
-		life.max = value + dl;
-		return value;
+		life.min = Value;
+		life.max = Value + dl;
+		
+		return Value;
 	}
 }
 

--- a/src/flixel/effects/particles/FlxTypedEmitterExt.hx
+++ b/src/flixel/effects/particles/FlxTypedEmitterExt.hx
@@ -3,7 +3,7 @@ package flixel.effects.particles;
 import flixel.util.FlxRandom;
 
 /**
- * Extended FlxEmitter that emits particles in a circle (instead of a square).
+ * Extended <code>FlxEmitter</code> that emits particles in a circle (instead of a square).
  * It also provides a new function setMotion to control particle behavior even more.
  * This was inspired by the way Chevy Ray Johnston implemented his particle emitter in Flashpunk.
  * @author Dirk Bunk
@@ -14,24 +14,21 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<FlxParticle>
 	 * 	Launch Direction.
 	 */
 	public var angle:Float;
-	
 	/**
 	 * 	Distance to travel.
 	 */
 	public var distance:Float;
-	
 	/**
 	 * 	Random amount to add to the particle's direction.
 	 */
 	public var angleRange:Float;
-	
 	/**
 	 * 	Random amount to add to the particle's distance.
 	 */
 	public var distanceRange:Float;
 	
 	/**
-	 * Creates a new <code>FlxEmitterExt</code> object at a specific position.
+	 * Creates a new <code>FlxTypedEmitterExt</code> object at a specific position.
 	 * Does NOT automatically generate or attach particles!
 	 * 
 	 * @param	X		The X position of the emitter.
@@ -41,78 +38,83 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<FlxParticle>
 	public function new(X:Float = 0, Y:Float = 0, Size:Float = 0) 
 	{
 		super(X, Y, Std.int(Size));
-		//set defaults
+		// Set defaults
 		setMotion(0, 0, 0.5, 360, 100, 1.5);
 	}
 	
 	/**
 	 * Defines the motion range for this emitter.
-	 * @param	angle			Launch Direction.
-	 * @param	distance		Distance to travel.
-	 * @param	lifespan		Particle duration.
-	 * @param	angleRange		Random amount to add to the particle's direction.
-	 * @param	distanceRange	Random amount to add to the particle's distance.
-	 * @param	lifespanRange	Random amount to add to the particle's duration.
+	 * 
+	 * @param	Angle			Launch Direction.
+	 * @param	Distance		Distance to travel.
+	 * @param	Lifespan		Particle duration.
+	 * @param	AngleRange		Random amount to add to the particle's direction.
+	 * @param	DistanceRange	Random amount to add to the particle's distance.
+	 * @param	LifespanRange	Random amount to add to the particle's duration.
 	 */
-	public function setMotion(angle:Float, distance:Float, lifespan:Float, angleRange:Float = 0, distanceRange:Float = 0, lifespanRange:Float = 0):Void
+	public function setMotion(Angle:Float, Distance:Float, Lifespan:Float, AngleRange:Float = 0, DistanceRange:Float = 0, LifespanRange:Float = 0):Void
 	{
-		this.angle = angle * 0.017453293;
-		this.distance = distance;
-		this.life.min = lifespan;
-		this.life.max = lifespan + lifespanRange;
-		this.angleRange = angleRange * 0.017453293;
-		this.distanceRange = distanceRange;
+		angle = Angle * 0.017453293;
+		distance = Distance;
+		life.min = Lifespan;
+		life.max = Lifespan + LifespanRange;
+		angleRange = AngleRange * 0.017453293;
+		distanceRange = DistanceRange;
 	}
 	
 	/**
 	 * Defines the motion range for a specific particle.
-	 * @param   particle		The Particle to set the motion for
-	 * @param	angle			Launch Direction.
-	 * @param	distance		Distance to travel.
-	 * @param	lifespan		Particle duration.
-	 * @param	angleRange		Random amount to add to the particle's direction.
-	 * @param	distanceRange	Random amount to add to the particle's distance.
-	 * @param	lifespanRange	Random amount to add to the particle's duration.
+	 * 
+	 * @param   Particle		The Particle to set the motion for
+	 * @param	Angle			Launch Direction.
+	 * @param	Distance		Distance to travel.
+	 * @param	Lifespan		Particle duration.
+	 * @param	AngleRange		Random amount to add to the particle's direction.
+	 * @param	DistanceRange	Random amount to add to the particle's distance.
+	 * @param	LifespanRange	Random amount to add to the particle's duration.
 	 */
-	private function setParticleMotion(particle:FlxParticle, angle:Float, distance:Float, angleRange:Float = 0, distanceRange:Float = 0):Void
+	private function setParticleMotion(Particle:FlxParticle, Angle:Float, Distance:Float, AngleRange:Float = 0, DistanceRange:Float = 0):Void
 	{			
 		//set particle direction and speed
-		var a:Float = angle + FlxRandom.float() * angleRange;
-		var d:Float = distance + FlxRandom.float() * distanceRange;
+		var a:Float = Angle + FlxRandom.float() * AngleRange;
+		var d:Float = Distance + FlxRandom.float() * DistanceRange;
 		
-		particle.velocity.x = Math.cos(a) * d;
-		particle.velocity.y = Math.sin(a) * d;
+		Particle.velocity.x = Math.cos(a) * d;
+		Particle.velocity.y = Math.sin(a) * d;
 	}
 	
 	/**
 	 * Call this function to start emitting particles.
 	 * 
-	 * @param	Explode		Whether the particles should all burst out at once.
-	 * @param	Lifespan	Unused parameter due to class override. Use setMotion to set things like a particle's lifespan.
-	 * @param	Frequency	Ignored if Explode is set to true. Frequency is how often to emit a particle. 0 = never emit, 0.1 = 1 particle every 0.1 seconds, 5 = 1 particle every 5 seconds.
-	 * @param	Quantity	How many particles to launch. 0 = "all of the particles".
+	 * @param	Explode			Whether the particles should all burst out at once.
+	 * @param	Lifespan		Unused parameter due to class override. Use setMotion to set things like a particle's lifespan.
+	 * @param	Frequency		Ignored if Explode is set to true. Frequency is how often to emit a particle. 0 = never emit, 0.1 = 1 particle every 0.1 seconds, 5 = 1 particle every 5 seconds.
+	 * @param	Quantity		How many particles to launch. 0 = "all of the particles".
 	 * @param	LifespanRange	Max amount to add to the particle's lifespan. Leave it to default (zero), if you want to make particle "live" forever (plus you should set Lifespan parameter to zero too).
 	 */
 	override public function start(Explode:Bool = true, Lifespan:Float = 0, Frequency:Float = 0.1, Quantity:Int = 0, LifespanRange:Float = 0):Void
 	{
 		super.start(Explode, Lifespan, Frequency, Quantity, LifespanRange);
 
-		//Immediately execute the explosion code part from the update function, to prevent other explosions to override this one.
-		//This fixes the problem, that you can not add two particle explosions in the same frame.
+		// Immediately execute the explosion code part from the update function, to prevent other explosions to override this one.
+		// This fixes the problem that you can not add two particle explosions in the same frame.
 		if (Explode)
 		{
 			on = false;
 			var i:Int = 0;
 			var l:Int = _quantity;
+			
 			if ((l <= 0) || (l > members.length))
 			{
 				l = members.length;
 			}
+			
 			while (i < l)
 			{
 				emitParticle();
 				i++;
 			}
+			
 			_quantity = 0;
 		}
 	}
@@ -163,6 +165,7 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<FlxParticle>
 			particle.useFading = false;
 			particle.rangeAlpha = 0;
 		}
+		
 		// particle color settings
 		var startRedComp:Float = particle.startRed = startRed.min;
 		var startGreenComp:Float = particle.startGreen = startGreen.min;
@@ -205,11 +208,13 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<FlxParticle>
 		particle.rangeBlue = endBlueComp - startBlueComp;
 		
 		particle.useColoring = false;
+		
 		if (particle.rangeRed != 0 || particle.rangeGreen != 0 || particle.rangeBlue != 0)
 		{
 			particle.useColoring = true;
 		}
-		// end of particle color settings
+		
+		// End of particle color settings
 		if (startScale.min != startScale.max)
 		{
 			particle.startScale = startScale.min + FlxRandom.float() * (startScale.max - startScale.min);
@@ -221,6 +226,7 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<FlxParticle>
 		particle.scale.x = particle.scale.y = particle.startScale;
 		
 		var particleEndScale:Float = endScale.min;
+		
 		if (endScale.min != endScale.max)
 		{
 			particleEndScale = endScale.min + Std.int(FlxRandom.float() * (endScale.max - endScale.min));
@@ -239,7 +245,7 @@ class FlxTypedEmitterExt<T:FlxParticle> extends FlxTypedEmitter<FlxParticle>
 		
 		particle.blend = blend;
 		
-		//set particle motion
+		// Set particle motion
 		setParticleMotion(particle, angle, distance, angleRange, distanceRange);
 		particle.acceleration.make(acceleration.x, acceleration.y);
 		


### PR DESCRIPTION
 #395, #457

Seems like moving `StarSprite` into its own file caused issues for non-flash targets regarding the `Stardef` typedef, not really sure why.
