### PR TITLE
Update Motion.hx, closes #632

### DIFF
--- a/flixel/tweens/motion/Motion.hx
+++ b/flixel/tweens/motion/Motion.hx
@@ -5,7 +5,7 @@ import flixel.tweens.FlxTween;
 import flixel.tweens.FlxEase;
 
 typedef Movable = {
-	public var immovable:Bool;
+	public var immovable(default, set):Bool;
 	public function setPosition(X:Float, Y:Float):Void;
 }
 


### PR DESCRIPTION
Errors with recent build. Needed to have set/get fields set in the typedef.
