### PR TITLE
Fix tilemapbuffer

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -293,6 +293,7 @@ class FlxTilemap extends FlxObject
 		_rectIDs = null;
 		#end
 		
+		_helperBuffer = null;
 		framesData = null;
 		cachedGraphics = null;
 		region = null;


### PR DESCRIPTION
#921, #922

This is not the best approach because we are checking the dimensions every frame, which is obviously unnecessary. Any ideas how to let the tilemaps get notified when there is a stage resize?
