### PR TITLE
Add FlxObject#setPositionUsingCenter()

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -857,6 +857,19 @@ class FlxObject extends FlxBasic
 	}
 	
 	/**
+	 * Helper function to set the coordinates of this object 
+	 * using the center instead of the top-left corner.
+	 * 
+	 * @param	X	The new x position of the center
+	 * @param	Y	The new y position of the center
+	 */	
+	public function setPositionUsingCenter(X:Float = 0, Y:Float = 0):Void
+	{
+		x = X - width / 2;
+		y = Y - height / 2;
+	}
+	
+	/**
 	 * Shortcut for setting both width and Height.
 	 * 
 	 * @param	Width	The new sprite width.


### PR DESCRIPTION
Added setPositionUsingCenter(), which is more convenient than setPosition() for some situations.

This is my first ever pull request. If this is ok, I have some ideas about introducing 'pivot' points on FlxObjects which generalize the origin and can be used for e.g. setting position, rotating around, connecting with other pivot points.