### PR TITLE
Update FlxMath.hx

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -12,7 +12,7 @@ import flixel.input.touch.FlxTouch;
  */
 class FlxMath
 {	
-	#if (flash || js || ios)
+	#if (flash || js || ios || blackberry)
 	/**
 	 * Minimum value of a floating point number.
 	 */


### PR DESCRIPTION
The minimum value for floats in BlackBerry should be the same used for Flash, js and iOS.

This fixes problems where FlxMath.MIN_VALUE_FLOAT is used on BlackBerry (e.g. FlxG.camera.fade)