### PR TITLE
Fix existsTransform problem

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -552,7 +552,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		
 		for (sprite in _sprites)
 		{
-			if ((sprite != null) /*&& sprite.exists*/)
+			if (sprite != null)
 			{
 				Function(cast sprite, Value);
 			}


### PR DESCRIPTION
fixes that existsTransform cannot transform a child's `exists` property from false to true
