### PR TITLE
Add support for T values with drawTriangles()

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -539,12 +539,12 @@ class FlxCamera extends FlxBasic
 		drawItem.addQuad(frame, _helperMatrix, cr, cg, cb, ca);
 	}
 	
-	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvs:DrawData<Float>, colors:DrawData<Int> = null, position:FlxPoint = null, blend:BlendMode = null, smoothing:Bool = false):Void
+	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, colors:DrawData<Int> = null, position:FlxPoint = null, blend:BlendMode = null, smoothing:Bool = false):Void
 	{
 		_bounds.set(0, 0, width, height);
 		var isColored:Bool = (colors != null && colors.length != 0);
 		var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend);
-		drawItem.addTriangles(vertices, indices, uvs, colors, position, _bounds);
+		drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds);
 	}
 #else
 	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:Matrix, cr:Float = 1.0, cg:Float = 1.0, cb:Float = 1.0, ca:Float = 1.0, blend:BlendMode = null, smoothing:Bool = false):Void
@@ -567,7 +567,7 @@ class FlxCamera extends FlxBasic
 	private static var drawVertices:Vector<Float> = new Vector<Float>();
 	private static var trianglesSprite:Sprite = new Sprite();
 	
-	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvs:DrawData<Float>, colors:DrawData<Int> = null, position:FlxPoint = null, blend:BlendMode = null, smoothing:Bool = false):Void
+	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, colors:DrawData<Int> = null, position:FlxPoint = null, blend:BlendMode = null, smoothing:Bool = false):Void
 	{
 		if (position == null)
 		{
@@ -614,7 +614,7 @@ class FlxCamera extends FlxBasic
 		{
 			trianglesSprite.graphics.clear();
 			trianglesSprite.graphics.beginBitmapFill(graphic.bitmap, null, false, smoothing);
-			trianglesSprite.graphics.drawTriangles(drawVertices, indices, uvs);
+			trianglesSprite.graphics.drawTriangles(drawVertices, indices, uvtData);
 			trianglesSprite.graphics.endFill();
 			buffer.draw(trianglesSprite);
 			#if !FLX_NO_DEBUG

--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -11,7 +11,7 @@ import openfl.Vector;
 
 /**
  * A very basic rendering component which uses drawTriangles.
- * You have access to vertices, indices and uvs vectors which are used as data storages for rendering.
+ * You have access to vertices, indices and uvtData vectors which are used as data storages for rendering.
  * The whole FlxGraphic object is used as a texture for this sprite.
  * Use these links for more info about drawTriangles method:
  * http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/Graphics.html#drawTriangles%28%29
@@ -33,7 +33,7 @@ class FlxStrip extends FlxSprite
 	/**
 	 * A Vector of normalized coordinates used to apply texture mapping.
 	 */
-	public var uvs:DrawData<Float>;
+	public var uvtData:DrawData<Float>;
 	
 	public var colors:DrawData<Int>;
 	
@@ -43,7 +43,7 @@ class FlxStrip extends FlxSprite
 		
 		vertices = new #if flash Vector #else Array #end<Float>();
 		indices = new #if flash Vector #else Array #end<Int>();
-		uvs = new #if flash Vector #else Array #end<Float>();
+		uvtData = new #if flash Vector #else Array #end<Float>();
 		colors = new #if flash Vector #else Array #end<Int>();
 	}
 	
@@ -51,7 +51,7 @@ class FlxStrip extends FlxSprite
 	{
 		vertices = null;
 		indices = null;
-		uvs = null;
+		uvtData = null;
 		colors = null;
 		
 		super.destroy();
@@ -72,7 +72,7 @@ class FlxStrip extends FlxSprite
 			}
 			
 			getScreenPosition(_point, camera);
-			camera.drawTriangles(graphic, vertices, indices, uvs, colors, _point, blend, antialiasing);
+			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, antialiasing);
 		}
 	}
 }

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -21,7 +21,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 {
 	public var vertices:DrawData<Float>;
 	public var indices:DrawData<Int>;
-	public var uvt:DrawData<Float>;
+	public var uvtData:DrawData<Float>;
 	public var colors:DrawData<Int>;
 	
 	public var verticesPosition:Int = 0;
@@ -38,12 +38,12 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		#if flash
 		vertices = new Vector<Float>();
 		indices = new Vector<Int>();
-		uvt = new Vector<Float>();
+		uvtData = new Vector<Float>();
 		colors = new Vector<Int>();
 		#else
 		vertices = new Array<Float>();
 		indices = new Array<Int>();
-		uvt = new Array<Float>();
+		uvtData = new Array<Float>();
 		colors = new Array<Int>();
 		#end
 		
@@ -60,9 +60,9 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		
 		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
 		#if flash
-		camera.canvas.graphics.drawTriangles(vertices, indices, uvt, TriangleCulling.NONE);
+		camera.canvas.graphics.drawTriangles(vertices, indices, uvtData, TriangleCulling.NONE);
 		#else
-		camera.canvas.graphics.drawTriangles(vertices, indices, uvt, TriangleCulling.NONE, (colored) ? colors : null, blending);
+		camera.canvas.graphics.drawTriangles(vertices, indices, uvtData, TriangleCulling.NONE, (colored) ? colors : null, blending);
 		#end
 		camera.canvas.graphics.endFill();
 		#if !FLX_NO_DEBUG
@@ -83,7 +83,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		super.reset();
 		vertices.splice(0, vertices.length);
 		indices.splice(0, indices.length);
-		uvt.splice(0, uvt.length);
+		uvtData.splice(0, uvtData.length);
 		colors.splice(0, colors.length);
 		
 		verticesPosition = 0;
@@ -97,12 +97,12 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		
 		vertices = null;
 		indices = null;
-		uvt = null;
+		uvtData = null;
 		colors = null;
 		bounds = null;
 	}
 	
