### PR TITLE
Check FlxGame.soundTray before use

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -349,7 +349,7 @@ class FlxGame extends Sprite
 		_total = ticks;
 		
 		#if !FLX_NO_SOUND_TRAY
-		if (soundTray.active)
+		if (soundTray != null && soundTray.active)
 		{
 			soundTray.update(elapsedMS);
 		}

--- a/flixel/system/input/keyboard/FlxKeyboard.hx
+++ b/flixel/system/input/keyboard/FlxKeyboard.hx
@@ -240,7 +240,10 @@ class FlxKeyboard extends FlxInputStates implements IFlxInput
 			}
 			
 			#if !FLX_NO_SOUND_TRAY
-			FlxG.game.soundTray.show();
+			if(FlxG.game.soundTray != null)
+			{
+				FlxG.game.soundTray.show();
+			}
 			#end
 		}
 		// Volume down
@@ -250,7 +253,10 @@ class FlxKeyboard extends FlxInputStates implements IFlxInput
 			FlxG.sound.volume -= 0.1;
 			
 			#if !FLX_NO_SOUND_TRAY
-			FlxG.game.soundTray.show();
+			if(FlxG.game.soundTray != null)
+			{
+				FlxG.game.soundTray.show();
+			}
 			#end
 		}
 		// Volume up
@@ -260,7 +266,10 @@ class FlxKeyboard extends FlxInputStates implements IFlxInput
 			FlxG.sound.volume += 0.1;
 			
 			#if !FLX_NO_SOUND_TRAY
-			FlxG.game.soundTray.show();
+			if(FlxG.game.soundTray != null)
+			{
+				FlxG.game.soundTray.show();
+			}
 			#end
 		}
 		


### PR DESCRIPTION
Fixes null pointer error on mobile platforms (tested on android)
