### PR TITLE
Added a global CachedGraphics persistence variable.

### DIFF
--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -18,11 +18,6 @@ class BitmapFrontEnd
 	@:allow(flixel.system.frontEnds.BitmapLogFrontEnd)
 	private var _cache:Map<String, CachedGraphics>;
 	
-	/**
-	 * The default value for the CachedGraphics persist variable. Determines whether or not CachedGraphics are destroyed on a state change.
-	 */
-	public var persistentCachedGraphics:Bool = false;
-	
 	public function new()
 	{
 		clearCache();

--- a/flixel/util/loaders/CachedGraphics.hx
+++ b/flixel/util/loaders/CachedGraphics.hx
@@ -10,6 +10,10 @@ import flixel.util.FlxDestroyUtil;
 class CachedGraphics
 {
 	/**
+	 * The default value for the CachedGraphics persist variable at creation. Determines if CachedGraphics persist through a state change.
+	 */
+	public static var defaultPersist:Bool = false;
+	/**
 	 * Key in BitmapFrontEnd cache
 	 */
 	public var key:String;
@@ -62,7 +66,7 @@ class CachedGraphics
 	{
 		key = Key;
 		bitmap = Bitmap;
-		persist = Persist != null ? Persist : FlxG.bitmap.persistentCachedGraphics;
+		persist = Persist != null ? Persist : defaultPersist;
 	}
 
 	/**


### PR DESCRIPTION
### Summary

If specified, `CachedGraphics` will use the `Persist:Null<Bool>` value supplied by the
constructor. Otherwise, it defaults to the value of
`defaultPersist` in `CachedGraphics`.

This allows globally setting what the persist value of `CachedGraphics`
should default to, making it easier to keep desired graphics persistent between state
changes.
#### Changes
1. Persist in `CachedGraphics`'s constructor becomes a `Null<Bool>` variable, so that if `Persist` is null, `persist` in the `CachedGraphics` is set to the default value (the value of `CachedGraphics.defaultPersist`).
2. `CachedGraphics` gets a simple `defaultPersist:Bool` so that persistence with all created `CachedGraphics` can be globally toggled.
#### Reasoning
1. Simply put, if one wishes to keep certain graphics persistent between state changes (`FlxSprite`, `FlxText` and so on), they have to manually adjust the `cachedGraphics.persist` variable for each object. This can be made easier with a global variable.
2. Rather than risk missing some objects, it's _considerably_ easier to just set `CachedGraphics.defaultPersist = true`, create the objects that you wish to be persistent, and then `CachedGraphics.defaultPersist = false`.
3. Persistence is handy for objects that will be used in `Menu` and `Play` states of a game. My own project has a Leaderboard menu that generates quite a bit of names and entries. Only having to create these objects once is a _significant_ advantage, since this menu is accessible from most areas of the game. Having an easy way to control the persistence of objects as a whole is extremely handy for this.
#### Update

Thanks to the feedback from gamedevsam and Gama11, I believe this static variable is clearer with its naming convention and position within CachedGraphics. Thanks guys.
