### PR TITLE
Fixes issues #619 and #620

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -222,7 +222,12 @@ class FlxText extends FlxSprite
 		updateFormat(_format);
 		borderStyle = BorderStyle;
 		borderColor = BorderColor;
+		
+		#if flash
 		_regen = true;
+		#else
+		calcFrame(true);
+		#end
 		
 		return this;
 	}


### PR DESCRIPTION
Call calcFrame() when setFormat() on non-flash targets.
