### PR TITLE
Changed swipe duration from milliseconds to seconds

### DIFF
--- a/flixel/input/FlxSwipe.hx
+++ b/flixel/input/FlxSwipe.hx
@@ -46,7 +46,7 @@ class FlxSwipe
 			LabelValuePair.weak("end", endPosition),
 			LabelValuePair.weak("distance", distance),
 			LabelValuePair.weak("angle", angle),
-			LabelValuePair.weak("duration", (duration / 1000))]);
+			LabelValuePair.weak("duration", duration)]);
 	}
 	
 	private inline function get_distance():Float
@@ -61,6 +61,6 @@ class FlxSwipe
 	
 	private inline function get_duration():Float
 	{
-		return (_endTimeInTicks - _startTimeInTicks);
+		return (_endTimeInTicks - _startTimeInTicks) / 1000;
 	}
 }


### PR DESCRIPTION
Changing swipe duration to be in seconds instead of in milliseconds. Also made debug string and actual duration consistent.
