### PR TITLE
Consistent FlxSpriteGroup#remove(), Closes #1417

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -282,9 +282,14 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 * @param	Splice	Whether the object should be cut from the array entirely or not.
 	 * @return	The removed object.
 	 */
-	public function remove(Object:T, Splice:Bool = false):T
+	public function remove(Sprite:T, Splice:Bool = false):T
 	{
-		return group.remove(Object, Splice);
+		var sprite:FlxSprite = cast Sprite;
+		sprite.x -= x;
+		sprite.y -= y;
+		// alpha
+		sprite.cameras = null;
+		return group.remove(Sprite, Splice);
 	}
 	
 	/**

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -278,7 +278,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	/**
 	 * Removes specified sprite from the group.
 	 * 
-	 * @param	Object	The FlxSprite you want to remove.
+	 * @param	Sprite	The FlxSprite you want to remove.
 	 * @param	Splice	Whether the object should be cut from the array entirely or not.
 	 * @return	The removed object.
 	 */


### PR DESCRIPTION
Closes #1417 

Doesn't deal with alpha #1373. Doesn't break anything, but the child sprite will shift on removal if users dealt with this inconsistency by manually subtracting x and y away each time. Not sure if it affects other libs or demos.