### PR TITLE
Exposed _globalScreenPosition in FlxMouse so I can send low-level mouse events

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -370,6 +370,19 @@ class FlxMouse extends FlxPoint implements IFlxInput
 	}
 	
 	/**
+	 * Directly set the underyling screen position variable.
+	 * WARNING! You should never use this unless you are trying to manually
+	 * dispatch low-level mouse events to the stage.
+	 * @param	X
+	 * @param	Y
+	 */
+	
+	public function setGlobalScreenPositionUnsafe(X:Float, Y:Float):Void 
+	{
+		_globalScreenPosition.set(X, Y);
+	}
+	
+	/**
 	 * Resets the just pressed/just released flags and sets mouse to not pressed.
 	 */
 	public function reset():Void


### PR DESCRIPTION
I added FlxUICursor to flixel-ui:
https://github.com/HaxeFlixel/flixel-ui/commit/cadf03c1695cdb5f3438f45bc39025eac87260dc

This is intended to let the user navigate the UI using just the keyboard. I can dispatch events to the stage, but unfortunately FlxMouse resets it's X/Y position _every frame_, and ALSO keeps it hidden in a private variable. This pull request exposes that X/Y value and marks it as dangerous to mess with if you don't know what you're doing.

Here's a new demo that showcases this new feature:
https://github.com/HaxeFlixel/flixel-demos/commit/9acaefe0c834bbeded4a53a2206657e8a771a270

If/when this pull request is accepted, the FlxUICursor branches on flixel-ui and flixel-demos can be safely merged into dev.
