### PR TITLE
Fix for next: Keyboard listeners would not work after the window lost…

### DIFF
--- a/flixel/system/debug/Console.hx
+++ b/flixel/system/debug/Console.hx
@@ -63,7 +63,7 @@ class Console extends Window
 	 */
 	private var _input:TextField;
 	
-	#if (cpp || neko)
+	#if (!next && sys)
 	private var inputMouseDown:Bool = false;
 	private var stageMouseDown:Bool = false;
 	#end
@@ -129,7 +129,7 @@ class Console extends Window
 		#end
 	}
 	
-	#if (cpp || neko)
+	#if (!next && sys)
 	override public function update():Void
 	{
 		super.update();

--- a/flixel/system/debug/Console.hx
+++ b/flixel/system/debug/Console.hx
@@ -112,7 +112,7 @@ class Console extends Window
 		_input.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		_input.addEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
 		
-		#if (cpp || neko) // workaround for broken TextField focus on native
+		#if (!next && sys) // workaround for broken TextField focus on native
 		_input.addEventListener(MouseEvent.MOUSE_DOWN, function(_)
 		{
 			inputMouseDown = true;
@@ -146,8 +146,16 @@ class Console extends Window
 	}
 	#end
 	
+	@:access(flixel.FlxGame)
 	private function onFocus(_):Void
 	{
+		#if (sys && next)
+			if (!FlxG.game._lostFocus)
+			{
+				return;
+			}
+		#end
+		
 		#if !FLX_NO_DEBUG
 		#if flash 
 		// Pause game
@@ -165,8 +173,16 @@ class Console extends Window
 		#end
 	}
 	
+	@:access(flixel.FlxGame)
 	private function onFocusLost(_):Void
 	{
+		#if (sys && next)
+			if (FlxG.game._lostFocus)
+			{
+				return;
+			}
+		#end
+		
 		#if !FLX_NO_DEBUG
 		#if flash
 		// Unpause game


### PR DESCRIPTION
… focus. This seems to fix it and doesn't seem to break the console's focus logic.