### PR TITLE
Comparing methods with == doesn't work

### DIFF
--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -175,7 +175,7 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 	{
 		for (handler in _handlers)
 		{
-			if (handler.listener == listener)
+			if (Reflect.compareMethods(handler.listener, listener))
 			{
 				return handler; // Listener was already registered.
 			}


### PR DESCRIPTION
The correct way seems to be with Reflect.
The == works for flash target, but doesn't work for neko target.
