### PR TITLE
FlxTypedSpriteGroup: change update order to save FlxObject.last

### DIFF
--- a/flixel/group/FlxTypedSpriteGroup.hx
+++ b/flixel/group/FlxTypedSpriteGroup.hx
@@ -203,12 +203,12 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	
 	override public function update():Void 
 	{
+		group.update();
+		
 		if (moves)
 		{
 			updateMotion();
 		}
-		
-		group.update();
 	}
 	
 	override public function draw():Void 


### PR DESCRIPTION
I found that moving FlxSpriteGroup does not collide correctly by FlxG.collide().
The problem is that FlxSpriteGroup changes members' position (by FlxTypedSpriteGroup.updateMotion()) before they store it as a last position, so I fix this problem by calling group.update() first.
