### PR TITLE
Alpha=0 in FlxSpriteGroup

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -97,6 +97,10 @@ class FlxSprite extends FlxObject
 	 */
 	public var alpha(default, set):Float = 1.0;
 	/**
+	 * Used in sprite groups when group.alpha is set to 0.
+	 */
+	public var oldAlpha(default, set):Float = 1.0;
+	/**
 	 * Set facing using FlxObject.LEFT, RIGHT, UP, and DOWN to take advantage 
 	 * of flipped sprites and/or just track player orientation more easily.
 	 */
@@ -1206,6 +1210,12 @@ class FlxSprite extends FlxObject
 	{
 		alpha = FlxMath.bound(Alpha, 0, 1);
 		updateColorTransform();
+		return alpha;
+	}
+	
+	private function set_oldAlpha(Alpha:Float):Float
+	{
+		oldAlpha = FlxMath.bound(Alpha, 0, 1);
 		return alpha;
 	}
 	

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -256,7 +256,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		var sprite:FlxSprite = cast Sprite;
 		sprite.x += x;
 		sprite.y += y;
-		sprite.alpha *= alpha;
+		alphaMultTransform(sprite, alpha);
 		sprite.scrollFactor.copyFrom(scrollFactor);
 		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
 		return group.add(Sprite);
@@ -284,6 +284,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	public function remove(Object:T, Splice:Bool = false):T
 	{
+		alphaDivTransform(Object, alpha);
 		return group.remove(Object, Splice);
 	}
 	
@@ -668,8 +669,9 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		
 		if (exists && alpha != Value)
 		{
-			var factor:Float = (alpha > 0) ? Value / alpha : 0;
-			transformChildren(alphaTransform, factor);
+			if (alpha == 0) transformChildren(alphaDivTransform, alpha);
+			var factor:Float = (alpha > 0) ? Value / alpha : Value;
+			transformChildren(alphaMultTransform, factor);
 		}
 		return alpha = Value;
 	}
@@ -834,7 +836,8 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	private inline function xTransform(Sprite:FlxSprite, X:Float)								{ Sprite.x += X; }								// addition
 	private inline function yTransform(Sprite:FlxSprite, Y:Float)								{ Sprite.y += Y; }								// addition
 	private inline function angleTransform(Sprite:FlxSprite, Angle:Float)						{ Sprite.angle += Angle; }						// addition
-	private inline function alphaTransform(Sprite:FlxSprite, Alpha:Float)						{ Sprite.alpha *= Alpha; }						// multiplication
+	private inline function alphaMultTransform(Sprite:FlxSprite, Alpha:Float)					{ if (Alpha == 0) Sprite.oldAlpha = Sprite.alpha; Sprite.alpha *= Alpha; }						// multiplication
+	private inline function alphaDivTransform(Sprite:FlxSprite, Alpha:Float)					{ if (Alpha == 0) Sprite.alpha = Sprite.oldAlpha;  else Sprite.alpha /= Alpha; }				// division
 	private inline function facingTransform(Sprite:FlxSprite, Facing:Int)						{ Sprite.facing = Facing; }						// set
 	private inline function flipXTransform(Sprite:FlxSprite, FlipX:Bool)						{ Sprite.flipX = FlipX; }						// set
 	private inline function flipYTransform(Sprite:FlxSprite, FlipY:Bool)						{ Sprite.flipY = FlipY; }						// set
@@ -848,7 +851,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	private inline function solidTransform(Sprite:FlxSprite, Solid:Bool)						{ Sprite.solid = Solid; }						// set
 	private inline function aliveTransform(Sprite:FlxSprite, Alive:Bool)						{ Sprite.alive = Alive; }						// set
 	private inline function existsTransform(Sprite:FlxSprite, Exists:Bool)						{ Sprite.exists = Exists; }						// set
-	private inline function camerasTransform(Sprite:FlxSprite, Cameras:Array<FlxCamera>)		{ Sprite.cameras = Cameras; }						// set
+	private inline function camerasTransform(Sprite:FlxSprite, Cameras:Array<FlxCamera>)		{ Sprite.cameras = Cameras; }					// set
 
 	private inline function offsetTransform(Sprite:FlxSprite, Offset:FlxPoint)					{ Sprite.offset.copyFrom(Offset); }				// set
 	private inline function originTransform(Sprite:FlxSprite, Origin:FlxPoint)					{ Sprite.origin.copyFrom(Origin); }				// set


### PR DESCRIPTION
Closes #1353 

I didn't really test it much, but I wanted to post this before going to sleep to get some comments. I had to add a new var to FlxSprite to store the old alpha value before you multiply it by 0. Then when "dividing by 0," it resets the alpha back to what it was before. The issue I brought up where setting the alpha to 0 twice in a row can't happen because it ignores setting children when Value already equals alpha.

Side note: how come `remove()` doesn't subtract away the x and y? The other stuff makes sense ignoring sorta, but if you moved a sprite from one group to another, it seems like its position would be off.
