### PR TITLE
FlxTrailArea fixes, closes #832

### DIFF
--- a/flixel/effects/FlxTrailArea.hx
+++ b/flixel/effects/FlxTrailArea.hx
@@ -181,7 +181,8 @@ class FlxTrailArea extends FlxSprite
 				{
 					if (simpleRender) 
 					{
-						framePixels.copyPixels(member.framePixels, new Rectangle(0, 0, member.frameWidth, member.frameHeight), 
+						framePixels.copyPixels(member.getFlxFrameBitmapData(), 
+												new Rectangle(0, 0, member.frameWidth, member.frameHeight), 
 												new Point(member.x - x, member.y - y), null, null, true);
 					}
 					else 
@@ -203,7 +204,7 @@ class FlxTrailArea extends FlxSprite
 							_matrix.translate((member.origin.x), (member.origin.y));
 						}
 						_matrix.translate(member.x - x, member.y - y);
-						framePixels.draw(member.framePixels, _matrix, member.colorTransform, blendMode, null, antialiasing);
+						framePixels.draw(member.getFlxFrameBitmapData(), _matrix, member.colorTransform, blendMode, null, antialiasing);
 					}
 					
 				}


### PR DESCRIPTION
Hi there folks, I've made some changes to FlxTrailArea to fix the problems related in issue https://github.com/HaxeFlixel/flixel/issues/832 
I'm not sure if there are the correct changes, need a haxeflixel guru review them :)
Changes made:
- Don't rotate or scale the sprite if the original one isn't scaled or rotated.
- Use the origin of the sprite and not the middle for rotate and scale calculations.
-  Fix Neko/cpp crashes by getting the FlxFrame BitmapData.
