### PR TITLE
Borders for FlxText

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -170,7 +170,8 @@ class FlxText extends FlxSprite
 		_format.align = convertTextAlignmentFromString(Alignment);
 		_textField.defaultTextFormat = _format;
 		updateFormat(_format);
-		setBorderStyle(BorderStyle, BorderColor);
+		borderStyle = BorderStyle;
+		borderColor = BorderColor;
 		_regen = true;
 		
 		return this;


### PR DESCRIPTION
This upgrades FlxText's "shadow" parameter to a full-fledged border style. 

There's three new parameters:
- borderStyle:Int 
- borderColor:Int
- borderSize:Float

borderStyle can be any one of four constants - FlxText.NONE, SHADOW, OUTLINE, or OUTLINE_FAST

For all border styles, borderColor is the color and borderSize is the offset distance

If NONE, no border is drawn.
If SHADOW, it draws the regular shadow, using 1 offset (SE)
If OUTLINE, it draws an outline, using 8 offsets (NW,N,NE,E,SE,S,SW,W), 
If OUTLINE_FAST, it draws an outline, using 4 offsets(NW,NE,SE,SW)

There's also a handy single function to set all three properties:
setBorderStyle(style,color,size);

Setting any one property or using setBorderStyle() will dirty the text and force it to update. The result is cached, so there shouldn't be much performance overhead unless the text is constantly being changed. 

OUTLINE_FAST uses half as many offsets as OUTLINE, and will usually get the same results, except for very narrow fonts (such as 1-pixel wide fonts), then there will be artifacts and OUTLINE is recommended instead. 

OUTLINE might have some minor artifacts with certain fonts and letters, notably the letter "x"

In general, OUTLINE should work for most purposes and is much more efficient than using a filter.

This change would deprecate the shadow and outline properties. I haven't removed them just yet, but I have updated the setFormat() function to use the border properties rather than shadow.
