### PR TITLE
FlxSprite's new set_clipRect wasn't checking to see if rect was null bef...

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1215,7 +1215,14 @@ class FlxSprite extends FlxObject
 	
 	private function set_clipRect(rect:FlxRect):FlxRect
 	{
-		clipRect = rect.round();
+		if (rect != null)
+		{
+			clipRect = rect.round();
+		}
+		else
+		{
+			clipRect = null;
+		}
 		
 		if (frames != null)
 		{


### PR DESCRIPTION
...ore accessing .round() function.

Simple oversight :) This was throwing crashes in flixel-ui, but a simple check fixes it.