### PR TITLE
fastSin/Cos, closes #1255

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -110,16 +110,9 @@ class FlxMath
 	 * @param	n	The number to check 
 	 * @return	True if the given number is odd. False if the given number is even.
 	 */
-	public static function isOdd(n:Float):Bool
+	public static inline function isOdd(n:Float):Bool
 	{
-		if ((Std.int(n) & 1) != 0)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return (Std.int(n) & 1) != 0;
 	}
 	
 	/**
@@ -130,14 +123,7 @@ class FlxMath
 	 */
 	public static function isEven(n:Float):Bool
 	{
-		if ((Std.int(n) & 1) != 0)
-		{
-			return false;
-		}
-		else
-		{
-			return true;
-		}
+		return (Std.int(n) & 1) == 0;
 	}
 	
 	/**
@@ -524,6 +510,49 @@ class FlxMath
 	public static inline function sameSign(f1:Float, f2:Float):Bool
 	{
 		return signOf(f1) == signOf(f2);
+	}
+	
+	/**
+	 * A faster but slightly less accurate version of Math.sin.
+	 * About 2-6 times faster with < 0.05% average error.
+	 * @param	f	The angle in radians.
+	 * @return	An approximated sine of f.
+	 */
+	public static inline function fastSin(f:Float):Float
+	{
+		f *= 0.3183098862; // divide by pi to normalize
+		
+		// bound between -1 and 1
+		if (f > 1) 
+		{
+			f -= (Math.ceil(f) >> 1) << 1;
+		}
+		else if (f < -1)
+		{
+			f += (Math.ceil( -f) >> 1) << 1;
+		}
+		
+		// this approx only works for -pi <= rads <= pi, but it's quite accurate in this region
+		if (f > 0)
+		{
+			return f * (3.1 + f * (0.5 + f * ( -7.2 + f * 3.6)));
+		}
+		
+		else
+		{
+			return f * (3.1 - f * (0.5 + f * (7.2 + f * 3.6)));
+		}
+	}
+	
+	/**
+	 * A faster but less accurate version of Math.cos.
+	 * About 2-6 times faster with < 0.05% average error.
+	 * @param	f	The angle in radians.
+	 * @return	An approximated cosine of f.
+	 */
+	public static inline function fastCos(f:Float):Float
+	{
+		return fastSin(f + 1.570796327); // sin and cos are the same, offset by pi/2
 	}
 	
 	/**

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -319,72 +319,9 @@ class FlxPoint implements IFlxPooled
 	 */
 	public function rotate(Pivot:FlxPoint, Angle:Float):FlxPoint
 	{
-		var sin:Float = 0;
-		var cos:Float = 0;
 		var radians:Float = Angle * FlxAngle.TO_RAD;
-		while (radians < -Math.PI)
-		{
-			radians += Math.PI * 2;
-		}
-		while (radians > Math.PI)
-		{
-			radians = radians - Math.PI * 2;
-		}
-		
-		if (radians < 0)
-		{
-			sin = 1.27323954 * radians + .405284735 * radians * radians;
-			if (sin < 0)
-			{
-				sin = .225 * (sin *-sin - sin) + sin;
-			}
-			else
-			{
-				sin = .225 * (sin * sin - sin) + sin;
-			}
-		}
-		else
-		{
-			sin = 1.27323954 * radians - 0.405284735 * radians * radians;
-			if (sin < 0)
-			{
-				sin = .225 * (sin *-sin - sin) + sin;
-			}
-			else
-			{
-				sin = .225 * (sin * sin - sin) + sin;
-			}
-		}
-		
-		radians += Math.PI / 2;
-		if (radians > Math.PI)
-		{
-			radians = radians - Math.PI * 2;
-		}
-		if (radians < 0)
-		{
-			cos = 1.27323954 * radians + 0.405284735 * radians * radians;
-			if (cos < 0)
-			{
-				cos = .225 * (cos *-cos - cos) + cos;
-			}
-			else
-			{
-				cos = .225 * (cos * cos - cos) + cos;
-			}
-		}
-		else
-		{
-			cos = 1.27323954 * radians - 0.405284735 * radians * radians;
-			if (cos < 0)
-			{
-				cos = .225 * (cos *-cos - cos) + cos;
-			}
-			else
-			{
-				cos = .225 * (cos * cos - cos) + cos;
-			}
-		}
+		var sin:Float = FlxMath.fastSin(radians);
+		var cos:Float = FlxMath.fastCos(radians);
 		
 		var dx:Float = x - Pivot.x;
 		var dy:Float = y - Pivot.y;

--- a/tests/unit/src/TestSuite.hx
+++ b/tests/unit/src/TestSuite.hx
@@ -14,6 +14,7 @@ import flixel.graphics.frames.FlxFramesCollectionTest;
 import flixel.graphics.frames.FlxFrameTest;
 import flixel.group.FlxGroupTest;
 import flixel.group.FlxSpriteGroupTest;
+import flixel.math.FlxMathTest;
 import flixel.math.FlxMatrixTest;
 import flixel.math.FlxPointTest;
 import flixel.math.FlxRandomTest;
@@ -67,6 +68,7 @@ class TestSuite extends massive.munit.TestSuite
 		add(flixel.graphics.frames.FlxFrameTest);
 		add(flixel.group.FlxGroupTest);
 		add(flixel.group.FlxSpriteGroupTest);
+		add(flixel.math.FlxMathTest);
 		add(flixel.math.FlxMatrixTest);
 		add(flixel.math.FlxPointTest);
 		add(flixel.math.FlxRandomTest);

--- a/tests/unit/src/flixel/math/FlxMathTest.hx
+++ b/tests/unit/src/flixel/math/FlxMathTest.hx
@@ -10,7 +10,7 @@ class FlxMathTest extends FlxTest
 	{
 		var eps = 0.0011; // max error is 0.001090292749970 or so
 		
-		var angles = [for (i in 0...100) Math.random() * i];
+		var angles = [for (i in 0...100) (Math.random() - .5) * i];
 		angles.push(0);
 		angles.push(Math.PI);
 		angles.push( -Math.PI);

--- a/tests/unit/src/flixel/math/FlxMathTest.hx
+++ b/tests/unit/src/flixel/math/FlxMathTest.hx
@@ -1,0 +1,29 @@
+package flixel.math;
+
+import massive.munit.Assert;
+
+class FlxMathTest extends FlxTest
+{
+	
+	@Test
+	function testFastTrig()
+	{
+		var eps = 0.0011; // max error is 0.001090292749970 or so
+		
+		var angles = [for (i in 0...100) Math.random() * i];
+		angles.push(0);
+		angles.push(Math.PI);
+		angles.push( -Math.PI);
+		
+		var maxError = 0.0;
+		for (angle in angles)
+		{
+			var eSin = Math.abs(FlxMath.fastSin(angle) - Math.sin(angle));
+			var eCos = Math.abs(FlxMath.fastCos(angle) - Math.cos(angle));
+			if (eSin > maxError) maxError = eSin;
+			if (eCos > maxError) maxError = eCos;
+		}
+		
+		Assert.isTrue(eps > maxError);
+	}
+}


### PR DESCRIPTION
The formula is a mathematical simplification of the original formula in `FlxPoint.rotate()`, except it's faster and more accurate.

It's 2-6 times faster within ~0.05% error versus Math.sin and cos, so it could probably be used elsewhere in flixel.