### PR TITLE
Remove race condition when opening/closing substates in same update

### DIFF
--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -77,7 +77,6 @@ class FlxState extends FlxGroup
 	public inline function closeSubState():Void
 	{
 		_requestSubStateReset = true;
-		_requestedSubState = null;
 	}
 
 	/**
@@ -100,6 +99,7 @@ class FlxState extends FlxGroup
 		
 		// Assign the requested state (or set it to null)
 		subState = _requestedSubState;
+		_requestedSubState = null;
 		
 		if (subState != null)
 		{

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -76,7 +76,7 @@ class FlxSubState extends FlxState
 	 */ 
 	public function close():Void
 	{
-		if (_parentState != null) 
+		if (_parentState != null && _parentState.subState == this) 
 		{ 
 			_parentState.closeSubState(); 
 		}


### PR DESCRIPTION
This took a while to figure out the issue, seeing as it only happened one in sixty or so tries.

Basically, if you have a state with `persistentUpdate = true`, it's possible it might try to open a new substate when a substate is already open, which is fine. However, the substate may also have a way of being closed. If the substate tries to close on the same frame as the parent state tries to open a new substate, there is a race condition which can result in the new substate not opening.
