### PR TITLE
Fix behavior of fadeIn and fadeOut methods

### DIFF
--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -440,7 +440,7 @@ class FlxSound extends FlxBasic
 	 * @param	Duration	The amount of time the fade-out operation should take.
 	 * @param	To			The volume to tween to, 0 by default.
 	 */
-	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0, ?onComplete:Void->Void = null):FlxSound
+	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0, ?onComplete:FlxTween->Void = null):FlxSound
 	{
 		FlxTween.num(volume, To, Duration, onComplete, volumeTween);
 		
@@ -454,7 +454,7 @@ class FlxSound extends FlxBasic
 	 * @param	From		The volume to tween from, 0 by default.
 	 * @param	To			The volume to tween to, 1 by default.
 	 */
-	public inline function fadeIn(Duration:Float = 1, From:Float = 0, To:Float = 1, ?onComplete:Void->Void = null):FlxSound
+	public inline function fadeIn(Duration:Float = 1, From:Float = 0, To:Float = 1, ?onComplete:FlxTween->Void = null):FlxSound
 	{
 		if (!playing)
 			play();

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -440,9 +440,13 @@ class FlxSound extends FlxBasic
 	 * @param	Duration	The amount of time the fade-out operation should take.
 	 * @param	To			The volume to tween to, 0 by default.
 	 */
-	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0):FlxSound
+	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0, ?onComplete = null):FlxSound
 	{
-		FlxTween.num(volume, To, Duration, { onComplete:function (_) { stop(); } }, volumeTween);
+		if (onComplete != null)
+			FlxTween.num(volume, To, Duration, onComplete, volumeTween);
+		else
+			FlxTween.num(volume, To, Duration, null, volumeTween);
+		
 		return this;
 	}
 	

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -440,12 +440,9 @@ class FlxSound extends FlxBasic
 	 * @param	Duration	The amount of time the fade-out operation should take.
 	 * @param	To			The volume to tween to, 0 by default.
 	 */
-	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0, ?onComplete = null):FlxSound
+	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0, ?onComplete:Void->Void = null):FlxSound
 	{
-		if (onComplete != null)
-			FlxTween.num(volume, To, Duration, onComplete, volumeTween);
-		else
-			FlxTween.num(volume, To, Duration, null, volumeTween);
+		FlxTween.num(volume, To, Duration, onComplete, volumeTween);
 		
 		return this;
 	}
@@ -457,11 +454,11 @@ class FlxSound extends FlxBasic
 	 * @param	From		The volume to tween from, 0 by default.
 	 * @param	To			The volume to tween to, 1 by default.
 	 */
-	public inline function fadeIn(Duration:Float = 1, From:Float = 0, To:Float = 1):FlxSound
+	public inline function fadeIn(Duration:Float = 1, From:Float = 0, To:Float = 1, ?onComplete:Void->Void = null):FlxSound
 	{
 		if (!playing)
 			play();
-		FlxTween.num(From, To, Duration, null, volumeTween);
+		FlxTween.num(From, To, Duration, onComplete, volumeTween);
 		return this;
 	}
 	

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -442,7 +442,7 @@ class FlxSound extends FlxBasic
 	 */
 	public inline function fadeOut(Duration:Float = 1, ?To:Float = 0):FlxSound
 	{
-		FlxTween.num(volume, To, Duration, null, volumeTween);
+		FlxTween.num(volume, To, Duration, { onComplete:function (_) { stop(); } }, volumeTween);
 		return this;
 	}
 	
@@ -455,6 +455,8 @@ class FlxSound extends FlxBasic
 	 */
 	public inline function fadeIn(Duration:Float = 1, From:Float = 0, To:Float = 1):FlxSound
 	{
+		if (!playing)
+			play();
 		FlxTween.num(From, To, Duration, null, volumeTween);
 		return this;
 	}


### PR DESCRIPTION
`fadeIn` and `fadeOut` do not play and stop the music - it is only logical that when the user calls `fadeIn` it is expected for the sound to start playing. 

The same applies to `fadeOut`: when the fading tween completes the sound should call stop instead of continue playing with the volume down.