### PR TITLE
fix for null pointer exception...

### DIFF
--- a/flixel/util/loaders/TexturePackerData.hx
+++ b/flixel/util/loaders/TexturePackerData.hx
@@ -77,9 +77,11 @@ class TexturePackerData implements IFlxDestroyable
 	 */
 	public function destroy():Void
 	{
-		for (frame in frames)
-		{
-			frame = FlxDestroyUtil.destroy(frame);
+		if (frames != null) {
+			for (frame in frames)
+			{	
+				frame = FlxDestroyUtil.destroy(frame);
+			}
 		}
 		frames = null;
 		assetName = null;


### PR DESCRIPTION
I have here a problem when switching states: after update to flixel 3.2.1 the frames==null, when adding this check everything works.
