### PR TITLE
FlxGamepad: update() fix

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -116,7 +116,7 @@ class FlxGamepad implements IFlxDestroyable
 		{
 			if (button == null) 
 			{
-				return;
+				continue;
 			}
 			
 			if ((button.last == -1) && (button.current == -1)) 


### PR DESCRIPTION
The for loop that updates the status of buttons is exited prematurely
and buttons do not transition form state justPressed / justReleased to
state pressed / released. A ‘continue’ is correct instead of a ‘return’
to keep looping on all buttons.
