### PR TITLE
revert of commit f2d936c58b9788db060cab6bd1aecc26df96f4a4, FlxG.antialia...

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -496,6 +496,7 @@ class FlxCamera extends FlxBasic
 		
 		alpha = 1.0;
 		angle = 0.0;
+		antialiasing = FlxG.antialiasByDefault;
 	}
 	
 	/**
@@ -1045,7 +1046,9 @@ class FlxCamera extends FlxBasic
 	 * Whether the camera display is smooth and filtered, or chunky and pixelated.
 	 * Default behavior is chunky-style.
 	 */
-	public var antialiasing(default, set):Bool = false;
+
+	public var antialiasing(default, set_antialiasing):Bool;
+
 	
 	private function set_antialiasing(Antialiasing:Bool):Bool
 	{

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -82,6 +82,11 @@ class FlxG
 	 */
 	static public var fixedTimestep:Bool = true;
 	/**
+	 * Applies smoothing to rotated / scaled sprites by default. Set this to true for smooth high resolution games, leave it off for pixelated games.
+	 * Setting this to true will slow down rendering on the Flash target (native targets are hardware accellerated, so this isn't much of a problem).
+	 */
+	static public var antialiasByDefault:Bool;
+	/**
 	 * Represents the amount of time in seconds that passed since last frame.
 	 */
 	static public var elapsed:Float = 0;

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -118,7 +118,7 @@ class FlxSprite extends FlxObject implements IFlxSprite
 	 * Controls whether the object is smoothed when rotated, affects performance.
 	 * @default false
 	 */
-	public var antialiasing:Bool = false;
+	public var antialiasing:Bool;
 	
 	public var colorTransform(get_colorTransform, never):ColorTransform;
 	
@@ -208,10 +208,13 @@ class FlxSprite extends FlxObject implements IFlxSprite
 		_flashPointZero = new Point();
 		offset = new FlxPoint();
 		origin = new FlxPoint();
+
 		scale = new FlxPoint(1, 1);
 		
 		facing = FlxObject.RIGHT;
 		
+		antialiasing = FlxG.antialiasByDefault;
+
 		_matrix = new Matrix();
 		
 		if (SimpleGraphic == null)


### PR DESCRIPTION
FlxG.antialiasByDefault does modify the default antialiasing value on FlxSprite, camera.antialiasing does not
image to clarify: http://i.imgur.com/hKiaqT0.png
Even though the camera should be antialiased, the image is not
