### PR TITLE
Fixed FlxRandom.int method when using an exclusion list

### DIFF
--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -76,7 +76,7 @@ class FlxRandom
 				
 				do
 				{
-					return Math.floor(Min + generate() / MODULUS * (Max - Min + 1));
+					result = Math.floor(Min + generate() / MODULUS * (Max - Min + 1));
 				}
 				while (Excludes.indexOf(result) >= 0);
 				


### PR DESCRIPTION
It used to ignore the exclusion list and return the first generated value anyways.
