### PR TITLE
dont use the same inthelper twice in the same function

### DIFF
--- a/flixel/util/FlxRandom.hx
+++ b/flixel/util/FlxRandom.hx
@@ -52,6 +52,7 @@ class FlxRandom
 	 */
 	static private var _intHelper:Int = 0;
 	static private var _intHelper2:Int = 0;
+	static private var _intHelper3:Int = 0;
 	static private var _floatHelper:Float = 0;
 	static private var _arrayFloatHelper:Array<Float> = null;
 	static private var _red:Int = 0;
@@ -278,11 +279,11 @@ class FlxRandom
 		
 		for ( i in 0...HowManyTimes )
 		{
-			_intHelper = intRanged( 0, Objects.length - 1 );
 			_intHelper2 = intRanged( 0, Objects.length - 1 );
-			tempObject = Objects[_intHelper];
-			Objects[_intHelper] = Objects[_intHelper2];
-			Objects[_intHelper2] = tempObject;
+			_intHelper3 = intRanged( 0, Objects.length - 1 );
+			tempObject = Objects[_intHelper2];
+			Objects[_intHelper2] = Objects[_intHelper3];
+			Objects[_intHelper3] = tempObject;
 		}
 		
 		return Objects;


### PR DESCRIPTION
Closes issue #790, previously the same intHelper was being used to both store an array position in shuffleArray and also to generate a random array position in shuffleArray. This has been fixed by adding a third intHelper.
