### PR TITLE
Abstract default cameras into FlxCamera.defaultCameras for customizability

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -17,10 +17,10 @@ class FlxBasic implements IFlxDestroyable
 	 */
 	public var ID:Int = -1;
 	/**
-	 * This determines on which FlxCameras this object will be drawn - by default, 
-	 * it uses FlxG.cameras.list), which means it is drawn on all existing cameras.
+	 * This determines on which FlxCameras this object will be drawn. If it is null / has not been
+	 * set, it uses FlxCamera.defaultCameras, which is a reference to FlxG.cameras.list (all cameras) by default.
 	 */
-	public var cameras:Array<FlxCamera>;
+	public var cameras(get, set):Array<FlxCamera>;
 	/**
 	 * Controls whether update() is automatically called by FlxState/FlxGroup.
 	 */
@@ -58,6 +58,8 @@ class FlxBasic implements IFlxDestroyable
 	public static var _VISIBLECOUNT:Int = 0;
 	#end
 	
+	private var _cameras:Array<FlxCamera>;
+	
 	public function new() 
 	{ 
 		collisionType = FlxCollisionType.NONE;
@@ -71,6 +73,7 @@ class FlxBasic implements IFlxDestroyable
 	{
 		exists = false;
 		collisionType = null;
+		_cameras = null;
 	}
 	
 	/**
@@ -111,11 +114,6 @@ class FlxBasic implements IFlxDestroyable
 	public function draw():Void
 	{
 		#if !FLX_NO_DEBUG
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		
 		for (camera in cameras)
 		{
 			_VISIBLECOUNT++;
@@ -128,15 +126,9 @@ class FlxBasic implements IFlxDestroyable
 	{
 		if (!ignoreDrawDebug)
 		{
-			var i:Int = 0;
-			if (cameras == null)
+			for (camera in cameras)
 			{
-				cameras = FlxG.cameras.list;
-			}
-			var l:Int = cameras.length;
-			while (i < l)
-			{
-				drawDebugOnCamera(cameras[i++]);
+				drawDebugOnCamera(camera);
 			}
 		}
 	}
@@ -146,8 +138,18 @@ class FlxBasic implements IFlxDestroyable
 	 * specified camera while the debugger's visual mode is toggled on.
 	 * @param	Camera	Which camera to draw the debug visuals to.
 	 */
-	public function drawDebugOnCamera(?Camera:FlxCamera):Void { }
+	public function drawDebugOnCamera(?Camera:FlxCamera):Void {}
 	#end
+	
+	private inline function get_cameras():Array<FlxCamera>
+	{
+		return (_cameras == null) ? FlxCamera.defaultCameras : _cameras;
+	}
+	
+	private inline function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
+	{
+		return _cameras = Value;
+	}
 	
 	/**
 	 * Property setters, to provide override functionality in sub-classes

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -64,6 +64,11 @@ class FlxCamera extends FlxBasic
 	 * this variable determines what value the camera will start at when created.
 	 */
 	public static var defaultZoom:Float;
+	/**
+	 * Which cameras a FlxBasic uses to be drawn on when nothing else has been specified. 
+	 * By default, this is just a reference to FlxG.cameras.list / all cameras, but it can be very useful to change.
+	 */
+	public static var defaultCameras:Array<FlxCamera>;
 	
 	/**
 	 * The X position of this camera's display.  Zoom does NOT affect this number.

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -253,7 +253,6 @@ class FlxObject extends FlxBasic
 		maxVelocity = null;
 		scrollFactor = null;
 		last = null;
-		cameras = null;
 		_point = null;
 		scrollFactor = null;
 		
@@ -318,24 +317,14 @@ class FlxObject extends FlxBasic
 	 */
 	override public function draw():Void
 	{
-		if (cameras == null)
+		for (camera in cameras)
 		{
-			cameras = FlxG.cameras.list;
-		}
-		var camera:FlxCamera;
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		while (i < l)
-		{
-			camera = cameras[i++];
-			if (!camera.visible || !camera.exists || !isOnScreen(camera))
+			if (camera.visible && camera.exists && isOnScreen(camera))
 			{
-				continue;
+				#if !FLX_NO_DEBUG
+				FlxBasic._VISIBLECOUNT++;
+				#end
 			}
-			
-			#if !FLX_NO_DEBUG
-			FlxBasic._VISIBLECOUNT++;
-			#end
 		}
 	}
 	

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -710,16 +710,13 @@ class FlxSprite extends FlxObject
 	override public function draw():Void
 	{
 		if (alpha == 0)	
+		{
 			return;
+		}
 		
 		if (dirty)	//rarely 
 		{
 			calcFrame();
-		}
-		
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
 		}
 		
 	#if !flash

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -49,11 +49,6 @@ class FlxSubState extends FlxState
 	{
 		//Draw background
 		#if flash
-		if (cameras == null) 
-		{ 
-			cameras = FlxG.cameras.list; 
-		}
-		
 		for (camera in cameras)
 		{
 			camera.fill(bgColor);

--- a/flixel/interfaces/IFlxBasic.hx
+++ b/flixel/interfaces/IFlxBasic.hx
@@ -5,7 +5,7 @@ import flixel.FlxCamera;
 interface IFlxBasic
 {
 	public var ID:Int;
-	public var cameras:Array<FlxCamera>;
+	public var cameras(get, set):Array<FlxCamera>;
 	public var active(default, set):Bool;
 	public var visible(default, set):Bool;
 	public var alive(default, set):Bool;

--- a/flixel/plugin/PathManager.hx
+++ b/flixel/plugin/PathManager.hx
@@ -48,22 +48,12 @@ class PathManager extends FlxPlugin
 	 */
 	override public function drawDebug():Void
 	{
-		if (!FlxG.debugger.drawDebug || ignoreDrawDebug)
+		if (FlxG.debugger.drawDebug && !ignoreDrawDebug)
 		{
-			return;	
-		}
-		
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		
-		while (i < l)
-		{
-			drawDebugOnCamera(cameras[i++]);
+			for (camera in cameras)
+			{
+				drawDebugOnCamera(camera);
+			}
 		}
 	}
 	

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -26,14 +26,6 @@ class FlxBGSprite extends FlxSprite
 	 */
 	override public function draw():Void
 	{
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		var camera:FlxCamera;
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		
 		var drawItem:DrawStackItem;
 		var currDrawData:Array<Float>;
 		var currIndex:Int;
@@ -41,10 +33,8 @@ class FlxBGSprite extends FlxSprite
 		var useAlpha:Bool = (alpha < 1);
 		#end
 		
-		while (i < l)
+		for (camera in cameras)
 		{
-			camera = cameras[i++];
-			
 			if (!camera.visible || !camera.exists)
 			{
 				continue;

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -162,6 +162,7 @@ class CameraFrontEnd
 	{
 		_cameraRect = new Rectangle();
 		list = new Array<FlxCamera>();
+		FlxCamera.defaultCameras = list;
 	}
 	
 	/**

--- a/flixel/text/FlxBitmapTextField.hx
+++ b/flixel/text/FlxBitmapTextField.hx
@@ -164,18 +164,10 @@ class FlxBitmapTextField extends FlxSprite
 			updateBitmapData();
 		}
 		
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		
-		var camera:FlxCamera;
 		var bgDrawItem:DrawStackItem = null;
 		var drawItem:DrawStackItem;
 		var currDrawData:Array<Float>;
 		var currIndex:Int;
-		var i:Int = 0;
-		var l:Int = cameras.length;
 		
 		var j:Int = 0;
 		var textLength:Int = Std.int(_drawData.length / 6);
@@ -196,10 +188,8 @@ class FlxBitmapTextField extends FlxSprite
 		
 		var camID:Int;
 		
-		while (i < l)
+		for (camera in cameras)
 		{
-			camera = cameras[i++];
-			
 			if (_background)
 			{
 				#if !js

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -640,11 +640,7 @@ class FlxTilemap extends FlxObject
 	 */
 	override public function draw():Void
 	{
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		
+		var cameras = cameras;
 		var camera:FlxCamera;
 		var buffer:FlxTilemapBuffer;
 		var i:Int = 0;

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -1005,23 +1005,14 @@ class FlxBar extends FlxSprite
 			return;
 		}
 		
-		if (cameras == null)
-		{
-			cameras = FlxG.cameras.list;
-		}
-		var camera:FlxCamera;
-		var i:Int = 0;
-		var l:Int = cameras.length;
-		
 		var percentFrame:Int = 2 * (Math.floor(percent) - 1);
 		
 		var currDrawData:Array<Float>;
 		var currIndex:Int;
 		var drawItem:DrawStackItem;
 		
-		while (i < l)
+		for (camera in cameras)
 		{
-			camera = cameras[i++];
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 			{
 				continue;

--- a/flixel/ui/FlxTypedButton.hx
+++ b/flixel/ui/FlxTypedButton.hx
@@ -203,11 +203,6 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite
 	 */
 	private function updateButton():Void
 	{
-		if (cameras == null) 
-		{
-			cameras = FlxG.cameras.list;
-		}
-		
 		// We're looking for any touch / mouse overlaps with this button
 		var overlapFound = false;
 		


### PR DESCRIPTION
Consider the following scenario:

You have a pixel art game with a resolution of 320x240 but a window size that is twice that, so the camera zoom level is 2. This can be problematic in conjunction with using text - with pixel fonts like the flixel default one, you're even more limited in the range of possible sizes than normally because of the scaling that's going on (those fonts only look good at powers of two, 8px, 16px etc...). With a regular font that uses anti-aliasing, it immediately looks shitty when you scale it up ([screenshot  from the person who ran into this issue / inspired this PR](http://i.snag.gy/KzoxP.jpg)).

The obvious / clever solution to this is using a seperate FlxCamera with a zoom level of one that only displays the text. With this you run into an issue though: the default cameras are hardcoded to `FlxG.cameras.list`. This means that if you were to create a `textCamera`, _all_ objects would be rendered on that by default, which means you'd have to change the `cameras` array of every single sprite to only use `FlxG.camera` except for the texts, which use `textCamera`.

With the changes in this pull request, it's as simple as in the following code snippet:

``` haxe
package;

import flixel.FlxCamera;
import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;
import flixel.text.FlxText;
import flixel.util.FlxColor;
import flixel.system.FlxAssets;

class PlayState extends FlxState
{
    var textCamera:FlxCamera;

    override public function create():Void
    {
        FlxG.cameras.add(textCamera = new FlxCamera(0, 0, 640, 480, 1));
        textCamera.bgColor = FlxColor.TRANSPARENT;

        var sprite = new FlxSprite().loadGraphic(GraphicLogo);
        add(sprite);

        FlxCamera.defaultCameras = [FlxG.camera];

        var text = new FlxText(0, 0, 200, "Hello World");
        text.cameras = [textCamera];
        add(text);

        super.create();
    }

    override public function update():Void
    {
        super.update();
    }   
}
```

This is with a `FlxGame` set up like this:

``` haxe
new FlxGame(320, 240, PlayState, 2)
```
