### PR TITLE
FlxTween#cancelTweensOf(), closes #1458

### DIFF
--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -3,6 +3,7 @@ package flixel.tweens;
 import flixel.FlxG;
 import flixel.FlxObject;
 import flixel.FlxSprite;
+import flixel.math.FlxPoint;
 import flixel.tweens.FlxEase.EaseFunction;
 import flixel.tweens.misc.AngleTween;
 import flixel.tweens.misc.ColorTween;
@@ -17,7 +18,6 @@ import flixel.tweens.motion.QuadPath;
 import flixel.util.FlxArrayUtil;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil.IFlxDestroyable;
-import flixel.math.FlxPoint;
 
 class FlxTween implements IFlxDestroyable
 {
@@ -343,14 +343,39 @@ class FlxTween implements IFlxDestroyable
 	/**
 	 * Registers an object-FlxTween mapping.
 	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
-	 * Convenience method for FlxTween.manager.registerTween()
+	 * Convenience method for FlxTween.manager.registerTweens()
 	 * 
 	 * @param	Tween	The FlxTween to add a mapping of.
 	 * @param	Object	The object that the FlxTween should be registered to.
 	 */
 	public function registerTween(Tween:FlxTween, Object:Dynamic):Void
 	{
-		manager.registerTween(Tween, Object);
+		manager.registerTweens([Tween], Object);
+	}
+	
+	/**
+	 * Registers multiple object-FlxTween mappings.
+	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
+	 * Convenience method for FlxTween.manager.registerTweens()
+	 * 
+	 * @param	Tweens	The Array of FlxTweens to add mappings of.
+	 * @param	Object	The object that each FlxTween should be registered to.
+	 */
+	public function registerTweens(Tweens:Array<FlxTween>, Object:Dynamic):Void
+	{
+		manager.registerTweens(Tweens, Object);
+	}
+	
+	/**
+	 * Unregisters an object-FlxTween mapping.
+	 * Convenience method for FlxTween.manager.unregisterTween()
+	 * 
+	 * @param	Tween	The FlxTween to remove the mapping of.
+	 * @param	Object	The object that the FlxTween should be deregistered from. If not specified, the object will be searched for.
+	 */
+	public function unregisterTween(Tween:FlxTween, Object:Dynamic):Void
+	{
+		manager.unregisterTween(Tween, Object);
 	}
 	
 	/**
@@ -767,15 +792,15 @@ class FlxTweenManager extends FlxBasic
 	}
 	
 	/**
-	 * Registers an object-FlxTween mapping.
+	 * Registers multiple object-FlxTween mappings.
 	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
 	 * 
-	 * @param	Tween	The FlxTween to add a mapping of.
-	 * @param	Object	The object that the FlxTween should be registered to.
+	 * @param	Tween	The Array of FlxTweens to add mappings of.
+	 * @param	Object	The object that each FlxTween should be registered to.
 	 */
-	public function registerTween(Tween:FlxTween, Object:Dynamic):Void
+	public function registerTweens(Tweens:Array<FlxTween>, Object:Dynamic):Void
 	{
-		if (Tween != null && Object != null)
+		if (Tweens != null && Object != null)
 		{
 			var mappings = _objMappings.get(Object);
 			
@@ -785,7 +810,24 @@ class FlxTweenManager extends FlxBasic
 				_objMappings.set(Object, mappings);
 			}
 			
-			mappings.push(Tween);
+			for (tween in Tweens)
+			{
+				mappings.push(tween);
+			}
+		}
+	}
+	
+	/**
+	 * Unregisters an object-FlxTween mapping.
+	 * 
+	 * @param	Tween	The FlxTween to remove the mapping of.
+	 * @param	Object	The optional object that the FlxTween should be deregistered from. If not specified, the object will be searched for.
+	 */
+	public function unregisterTween(Tween:FlxTween, Object:Dynamic):Void
+	{
+		if (Tween != null && Object != null)
+		{
+			_objMappings.get(Object).remove(Tween);
 		}
 	}
 	

--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -348,7 +348,7 @@ class FlxTween implements IFlxDestroyable
 	 * @param	Tween	The FlxTween to add a mapping of.
 	 * @param	Object	The object that the FlxTween should be registered to.
 	 */
