### PR TITLE
Implement pixel-perfect/subpixel rendereing toggle for FlxCamera

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -147,6 +147,12 @@ class FlxCamera extends FlxBasic
 	 * Uses include 3D projection, advanced display list modification, and more.
 	 */
 	public var flashSprite:Sprite;
+
+	/**
+	 * Whether the camera movement is smooth or locked to pixels.
+	 * Default behavior is per-pixel.
+	 */
+	public var pixelPerfect:Bool = true;
 	
 	/**
 	 * How wide the camera display is, in game pixels.

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -348,7 +348,7 @@ class FlxObject extends FlxBasic
 	 * Only affects tilesheet rendering and rendering using BitmapData.draw() in blitting.
 	 * (copyPixels() only renders on whole pixels by nature). Causes draw() to be used if false, which is more expensive.
 	 */
-	public var pixelPerfectRender(default, set):Bool = true;
+	public var pixelPerfectRender(default, set):Null<Bool>;
 	/**
 	 * Set the angle of a sprite to rotate it. WARNING: rotating sprites decreases rendering
 	 * performance for this sprite by a factor of 10x (in Flash target)!
@@ -880,7 +880,7 @@ class FlxObject extends FlxBasic
 		var boundingBoxX:Float = x - (Camera.scroll.x * scrollFactor.x); //copied from getScreenXY()
 		var boundingBoxY:Float = y - (Camera.scroll.y * scrollFactor.y);
 		
-		if (pixelPerfectRender)
+		if (isPixelPerfect(Camera))
 		{
 			boundingBoxX = Math.floor(boundingBoxX);
 			boundingBoxY = Math.floor(boundingBoxY);
@@ -950,6 +950,15 @@ class FlxObject extends FlxBasic
 			LabelValuePair.weak("h", height), 
 			LabelValuePair.weak("visible", visible), 
 			LabelValuePair.weak("velocity", velocity)]);
+	}
+
+	/**
+	 * Check if object is rendered pexel perfect on a specific camera.
+	 */
+	public function isPixelPerfect(Camera:FlxCamera = null):Bool
+	{
+		if (Camera == null) Camera = FlxG.camera;
+		return pixelPerfectRender == null ? Camera.pixelPerfect : pixelPerfectRender;
 	}
 	
 		private function set_x(NewX:Float):Float

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -790,7 +790,7 @@ class FlxSprite extends FlxObject
 				_point.x += origin.x;
 				_point.y += origin.y;
 				
-				if (pixelPerfectRender)
+				if (isPixelPerfect(camera))
 				{
 					_point.floor();
 				}
@@ -876,7 +876,7 @@ class FlxSprite extends FlxObject
 			_point.x -= x2;
 			_point.y -= y2;
 			
-			if (pixelPerfectRender)
+			if (isPixelPerfect(camera))
 			{
 				_point.floor();
 			}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1644,8 +1644,8 @@ class FlxTilemap extends FlxObject
 					drawX = _helperPoint.x + (columnIndex % widthInTiles) * _scaledTileWidth;
 					drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * _scaledTileHeight;
 					
-					currDrawData[currIndex++] = pixelPerfectRender ? Math.floor(drawX) : drawX;
-					currDrawData[currIndex++] = pixelPerfectRender ? Math.floor(drawY) : drawY;
+					currDrawData[currIndex++] = isPixelPerfect(Camera) ? Math.floor(drawX) : drawX;
+					currDrawData[currIndex++] = isPixelPerfect(Camera) ? Math.floor(drawY) : drawY;
 					currDrawData[currIndex++] = tileID;
 					
 					// Tilemap tearing hack

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -47,7 +47,7 @@ class FlxTilemapBuffer
 	 * Only affects tilesheet rendering and rendering using BitmapData.draw() in blitting.
 	 * (copyPixels() only renders on whole pixels by nature). Causes draw() to be used if false, which is more expensive.
 	 */
-	public var pixelPerfectRender:Bool = true;
+	public var pixelPerfectRender:Null<Bool> = true;
 	
 	#if FLX_RENDER_BLIT
 	/**
@@ -113,13 +113,13 @@ class FlxTilemapBuffer
 	 */
 	public function draw(Camera:FlxCamera, FlashPoint:Point, ScaleX:Float = 1.0, ScaleY:Float = 1.0):Void
 	{
-		if (pixelPerfectRender)
+		if (isPixelPerfect(Camera))
 		{
 			FlashPoint.x = Math.floor(FlashPoint.x);
 			FlashPoint.y = Math.floor(FlashPoint.y);
 		}
 		
-		if (pixelPerfectRender && (ScaleX == 1.0 && ScaleY == 1.0))
+		if (isPixelPerfect(Camera) && (ScaleX == 1.0 && ScaleY == 1.0))
 		{
 			Camera.buffer.copyPixels(pixels, _flashRect, FlashPoint, null, null, true);
 		}
@@ -175,5 +175,14 @@ class FlxTilemapBuffer
 		}
 		
 		height = Std.int(rows * TileHeight * ScaleY);
+	}
+
+	/**
+	 * Check if object is rendered pexel perfect on a specific camera.
+	 */
+	public function isPixelPerfect(Camera:FlxCamera = null):Bool
+	{
+		if (Camera == null) Camera = FlxG.camera;
+		return pixelPerfectRender == null ? Camera.pixelPerfect : pixelPerfectRender;
 	}
 }


### PR DESCRIPTION
This change adds `pixelPerfect` to `FlxCamera`, allowing you to set pixel-perfect rendering per-camera, and changes instances of `pixelPerfectRender` to use a `pixelPerfect`-aware check, while preserving the existing behavior.

Notes:
I had spoken to Gama11 about this in IRC, and was recommended an approach similar to antialiasing (`antialiasing || camera.antialiasing`).

If I had done `Camera.pixelPerfect && pixelPerfectRender`, it would exclude the case where you had set `Camera.pixelPerfect = false`, but wanted to set `pixelPerfectRender = true` on your object; this allows `pixelPerfectRender` to take precedence regardless of what value `Camera.pixelPerfect` has been assigned.
