### PR TITLE
PS3 / PS4ButtonID: consistent naming

### DIFF
--- a/flixel/input/gamepad/PS3ButtonID.hx
+++ b/flixel/input/gamepad/PS3ButtonID.hx
@@ -5,30 +5,32 @@ package flixel.input.gamepad;
  */
 class PS3ButtonID
 {
-        public static inline var TRIANGLE_BUTTON:Int = 12;
-        public static inline var CIRCLE_BUTTON:Int = 13;
-        public static inline var X_BUTTON:Int = 14;
-        public static inline var SQUARE_BUTTON:Int = 15;
-        public static inline var L1_BUTTON:Int = 10;
-        public static inline var R1_BUTTON:Int = 11;
-        public static inline var L2_BUTTON:Int = 8;
-        public static inline var R2_BUTTON:Int = 9;
-        public static inline var SELECT_BUTTON:Int = 0;
-        public static inline var START_BUTTON:Int = 3;
-        public static inline var PS_BUTTON:Int = 16;
-        public static inline var LEFT_ANALOGUE_BUTTON:Int = 1;
-        public static inline var RIGHT_ANALOGUE_BUTTON:Int = 2;
-        public static inline var DPAD_UP:Int = 4;
-        public static inline var DPAD_DOWN:Int = 6;
-        public static inline var DPAD_LEFT:Int = 7;
-        public static inline var DPAD_RIGHT:Int = 5;
-
-        public static inline var LEFT_ANALOGUE_X:Int = 0;
-        public static inline var LEFT_ANALOGUE_Y:Int = 1;
-        public static inline var RIGHT_ANALOGUE_X:Int = 2;
-        public static inline var RIGHT_ANALOGUE_Y:Int = 3;
-        public static inline var TRIANGLE_BUTTON_PRESSURE:Int = 16;
-        public static inline var CIRCLE_BUTTON_PRESSURE:Int = 17;
-        public static inline var X_BUTTON_PRESSURE:Int = 18;
-        public static inline var SQUARE_BUTTON_PRESSURE:Int = 19;
+	public static inline var TRIANGLE:Int = 12;
+	public static inline var CIRCLE:Int = 13;
+	public static inline var X:Int = 14;
+	public static inline var SQUARE:Int = 15;
+	public static inline var L1:Int = 10;
+	public static inline var R1:Int = 11;
+	public static inline var L2:Int = 8;
+	public static inline var R2:Int = 9;
+	public static inline var SELECT:Int = 0;
+	public static inline var START:Int = 3;
+	public static inline var PS:Int = 16;
+	public static inline var LEFT_ANALOGUE:Int = 1;
+	public static inline var RIGHT_ANALOGUE:Int = 2;
+	
+	public static inline var DPAD_UP:Int = 4;
+	public static inline var DPAD_DOWN:Int = 6;
+	public static inline var DPAD_LEFT:Int = 7;
+	public static inline var DPAD_RIGHT:Int = 5;
+	
+	public static inline var LEFT_ANALOGUE_X:Int = 0;
+	public static inline var LEFT_ANALOGUE_Y:Int = 1;
+	public static inline var RIGHT_ANALOGUE_X:Int = 2;
+	public static inline var RIGHT_ANALOGUE_Y:Int = 3;
+	
+	public static inline var TRIANGLE_PRESSURE:Int = 16;
+	public static inline var CIRCLE_PRESSURE:Int = 17;
+	public static inline var X_PRESSURE:Int = 18;
+	public static inline var SQUARE_PRESSURE:Int = 19;
 }

--- a/flixel/input/gamepad/PS4ButtonID.hx
+++ b/flixel/input/gamepad/PS4ButtonID.hx
@@ -6,26 +6,26 @@ package flixel.input.gamepad;
  */
 class PS4ButtonID
 {
-        public static inline var TRIANGLE_BUTTON:Int = 3;
-        public static inline var CIRCLE_BUTTON:Int = 2;
-        public static inline var X_BUTTON:Int = 1;
-        public static inline var SQUARE_BUTTON:Int = 0;
-        public static inline var L1_BUTTON:Int = 4;
-        public static inline var R1_BUTTON:Int = 5;
-        public static inline var L2_BUTTON:Int = 6;
-        public static inline var R2_BUTTON:Int = 7;
-        public static inline var SHARE_BUTTON:Int = 0;
-        public static inline var START_BUTTON:Int = 9;
-        public static inline var PS_BUTTON:Int = 12;
-        public static inline var TOUCHPAD:Int = 13;
-        public static inline var LEFT_ANALOGUE_BUTTON:Int = 10;
-        public static inline var RIGHT_ANALOGUE_BUTTON:Int = 11;
-
-        public static inline var LEFT_ANALOGUE_X:Int = 0;
-        public static inline var LEFT_ANALOGUE_Y:Int = 1;
-        public static inline var RIGHT_ANALOGUE_X:Int = 2;
-        public static inline var RIGHT_ANALOGUE_Y:Int = 5;
-
-        public static inline var L2_BUTTON_Y:Int = 3;
-        public static inline var R2_BUTTON_Y:Int = 4;
+	public static inline var TRIANGLE:Int = 3;
+	public static inline var CIRCLE:Int = 2;
+	public static inline var X:Int = 1;
+	public static inline var SQUARE:Int = 0;
+	public static inline var L1:Int = 4;
+	public static inline var R1:Int = 5;
+	public static inline var L2:Int = 6;
+	public static inline var R2:Int = 7;
+	public static inline var SHARE:Int = 0;
+	public static inline var START:Int = 9;
+	public static inline var PS:Int = 12;
+	public static inline var TOUCHPAD:Int = 13;
+	public static inline var LEFT_ANALOGUE:Int = 10;
+	public static inline var RIGHT_ANALOGUE:Int = 11;
+	
+	public static inline var LEFT_ANALOGUE_X:Int = 0;
+	public static inline var LEFT_ANALOGUE_Y:Int = 1;
+	public static inline var RIGHT_ANALOGUE_X:Int = 2;
+	public static inline var RIGHT_ANALOGUE_Y:Int = 5;
+	
+	public static inline var L2_Y:Int = 3;
+	public static inline var R2_Y:Int = 4;
 }


### PR DESCRIPTION
The `_BUTTON` is inconsistent with `XboxButtonID` / `OUYAButtonID` and kind of redundant (the name of the .hx file already contains "button").
