### PR TITLE
Add "enabled" to FlxButton

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -207,7 +207,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite
 		setupAnimation("normal", FlxButton.NORMAL);
 		setupAnimation("highlight", FlxButton.HIGHLIGHT);
 		setupAnimation("pressed", FlxButton.PRESSED);
-		setupAnimation("pressed", FlxButton.DISABLED);
+		setupAnimation("disabled", FlxButton.DISABLED);
 	}
 	
 	private function setupAnimation(animationName:String, frameIndex:Int):Void


### PR DESCRIPTION
I added an enabled field to FlxButton. When true, it acts as normal (default). When false, it disables the button, and prevents any events/callbacks from being called. 

Having some slight issues with the text alpha, but I have tested functionality with the following code:

```
package states;

import flixel.FlxState;
import flixel.ui.FlxButton;

class TestState extends FlxState
{
  var btn:FlxButton;
  override public function create():Void
  {
    btn = new FlxButton(20,20,"TEST", callback);
    btn.enabled = false;
    add(btn);

    var btn2:FlxButton = new FlxButton(20,50,"Toggle", callback2);
    add(btn2);
  }
  public function callback():Void
  {
    trace("CALLBACK");
  }

  public function callback2():Void
  {
    trace("callback 2");
    btn.enabled = !btn.enabled;
  }
}
```

Let me know if there's any issues with the commit, and I will do my best to correct them if needed.
