### PR TITLE
Revert sprite properties when removed from a sprite group

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -297,9 +297,9 @@ class FlxSpriteGroup extends FlxSprite
 	 */
 	public function remove(Object:FlxSprite, Splice:Bool = false):FlxSprite
 	{
-		Sprite.x -= x;
-		Sprite.y -= y;
-		Sprite.alpha /= alpha;
+		Object.x -= x;
+		Object.y -= y;
+		Object.alpha /= alpha;
 		return group.remove(Object, Splice);
 	}
 	


### PR DESCRIPTION
Otherwise it will cause problems when sprites are added and removed repeatedly.
