### PR TITLE
More consistent API for FlxTween / FlxPath / FlxTimer

### DIFF
--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -148,7 +148,7 @@ class FlxFlicker implements IFlxDestroyable
 	*/
 	private function stop():Void
 	{
-		timer.abort();
+		timer.cancel();
 		object.visible = true;
 		release();
 	}

--- a/flixel/plugin/PathManager.hx
+++ b/flixel/plugin/PathManager.hx
@@ -36,7 +36,7 @@ class PathManager extends FlxPlugin
 	{
 		for (path in _paths)
 		{
-			if (!path.paused)
+			if (path.active)
 			{
 				path.update();
 			}

--- a/flixel/plugin/TimerManager.hx
+++ b/flixel/plugin/TimerManager.hx
@@ -42,7 +42,7 @@ class TimerManager extends FlxPlugin
 	{
 		for (timer in _timers)
 		{
-			if (!timer.paused && !timer.finished && timer.time > 0)
+			if (timer.active && !timer.finished && timer.time > 0)
 			{
 				timer.update();
 			}

--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -330,11 +330,6 @@ class FlxTween implements IFlxDestroyable
 	public var ease:EaseFunction;
 	public var complete:CompleteCallback;
 	
-	/**
-	 * Useful to store values you want to access within your callback function.
-	 */
-	public var userData:Dynamic;
-	
 	public var type(default, set):Int;
 	public var percent(get, set):Float;
 	public var finished(default, null):Bool;
@@ -371,7 +366,6 @@ class FlxTween implements IFlxDestroyable
 		complete = Options.complete;
 		ease = Options.ease;
 		setDelays(Options.startDelay, Options.loopDelay);
-		userData = {};
 	}
 	
 	private function resolveTweenOptions(Options:TweenOptions):TweenOptions
@@ -389,7 +383,6 @@ class FlxTween implements IFlxDestroyable
 	{
 		complete = null;
 		ease = null;
-		userData = null;
 	}
 
 	private function update():Void
@@ -436,6 +429,7 @@ class FlxTween implements IFlxDestroyable
 	public function cancel():Void
 	{
 		active = false;
+		finished = true;
 		manager.remove(this);
 	}
 	

--- a/flixel/util/FlxPath.hx
+++ b/flixel/util/FlxPath.hx
@@ -110,7 +110,7 @@ class FlxPath implements IFlxDestroyable
 	/**
 	 * Pauses or checks the pause state of the path.
 	 */
-	public var paused:Bool = false;
+	public var active:Bool = false;
 	
 	public var onComplete:FlxPath->Void;
 
@@ -182,10 +182,10 @@ class FlxPath implements IFlxDestroyable
 		}
 		
 		finished = false;
-		paused = false;
+		active = true;
 		if (nodes.length <= 0)
 		{
-			paused = true;
+			active = false;
 		}
 		
 		//get starting node
@@ -328,7 +328,7 @@ class FlxPath implements IFlxDestroyable
 			
 			if (finished)
 			{
-				abort();
+				cancel();
 			}
 		}
 	}
@@ -441,7 +441,7 @@ class FlxPath implements IFlxDestroyable
 	/**
 	 * Stops path movement and removes this path it from the path manager.
 	 */
-	public function abort():Void
+	public function cancel():Void
 	{
 		finished = true;
 		

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -48,16 +48,11 @@ class FlxTimer implements IFlxDestroyable
 	/**
 	 * Pauses or checks the pause state of the timer.
 	 */
-	public var paused:Bool = false;
+	public var active:Bool = true;
 	/**
 	 * Check to see if the timer is finished.
 	 */
 	public var finished:Bool = false;
-	/**
-	 * Useful to store values you want to access within your callback function, ex:
-	 * FlxTimer.start(1, function(t) { trace(t.userData); } ).userData = "Hello World!";
-	 */
-	public var userData:Dynamic;
 	/**
 	 * Function that gets called when timer completes.
 	 * Callback should be formed "onTimer(Timer:FlxTimer);"
@@ -83,6 +78,7 @@ class FlxTimer implements IFlxDestroyable
 	 * Read-only: how far along the timer is, on a scale of 0.0 to 1.0.
 	 */
 	public var progress(get, never):Float;
+	
 	/**
 	 * Internal tracker for the actual timer counting up.
 	 */
@@ -98,7 +94,6 @@ class FlxTimer implements IFlxDestroyable
 	public function destroy():Void
 	{
 		complete = null;
-		userData = null;
 	}
 	
 	/**
@@ -116,7 +111,7 @@ class FlxTimer implements IFlxDestroyable
 			manager.add(this);
 		}
 		
-		paused = false;
+		active = true;
 		finished = false;
 		time = Math.abs(Time);
 		
@@ -148,7 +143,7 @@ class FlxTimer implements IFlxDestroyable
 	/**
 	 * Stops the timer and removes it from the timer manager.
 	 */
-	public function abort():Void
+	public function cancel():Void
 	{
 		finished = true;
 		if (manager != null)
@@ -168,7 +163,7 @@ class FlxTimer implements IFlxDestroyable
 	{
 		_timeCounter += FlxG.elapsed;
 		
-		while ((_timeCounter >= time) && !paused && !finished)
+		while ((_timeCounter >= time) && active && !finished)
 		{
 			_timeCounter -= time;
 			_loopsCounter++;
@@ -180,7 +175,7 @@ class FlxTimer implements IFlxDestroyable
 			
 			if (loops > 0 && (_loopsCounter >= loops))
 			{
-				abort();
+				cancel();
 			}
 		}
 	}


### PR DESCRIPTION
`FlxTimer` and `FlxPath` (now consistent with tweens): 
- `abort()` -> `cancel()`
- `paused` -> `active`

Removed `userData` from tweens and timers. `function.bind()` should be used for that, and we are already discouraging the use of `Dynamic` and `cast` with the recent callback function changes.

`FlxTween.cancel()` now sets `finished` to true.
