### PR TITLE
Renaming FlxCollisionType to FlxFlixelType

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -54,9 +54,9 @@ class FlxBasic implements IFlxDestroyable
 	public var cameras(get, set):Array<FlxCamera>;
 	
 	/**
-	 * Enum that informs the collision system which type of object this is (to avoid expensive type casting).
+	 * Enum used to avoid expensive type casting (mainly used during collision detection).
 	 */
-	public var collisionType(default, null):FlxCollisionType = NONE;
+	public var flixelType(default, null):FlxFlixelType = BASIC;
 	
 	private var _cameras:Array<FlxCamera>;
 	
@@ -169,15 +169,15 @@ class FlxBasic implements IFlxDestroyable
 }
 
 /**
- * Types of collidable objects.
+ * Types of flixel objects (used to avoid expensive type casting).
  * 
  * Abstracted from an Int type for fast comparison code:
  * http://nadako.tumblr.com/post/64707798715/cool-feature-of-upcoming-haxe-3-2-enum-abstracts
  */
 @:enum
-abstract FlxCollisionType(Int)
+abstract FlxFlixelType(Int)
 {
-	var NONE        = 0;
+	var BASIC       = 0;
 	var OBJECT      = 1;
 	var GROUP       = 2;
 	var TILEMAP     = 3;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -97,11 +97,11 @@ class FlxObject extends FlxBasic
 		}
 		
 		//If one of the objects is a tilemap, just pass it off.
-		if (Object1.collisionType == TILEMAP)
+		if (Object1.flixelType == TILEMAP)
 		{
 			return cast(Object1, FlxTilemap).overlapsWithCallback(Object2, separateX);
 		}
-		if (Object2.collisionType == TILEMAP)
+		if (Object2.flixelType == TILEMAP)
 		{
 			return cast(Object2, FlxTilemap).overlapsWithCallback(Object1, separateX, true);
 		}
@@ -210,11 +210,11 @@ class FlxObject extends FlxBasic
 		}
 		
 		//If one of the objects is a tilemap, just pass it off.
-		if (Object1.collisionType == TILEMAP)
+		if (Object1.flixelType == TILEMAP)
 		{
 			return cast(Object1, FlxTilemap).overlapsWithCallback(Object2, separateY);
 		}
-		if (Object2.collisionType == TILEMAP)
+		if (Object2.flixelType == TILEMAP)
 		{
 			return cast(Object2, FlxTilemap).overlapsWithCallback(Object1, separateY, true);
 		}
@@ -474,7 +474,7 @@ class FlxObject extends FlxBasic
 	 */
 	private function initVars():Void
 	{
-		collisionType = OBJECT;
+		flixelType = OBJECT;
 		last = FlxPoint.get(x, y);
 		scrollFactor = FlxPoint.get(1, 1);
 		_point = FlxPoint.get();
@@ -588,7 +588,7 @@ class FlxObject extends FlxBasic
 			return FlxTypedGroup.overlaps(overlapsCallback, group, 0, 0, InScreenSpace, Camera);
 		}
 		
-		if (ObjectOrGroup.collisionType == TILEMAP)
+		if (ObjectOrGroup.flixelType == TILEMAP)
 		{
 			//Since tilemap's have to be the caller, not the target, to do proper tile-based collisions,
 			// we redirect the call to the tilemap overlap here.
@@ -636,7 +636,7 @@ class FlxObject extends FlxBasic
 			return FlxTypedGroup.overlaps(overlapsAtCallback, group, X, Y, InScreenSpace, Camera);
 		}
 		
