### PR TITLE
Force class on FlxTypedGroup.recycle()

### DIFF
--- a/flixel/group/FlxTypedGroup.hx
+++ b/flixel/group/FlxTypedGroup.hx
@@ -254,9 +254,10 @@ class FlxTypedGroup<T:IFlxBasic> extends FlxBasic
 	 * 
 	 * @param	ObjectClass		The class type you want to recycle (e.g. FlxSprite, EvilRobot, etc). Do NOT "new" the class in the parameter!
 	 * @param 	ContructorArgs  An array of arguments passed into a newly object if there aren't any dead members to recycle. 
+	 * @param 	Force           Force the object to be an ObjectClass and not a super class of ObjectClass. 
 	 * @return	A reference to the object that was created.  Don't forget to cast it back to the Class you want (e.g. myObject = myGroup.recycle(myObjectClass) as myObjectClass;).
 	 */
-	public function recycle(ObjectClass:Class<T> = null, ContructorArgs:Array<Dynamic> = null):T
+	public function recycle(ObjectClass:Class<T> = null, ContructorArgs:Array<Dynamic> = null, Force:Bool = false):T
 	{
 		if (ContructorArgs == null)
 		{
@@ -290,7 +291,7 @@ class FlxTypedGroup<T:IFlxBasic> extends FlxBasic
 		}
 		else
 		{
-			basic = getFirstAvailable(ObjectClass);
+			basic = getFirstAvailable(ObjectClass, Force);
 			
 			if (basic != null)
 			{
@@ -439,9 +440,10 @@ class FlxTypedGroup<T:IFlxBasic> extends FlxBasic
 	 * This is handy for recycling in general, e.g. respawning enemies.
 	 * 
 	 * @param	ObjectClass		An optional parameter that lets you narrow the results to instances of this particular class.
+	 * @param 	Force           Force the object to be an ObjectClass and not a super class of ObjectClass. 
 	 * @return	A <code>FlxBasic</code> currently flagged as not existing.
 	 */
-	public function getFirstAvailable(ObjectClass:Class<T> = null):T
+	public function getFirstAvailable(ObjectClass:Class<T> = null, Force:Bool = false):T
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
@@ -452,6 +454,10 @@ class FlxTypedGroup<T:IFlxBasic> extends FlxBasic
 			
 			if ((basic != null) && !basic.exists && ((ObjectClass == null) || Std.is(basic, ObjectClass)))
 			{
+				if (Force && Type.getClassName(Type.getClass(basic)) != Type.getClassName(ObjectClass)) 
+				{
+					continue;
+				}
 				return _members[i - 1];
 			}
 		}


### PR DESCRIPTION
I was having problems with FlxTypedGroup.recycle(). The object returned was a super class of the class passed to the function because `Std.is(object, Class)` will return `true` if `object` is `Class` or `Class` is a super class of the `object` class.
For example, before this commit:

``` haxe
class Note extends FlxSprite { ... }
class LongNote extends Note { ... }

class PlayState extends FlxState {
    override public function create():Void {
        var group:FlxTypedGroup<FlxSprite> = new FlxTypedGroup<FlxSprite>();
        // Add a LongNote and Note objects
        group.add(new LongNote());
        group.add(new Note());

        for (n in group.members) {
            n.exists = false;       // Set exists to false so we can recycle them
        }

        var note:Note = cast(group.recycle(Note), Note);    // Should return a Note object
                                                            // but, because the first object 
                                                            // available is a LongNote and
                                                            // its super class is Note, it
        trace(Type.getClassName(Type.getClass(note)));      // will return that LongNote object

        var long:Note = cast(group.recycle(LongNote), LongNote);    // Should return a LongNote object
                                                                    // but, because there are no more
                                                                    // LongNote objects to return, it
        trace(Type.getClassName(Type.getClass(long)));              // will return a new LongNote object

        super.create();
    }
...
}
```

With this commit:

``` haxe
class Note extends FlxSprite { ... }
class LongNote extends Note { ... }

class PlayState extends FlxState {
    override public function create():Void {
        var group:FlxTypedGroup<FlxSprite> = new FlxTypedGroup<FlxSprite>();
        // Add a LongNote and Note objects
        group.add(new LongNote());
        group.add(new Note());

        for (n in group.members) {
            n.exists = false;       // Set exists to false so we can recycle them
        }

        var note:Note = cast(group.recycle(Note, null, true), Note);
                                                            // Should return a Note object.
                                                            // The first object available is
                                                            // a LongNote but we are forcing it
                                                            // to be a Note object. It will return 
        trace(Type.getClassName(Type.getClass(note)));      // the old Note object

        var long:Note = cast(group.recycle(LongNote, null, true), LongNote);    
                                                            // Should return a LongNote object
                                                            // Because the first object available
                                                            // is a LongNote it will return 
        trace(Type.getClassName(Type.getClass(long)));      // will return that Longnote object

        super.create();
    }
...
}
```

I'm not sure if this is the best way to do it because `Type.getClass(basic) == ObjectClass` will throw the following error:
`Class<flixel.group.FlxTypedGroup.T> should be Class<flixel.FlxBasic>`
