### PR TITLE
Update FlxMatrix.hx

### DIFF
--- a/flixel/math/FlxMatrix.hx
+++ b/flixel/math/FlxMatrix.hx
@@ -14,6 +14,13 @@ class FlxMatrix extends Matrix
 	 */
 	public static var MATRIX:FlxMatrix = new FlxMatrix();
 	
+	#if flash
+	public function new()
+	{
+		super();
+	}
+	#end
+	
 	/**
 	 * Rotates this matrix, but takes the values of sine and cosine,
 	 * so it might be usefull when you rotate multiple matrices by the same angle


### PR DESCRIPTION
It's probably how haxe handles things in flash, but for some reason, in flash, calling new FlxMatrix() didn't called the extended Matrix() constructor, leaving every variable nulled out, while on other targets, it worked correctly and returned an identity matrix.

EDIT : This seems to be a problem with some extern classes. I couldn't reproduce it with classes built-in (http://try.haxe.org/#6dB14), while @Gama11 reproduced it using the Matrix class (http://try.haxe.org/#8ecc2)