-		if (ObjectOrGroup.collisionType == TILEMAP)
+		if (ObjectOrGroup.flixelType == TILEMAP)
 		{
 			//Since tilemap's have to be the caller, not the target, to do proper tile-based collisions,
 			// we redirect the call to the tilemap overlap here.

--- a/flixel/group/FlxTypedGroup.hx
+++ b/flixel/group/FlxTypedGroup.hx
@@ -13,56 +13,6 @@ import flixel.util.FlxSort;
 class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 {
 	/**
-	 * Helper function for overlap functions in FlxObject and FlxTilemap.
-	 */
-	@:allow(flixel.FlxObject)
-	@:allow(flixel.tile.FlxTilemap)
-	private static inline function overlaps(Callback:FlxBasic->Float->Float->Bool->FlxCamera->Bool, 
-		Group:FlxTypedGroup<FlxBasic>, X:Float, Y:Float, InScreenSpace:Bool, Camera:FlxCamera):Bool
-	{
-		var result:Bool = false;
-		if (Group != null)
-		{
-			var i = 0;
-			var l = Group.length;
-			var basic:FlxBasic;
-			
-			while (i < l)
-			{
-				basic = cast Group.members[i++];
-				
-				if (basic != null && Callback(basic, X, Y, InScreenSpace, Camera))
-				{
-					result = true;
-					break;
-				}
-			}
-		}
-		return result;
-	}
-	
-	@:allow(flixel.FlxObject)
-	@:allow(flixel.tile.FlxTilemap)
-	@:allow(flixel.system.FlxQuadTree)
-	private static inline function resolveGroup(ObjectOrGroup:FlxBasic):FlxTypedGroup<FlxBasic>
-	{
-		var group:FlxTypedGroup<FlxBasic> = null;
-		if ((ObjectOrGroup.collisionType == SPRITEGROUP) || 
-		    (ObjectOrGroup.collisionType == GROUP))
-		{
-			if (ObjectOrGroup.collisionType == GROUP)
-			{
-				group = cast ObjectOrGroup;
-			}
-			else if (ObjectOrGroup.collisionType == SPRITEGROUP)
-			{
-				group = cast cast(ObjectOrGroup, FlxTypedSpriteGroup<Dynamic>).group;
-			}
-		}
-		return group;
-	}
-	
-	/**
 	 * Array of all the members in this group.
 	 */
 	public var members(default, null):Array<T>;
@@ -91,7 +41,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		
 		maxSize = Std.int(Math.abs(MaxSize));
 		
-		collisionType = GROUP;
+		flixelType = GROUP;
 	}
 	
 	/**
@@ -369,7 +319,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			
 			if (basic != null)
 			{
-				if (Recurse && basic.collisionType == GROUP)
+				if (Recurse && basic.flixelType == GROUP)
 				{
 					(cast basic).setAll(VariableName, Value, Recurse);
 				}
@@ -402,7 +352,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			
 			if (basic != null)
 			{
-				if (Recurse && (basic.collisionType == GROUP))
+				if (Recurse && (basic.flixelType == GROUP))
 				{
 					(cast(basic, FlxTypedGroup<Dynamic>)).callAll(FunctionName, Args, Recurse);
 				}
@@ -789,6 +739,55 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		length = members.length;
 		
 		return maxSize;
+	}
+	
+	/**
+	 * Helper function for overlap functions in FlxObject and FlxTilemap.
+	 */
+	@:allow(flixel.FlxObject)
+	@:allow(flixel.tile.FlxTilemap)
+	private static inline function overlaps(Callback:FlxBasic->Float->Float->Bool->FlxCamera->Bool, 
+		Group:FlxTypedGroup<FlxBasic>, X:Float, Y:Float, InScreenSpace:Bool, Camera:FlxCamera):Bool
+	{
+		var result:Bool = false;
+		if (Group != null)
+		{
+			var i = 0;
+			var l = Group.length;
+			var basic:FlxBasic = null;
+			
+			while (i < l)
+			{
+				basic = Group.members[i++];
+				
+				if (basic != null && Callback(basic, X, Y, InScreenSpace, Camera))
+				{
+					result = true;
+					break;
+				}
+			}
+		}
+		return result;
+	}
+	
+	/**
+	 * Helper function to determine if an FlxBasic object is a group.
+	 */
+	@:allow(flixel.FlxObject)
+	@:allow(flixel.tile.FlxTilemap)
+	@:allow(flixel.system.FlxQuadTree)
+	private static inline function resolveGroup(ObjectOrGroup:FlxBasic):FlxTypedGroup<FlxBasic>
+	{
+		var group:FlxTypedGroup<FlxBasic> = null;
+		if (ObjectOrGroup.flixelType == GROUP)
+		{
+			group = cast ObjectOrGroup;
+		}
+		else if (ObjectOrGroup.flixelType == SPRITEGROUP)
+		{
+			group = cast cast(ObjectOrGroup, FlxTypedSpriteGroup<Dynamic>).group;
+		}
+		return group;
 	}
 }
 

--- a/flixel/group/FlxTypedSpriteGroup.hx
+++ b/flixel/group/FlxTypedSpriteGroup.hx
@@ -79,7 +79,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	override private function initVars():Void 
 	{
-		collisionType = SPRITEGROUP;
+		flixelType = SPRITEGROUP;
 		
 		offset = new FlxCallbackPoint(offsetCallback);
 		origin = new FlxCallbackPoint(originCallback);

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -196,7 +196,7 @@ class FlxTilemap extends FlxObject
 	{
 		super();
 		
-		collisionType = TILEMAP;
+		flixelType = TILEMAP;
 		
 		_buffers = new Array<FlxTilemapBuffer>();
 		_flashPoint = new Point();
@@ -857,8 +857,8 @@ class FlxTilemap extends FlxObject
 	
 	private inline function tilemapOverlapsCallback(ObjectOrGroup:FlxBasic, X:Float = 0, Y:Float = 0, InScreenSpace:Bool = false, ?Camera:FlxCamera):Bool
 	{
-		if ((ObjectOrGroup.collisionType == OBJECT) || 
-		    (ObjectOrGroup.collisionType == TILEMAP))
+		if ((ObjectOrGroup.flixelType == OBJECT) || 
+		    (ObjectOrGroup.flixelType == TILEMAP))
 		{
 			return overlapsWithCallback(cast(ObjectOrGroup, FlxObject));
 		}
@@ -897,8 +897,8 @@ class FlxTilemap extends FlxObject
 	
 	private inline function tilemapOverlapsAtCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool, Camera:FlxCamera):Bool
 	{
-		if (ObjectOrGroup.collisionType == OBJECT || 
-		    ObjectOrGroup.collisionType == TILEMAP)
+		if (ObjectOrGroup.flixelType == OBJECT || 
+		    ObjectOrGroup.flixelType == TILEMAP)
 		{
 			return overlapsWithCallback(cast(ObjectOrGroup, FlxObject), null, false, _point.set(X, Y));
 		}


### PR DESCRIPTION
It better reflects the functionality of this enum, and opens up the possibility of using it for more than the collision system.
