### PR TITLE
Added option to pixel-perfect collision check in MouseEventManager

### DIFF
--- a/flixel/plugin/MouseEventManager.hx
+++ b/flixel/plugin/MouseEventManager.hx
@@ -75,6 +75,7 @@ class MouseEventManager extends FlxPlugin
 	* @param 	OnMouseOut 		Callback when mouse moves out of this sprite. Must have Sprite as argument - e.g. onMouseDown(sprite:FlxSprite).
 	* @param 	MouseChildren 	If mouseChildren is enabled, other sprites overlaped by this will still receive mouse events.
 	* @param 	MouseEnabled 	If mouseEnabled this sprite will receive mouse events.
+	* @param	PixelPerfect	If enabled the collision check will be pixel-perfect.
 	*/
 	static public function addSprite(Sprite:FlxSprite, ?OnMouseDown:FlxSprite->Void, ?OnMouseUp:FlxSprite->Void, ?OnMouseOver:FlxSprite->Void, ?OnMouseOut:FlxSprite->Void, MouseChildren = false, MouseEnabled = true, PixelPerfect = true)
 	{


### PR DESCRIPTION
Added parameter `PixelPerfect = true` to `addSprite()`.

Removed the following inconsistent behavior between flash & non-flash targets.

``` haxe
#if flash
if (Sprite.pixelsOverlapPoint(_point, 0x0, camera))
#else
if (Sprite.pixelsOverlapPoint(_point, 0x01, camera))
#end
```

now becomes `if (!PixelPerfect || Sprite.pixelsOverlapPoint(_point, 0x01, camera))`
