### PR TITLE
FlxGroup: implement revive()

### DIFF
--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -430,7 +430,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 	 */
 	public function start(Explode:Bool = true, Frequency:Float = 0.1, Quantity:Int = 0):FlxTypedEmitter<T>
 	{
-		revive();
+		exists = true;
 		visible = true;
 		emitting = true;
 		

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -593,7 +593,28 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		
 		super.kill();
 	}
-	
+
+	/**
+	 * Calls revive on the group's members and then on the group itself.
+	 */
+	override public function revive():Void
+	{
+		var i:Int = 0;
+		var basic:FlxBasic = null;
+
+		while (i < length)
+		{
+			basic = members[i++];
+
+			if (basic != null && ! basic.exists)
+			{
+				basic.revive();
+			}
+		}
+
+		super.revive();
+	}
+
 	/**
 	 * Iterate through every member
 	 */

--- a/tests/src/TestSuite.hx
+++ b/tests/src/TestSuite.hx
@@ -1,6 +1,7 @@
 import massive.munit.TestSuite;
 
 import flixel.animation.FlxAnimationControllerTest;
+import flixel.effects.particles.FlxEmitterTest;
 import flixel.FlxCameraTest;
 import flixel.FlxGTest;
 import flixel.FlxSpriteTest;
@@ -30,6 +31,7 @@ class TestSuite extends massive.munit.TestSuite
 		super();
 
 		add(flixel.animation.FlxAnimationControllerTest);
+		add(flixel.effects.particles.FlxEmitterTest);
 		add(flixel.FlxCameraTest);
 		add(flixel.FlxGTest);
 		add(flixel.FlxSpriteTest);

--- a/tests/src/flixel/effects/particles/FlxEmitterTest.hx
+++ b/tests/src/flixel/effects/particles/FlxEmitterTest.hx
@@ -1,0 +1,31 @@
+package flixel.effects.particles;
+
+import flixel.effects.particles.FlxEmitter;
+import massive.munit.Assert;
+
+class FlxEmitterTest extends FlxTest
+{
+	var emitter:FlxEmitter;
+
+	@Before
+	function before():Void
+	{
+		emitter = new FlxEmitter();
+
+		destroyable = emitter;
+	}
+
+	@Test
+	function testStartShouldNotReviveMembers():Void
+	{
+		emitter.makeParticles(1, 1, 1);
+		// precondition
+		Assert.isFalse(emitter.exists);
+		emitter.forEach(function(each){Assert.isFalse(each.exists);});
+		// exercise
+		emitter.start();
+		// verify
+		Assert.isTrue(emitter.exists);
+		emitter.forEach(function(each){Assert.isFalse(each.exists);});
+	}
+}

--- a/tests/src/flixel/group/FlxGroupTest.hx
+++ b/tests/src/flixel/group/FlxGroupTest.hx
@@ -101,4 +101,17 @@ class FlxGroupTest extends FlxTest
 		}
 		group.members[0].exists = true;
 	}
+
+	@Test
+	function testKillAndRevive():Void
+	{
+		group.kill();
+		group.forEach(function(each){
+			Assert.isFalse(each.exists);
+		});
+		group.revive();
+		group.forEach(function(each){
+			Assert.isTrue(each.exists);
+		});
+	}
 }


### PR DESCRIPTION
FlxTypedGroup has method kill() that kills all members in group, but revive() did not revive them.
I have implemented revive() so that all members to be revived.
Please merge.
