### PR TITLE
FlxSubState API cleanup

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -662,7 +662,7 @@ class FlxGame extends Sprite
 		#end
 		FlxG.plugins.update();
 		
-		state.tryUpdate(); // Update the current state
+		state.tryUpdate();
 		
 		FlxG.cameras.update();
 		

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -30,7 +30,7 @@ class FlxState extends FlxGroup
 	/**
 	 * Current substate. Substates also can be nested.
 	 */
-	public var subState(default, null):FlxSubState;
+	public var subState(default, set):FlxSubState;
 	
 	/**
 	 * If a state change was requested, the new state object is stored here until we switch to it.
@@ -46,7 +46,7 @@ class FlxState extends FlxGroup
 	 * This function is called after the game engine successfully switches states. Override this function, NOT the constructor, to initialize or set up your game state.
 	 * We do NOT recommend overriding the constructor, unless you want some crazy unpredictable things to happen!
 	 */
-	public function create():Void { }
+	public function create():Void {}
 
 	override public function draw():Void
 	{
@@ -75,22 +75,13 @@ class FlxState extends FlxGroup
 		}
 	}
 	#end
-
-	/**
-	 * Manually close the sub-state
-	 */
-	public inline function setSubState(subState:FlxSubState):Void
-	{
-		_requestedSubState = subState;
-		_requestSubStateReset = true;
-	}
 	
 	/**
-	 * Manually close the sub-state
+	 * Closes the current substate.
 	 */
 	public inline function closeSubState():Void
 	{
-		setSubState(null);
+		set_subState(null);
 	}
 
 	/**
@@ -99,7 +90,7 @@ class FlxState extends FlxGroup
 	public function resetSubState():Void
 	{
 		// Close the old state (if there is an old state)
-		if(subState != null)
+		if (subState != null)
 		{
 			if (subState.closeCallback != null)
 			{
@@ -116,18 +107,15 @@ class FlxState extends FlxGroup
 		
 		if (subState != null)
 		{
-			// I'm just copying the code from "FlxGame::switchState" which doesn't check for already craeted states. :/
-			subState._parentState = this;
-			
 			//Reset the input so things like "justPressed" won't interfere
 			if (!persistentUpdate)
 			{
 				FlxG.inputs.reset();
 			}
 			
-			if (!subState.initialized)
+			if (!subState._initialized)
 			{
-				subState.initialize();
+				subState._initialized = true;
  				subState.create();
 			}
 		}
@@ -190,5 +178,11 @@ class FlxState extends FlxGroup
 	private function set_bgColor(Value:Int):Int
 	{
 		return FlxG.cameras.bgColor = Value;
+	}
+	
+	private function set_subState(SubState:FlxSubState):FlxSubState
+	{
+		_requestSubStateReset = true;
+		return _requestedSubState = subState;
 	}
 }

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -10,10 +10,6 @@ import flixel.util.FlxColor;
 class FlxSubState extends FlxState
 {
 	/**
-	 * Internal helper
-	 */
-	public var _parentState:FlxState;
-	/**
 	 * Callback method for state close event
 	 */
 	public var closeCallback:Void->Void;
@@ -25,32 +21,16 @@ class FlxSubState extends FlxState
 	private var _bgSprite:FlxBGSprite;
 	#end
 	
-	/**
-	 * Internal helper for substates which can be reused
-	 */
-	private var _initialized:Bool = false;
-	
 	private var _bgColor:Int;
 	
-	public var initialized(get, null):Bool;
-	
-	private inline function get_initialized():Bool
-	{ 
-		return _initialized; 
-	}
+	/**
+	 * Helper var for the parent state to determine whether to call create() or not. 
+	 */  
+	@:allow(flixel.FlxState)
+	private var _initialized:Bool = false;
 	
 	/**
-	 * Internal helper method
-	 */
-	public inline function initialize():Void
-	{ 
-		_initialized = true; 
-	}
-	
-	/**
-	 * Substate constructor
 	 * @param	BGColor		background color for this substate
-	 * @param	UseMouse	whether to show mouse pointer or not
 	 */
 	public function new(BGColor:Int = FlxColor.TRANSPARENT)
 	{
@@ -61,6 +41,36 @@ class FlxSubState extends FlxState
 		_bgSprite = new FlxBGSprite();
 		#end
 		bgColor = BGColor;
+	}
+	
+	override public function draw():Void
+	{
+		//Draw background
+		#if flash
+		if (cameras == null) 
+		{ 
+			cameras = FlxG.cameras.list; 
+		}
+		
+		for (camera in cameras)
+		{
+			camera.fill(bgColor);
+		}
+		#else
+		_bgSprite.draw();
+		#end
+		
+		//Now draw all children
+		super.draw();
+	}
+	
+	override public function destroy():Void 
+	{
+		super.destroy();
+		closeCallback = null;
+		#if !flash
+		_bgSprite = null;
+		#end
 	}
 	
 	override private inline function get_bgColor():Int
@@ -78,52 +88,5 @@ class FlxSubState extends FlxState
 		#end
 		
 		return _bgColor = Value;
-	}
-	
-	override public function draw():Void
-	{
-		//Draw background
-		#if flash
-		if(cameras == null) { cameras = FlxG.cameras.list; }
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		while (i < l)
-		{
-			var camera:FlxCamera = cameras[i++];
-			camera.fill(this.bgColor);
-		}
-		#else
-		_bgSprite.draw();
-		#end
-		
-		//Now draw all children
-		super.draw();
-	}
-	
-	/**
-	 * Use this method to close this substate
-	 * @param	destroy	whether to destroy this state or leave it in memory
-	 */
-	public function close():Void
-	{
-		if (_parentState != null) 
-		{ 
-			_parentState.closeSubState(); 
-		}
-		#if !FLX_NO_DEBUG
-		else 
-		{ 
-			// Missing parent from this state! Do something!!
-			throw "This subState haven't any parent state";
-		}
-		#end
-	}
-	
-	override public function destroy():Void 
-	{
-		super.destroy();
-		_initialized = false;
-		_parentState = null;
-		closeCallback = null;
 	}
 }


### PR DESCRIPTION
- made FlxState.subState (default, set) and removed setSubState()
- removed initialize() and make initialized private
- removed unnecessary subState._parentState
- removed FlxSubState.close(), FlxState already has a closeSubState() method
