### PR TITLE
Fix equality and operations (*, +, -) for FlxColor:

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -701,11 +701,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * Multiply the RGB channels of two FlxColors
 	 */
 	@:op(A * B)
-	#if flash
-	public static function multiply(lhs:FlxColor, rhs:FlxColor):FlxColor
-	#else
 	public static function multiply(lhs:Null<FlxColor>, rhs:Null<FlxColor>):FlxColor
-	#end
 	{
 		if (lhs == null && rhs == null)
 		{
@@ -729,11 +725,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * Add the RGB channels of two FlxColors
 	 */
 	@:op(A + B)
-	#if flash
-	public static function add(lhs:FlxColor, rhs:FlxColor):FlxColor
-	#else
 	public static function add(lhs:Null<FlxColor>, rhs:Null<FlxColor>):FlxColor
-	#end
 	{
 		if (lhs == null && rhs == null)
 		{
@@ -757,11 +749,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * Subtract the RGB channels of one FlxColor from another
 	 */
 	@:op(A - B)
-	#if flash
-	public static function subtract(lhs:FlxColor, rhs:FlxColor):FlxColor
-	#else
 	public static function subtract(lhs:Null<FlxColor>, rhs:Null<FlxColor>):FlxColor
-	#end
 	{
 		if (lhs == null && rhs == null)
 		{

--- a/tests/src/flixel/util/FlxColorTest.hx
+++ b/tests/src/flixel/util/FlxColorTest.hx
@@ -1,0 +1,99 @@
+package flixel.util;
+
+import flixel.util.FlxColor;
+import massive.munit.Assert;
+
+class FlxColorTest extends FlxTest
+{
+
+	@Test
+	function isNull():Void
+	{
+		var color:Null<FlxColor> = null;
+		Assert.isNull(color);
+	}
+	
+	@Test
+	function isNullFunction():Void
+	{
+		var f = function(?c:FlxColor, isTrue:Bool) { if (isTrue) Assert.isTrue(c == null); else Assert.isFalse(c == null); };
+		f(null, true);
+		f(0, false);
+		f(FlxColor.RED, false);
+	}
+	
+	@Test
+	function equalityToNull():Void
+	{
+		var color1:Null<FlxColor> = null;
+		var color2:FlxColor = FlxColor.BLACK;
+		Assert.isFalse(color1 == color2);
+	}
+	
+	@Test
+	function equalityToSame():Void
+	{
+		var color1:FlxColor = FlxColor.BLACK;
+		var color2:FlxColor = FlxColor.BLACK;
+		Assert.isTrue(color1 == color2);
+	}
+	
+	@Test
+	function equalityNotSame():Void
+	{
+		var color1:FlxColor = FlxColor.RED;
+		var color2:FlxColor = FlxColor.BLUE;
+		Assert.isFalse(color1 == color2);
+	}
+	
+	@Test
+	function addSame():Void
+	{
+		var null_color:Null<FlxColor> = null;
+		Assert.areSame(FlxColor.RED, (FlxColor.RED + FlxColor.RED));
+		Assert.areSame(FlxColor.RED, (FlxColor.RED + null_color));
+		Assert.areSame(FlxColor.RED, (null_color + FlxColor.RED));
+		Assert.areSame(FlxColor.BLACK, (null_color + null_color));
+	}
+	
+	@Test
+	function subtractSame():Void
+	{
+		var null_color:Null<FlxColor> = null;
+		Assert.areSame(FlxColor.BLACK, (FlxColor.RED - FlxColor.RED));
+		Assert.areSame(FlxColor.RED, (FlxColor.RED - null_color));
+		Assert.areSame(FlxColor.RED, (null_color - FlxColor.RED));
+		Assert.areSame(FlxColor.BLACK, (null_color - null_color));
+	}
+	
+	@Test
+	function multiplySame():Void
+	{
+		var null_color:Null<FlxColor> = null;
+		Assert.areSame(FlxColor.RED, (FlxColor.RED * FlxColor.RED));
+		Assert.areSame(FlxColor.RED, (FlxColor.RED * null_color));
+		Assert.areSame(FlxColor.RED, (null_color * FlxColor.RED));
+		Assert.areSame(FlxColor.BLACK, (null_color * null_color));
+	}
+	
+	@Test
+	function addNotSame():Void
+	{
+		Assert.areSame(0xFFFF8000, (FlxColor.RED + FlxColor.GREEN)); // 0xFFFF0000 + 0xFF008000
+		Assert.areSame(0xFFFF8000, (FlxColor.GREEN + FlxColor.RED));
+	}
+	
+	@Test
+	function subtractNotSame():Void
+	{
+		Assert.areSame(FlxColor.RED, (FlxColor.RED - FlxColor.GREEN));
+		Assert.areSame(FlxColor.GREEN, (FlxColor.GREEN - FlxColor.RED));
+	}
+	
+	@Test
+	function multiplyNotSame():Void
+	{
+		Assert.areSame(FlxColor.BLACK, (FlxColor.RED * FlxColor.GREEN));
+		Assert.areSame(FlxColor.BLACK, (FlxColor.GREEN * FlxColor.RED));
+	}
+}


### PR DESCRIPTION
- Equality: In cpp a null FlxColor can't exist because there is no null
  int, they will be initialized to 0 so if you compare FlxColor == null it
  will always be false because 0 == null is false.
- Operations: Because it's possible to make an operation in null members,
  fallbacks are needed so it won't happen.
  If both members are null the returned color is Black, if only a member
  is null the non-null member will be returned, if both are not null the
  operation proceeds as expected.
