### PR TITLE
Added super.destroy() to overridden destroys

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -391,6 +391,8 @@ class FlxMouse extends FlxPoint implements IFlxInput
 		#end
 		
 		_cursorBitmapData = FlxDestroyUtil.dispose(_cursorBitmapData);
+
+		super.destroy();
 	}
 	
 	/**

--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -55,6 +55,8 @@ class FlxTouch extends FlxPoint implements IFlxDestroyable
 		_globalScreenPosition = null;
 		_flashPoint = null;
 		_justPressedPosition = null;
+
+		super.destroy();
 	}
 	
 	/**

--- a/flixel/system/FlxQuadTree.hx
+++ b/flixel/system/FlxQuadTree.hx
@@ -362,6 +362,8 @@ class FlxQuadTree extends FlxRect
 		next = _cachedTreesHead;
 		_cachedTreesHead = this;
 		_NUM_CACHED_QUAD_TREES++;
+
+		super.destroy();
 	}
 
 	/**


### PR DESCRIPTION
For consistency's sake and as part of #776
Now all overridden destroy() methods call super.destroy()
