### PR TITLE
_registeredObjects and _mouseOverObjects weren't initialized.

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -308,6 +308,8 @@ class FlxMouseEventManager extends FlxBasic
 		{
 			clearRegistry();
 		}
+		_registeredObjects = new Array<ObjectMouseData<FlxObject>>();
+		_mouseOverObjects = new Array<ObjectMouseData<FlxObject>>();
 	}
 	
 	override public function destroy():Void


### PR DESCRIPTION
Fixes commit f0370a235045c9da3675cdb464488f87de0abc7a.

Error was:
Invalid field access : unshift
Called from flixel/input/mouse/FlxMouseEventManager.hx line 78
