### PR TITLE
Ensure FlxSprite's animation has the right angle.

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1225,11 +1225,17 @@ class FlxSprite extends FlxObject
 		return color;
 	}
 	
-	override private function set_angle(Value:Float):Float
-	{
-		_angleChanged = (angle != Value) || _angleChanged;
-		return super.set_angle(Value);
-	}
+        override private function set_angle(Value:Float):Float
+        {
+                var newAngle = (angle != Value);
+                var ret = super.set_angle(Value);
+                if (newAngle)
+                {
+                        _angleChanged = true;
+                        animation.update(0);
+                }
+                return ret;
+        }
 	
 	private function set_blend(Value:BlendMode):BlendMode 
 	{

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -122,6 +122,7 @@ class FlxAnimationController implements IFlxDestroyable
 		destroyAnimations();
 		Controller = (Controller != null) ? Controller : this;
 		_prerotated = new FlxPrerotatedAnimation(Controller, Controller._sprite.bakedRotationAngle);
+                _prerotated.angle = _sprite.angle;
 	}
 	
 	public function destroyAnimations():Void


### PR DESCRIPTION
When we have a FlxPrerotatedAnimation, it used to have its angle lag
behind until the next update() call, both for the initial value of
FlxSprite.angle, and for any updates to it.

This prepopulates the FlxPrerotatedAnimation.angle, and makes sure to
call FlxAnimationController's update().

Fixes #1395.
