### PR TITLE
Make MouseEventManager compatible with FlxObject, closes #823

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -17,6 +17,10 @@ class FlxBasic implements IFlxDestroyable
 	 */
 	public var ID:Int = -1;
 	/**
+	 * Gets ot sets the first camera of this object.
+	 */
+	public var camera(get, set):FlxCamera;
+	/**
 	 * This determines on which FlxCameras this object will be drawn. If it is null / has not been
 	 * set, it uses FlxCamera.defaultCameras, which is a reference to FlxG.cameras.list (all cameras) by default.
 	 */
@@ -136,10 +140,25 @@ class FlxBasic implements IFlxDestroyable
 	/**
 	 * Override this function to draw custom "debug mode" graphics to the
 	 * specified camera while the debugger's visual mode is toggled on.
+	 * 
 	 * @param	Camera	Which camera to draw the debug visuals to.
 	 */
 	public function drawDebugOnCamera(?Camera:FlxCamera):Void {}
 	#end
+	
+	private function get_camera():FlxCamera
+	{
+		return (_cameras == null || _cameras.length == 0) ? FlxCamera.defaultCameras[0] : _cameras[0];
+	}
+	
+	private function set_camera(Value:FlxCamera):FlxCamera
+	{
+		if (_cameras == null)
+			_cameras = [ Value ];
+		else
+			_cameras[0] = Value;
+		return Value;
+	}
 	
 	private function get_cameras():Array<FlxCamera>
 	{
@@ -151,34 +170,32 @@ class FlxBasic implements IFlxDestroyable
 		return _cameras = Value;
 	}
 	
-	/**
-	 * Property setters, to provide override functionality in sub-classes
-	 */
 	private function set_visible(Value:Bool):Bool
 	{
 		return visible = Value;
 	}
+	
 	private function set_active(Value:Bool):Bool
 	{
 		return active = Value;
 	}
+	
 	private function set_alive(Value:Bool):Bool
 	{
 		return alive = Value;
 	}
+	
 	private function set_exists(Value:Bool):Bool
 	{
 		return exists = Value;
 	}
 	
-	/**
-	 * Convert object to readable string name.  Useful for debugging, save games, etc.
-	 */
 	public function toString():String
 	{
-		return FlxStringUtil.getDebugString([ { label: "active", value: active }, 
-		                                      { label: "visible", value: visible },
-		                                      { label: "alive", value: alive },
-		                                      { label: "exists", value: exists } ]);
+		return FlxStringUtil.getDebugString([
+			LabelValuePair.weak("active", active),
+			LabelValuePair.weak("visible", visible),
+			LabelValuePair.weak("alive", alive),
+			LabelValuePair.weak("exists", exists)]);
 	}
 }

--- a/flixel/plugin/MouseEventManager.hx
+++ b/flixel/plugin/MouseEventManager.hx
@@ -280,7 +280,7 @@ class MouseEventManager extends FlxPlugin
 	{
 		super();
 		
-		_point = new FlxPoint();
+		_point = FlxPoint.get();
 		
 		if (_registeredObjects != null)
 		{

--- a/flixel/text/FlxTextField.hx
+++ b/flixel/text/FlxTextField.hx
@@ -214,17 +214,12 @@ class FlxTextField extends FlxText
 		}
 	}
 	
-	/**
-	 * Camera on which this text will be displayed. Default is FlxG.camera.
-	 */
-	public var camera(get, set):FlxCamera;
-	
-	private function get_camera():FlxCamera 
+	override private function get_camera():FlxCamera 
 	{
 		return _camera;
 	}
 	
-	private function set_camera(Value:FlxCamera):FlxCamera 
+	override private function set_camera(Value:FlxCamera):FlxCamera 
 	{
 		if (_camera != Value)
 		{


### PR DESCRIPTION
Allowing to use this class only on `FlxSprite` was kind of an arbitrary restriction, as the hitbox is added at `FlxObject` level. 

This includes the following API changes:

```
addSprite() -> add()
removeSprite() -> remove()
setSpriteMouseChildren() -> setObjectMouseChildren()
isSpriteMouseChildren() -> isObjectMouseChildren()
setSpriteMouseEnabled() -> setObjectMouseEnabled()
isSpriteMouseEnabled() -> isObjectMouseEnabled()
```

Lots of type params. I have a feeling @crazysam is not gonna like this. :P They make sense though, otherwise you can't properly type the callback functions.

Also, might have found a bug in hxcpp.. This won't compile to cpp with `FlxBasic.get_cameras()` being inlined... :/
