### PR TITLE
Update FlxPreloader.hx

### DIFF
--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -283,8 +283,17 @@ class FlxPreloader extends NMEPreloader
 	
 	override public function onUpdate(bytesLoaded:Int, bytesTotal:Int):Void 
 	{
-		_percent = (bytesTotal != 0) ? bytesLoaded / bytesTotal : 0;
-	}
+		//in case there is a problem with reading the bytesTotal (like on Chrome, or a Gzipped swf)
+		if (root.loaderInfo.bytesTotal == 0) 
+    		{
+        	 //Set Any value (650000>x>0) in bytesTotal to avoid "stucking" the preloader. 
+        	 //Attention! try to find the actual size of your file for better accuracy on Chrome.
+        	 var bytesTotal:Int = 50000; 
+        	 _percent = (bytesTotal != 0) ? bytesLoaded / bytesTotal : 0;
+    		}
+		else //Continue regulary
+         	_percent = (bytesTotal != 0) ? bytesLoaded / bytesTotal : 0;
+		}
 	
 	private function onEnterFrame(event:Event):Void
 	{


### PR DESCRIPTION
Fixes the Preloader_gets_stuck_on_Chrome. No reason for disabling it anymore.
