### PR TITLE
FlxAssets: getFileReferences() fix

### DIFF
--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -80,7 +80,7 @@ class FlxAssets
 				{
 					var extension:String = name.split(".")[1]; // get the string after the dot
 					if (filterExtensions.indexOf(extension) == -1)
-						break;
+						continue;
 				}
 				
 				fileReferences.push(new FileReference(directory + name));


### PR DESCRIPTION
For filterExtensions to work properly, ‘continue’ should be used
instead of ‘break’.
In the current implementation, the loop stops as soon as it finds a
file with an extension not included in filterExtensions.
