### PR TITLE
Allow TexturePacker's JSON-Hash

### DIFF
--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -53,36 +53,53 @@ class FlxAtlasFrames extends FlxFramesCollection
 		
 		var data:Dynamic = Json.parse(Description);
 		
-		var rotated:Bool;
-		var name:String;
-		var sourceSize:FlxPoint;
-		var offset:FlxPoint;
-		var angle:FlxFrameAngle;
-		var frameRect:FlxRect;
-		
-		for (frame in Lambda.array(data.frames))
+		// JSON-Array
+		if (Std.is(data.frames, Array))
 		{
-			rotated = frame.rotated;
-			name = frame.filename;
-			sourceSize = FlxPoint.get(frame.sourceSize.w, frame.sourceSize.h);
-			offset = FlxPoint.get(frame.spriteSourceSize.x, frame.spriteSourceSize.y);
-			angle = FlxFrameAngle.ANGLE_0;
-			frameRect = null;
-			
-			if (rotated)
+			for (frame in Lambda.array(data.frames))
 			{
-				frameRect = new FlxRect(frame.frame.x, frame.frame.y, frame.frame.h, frame.frame.w);
-				angle = FlxFrameAngle.ANGLE_NEG_90;
+				texturePackerHelper(frame.filename, frame, frames);
 			}
-			else
+		}
+		
+		// JSON-Hash
+		else
+		{
+			for (frameName in Reflect.fields(data.frames))
 			{
-				frameRect = new FlxRect(frame.frame.x, frame.frame.y, frame.frame.w, frame.frame.h);
+				texturePackerHelper(frameName, Reflect.field(data.frames, frameName), frames);
 			}
-			
-			frames.addAtlasFrame(frameRect, sourceSize, offset, name, angle);
 		}
 		
 		return frames;
+	}
+	
+	/**
+	 * Internal method for TexturePacker parsing. Parses the actual frame data.
+	 * @param	FrameName		Name of the frame (filename of the original source image).
+	 * @param	FrameData		The TexturePacker data excluding "filename".
+	 * @param	Frames			The FlxAtlasFrames to add this frame to.
+	 */
+	private static function texturePackerHelper(FrameName:String, FrameData:Dynamic, Frames:FlxAtlasFrames):Void
+	{
+		var rotated:Bool = FrameData.rotated;
+		var name:String = FrameName;
+		var sourceSize:FlxPoint = FlxPoint.get(FrameData.sourceSize.w, FrameData.sourceSize.h);
+		var offset:FlxPoint = FlxPoint.get(FrameData.spriteSourceSize.x, FrameData.spriteSourceSize.y);
+		var angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0;
+		var frameRect:FlxRect = null;
+		
+		if (rotated)
+		{
+			frameRect = new FlxRect(FrameData.frame.x, FrameData.frame.y, FrameData.frame.h, FrameData.frame.w);
+			angle = FlxFrameAngle.ANGLE_NEG_90;
+		}
+		else
+		{
+			frameRect = new FlxRect(FrameData.frame.x, FrameData.frame.y, FrameData.frame.w, FrameData.frame.h);
+		}
+		
+		Frames.addAtlasFrame(frameRect, sourceSize, offset, name, angle);
 	}
 	
 	/**

--- a/tests/src/TestSuite.hx
+++ b/tests/src/TestSuite.hx
@@ -8,6 +8,7 @@ import flixel.FlxObjectTest;
 import flixel.FlxSpriteTest;
 import flixel.FlxStateTest;
 import flixel.FlxSubStateTest;
+import flixel.graphics.frames.FlxAtlasFramesTest;
 import flixel.graphics.frames.FlxFrameTest;
 import flixel.group.FlxGroupTest;
 import flixel.group.FlxSpriteGroupTest;
@@ -56,6 +57,7 @@ class TestSuite extends massive.munit.TestSuite
 		add(flixel.FlxSpriteTest);
 		add(flixel.FlxStateTest);
 		add(flixel.FlxSubStateTest);
+		add(flixel.graphics.frames.FlxAtlasFramesTest);
 		add(flixel.graphics.frames.FlxFrameTest);
 		add(flixel.group.FlxGroupTest);
 		add(flixel.group.FlxSpriteGroupTest);

--- a/tests/src/flixel/graphics/frames/FlxAtlasFramesTest.hx
+++ b/tests/src/flixel/graphics/frames/FlxAtlasFramesTest.hx
@@ -1,0 +1,28 @@
+package flixel.graphics.frames;
+
+import flash.display.BitmapData;
+import flixel.graphics.frames.FlxAtlasFrames;
+import massive.munit.Assert;
+
+class FlxAtlasFramesTest extends FlxTest
+{
+	@Test
+	function testTexturePackerJson()
+	{
+		var bmd:BitmapData = new BitmapData(1, 1);
+		var arrJson = '{"frames":[{"filename":"alien.png","frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},{"filename":"medium.png","frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},{"filename":"ship.png","frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},{"filename":"small.png","frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}]}';
+		var hashJson = '{"frames":{"alien.png":{"frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},"medium.png":{"frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},"ship.png":{"frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},"small.png":{"frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}}}';
+		var atlasArray:FlxAtlasFrames = FlxAtlasFrames.fromTexturePackerJson(bmd, arrJson);
+		var atlasHash:FlxAtlasFrames = FlxAtlasFrames.fromTexturePackerJson(bmd, hashJson);
+		
+		Assert.areEqual(atlasArray.numFrames, atlasHash.numFrames);
+		
+		var hashArr:FlxFrame;
+		for (frameArr in atlasArray.frames)
+		{
+			hashArr = atlasHash.framesHash.get(frameArr.name);
+			Assert.areEqual(frameArr.name, hashArr.name);
+			Assert.isTrue(frameArr.sourceSize.equals(hashArr.sourceSize));
+		}
+	}
+}


### PR DESCRIPTION
Export options in TP for json include JSON-Array and JSON-Hash, with hash being more useful imo.

No breaking changes.