### PR TITLE
Fix iteration bug in FlxSignal

### DIFF
--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -277,12 +277,18 @@ private class Macro
 	{
 		return macro
 		{ 
+			var pendingRemove = [];
 			for (handler in _handlers)
 			{
 				handler.listener($a{exprs});
 				
 				if (handler.dispatchOnce)
-					remove(handler.listener);
+					pendingRemove.push(handler);
+			}
+			
+			for (handler in pendingRemove)
+			{
+				remove(handler.listener);
 			}
 		}
 	}


### PR DESCRIPTION
There would be array iteration bug if the listener is removed while the signal is processing the array of listeners inside `dispatch()` (no matter the remove is invoked by `dispatchOnce` property or by user code through the `remove()` function)