### PR TITLE
Limit FlxG.elapsed when using variable timestep

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -674,6 +674,7 @@ class FlxGame extends Sprite
 		else
 		{
 			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
+			if (FlxG.elapsed > FlxG.maxElapsed * FlxG.timeScale) FlxG.elapsed = FlxG.maxElapsed * FlxG.timeScale;
 		}
 		
 		updateInput();


### PR DESCRIPTION
When using variable timestep, FlxG.maxElapsed will prevent FlxG.elapsed from being too high, which can cause very jerky movement and erratic behavior, especially when the game lags for a second.
