### PR TITLE
Don't copy align values when applying the formats.

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -966,7 +966,7 @@ class FlxText extends FlxSprite
 		}
 	}
 	
-	private function copyTextFormat(from:TextFormat, to:TextFormat, ?withAlign:Bool = true):Void
+	private function copyTextFormat(from:TextFormat, to:TextFormat, withAlign:Bool = true):Void
 	{
 		to.font = from.font;
 		to.bold = from.bold;


### PR DESCRIPTION
It was having problems if the default align was set to CENTER and we are
manually centering the text to avoid blur. (It was setting the adjusted
format align to LEFT but, when applying the formats, the CENTER align
from the default format was copied again to the adjusted format making
it draw in the center but with the manual centering applied, so it was
finally drawn like a RIGHT align would look)
