### PR TITLE
Added fromName to FlxColor

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -150,6 +150,17 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var color = new FlxColor();
 		return color.setHSL(Hue, Saturation, Lightness, Alpha);
 	}
+
+	/** 
+	 * Generates a color from a String name.
+	 * 
+	 * @param Name	The name of the color
+	 * @return The color as a FlxColor
+	 */
+	public static inline function fromName(Name:String):FlxColor
+	{
+		return Reflect.field(FlxColor, Name);
+	}
 	
 	/**
 	 * Get HSB color wheel values in an array which will be 360 elements in size


### PR DESCRIPTION
Create `FlxColor.fromName()` per https://github.com/HaxeFlixel/flixel-ui/pull/68
Utilizes reflection to allow mapping from string names (such as BLUE and YELLOW) to FlxColors. 

Of course, there's still a couple minor tweaks available depending on what's desired:
- handling of lowercase names
- handling of misspellings (such as BLU)
- handling of GRAY/GREY (per https://github.com/HaxeFlixel/flixel/pull/1233, probably should add GREY for those who want it). 
