### PR TITLE
Add button IDs for Dualshock 4

### DIFF
--- a/flixel/input/gamepad/PS4ButtonID.hx
+++ b/flixel/input/gamepad/PS4ButtonID.hx
@@ -1,0 +1,31 @@
+package flixel.input.gamepad;
+
+/**
+ * Button IDs for PlayStation 4 controllers
+ * (D-pad values are obtained from FlxGamepad.hat)
+ */
+class PS4ButtonID
+{
+        public static inline var TRIANGLE_BUTTON:Int = 3;
+        public static inline var CIRCLE_BUTTON:Int = 2;
+        public static inline var X_BUTTON:Int = 1;
+        public static inline var SQUARE_BUTTON:Int = 0;
+        public static inline var L1_BUTTON:Int = 4;
+        public static inline var R1_BUTTON:Int = 5;
+        public static inline var L2_BUTTON:Int = 6;
+        public static inline var R2_BUTTON:Int = 7;
+        public static inline var SHARE_BUTTON:Int = 0;
+        public static inline var START_BUTTON:Int = 9;
+        public static inline var PS_BUTTON:Int = 12;
+        public static inline var TOUCHPAD:Int = 13;
+        public static inline var LEFT_ANALOGUE_BUTTON:Int = 10;
+        public static inline var RIGHT_ANALOGUE_BUTTON:Int = 11;
+
+        public static inline var LEFT_ANALOGUE_X:Int = 0;
+        public static inline var LEFT_ANALOGUE_Y:Int = 1;
+        public static inline var RIGHT_ANALOGUE_X:Int = 2;
+        public static inline var RIGHT_ANALOGUE_Y:Int = 5;
+
+        public static inline var L2_BUTTON_Y:Int = 3;
+        public static inline var R2_BUTTON_Y:Int = 4;
+}


### PR DESCRIPTION
Hello! I've added the button IDs from my Dualshock 4 for usage in HaxeFlixel. I modeled the code off of the PS3 and Ouya mappings, so hopefully everything's OK. Let me know if there's anything else I need to do. Cheers!
