### PR TITLE
Null text parameter

### DIFF
--- a/flixel/text/FlxTextField.hx
+++ b/flixel/text/FlxTextField.hx
@@ -37,7 +37,7 @@ class FlxTextField extends FlxText
 	{
 		super(X, Y, Width, Text, Size, EmbeddedFont);
 		
-		height = (Text.length <= 0) ? 1 : _textField.textHeight + 4;
+		height = (Text == null || Text.length <= 0) ? 1 : _textField.textHeight + 4;
 		
 		_textField.multiline = false;
 		_textField.wordWrap = false;


### PR DESCRIPTION
`?Text` is an optional parameter, but its `length` property is accessed in the constructor.
