### PR TITLE
Added a speed property to FlxEmitter

### DIFF
--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -180,7 +180,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		y = Y;
 		
 		velocity = new FlxPointRangeBounds(-100, -100, 100, 100);
-		speed = new FlxRangeBounds<Float>(0, 0);
+		speed = new FlxRangeBounds<Float>(0, 100);
 		angularVelocity = new FlxRangeBounds<Float>(0, 0);
 		angle = new FlxRangeBounds<Float>(0);
 		launchAngle = new FlxBounds<Float>(-180, 180);


### PR DESCRIPTION
It will be used when the emitter mode is set to CIRCLE
