### PR TITLE
Allow different HTML5 backends

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -5,7 +5,7 @@
 	<assets path="assets/sounds" include="*.mp3" if="web" />
 	<assets path="assets/sounds" include="*.ogg" unless="flash" />
 	
-	<set name="html5-backend" value="openfl-bitfive" />
+	<set name="html5-backend" value="openfl-bitfive" unless="html5-backend" />
 	<haxelib name="openfl" />
 	
 	<!-- Allow this setting to be overridden on the command-line -->


### PR DESCRIPTION
In the latest release of Flixel, openfl-bitfive does not appear to work, so it may be best not to use it by default. Regardless, if you would like to use it by default, this change should allow for an "html5-backend" define to override your choice, so that users can try other backends against Flixel. Thanks!
