### PR TITLE
Checks for an exception

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -591,6 +591,11 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var i:Int = Tile;
 		var l:Int = Tile + Range;
 		
+		if (l>_tileObjects.length) 
+		{
+			throw 'Cannot access tile with index $l maximum possible is ${_tileObjects.length} probale error is in Tile=$Tile and Range=$Range parameters';
+		}
+		
 		while (i < l)
 		{
 			tile = _tileObjects[i++];


### PR DESCRIPTION
If l is bigger than _tileObjects.length then there is an exception when trying to access the null tile. (In row 602) The user also must be warned about the error, because probably he haven't supplied the correct Tile or Range parameter.
