### PR TITLE
Override FlxSpriteGroup.add() method to transform sprites relative to group's coordinates, closes #553

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -201,4 +201,23 @@ class FlxSpriteGroup extends FlxTypedGroup<FlxSprite>
 	{
 		Sprite.alpha = NewAlpha;
 	}
+	
+	/**
+	 * Adds a new <code>FlxBasic</code> subclass (FlxBasic, FlxSprite, Enemy, etc) to the group.
+	 * FlxGroup will try to replace a null member of the array first.
+	 * Object is translated to coordinates relative to group.
+	 * Failing that, FlxGroup will add it to the end of the member array,
+	 * assuming there is room for it, and doubling the size of the array if necessary.
+	 * WARNING: If the group has a maxSize that has already been met,
+	 * the object will NOT be added to the group!
+	 * 
+	 * @param	Object		The object you want to add to the group.
+	 * @return	The same <code>FlxBasic</code> object that was passed in.
+	 */
+	override public function add(Object:FlxSprite):FlxSprite
+	{
+		xTransform(Object, this.x);
+		yTransform(Object, this.y);
+		return super.add(Object);
+	}
 }


### PR DESCRIPTION
Suggested change: when sprites are added to group, they are transformed relative to the position of the group. So a sprite at coordinates (0,0) would spawn at the group's x and y coords, etc.
