### PR TITLE
Added two new functions for cleaning up arrays. 

### DIFF
--- a/flixel/util/FlxArrayUtil.hx
+++ b/flixel/util/FlxArrayUtil.hx
@@ -104,4 +104,35 @@ class FlxArrayUtil
 		}
 		return array;
 	}
+	
+	/**
+	 * Clears an array structure, but leaves the object data untouched
+	 * Useful for cleaning up temporary references to data you want to preserve
+	 * WARNING: Can lead to memory leaks. Use destroyArray() instead for data you truly want GONE.
+	 *
+	 * @param	Arr			The array to clear out
+	 * @param	Recursive	Whether to search for arrays inside of arr and clear them out, too (false by default)
+	 */
+	
+	public static function clearArray(Arr:Array<Dynamic>,Recursive:Bool=false):Void
+	{
+		if (Arr != null)
+		{
+			if (!Recursive)
+			{
+				Arr.length = 0;
+			}
+			else
+			{
+				while (Arr.length > 0)
+				{
+					var thing:Dynamic = Arr.pop();
+					if (Std.is(thing, Array<Dynamic>)
+					{
+						clearArray(Arr, Recursive);
+					}
+				}
+			}
+		}
+	}
 }

--- a/flixel/util/FlxDestroyUtil.hx
+++ b/flixel/util/FlxDestroyUtil.hx
@@ -40,25 +40,6 @@ class FlxDestroyUtil
 	}
 	
 	/**
-	 * Clears an array structure, but leaves the object data untouched
-	 * Useful for cleaning up temporary references to data you want to preserve
-	 * WARNING: Can lead to memory leaks. Use destroyArray() instead for data you truly want GONE.
-	 *
-	 * @param	arr
-	 */
-	
-	public static function clearArray(arr:Array<Dynamic>):Void
-	{
-		if (arr != null)
-		{
-			while (arr.length > 0)
-			{
-				arr.pop();
-			}
-		}
-	}
-	
-	/**
 	 * Checks if an object is not null before putting it back into the pool, always returns null.
 	 * 
 	 * @param	Object	An IFlxPooled object that will be put back into the pool if it's not null


### PR DESCRIPTION
I could have sworn flixel core would have had utility functions for cleaning up arrays, but I can't find them anywhere, not in FlxDestroyUtil or in FlxArrayUtil. 

At any rate, here's two useful functions for cleaning up arrays. 

destroyArray() will go through an Array<IFlxDestroyable> and call FlxDestroyUtil.destroy() on everything and also clear out the array structure.

clearArray() will just clear the array structure of an Array<Dynamic>, but leave all the object data alone. 

I use my own home-grown versions of these all the time, seems like it would be useful to have in flixel-core, especially given the new utility class. 

Do these make more sense here or in FlxArrayUtil?
