### PR TITLE
Added removeAll to simplify reference cleanup.

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -97,6 +97,21 @@ class FlxMouseEventManager extends FlxBasic
 	}
 
 	/**
+	 * Removes all sprites from the registry.
+	 */
+	public static function removeAll():Void {
+		if (_registeredObjects != null)
+		{
+			for (reg in _registeredObjects)
+			{
+				remove(reg.object);
+			}
+		}
+		_registeredObjects = new Array<ObjectMouseData<FlxObject>>();
+		_mouseOverObjects = new Array<ObjectMouseData<FlxObject>>();
+	}
+
+	/**
 	 * Reorders the registered objects, using the current object drawing order.
 	 * This should be called if you alter the draw/update order of a registered object,
 	 * That is, if you alter the position of a registered object inside its FlxGroup.


### PR DESCRIPTION
Currently the simplest way to stop FlxMouseEventManager from handling events (without having to individually remove each sprite that was added) was the effective, but ugly:

```
    new FlxMouseEventManager();
```

I just got tired of seeing that call in my FlxState.destroy() functions which doesn't express at all the intent (cleanup references to objects I'm destroying).  So I propose the the following instead:

```
    FlxMouseEventManager.removeAll()
```
