### PR TITLE
Make start() of FlxTimer and FlxPath explicit

### DIFF
--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -140,7 +140,7 @@ class FlxFlicker implements IFlxDestroyable
 		completionCallback = CompletionCallback;
 		progressCallback = ProgressCallback;
 		endVisibility = EndVisibility;
-		timer = new FlxTimer(interval, flickerProgress, Std.int(duration / interval));
+		timer = new FlxTimer().start(interval, flickerProgress, Std.int(duration / interval));
 	}
 	
 	/**

--- a/flixel/system/FlxSplash.hx
+++ b/flixel/system/FlxSplash.hx
@@ -51,7 +51,7 @@ class FlxSplash extends FlxState
 		
 		for (time in _times)
 		{
-			new FlxTimer(time, timerCallback);
+			new FlxTimer().start(time, timerCallback);
 		}
 		
 		var stageWidth:Int = Lib.current.stage.stageWidth;

--- a/flixel/util/FlxPath.hx
+++ b/flixel/util/FlxPath.hx
@@ -131,15 +131,9 @@ class FlxPath implements IFlxDestroyable
 	private var _wasObjectImmovable:Bool;
 	
 	/**
-	 * Creates a new FlxPath (and calls start() right away if Object != null).
+	 * Creates a new FlxPath.
 	 */
-	public function new(?Object:FlxObject, ?Nodes:Array<FlxPoint>, Speed:Float = 100, Mode:Int = FlxPath.FORWARD, AutoRotate:Bool = false) 
-	{
-		if (Object != null)
-		{
-			start(Object, Nodes, Speed, Mode, AutoRotate);
-		}
-	}
+	public function new() {}
 	
 	public function reset():FlxPath
 	{

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -68,23 +68,9 @@ class FlxTimer implements IFlxDestroyable
 	private var _inManager:Bool = false;
 	
 	/**
-	 * Creates a new timer (and calls start() right away if Time != null).
-	 * 
-	 * @param	Time		How many seconds it takes for the timer to go off.
-	 * 						If null then timer will fire OnComplete callback only once at the first call of update method (which means that Loops argument will be ignored).
-	 * @param	OnComplete	Optional, triggered whenever the time runs out, once for each loop.
-	 * 						Callback should be formed "onTimer(Timer:FlxTimer);"
-	 * @param	Loops		How many times the timer should go off. 0 means "looping forever".
+	 * Creates a new timer.
 	 */
-	public function new(?Time:Null<Float>, ?OnComplete:FlxTimer->Void, Loops:Int = 1)
-	{
-		if (Time == null)
-		{
-			Time = 0;
-		}
-		
-		start(Time, OnComplete, Loops);
-	}
+	public function new() {}
 	
 	/**
 	 * Clean up memory.
@@ -166,16 +152,6 @@ class FlxTimer implements IFlxDestroyable
 	public function update(elapsed:Float):Void
 	{
 		_timeCounter += elapsed;
-		
-		if (time == 0)
-		{
-			if (onComplete != null)
-			{
-				onComplete(this);
-			}
-			
-			cancel();
-		}
 		
 		while ((_timeCounter >= time) && active && !finished)
 		{

--- a/tests/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/src/flixel/tweens/FlxTweenTest.hx
@@ -38,7 +38,7 @@ class FlxTweenTest extends FlxTest
 			function (tween:FlxTween)
 			{
 				tween.active = false;
-				new FlxTimer(0.05, function(_)
+				new FlxTimer().start(0.05, function(_)
 				{
 					tweenActive = tween.active;
 				});


### PR DESCRIPTION
@gamedevsam @Beeblerox 

Previously discussed [here](https://github.com/HaxeFlixel/flixel/commit/1e6934e2538d1b33cb2fd0148d609144be1a1cf9#commitcomment-8584704).

I feel like this change makes things much less confusing (#1352).
