### PR TITLE
Preliminary support for flash player native cursor api.

### DIFF
--- a/flixel/system/FlxDebugger.hx
+++ b/flixel/system/FlxDebugger.hx
@@ -229,7 +229,7 @@ class FlxDebugger extends Sprite
 		hasMouse = true;
 		
 		#if !FLX_NO_MOUSE
-		Mouse.show();
+		FlxG.mouse.useSystemCursor = true;
 		#end
 	}
 	
@@ -242,8 +242,10 @@ class FlxDebugger extends Sprite
 		hasMouse = false;
 		
 		#if !FLX_NO_MOUSE
-		if (!FlxG.mouse.useSystemCursor && !FlxG.game.debugger.vcr.paused)
-			Mouse.hide();
+		#if !FLX_NO_DEBUG
+		if(FlxG.game.debugger != null && !FlxG.game.debugger.vcr.paused)
+		#end
+		FlxG.mouse.useSystemCursor = false;
 		#end
 	}
 	

--- a/flixel/system/input/FlxMouse.hx
+++ b/flixel/system/input/FlxMouse.hx
@@ -6,6 +6,10 @@ import flash.display.Sprite;
 import flash.events.MouseEvent;
 import flash.Lib;
 import flash.ui.Mouse;
+import flash.ui.MouseCursorData;
+import flash.ui.MouseCursor;
+import flash.geom.Point;
+import flash.Vector;
 import flixel.FlxCamera;
 import flixel.FlxG;
 import flixel.system.FlxAssets;
@@ -90,6 +94,16 @@ class FlxMouse extends FlxPoint implements IFlxInput
 	 * @default false
 	 */
 	public var useSystemCursor(default, set_useSystemCursor):Bool;
+
+	#if (flash && !FLX_NO_NATIVE_CURSOR)
+	/**
+	 * Names for the Native Flash 10.2 Cursors
+	 */
+	private var _cursorDefaultName:String = "defaultCursor";
+	private var _currentNativeCursor:String;
+	private var _previousNativeCursor:String;
+	#end
+
 
 	/**
 	 * Constructor.
@@ -359,8 +373,14 @@ class FlxMouse extends FlxPoint implements IFlxInput
 		_cursor.y = YOffset;
 		_cursor.scaleX = Scale;
 		_cursor.scaleY = Scale;
-		
+
+
+		#if (flash && !FLX_NO_NATIVE_CURSOR)
+		setSimpleNativeCursorData(_cursorDefaultName, _cursor.bitmapData);
+		#else
 		cursorContainer.addChild(_cursor);
+		#end
+
 	}
 
 	/**
@@ -382,6 +402,58 @@ class FlxMouse extends FlxPoint implements IFlxInput
 			}
 		}
 	}
+
+	#if (flash && !FLX_NO_NATIVE_CURSOR)
+	/**
+	 * Set a Native cursor that has been registered by Name
+	 * Warning, you need to use registerNativeCursor before you use it here
+	 * @param Name The name ID used when registered
+	 */
+	public function setNativeCursor(Name:String):Void
+	{
+		if(_currentNativeCursor != Name)
+		{
+			_previousNativeCursor = _currentNativeCursor;
+			_currentNativeCursor = Name;
+			Mouse.cursor = _currentNativeCursor;
+		}
+	}
+
+	/**
+	 * Shortcut to register a Native cursor for > Flash 10.2
+	 * @param  Name       The ID name used for the cursor
+	 * @param  CursorData MouseCursorData contains the bitmap, hotspot etc
+	 */
+	public function registerNativeCursor(Name:String, CursorData:MouseCursorData):Void
+	{
+		untyped Mouse.registerCursor(Name, CursorData);
+	}
+
+	/**
+	 * Shortcut to create and set a simple MouseCursorData
+	 * @param  Name       The ID name used for the cursor
+	 * @param  CursorData MouseCursorData contains the bitmap, hotspot etc
+	 */
+	public function setSimpleNativeCursorData(Name:String, CursorBitmap:BitmapData):MouseCursorData
+	{
+		var cursorVector = new Vector<BitmapData>();
+		cursorVector[0] = CursorBitmap;
+
+		if(_cursor.bitmapData.width > 32 ||_cursor.bitmapData.height > 32)
+			FlxG.log.warn ("Bitmap files used for the cursors should not exceed 32 × 32 pixels, due to an OS limitation.");
+
+		var cursorData = new MouseCursorData();
+		cursorData.hotSpot = new Point(0, 0);
+		cursorData.data = cursorVector;
+
+		registerNativeCursor( Name, cursorData );
+		setNativeCursor( Name );
+
+		Mouse.show();
+
+		return cursorData;
+	}
+	#end
 
 	/**
 	 * Called by the internal game loop to update the mouse pointer's position in the game world.
@@ -579,19 +651,17 @@ class FlxMouse extends FlxPoint implements IFlxInput
 		updateCursor();
 	}
 
+	/**
+	 * Called from the main Event.ACTIVATE is dispatched in FlxGame
+	 */
 	public function onFocus( ):Void
 	{
-		#if !FLX_NO_DEBUG
-		if (!FlxG.game.debuggerUp && !useSystemCursor)
-		#else
-		if (!useSystemCursor)
-		#end
-		{
-			Mouse.hide();
-		}
 		reset();
 	}
 
+	/**
+	 * Called from the main Event.DEACTIVATE is dispatched in FlxGame
+	 */
 	public function onFocusLost( ):Void
 	{
 		Mouse.show();
@@ -600,14 +670,44 @@ class FlxMouse extends FlxPoint implements IFlxInput
 	private function set_useSystemCursor(value:Bool):Bool
 	{
 		useSystemCursor = value;
+
 		if (!useSystemCursor)
 		{
-			Mouse.hide();
-		} 
-		else 
+			hideSystemCursor();
+		}
+		else
 		{
-			Mouse.show();
+			showSystemCursor();
 		}
 		return value;
+	}
+
+	/**
+	 * Show the default system cursor, if Flash 10.2 return to AUTO
+	 */
+	private function showSystemCursor():Void
+	{
+		#if (flash && !FLX_NO_NATIVE_CURSOR)
+		setNativeCursor(MouseCursor.AUTO);
+		#else
+		Mouse.show();
+		cursorContainer.visible = false;
+		#end
+	}
+
+	/**
+	 * Hide the system cursor, if Flash 10.2 return to default
+	 */
+	private function hideSystemCursor():Void
+	{
+		#if (flash && !FLX_NO_NATIVE_CURSOR)
+		if(Mouse.supportsCursor && _previousNativeCursor != null)
+		{
+			setNativeCursor(_previousNativeCursor);
+		}
+		#else
+		Mouse.hide();
+		cursorContainer.visible = true;
+		#end
 	}
 }


### PR DESCRIPTION
Relates to https://github.com/HaxeFlixel/flixel/issues/497

If more targets supported a Native cursor api I would suggest we use FLX_NATIVE_CURSOR or something, but for now I think #if flash10_2 should be used.
