### PR TITLE
Fix debugger init with cropping camera.

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -236,7 +236,7 @@ class FlxGame extends Sprite
 		
 		// Creating the debugger overlay
 		#if !FLX_NO_DEBUG
-		debugger = new FlxDebugger(FlxG.width * FlxCamera.defaultZoom, FlxG.height * FlxCamera.defaultZoom);
+		debugger = new FlxDebugger(Lib.current.stage.stageWidth, Lib.current.stage.stageHeight);
 		addChild(debugger);
 		#end
 		


### PR DESCRIPTION
When the camera does not cover the entire game world, the debugger is
initialized with incorrect bounds, so you end up not seeing the debugger
windows. If you resize the window, it's corrected, since FlxDebugger.onResize()
is passed the window dimensions and then corrects it.

This initializes it correctly by just passing the stageWidth / stageHeight.
