### PR TITLE
Fixes a missing class error I was getting after recent updates.

### DIFF
--- a/flixel/plugin/TimerManager.hx
+++ b/flixel/plugin/TimerManager.hx
@@ -4,6 +4,7 @@ import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.util.FlxArrayUtil;
 import flixel.util.FlxTimer;
+import flixel.util.FlxPool;
 
 /**
  * A simple manager for tracking and updating game timer objects.


### PR DESCRIPTION
/usr/lib/haxe/lib/flixel/git/flixel/plugin/TimerManager.hx:16: characters 9-37 : Class not found : FlxPool
