### PR TITLE
FlxSpriteGroup: if you turn out outlines in the debugger, drawDebug() fa...

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -14,6 +14,9 @@ import flixel.system.FlxAssets.FlxTextureAsset;
 import flixel.system.layer.frames.FlxFrame;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSort;
+#if !FLX_NO_DEBUG
+	import flixel.math.FlxRect;
+#end
 
 typedef FlxSpriteGroup = FlxTypedSpriteGroup<FlxSprite>;
 
@@ -93,6 +96,11 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		scrollFactor.set(1, 1);
 	 	
 		initMotionVars();
+		#if !FLX_NO_DEBUG
+			//initialize these to avoid a null error if drawDebug() is called
+			_point = FlxPoint.get();
+			_rect = FlxRect.get();
+		#end
 	}
 	
 	/**


### PR DESCRIPTION
...ils on a null check because _point and _rect do not exist and are assumed to exist in FlxObject.drawDebug().

The overriden initVars() function in FlxSpriteGroup implies that these variables were excluded because they are not otherwise used by FlxSpriteGroup; Therefore, I added a compiler conditional that only creates them if the debugger overlay is available.
