### PR TITLE
Suggested addition to FlxTilemap - getTileCollisions - closes #559

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -826,7 +826,6 @@ class FlxTilemap extends FlxObject
 		return data;
 	}
 	
-	
 	/**
 	 * Set the dirty flag on all the tilemap buffers.
 	 * Basically forces a reset of the drawn tilemaps, even if it wasn'tile necessary.


### PR DESCRIPTION
I started an issue on this over at https://github.com/HaxeFlixel/flixel/issues/559, so I submit this for consideration. Right now there is no way of accessing the <code>allowCollisions</code> value for tiles outside the class. This is something I use extensively - for recognizing ledges the player can grab on to, creating drop-down floors and calculating simplified collision detection for NPC characters - and I just find it silly that this data is tucked away under a private member.

So in order to save other people the head-ache, please consider adding this little function that gives read-only access to tile collisions. It would also make any implementation using this data cleaner and easier to maintain, as you no longer need to resort to hacky solutions to access it.
