### PR TITLE
Update FlxSprite.hx class description

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -37,6 +37,17 @@ private class GraphicDefault extends BitmapData {}
 /**
  * The main "game object" class, the sprite is a FlxObject
  * with a bunch of graphics options and abilities, like animation and stamping.
+ *
+ * Load an image onto a sprite using the loadGraphic*() functions, 
+ * or create a base monochromatic rectangle using makeGraphic().
+ * The image bitmap is stored in the pixels field.
+ *
+ * HaxeFlixel's graphic caching system keeps track of loaded image data. 
+ * When you load or make an identical copy of a previously used image, by default
+ * HaxeFlixel copies the previous reference onto pixels instead of creating
+ * another copy of the image data, to save memory. If you need to work with
+ * the image data independently, you can disable this by setting the 'Unique' 
+ * parameter in the loadGraphic*() or makeGraphic() functions to true. 
  */
 class FlxSprite extends FlxObject
 {

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -47,7 +47,7 @@ private class GraphicDefault extends BitmapData {}
  * HaxeFlixel copies the previous reference onto pixels instead of creating
  * another copy of the image data, to save memory. If you need to work with
  * the image data independently, you can disable this by setting the 'Unique' 
- * parameter in the loadGraphic*() or makeGraphic() functions to true. 
+ * parameter in the loadGraphic(), loadGraphicFromTexture(), or makeGraphic() functions to true. 
  */
 class FlxSprite extends FlxObject
 {

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -41,13 +41,6 @@ private class GraphicDefault extends BitmapData {}
  * Load an image onto a sprite using the loadGraphic*() functions, 
  * or create a base monochromatic rectangle using makeGraphic().
  * The image bitmap is stored in the pixels field.
- *
- * HaxeFlixel's graphic caching system keeps track of loaded image data. 
- * When you load or make an identical copy of a previously used image, by default
- * HaxeFlixel copies the previous reference onto pixels instead of creating
- * another copy of the image data, to save memory. If you need to work with
- * the image data independently, you can disable this by setting the 'Unique' 
- * parameter in the loadGraphic(), loadGraphicFromTexture(), or makeGraphic() functions to true. 
  */
 class FlxSprite extends FlxObject
 {
@@ -307,13 +300,19 @@ class FlxSprite extends FlxObject
 	
 	/**
 	 * Load an image from an embedded graphic file.
+	 *
+ 	 * HaxeFlixel's graphic caching system keeps track of loaded image data. 
+ 	 * When you load an identical copy of a previously used image, by default
+ 	 * HaxeFlixel copies the previous reference onto the pixels field instead
+ 	 * of creating another copy of the image data, to save memory.
 	 * 
 	 * @param	Graphic		The image you want to use.
 	 * @param	Animated	Whether the Graphic parameter is a single sprite or a row of sprites.
 	 * @param	Width		Optional, specify the width of your sprite (helps FlxSprite figure out what to do with non-square sprites or sprite sheets).
 	 * @param	Height		Optional, specify the height of your sprite (helps FlxSprite figure out what to do with non-square sprites or sprite sheets).
 	 * @param	Unique		Optional, whether the graphic should be a unique instance in the graphics cache.  Default is false.
-	 * @param	Key			Optional, set this parameter if you're loading BitmapData.
+	 *				Set this to true if you want to modify the pixels field without changing the pixels of other sprites with the same BitmapData.
+	 * @param	Key		Optional, set this parameter if you're loading BitmapData.
 	 * @return	This FlxSprite instance (nice for chaining stuff together, if you're into that).
 	 */
 	public function loadGraphic(Graphic:FlxGraphicAsset, Animated:Bool = false, Width:Int = 0, Height:Int = 0, Unique:Bool = false, ?Key:String):FlxSprite
@@ -435,13 +434,19 @@ class FlxSprite extends FlxObject
 	}
 	
 	/**
-	 * This function creates a flat colored square image dynamically.
-	 * 
+	 * This function creates a flat colored rectangular image dynamically.
+	 *
+ 	 * HaxeFlixel's graphic caching system keeps track of loaded image data. 
+ 	 * When you make an identical copy of a previously used image, by default
+ 	 * HaxeFlixel copies the previous reference onto the pixels field instead
+ 	 * of creating another copy of the image data, to save memory.
+ 	 * 
 	 * @param	Width		The width of the sprite you want to generate.
 	 * @param	Height		The height of the sprite you want to generate.
 	 * @param	Color		Specifies the color of the generated block (ARGB format).
 	 * @param	Unique		Whether the graphic should be a unique instance in the graphics cache.  Default is false.
-	 * @param	Key			Optional parameter - specify a string key to identify this graphic in the cache.  Trumps Unique flag.
+	 *				Set this to true if you want to modify the pixels field without changing the pixels of other sprites with the same BitmapData.
+	 * @param	Key		Optional parameter - specify a string key to identify this graphic in the cache.  Trumps Unique flag.
 	 * @return	This FlxSprite instance (nice for chaining stuff together, if you're into that).
 	 */
 	public function makeGraphic(Width:Int, Height:Int, Color:FlxColor = FlxColor.WHITE, Unique:Bool = false, ?Key:String):FlxSprite


### PR DESCRIPTION
Expanded the description of the class to explain a bit about how HaxeFlixel handles the BitmapData. 

I had a frustrating evening with #1490. I didn't expect the default behaviour, and after realizing the BitmapData from both sprites had the same reference, I didn't find anything that explained it via Ctrl-F 'pixels', 'BitmapData'. Hopefully an explicit explanation can save other people the frustration.