### PR TITLE
Compile fix for OpenFL w/o legacy

### DIFF
--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -176,6 +176,7 @@ class PostProcess extends OpenGLView
 		time += elapsed;
 	}
 
+	#if openfl_legacy
 	/**
 	 * Renders to a framebuffer or the screen every frame
 	 */
@@ -225,6 +226,7 @@ class PostProcess extends OpenGLView
 			trace("INVALID_FRAMEBUFFER_OPERATION!!");
 		}
 	}
+	#end
 
 	private var framebuffer:GLFramebuffer;
 	private var renderbuffer:GLRenderbuffer;


### PR DESCRIPTION
Right now flixel is forcing -Dlegacy in the background, PostProcess.hx is currently blocking it from compiling with -Dnext (which disables -Dlegacy). A new implementation will be necessary for -Dlegacy, but this at least gets things compiling and running again, without affecting legacy's functionality.