### PR TITLE
Update FlxSpriteUtil.drawPolygon(), used to remove the first element of the Vertices array

### DIFF
--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -466,6 +466,7 @@ class FlxSpriteUtil
 			flashGfx.lineTo(p.x, p.y);
 		}
 		endDraw(sprite, drawStyle);
+		Vertices.unshift(p);
 		return sprite;
 	}
 


### PR DESCRIPTION
As in the title, drawPolygon() removed the first element of the Vertices array without any warning whatsoever. Caused me quite a headache while testing Polygon hitboxes to find out that the source of the problem was this function.
