### PR TITLE
Ignore tiled xml data in csv tilemaps

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -313,12 +313,15 @@ class FlxTilemap extends FlxObject
 		{
 			var mapString : String = cast MapData; //cast the data to a string to prevent neko getting map for invalid calls
 			//remove any tiled xml data at the start or end
-			if (mapString.charAt(0) == "<")
+			if (IgnoreXml)
 			{
-				var startData : Int = mapString.indexOf("\"csv\">") + 7; //the 7 is the "csv"> + the \n
-				var endData : Int = mapString.indexOf("</data>");
-				
-				mapString = mapString.substring(startData, endData);
+				if (mapString.charAt(0) == "<")
+				{
+					var startData : Int = mapString.indexOf("\"csv\">") + 7; //the 7 is the "csv"> + the \n
+					var endData : Int = mapString.indexOf("</data>");
+					
+					mapString = mapString.substring(startData, endData);
+				}
 			}
 			// Figure out the map dimensions based on the data string
 			_data = new Array<Int>();


### PR DESCRIPTION
this pull adds a way to ignore leading and trailing xml created by the tiled map editor in FlxTilemap. This was an unintended benefit of my previous pull, but it turned out that that was actually not loading in the entire map if there was xml....thats what you get for not thoroughly checking out why exactly something is happening, even if it seems beneficial.
hope this helps,
Nico
