### PR TITLE
fixes an issue where tilemaps with rows ending in commas crash neko

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -324,19 +324,30 @@ class FlxTilemap extends FlxObject
 				
 				while (column < widthInTiles)
 				{
-					var curColumn : Int = Std.parseInt(columns[column]);
+					//the current tile to be added:
+					var curTile : Int = Std.parseInt(columns[column]);
+
+					//if neko, make sure the value was not null, and if it is null,
+					//make sure it is the last in the row (used to ignore commas)
 					#if neko
-					if (curColumn != null)
+					if (curTile != null)
 					{
-						_data.push(curColumn);	
+						_data.push(curTile);	
 						column++;
+					}
+					else if(column == columns.length - 1)
+					{
+						//if value was a comma, decrease the width by one
+						widthInTiles--;
 					}
 					else
 					{
-						widthInTiles--;
+						//if a non-int value was passed not at the end, warn the user
+						throw "Value passed wan NaN";
 					}
 					#else
-					_data.push(curColumn);	
+					//if not neko, dont worry about the comma
+					_data.push(curTile);	
 					column++;
 					#end
 					


### PR DESCRIPTION
tilemaps created in tiled end the rows with a comma, which on neko causes an invalid array access error, this fixes that, although it could probably be done with regular expressions in a neater way, but I didn't want to change the code too much, hope this is helpful:),
Nico
