### PR TITLE
Added ability to manually get / set _transform.pan

### DIFF
--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -68,11 +68,11 @@ class FlxSound extends FlxBasic
 	 */
 	public var pan(get, set):Float;
 
-	private function get_pan():Float
+	private inline function get_pan():Float
 	{
 		return _transform.pan;
 	}
-	private function set_pan(pan:Float):Float
+	private inline function set_pan(pan:Float):Float
 	{
 		return _transform.pan = pan;
 	}


### PR DESCRIPTION
I use this as a cheaper alternative to "proximity" which only seems worth using for looped sounds. I set the volume and pan of the sound based on distance from center of camera and then just play the sound, no overheads after the initial calculations.
