### PR TITLE
Embed sound assets, except HTML5

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -2,8 +2,9 @@
 <project>
 	<icon path="assets/images/logo/HaxeFlixel.svg" />
 	
-	<assets path="assets/sounds" include="*.mp3" if="web" />
-	<assets path="assets/sounds" include="*.ogg" unless="flash" />
+	<assets path="assets/sounds" include="*.ogg" if="html5" />
+	<assets path="assets/sounds" include="*.mp3" if="flash" embed="true" />
+	<assets path="assets/sounds" include="*.ogg" unless="flash || html5" embed="true" />
 	
 	<set name="html5-backend" value="openfl-bitfive" unless="html5-backend" />
 	<haxelib name="openfl" />


### PR DESCRIPTION
This pull request embeds sound assets on all targets except HTML5. Compiler conditionals ensure that the 'beep' asset is only embedded if needed, and embeds MP3 for Flash and OGG for everything else. I had to re-encode `beep.mp3` as Neko didn't like the previous sound file, and I re-encoded `flixel.mp3` as well for consistency. Essentially this just adds `FlxAssets.getBeep()` and `FlxAssets.getFlixelSound()`.

This has been tested in Flash, HTML5, Neko, and Windows, all with `FLX_NO_SOUND_SYSTEM` and `FLX_NO_DEBUG` toggled on or off to test all combinations.
