### PR TITLE
FlxGamepad: anyPressed() consistency fix

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -200,7 +200,7 @@ class FlxGamepad implements IFlxDestroyable
 		{
 			if (buttons[b] != null)
 			{
-				if (buttons[b].current == PRESSED)
+				if (buttons[b].current > RELEASED)
 					return true;
 			}
 		}


### PR DESCRIPTION
For consistency, if condition for pressed() is ‘current > RELEASED’
then condition for anyPressed() should be the same.