-	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvs:DrawData<Float>, colors:DrawData<Int> = null, position:FlxPoint = null, cameraBounds:FlxRect = null):Void
+	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, colors:DrawData<Int> = null, position:FlxPoint = null, cameraBounds:FlxRect = null):Void
 	{
 		if (position == null)
 		{
@@ -118,6 +118,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		var prevVerticesLength:Int = this.vertices.length;
 		var numberOfVertices:Int = Std.int(verticesLength / 2);
 		var prevIndicesLength:Int = this.indices.length;
+		var prevUVTDataLength:Int = this.uvtData.length;
 		var prevColorsLength:Int = this.colors.length;
 		var prevNumberOfVertices:Int = this.numVertices;
 		
@@ -152,9 +153,10 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		}
 		else
 		{
-			for (i in 0...verticesLength)
+			var uvtDataLength:Int = uvtData.length;
+			for (i in 0...uvtDataLength)
 			{
-				uvt[prevVerticesLength + i] = uvs[i];
+				this.uvtData[prevUVTDataLength + i] = uvtData[i];
 			}
 			
 			var indicesLength:Int = indices.length;
@@ -221,8 +223,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		vertices[prevVerticesPos] = point.x;
 		vertices[prevVerticesPos + 1] = point.y;
 		
-		uvt[prevVerticesPos] = frame.uv.x;
-		uvt[prevVerticesPos + 1] = frame.uv.y;
+		uvtData[prevVerticesPos] = frame.uv.x;
+		uvtData[prevVerticesPos + 1] = frame.uv.y;
 		
 		point.set(frame.frame.width, 0);
 		point.transform(matrix);
@@ -230,8 +232,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		vertices[prevVerticesPos + 2] = point.x;
 		vertices[prevVerticesPos + 3] = point.y;
 		
-		uvt[prevVerticesPos + 2] = frame.uv.width;
-		uvt[prevVerticesPos + 3] = frame.uv.y;
+		uvtData[prevVerticesPos + 2] = frame.uv.width;
+		uvtData[prevVerticesPos + 3] = frame.uv.y;
 		
 		point.set(frame.frame.width, frame.frame.height);
 		point.transform(matrix);
@@ -239,8 +241,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		vertices[prevVerticesPos + 4] = point.x;
 		vertices[prevVerticesPos + 5] = point.y;
 		
-		uvt[prevVerticesPos + 4] = frame.uv.width;
-		uvt[prevVerticesPos + 5] = frame.uv.height;
+		uvtData[prevVerticesPos + 4] = frame.uv.width;
+		uvtData[prevVerticesPos + 5] = frame.uv.height;
 		
 		point.set(0, frame.frame.height);
 		point.transform(matrix);
@@ -248,8 +250,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		vertices[prevVerticesPos + 6] = point.x;
 		vertices[prevVerticesPos + 7] = point.y;
 		
-		uvt[prevVerticesPos + 6] = frame.uv.x;
-		uvt[prevVerticesPos + 7] = frame.uv.height;
+		uvtData[prevVerticesPos + 6] = frame.uv.x;
+		uvtData[prevVerticesPos + 7] = frame.uv.height;
 		
 		indices[prevIndicesPos] = prevNumberOfVertices;
 		indices[prevIndicesPos + 1] = prevNumberOfVertices + 1;


### PR DESCRIPTION
These changes add the missing support for "T values" when passing UVT data to the `drawTriangles()` method from `flixel.graphics.tile.FlxDrawTrianglesItem`. I have also updated the naming of this data to be consistent with that used throughout online documentation for `drawTriangles()` (e.g. http://help.adobe.com/en_US/ActionScript/3.0_ProgrammingAS3/WS509D19BB-239B-4489-B965-844DDA611AE7.html) in `flixel.FlxCamera`, `flixel.FlxStrip` and `flixel.graphics.tile.FlxDrawTrianglesItem`.

With this addition it is now possible to use `FlxStrip` objects to simulate 3D transforms of a sprite with perspective correction for the texture. Take a look at https://www.youtube.com/watch?v=X5wkpPH3qR8 for an example.

Associated fixes to other repos:
https://github.com/HaxeFlixel/flixel-addons/pull/164
https://github.com/HaxeFlixel/flixel-demos/pull/170