### PR TITLE
Change the updateFollow function, style SCREEN_BY_SCREEN check

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -571,7 +571,7 @@ class FlxCamera extends FlxBasic
 			
 			if (style == SCREEN_BY_SCREEN) 
 			{
-				if (targetX > (scroll.x + width))
+				if (targetX >= (scroll.x + width))
 				{
 					_scrollTarget.x += width;
 				}
@@ -580,7 +580,7 @@ class FlxCamera extends FlxBasic
 					_scrollTarget.x -= width;
 				}
 
-				if (targetY > (scroll.y + height))
+				if (targetY >= (scroll.y + height))
 				{
 					_scrollTarget.y += height;
 				}


### PR DESCRIPTION
Change the updateFollow function. In the style SCREEN_BY_SCREEN check, changed the lines targetX > (scroll.x + width) to targetX >= (scroll.x + width). Same for the TargetY section.

This allows for switching to the next screen when moving right or down upon
the followed sprite moving completely to the next screen rather than
waiting until they move further in to the screen.

This came to light when using this camera style in combination with grid based movement.
