### PR TITLE
Fix delays in tweens, closes #1104

### DIFF
--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -62,18 +62,29 @@ class VarTween extends FlxTween
 	
 	override private function update():Void
 	{
-		if (_vars.length < 1)
-		{
-			// We don't initalize() in tween() because otherwise the start values 
-			// will be inaccurate with delays
-			initializeVars();
-		}
+		var delay:Float = (executions > 0) ? loopDelay : startDelay;
 		
-		super.update();
-		var i:Int = _vars.length;
-		while (i-- > 0) 
+		if (_secondsSinceStart < delay)
 		{
-			Reflect.setProperty(_object, _vars[i], (_startValues[i] + _range[i] * scale));
+			// Leave properties alone until delay is over
+			super.update();
+		}
+		else
+		{
+			if (_vars.length < 1)
+			{
+				// We don't initalize() in tween() because otherwise the start values 
+				// will be inaccurate with delays
+				initializeVars();
+			}
+			
+			super.update();
+			
+			var i:Int = _vars.length;
+			while (i-- > 0) 
+			{
+				Reflect.setProperty(_object, _vars[i], (_startValues[i] + _range[i] * scale));
+			}
 		}
 	}
 	


### PR DESCRIPTION
Closes #1104

It still needs to update during the delay, but the vars shouldn't be initialized until when or after the delay is reached.  Tested with `player.y` instead of `FlxG.timeScale` this time :P

I didn't test loopDelay, but it should work if it was already working.