-	public function registerTween(Tween:FlxTween, Object:Dynamic):Void
+	public static function registerTween(Tween:FlxTween, Object:Dynamic):Void
 	{
 		manager.registerTweens([Tween], Object);
 	}
@@ -361,7 +361,7 @@ class FlxTween implements IFlxDestroyable
 	 * @param	Tweens	The Array of FlxTweens to add mappings of.
 	 * @param	Object	The object that each FlxTween should be registered to.
 	 */
-	public function registerTweens(Tweens:Array<FlxTween>, Object:Dynamic):Void
+	public static function registerTweens(Tweens:Array<FlxTween>, Object:Dynamic):Void
 	{
 		manager.registerTweens(Tweens, Object);
 	}
@@ -373,7 +373,7 @@ class FlxTween implements IFlxDestroyable
 	 * @param	Tween	The FlxTween to remove the mapping of.
 	 * @param	Object	The object that the FlxTween should be deregistered from. If not specified, the object will be searched for.
 	 */
-	public function unregisterTween(Tween:FlxTween, Object:Dynamic):Void
+	public static function unregisterTween(Tween:FlxTween, Object:Dynamic):Void
 	{
 		manager.unregisterTween(Tween, Object);
 	}
@@ -385,7 +385,7 @@ class FlxTween implements IFlxDestroyable
 	 * 
 	 * @param	Object	The object whose registered FlxTweens should be destroyed.
 	 */
-	public function cancelTweensOf(Object:Dynamic):Void
+	public static function cancelTweensOf(Object:Dynamic):Void
 	{
 		manager.cancelTweensOf(Object);
 	}
@@ -685,13 +685,12 @@ class FlxTweenManager extends FlxBasic
 	/**
 	 * Stores object-FlxTween relations to cancel() all of an object's FlxTweens at once.
 	 */
-	private var _objMappings:Map<Dynamic, Array<FlxTween>>;
+	private var _objMappings:Map<{}, Array<FlxTween>> = new Map<{}, Array<FlxTween>>();
 	
 	public function new():Void
 	{
 		super();
 		visible = false; // No draw-calls needed
-		_objMappings = new Map<Dynamic, Array<FlxTween>>();
 		FlxG.signals.stateSwitched.add(clear);
 	}
 	

--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -340,6 +340,31 @@ class FlxTween implements IFlxDestroyable
 		return manager.add(tween);
 	}
 	
+	/**
+	 * Registers an object-FlxTween mapping.
+	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
+	 * Convenience method for FlxTween.manager.registerTween()
+	 * 
+	 * @param	Tween	The FlxTween to add a mapping of.
+	 * @param	Object	The object that the FlxTween should be registered to.
+	 */
+	public function registerTween(Tween:FlxTween, Object:Dynamic):Void
+	{
+		manager.registerTween(Tween, Object);
+	}
+	
+	/**
+	 * Cancels all registered FlxTweens of an object.
+	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
+	 * Convenience method for FlxTween.manager.cancelTweensOf()
+	 * 
+	 * @param	Object	The object whose registered FlxTweens should be destroyed.
+	 */
+	public function cancelTweensOf(Object:Dynamic):Void
+	{
+		manager.cancelTweensOf(Object);
+	}
+	
 	public var active(default, set):Bool = false;
 	public var duration:Float = 0;
 	public var ease:EaseFunction;
