### PR TITLE
Clearer description of FlxBars fixedPosition

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -30,7 +30,7 @@ import flixel.util.loaders.CachedGraphics;
 class FlxBar extends FlxSprite
 {
 	/**
-	 * fixedPosition controls if the FlxBar sprite is at a fixed location on screen, or tracking its parent
+	 * fixedPosition controls if the FlxBar sprite is at a fixed location in game, or tracking its parent
 	 */
 	public var fixedPosition:Bool = true;
 	/**


### PR DESCRIPTION
It confused me, I expected the bar to stay in the same place on screen, which `scrollFactor.x = scrollFactor.y = 0;` does. 
I think it'd be easier to understand this way.
