### PR TITLE
Check all FlxObjects for mouse events, closes #1252

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -69,11 +69,6 @@ class FlxMouseEventManager extends FlxBasic
 	public static function add<T:FlxObject>(Object:T, ?OnMouseDown:T->Void, ?OnMouseUp:T->Void, ?OnMouseOver:T->Void,
 		?OnMouseOut:T->Void, MouseChildren = false, MouseEnabled = true, PixelPerfect = true, ?MouseButtons:Array<FlxMouseButtonID>):T
 	{
-		if (Std.is(Object, FlxTypedSpriteGroup))
-		{
-			throw "FlxSpriteGroups are not supported by FlxMouseEventManager";
-		}
-		
 		init(); // MEManager is initialized and added to plugins if it was not there already.
 		
 		var newReg = new ObjectMouseData<T>(Object, OnMouseDown, OnMouseUp, OnMouseOver,
@@ -279,9 +274,9 @@ class FlxMouseEventManager extends FlxBasic
 			{
 				traverseFlxGroup(group, OrderedObjects);
 			}
-			else if (Std.is(basic, FlxSprite))
+			if (Std.is(basic, FlxObject))
 			{
-				var reg = getRegister(cast(basic, FlxSprite));
+				var reg = getRegister(cast basic);
 				
 				if (reg != null)
 				{


### PR DESCRIPTION
Closes #1252. 

All FlxObjects + groups will now be checked when traversing groups rather than just FlxSprites and FlxGroups.  Sprite groups are treated as sprites + groups. Tilemaps are mouse-able now (you could `add()` them, but they wouldn't be checked). If you can `add()` any FlxObject to the mouse event manager, mouse events should be available for any FlxObject.

It was easier to `Std.is` than to compare `flixelType` since `OBJECT | TILEMAP | SPRITEGROUP` all extend FlxObject and `NONE | GROUP` don't.
