### PR TITLE
Function transformed sprites twice in row. Removed the first transform.

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -90,14 +90,6 @@ class FlxSpriteGroup extends FlxTypedGroup<FlxSprite>
 	 */
 	public function setPosition(X:Float, Y:Float):Void
 	{
-		var xOffset:Float = X - x;
-		var yOffset:Float = Y - y;
-		
-		var valueArr:Array<Dynamic> = [xOffset, yOffset];
-		var lambdaArr:Array < FlxSprite-> Dynamic->Void > = [xTransform, yTransform];
-		
-		multiTransformChildren(lambdaArr, valueArr);
-		
 		x = X;
 		y = Y;
 	}


### PR DESCRIPTION
SetPosition function would always transform sprites twice: first within the setPosition function itself, second within the x and y setter functions.
