### PR TITLE
Added overlap condition for button touch release. 

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -383,7 +383,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite
 		}
 		
 		#if !FLX_NO_TOUCH // there's only a mouse event listener for onUp
-			if (currentInput != null && currentInput.justReleased && Std.is(currentInput, FlxTouch))
+			if (currentInput != null && currentInput.justReleased && Std.is(currentInput, FlxTouch) && overlapFound)
 			{
 				onUpHandler();
 			}


### PR DESCRIPTION
Previously it fired a click event if you had touched it, and released outside of it. Not anymore