### PR TITLE
Don't automatically install dependencies

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -6,6 +6,5 @@
 	"description": "HaxeFlixel is a 2D game framework based on OpenFL that delivers cross-platform games.",
 	"version": "3.3.6",
 	"releasenote": "Compatibility fix for OpenFL 2.1.6.",
-	"contributors": ["haxeflixel"],
-	"dependencies": { "lime": "", "openfl": "" }
+	"contributors": ["haxeflixel"]
 }


### PR DESCRIPTION
Haxelib's dependency management is problematic. Even if I have a particular version of OpenFL and/or Lime installed, installing Flixel from Haxelib automatically starts installing these libraries, which can break often fragile Haxelib configurations.

Speaking as someone who has had to cancel these installations many times, I recommend that Flixel not force users to download them.