### PR TITLE
Fix LinearMotion tween

### DIFF
--- a/flixel/plugin/TweenManager.hx
+++ b/flixel/plugin/TweenManager.hx
@@ -29,6 +29,10 @@ class TweenManager extends FlxPlugin
 			if (tween.active)
 			{
 				tween.update();
+				if(tween.finished)
+				{
+					tween.finish();
+				}
 			}
 		}
 	}

--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -473,7 +473,7 @@ class FlxTween
 				_t = 0;
 			}
 			
-			finish();
+			finished = true;
 		}
 	}
 
@@ -502,7 +502,7 @@ class FlxTween
 	}
 
 	/** @private Called when the Tween completes. */
-	private function finish():Void
+	public function finish():Void
 	{
 		executions++;
 		
@@ -533,6 +533,8 @@ class FlxTween
 				active = false;
 				manager.remove(this, true);
 		}
+
+		finished = false;
 	}
 
 	public var percent(get_percent, set_percent):Float;
@@ -541,6 +543,8 @@ class FlxTween
 
 	public var scale(get_scale, null):Float;
 	private function get_scale():Float { return _t; }
+
+	public var finished(default, null):Bool;
 
 	private var _type:Int;
 	private var _ease:EaseFunction;

--- a/flixel/tweens/motion/LinearMotion.hx
+++ b/flixel/tweens/motion/LinearMotion.hx
@@ -58,7 +58,14 @@ class LinearMotion extends Motion
 		super.update();
 		x = _fromX + _moveX * _t;
 		y = _fromY + _moveY * _t;
-		if (x == _fromX + _moveX && y == _fromY + _moveY && active) finish();
+		if (x == _fromX + _moveX && y == _fromY + _moveY && active)
+		{
+			finished = true;
+		}
+		if(finished)
+		{
+			postUpdate();
+		}
 	}
 
 	/**


### PR DESCRIPTION
What problem is
- we tween object with linear motion during x seconds
- when x seconds elapsed FlxTween decide that tween should be finished and finish it
- if LinearMotion tween finished it removed from TweenManager
- if tween removed from manager it (tween) destroyed
- if LinearMotion tween is destroyed his _object set to null
- Motion tween update calls postUpdate after FlxTween.update
- postUpdate check _object and if it is not null set object to new position
- and problem is this - after finish _object is null and object to set to last position

I create a test - https://github.com/sergey-miryanov/LinearMotionTween
