### PR TITLE
Add support for pixelPerfectRender in FlxTilemap, closes #1057

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1644,8 +1644,8 @@ class FlxTilemap extends FlxObject
 					drawX = _helperPoint.x + (columnIndex % widthInTiles) * _scaledTileWidth;
 					drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * _scaledTileHeight;
 					
-					currDrawData[currIndex++] = drawX;
-					currDrawData[currIndex++] = drawY;
+					currDrawData[currIndex++] = pixelPerfectRender ? Math.floor(drawX) : drawX;
+					currDrawData[currIndex++] = pixelPerfectRender ? Math.floor(drawY) : drawY;
 					currDrawData[currIndex++] = tileID;
 					
 					// Tilemap tearing hack


### PR DESCRIPTION
When you render a sprite on the screen at the same time as a FlxTilemap, the sprite appears to jitter around on the screen. It's because FlxTilemap ignores pixelPerfectRender (which is on by default) so FlxSprites move around in chunks, but FlxTilemaps do not.

This changes it so the position of the tile is floored if pixelPerfectRender is enabled, which is the same behavior as FlxSprite.
