### PR TITLE
run travis-ci on the automatic clone instead of git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - haxelib git flixel-demos https://github.com/HaxeFlixel/flixel-demos
   - haxelib git flixel-tools https://github.com/HaxeFlixel/flixel-tools
   - haxelib git flixel-ui https://github.com/HaxeFlixel/flixel-ui dev
-  - haxelib git flixel https://github.com/HaxeFlixel/flixel
+  - haxelib dev flixel .
 
 script:
   - haxelib run flixel-tools testdemos


### PR DESCRIPTION
This should allow pull requests to verify otherwise travis-ci wont see the changes.
