### PR TITLE
Do not allow invalid data in tilemap loading

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -327,15 +327,16 @@ class FlxTilemap extends FlxObject
 				{
 					heightInTiles--;
 					
-					if (columns.length == 1)
+					if (columns.length == 1) //if a row only has one section of text
 					{
-						var isSpaces:EReg = ~/^[ ]*\r?$/;
+						var isSpaces:EReg = ~/^[ ]*\r?$/; //check that the text is only spaces
 						if (isSpaces.match(columns[0]))
 						{
-							continue;
+							continue; //skip this row if its empty
+							//this ensures no data is allowed to get through simply because it is not separated by commas
 						}
 					}
-					else
+					else //if the row is empty, skip it
 					{
 						continue;
 					}


### PR DESCRIPTION
this ensures that input data is actually a number before pushing it to the map, not only to warn the user, but previously the map sizes would be wrongly set if there were commas at the end or xml at the start,
hope its good enough:),
Nico
