### PR TITLE
Non flash targets bakedrotation fix

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -829,7 +829,7 @@ class FlxSprite extends FlxObject
 			
 			if (!isSimpleRender)
 			{
-				if (_angleChanged)
+				if (_angleChanged && (bakedRotation <= 0))
 				{
 					var radians:Float = -angle * FlxAngle.TO_RAD;
 					_sinAngle = Math.sin(radians);


### PR DESCRIPTION
If a FlxSprite has a baked rotation, don't rotate and use the spritesheet created. Fix for non flash targets.
