### PR TITLE
Add FlxTilemap offset property

### DIFF
--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -213,6 +213,34 @@ class FlxPoint implements IFlxPooled
 		FlashPoint.y = y;
 		return FlashPoint;
 	}
+
+	/**
+	 * Helper function, just increases the values of the specified Flash point by the values of this point.
+	 * 
+	 * @param	Point	Any Point.
+	 * @return	A reference to the altered point parameter.
+	 */
+	public inline function addToFlash(FlashPoint:Point):Point
+	{
+		FlashPoint.x += x;
+		FlashPoint.y += y;
+
+		return FlashPoint;
+	}
+
+	/**
+	 * Helper function, just decreases the values of the specified Flash point by the values of this point.
+	 * 
+	 * @param	Point	Any Point.
+	 * @return	A reference to the altered point parameter.
+	 */
+	public inline function subtractFromFlash(FlashPoint:Point):Point
+	{
+		FlashPoint.x -= x;
+		FlashPoint.y -= y;
+
+		return FlashPoint;
+	}
 	
 	/**
 	 * Returns true if this point is within the given rectangular block

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -98,7 +98,7 @@ class FlxPoint implements IFlxPooled
 	}
 	
 	/**
-	 * Adds the to the coordinates of this point.
+	 * Adds to the coordinates of this point.
 	 * 
 	 * @param	X	Amount to add to x
 	 * @param	Y	Amount to add to y
@@ -126,7 +126,7 @@ class FlxPoint implements IFlxPooled
 	}
 	
 	/**
-	 * Adds the to the coordinates of this point.
+	 * Subtracts from the coordinates of this point.
 	 * 
 	 * @param	X	Amount to subtract from x
 	 * @param	Y	Amount to subtract from y
@@ -140,7 +140,7 @@ class FlxPoint implements IFlxPooled
 	}
 	
 	/**
-	 * Adds the coordinates of another point to the coordinates of this point.
+	 * Subtracts the coordinates of another point from the coordinates of this point.
 	 * 
 	 * @param	point	The point to subtract from this point
 	 * @return	This point.

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -920,7 +920,9 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 							debugTile = _debugTileSolid; 
 						}
 						
+						offset.addToFlash(_flashPoint);
 						Buffer.pixels.copyPixels(debugTile, _debugRect, _flashPoint, null, null, true);
+						offset.subtractFromFlash(_flashPoint);
 					}
 					#end
 				#else

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -323,8 +323,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		}
 		
 		// Copied from getScreenPosition()
-		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x - offset.x;
-		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y - offset.y;
+		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x;
+		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y;
 		
 		_helperPoint.x *= Camera.totalScaleX;
 		_helperPoint.y *= Camera.totalScaleY;
@@ -338,8 +338,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	
 		// Copy tile images into the tile buffer
 		// Modified from getScreenPosition()
-		_point.x = (Camera.scroll.x * scrollFactor.x) - x - offset.x; 
-		_point.y = (Camera.scroll.y * scrollFactor.y) - y - offset.y;
+		_point.x = (Camera.scroll.x * scrollFactor.x) - x; 
+		_point.y = (Camera.scroll.y * scrollFactor.y) - y;
 		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
 		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);
 		var screenRows:Int = buffer.rows;

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -61,6 +61,12 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * Anything other than the default is very slow with blitting!
 	 */
 	public var scale(default, null):FlxPoint;
+
+	/**
+	 * Use to offset the drawing position of the tilemap,
+	 * just like FlxSprite.
+	 */
+	public var offset(default, null):FlxPoint;
 	
 	/**
 	 * Rendering variables.
@@ -160,6 +166,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		
 		scale = new FlxCallbackPoint(setScaleXCallback, setScaleYCallback, setScaleXYCallback);
 		scale.set(1, 1);
+
+		offset = FlxPoint.get();
 		
 		FlxG.signals.gameResized.add(onGameResize);
 	}
@@ -194,6 +202,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		
 		// need to destroy FlxCallbackPoints
 		scale = FlxDestroyUtil.destroy(scale);
+
+		offset = FlxDestroyUtil.put(offset);
 		
 		colorTransform = null;
 		
@@ -313,8 +323,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		}
 		
 		// Copied from getScreenPosition()
-		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x;
-		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y;
+		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x - offset.x;
+		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y - offset.y;
 		
 		_helperPoint.x *= Camera.totalScaleX;
 		_helperPoint.y *= Camera.totalScaleY;
@@ -328,8 +338,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	
 		// Copy tile images into the tile buffer
 		// Modified from getScreenPosition()
-		_point.x = (Camera.scroll.x * scrollFactor.x) - x; 
-		_point.y = (Camera.scroll.y * scrollFactor.y) - y;
+		_point.x = (Camera.scroll.x * scrollFactor.x) - x - offset.x; 
+		_point.y = (Camera.scroll.y * scrollFactor.y) - y - offset.y;
 		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
 		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);
 		var screenRows:Int = buffer.rows;
@@ -417,7 +427,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			buffer = _buffers[i];
 			
 			#if FLX_RENDER_BLIT
-			getScreenPosition(_point, camera).add(buffer.x, buffer.y);
+			getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y);
 			buffer.dirty = buffer.dirty || _point.x > 0 || (_point.y > 0) || (_point.x + buffer.width < camera.width) || (_point.y + buffer.height < camera.height);
 			
 			if (buffer.dirty)
@@ -425,7 +435,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				drawTilemap(buffer, camera);
 			}
 			
-			getScreenPosition(_point, camera).add(buffer.x, buffer.y).copyToFlash(_flashPoint);
+			getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y).copyToFlash(_flashPoint);
 			buffer.draw(camera, _flashPoint, scale.x, scale.y);
 			#else			
 			drawTilemap(buffer, camera);
@@ -813,7 +823,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	#if FLX_RENDER_BLIT
 		Buffer.fill();
 	#else
-		getScreenPosition(_point, Camera).copyToFlash(_helperPoint);
+		getScreenPosition(_point, Camera).subtractPoint(offset).copyToFlash(_helperPoint);
 		
 		_helperPoint.x *= Camera.totalScaleX;
 		_helperPoint.y *= Camera.totalScaleY;
@@ -839,8 +849,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		var isColored:Bool = ((alpha != 1) || (color != 0xffffff));
 		
 		// Copy tile images into the tile buffer
-		_point.x = (Camera.scroll.x * scrollFactor.x) - x; //modified from getScreenPosition()
-		_point.y = (Camera.scroll.y * scrollFactor.y) - y;
+		_point.x = (Camera.scroll.x * scrollFactor.x) - x - offset.x; //modified from getScreenPosition()
+		_point.y = (Camera.scroll.y * scrollFactor.y) - y - offset.y;
 		
 		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
 		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);


### PR DESCRIPTION
Very useful for games where your tilemap graphic has non-collidible "isometric" areas. This branch does have one issue: if you have a tilemap with a positive offset, the debug boxes will be drawn over, making them difficult to see. If anyone has a fix for that I'd be happy to implement it!