@@ -682,54 +707,6 @@ class FlxTweenManager extends FlxBasic
 	}
 	
 	/**
-	 * Adds an object-FlxTween mapping.
-	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
-	 * Manually call this to add tweens that use an object indirectly (e.g. NumTween on an object's property).
-	 * 
-	 * @param	Tween	The FlxTween to add a mapping of.
-	 * @param	Object	The object that the FlxTween relies on.
-	 */
-	public function addTweenOf(Tween:FlxTween, Object:Dynamic):Void
-	{
-		if (Tween != null && Object != null)
-		{
-			var mappings = _objMappings.get(Object);
-			
-			if (mappings == null)
-			{
-				mappings = [];
-				_objMappings.set(Object, mappings);
-			}
-			
-			mappings.push(Tween);
-		}
-	}
-	
-	/**
-	 * Cancels all added FlxTweens of an object.
-	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
-	 * 
-	 * @param	Object	The object whose related FlxTweens should be destroyed.
-	 */
-	public function cancelTweensOf(Object:Dynamic):Void
-	{
-		if (Object != null)
-		{
-			var mappings = _objMappings.get(Object);
-			
-			if (mappings != null)
-			{
-				for (tween in mappings)
-				{
-					tween.cancel();
-				}
-				
-				_objMappings.remove(Object);
-			}
-		}
-	}
-	
-	/**
 	 * Add a FlxTween.
 	 * 
 	 * @param	Tween	The FlxTween to add.
@@ -786,6 +763,53 @@ class FlxTweenManager extends FlxBasic
 		while (_tweens.length > 0)
 		{
 			remove(_tweens[0]);
+		}
+	}
+	
+	/**
+	 * Registers an object-FlxTween mapping.
+	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
+	 * 
+	 * @param	Tween	The FlxTween to add a mapping of.
+	 * @param	Object	The object that the FlxTween should be registered to.
+	 */
+	public function registerTween(Tween:FlxTween, Object:Dynamic):Void
+	{
+		if (Tween != null && Object != null)
+		{
+			var mappings = _objMappings.get(Object);
+			
+			if (mappings == null)
+			{
+				mappings = [];
+				_objMappings.set(Object, mappings);
+			}
+			
+			mappings.push(Tween);
+		}
+	}
+	
+	/**
+	 * Cancels all registered FlxTweens of an object.
+	 * Useful to avoid null object reference errors when an object is destroyed before its tween is complete.
+	 * 
+	 * @param	Object	The object whose registered FlxTweens should be destroyed.
+	 */
+	public function cancelTweensOf(Object:Dynamic):Void
+	{
+		if (Object != null)
+		{
+			var mappings = _objMappings.get(Object);
+			
+			if (mappings != null)
+			{
+				for (tween in mappings)
+				{
+					tween.cancel();
+				}
+				
+				_objMappings.remove(Object);
+			}
 		}
 	}
 }

--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -1,7 +1,6 @@
 package flixel.tweens.misc;
 
 import flixel.tweens.FlxTween;
-import flixel.util.FlxArrayUtil;
 
 /**
  * Tweens multiple numeric public properties of an Object simultaneously.
@@ -56,8 +55,6 @@ class VarTween extends FlxTween
 		_object = object;
 		_properties = properties;
 		this.duration = duration;
-		
-		FlxTween.manager.addTweenOf(this, _object);
 		
 		start();
 		return this;

--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -56,6 +56,9 @@ class VarTween extends FlxTween
 		_object = object;
 		_properties = properties;
 		this.duration = duration;
+		
+		FlxTween.manager.addTweenOf(this, _object);
+		
 		start();
 		return this;
 	}

--- a/flixel/tweens/motion/Motion.hx
+++ b/flixel/tweens/motion/Motion.hx
@@ -32,6 +32,7 @@ class Motion extends FlxTween
 		_object = object;
 		_wasObjectImmovable = _object.immovable;
 		_object.immovable = true;
+		FlxTween.manager.addTweenOf(this, _object);
 		return this;
 	}
 	

--- a/flixel/tweens/motion/Motion.hx
+++ b/flixel/tweens/motion/Motion.hx
@@ -2,7 +2,6 @@
 
 import flixel.FlxObject;
 import flixel.tweens.FlxTween;
-import flixel.tweens.FlxEase;
 
 /**
  * Base class for motion Tweens.
@@ -32,7 +31,6 @@ class Motion extends FlxTween
 		_object = object;
 		_wasObjectImmovable = _object.immovable;
 		_object.immovable = true;
-		FlxTween.manager.addTweenOf(this, _object);
 		return this;
 	}
 	


### PR DESCRIPTION
#1458

I chose to make it manual adding and removing/canceling tweens instead of automatic so performance wouldn't be affected.

Usage would be like
```haxe
var tw = FlxTween.num(..., { onComplete : FlxTween.unregisterTween.bind(_, this) }, ...);
FlxTween.registerTween(tw, this);

override public function destroy():Void {
     super.destroy();
     FlxTween.cancelTweensOf(this);
}
```