### PR TITLE
call .revive() last on object .reset()

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -757,12 +757,12 @@ class FlxObject extends FlxBasic
 	 */
 	public function reset(X:Float, Y:Float):Void
 	{
-		revive();
 		touching = NONE;
 		wasTouching = NONE;
 		setPosition(X, Y);
 		last.set(x, y);
 		velocity.set();
+		revive();
 	}
 	
 	/**


### PR DESCRIPTION
I was having some strange bugs because revive was the first being called in reset() I think it's sane to call it last after setting all the variables.
