### PR TITLE
Move FlxSpriteUtil.screenCenter() to FlxObject, closes #1540

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -7,7 +7,6 @@ import flash.display.Sprite;
 import flash.geom.ColorTransform;
 import flash.geom.Point;
 import flash.geom.Rectangle;
-import flixel.FlxCamera.FlxCameraShakeDirection;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.frames.FlxFrame;
 import flixel.graphics.tile.FlxDrawBaseItem;
@@ -17,6 +16,7 @@ import flixel.math.FlxMath;
 import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
+import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
@@ -276,7 +276,7 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Internal, used to control the "shake" special effect.
 	 */
-	private var _fxShakeDirection:FlxCameraShakeDirection = BOTH_AXES;
+	private var _fxShakeAxes:FlxAxes = XY;
 	/**
 	 * Internal, to help avoid costly allocations.
 	 */
@@ -944,11 +944,11 @@ class FlxCamera extends FlxBasic
 			}
 			else
 			{
-				if ((_fxShakeDirection == BOTH_AXES) || (_fxShakeDirection == X_AXIS))
+				if (_fxShakeAxes != FlxAxes.Y)
 				{
 					_fxShakeOffset.x = FlxG.random.float( -_fxShakeIntensity * width, _fxShakeIntensity * width) * zoom;
 				}
-				if ((_fxShakeDirection == BOTH_AXES) || (_fxShakeDirection == Y_AXIS))
+				if (_fxShakeAxes != FlxAxes.X)
 				{
 					_fxShakeOffset.y = FlxG.random.float( -_fxShakeIntensity * height, _fxShakeIntensity * height) * zoom;
 				}
@@ -1160,14 +1160,12 @@ class FlxCamera extends FlxBasic
 	 * @param	Duration	The length in seconds that the shaking effect should last.
 	 * @param	OnComplete	A function you want to run when the shake effect finishes.
 	 * @param	Force		Force the effect to reset (default = true, unlike flash() and fade()!).
-	 * @param	Direction	Whether to shake on both axes, just up and down, or just side to side. Default value is BOTH_AXES.
+	 * @param	Axes		On what axes to shake. Default value is XY / both.
 	 */
-	public function shake(Intensity:Float = 0.05, Duration:Float = 0.5, ?OnComplete:Void->Void, Force:Bool = true, ?Direction:FlxCameraShakeDirection):Void
+	public function shake(Intensity:Float = 0.05, Duration:Float = 0.5, ?OnComplete:Void->Void, Force:Bool = true, ?Axes:FlxAxes):Void
 	{
-		if (Direction == null)
-		{
-			Direction = BOTH_AXES;
-		}
+		if (Axes == null)
+			Axes = XY;
 		
 		if (!Force && ((_fxShakeOffset.x != 0) || (_fxShakeOffset.y != 0)))
 		{
@@ -1176,7 +1174,7 @@ class FlxCamera extends FlxBasic
 		_fxShakeIntensity = Intensity;
 		_fxShakeDuration = Duration;
 		_fxShakeComplete = OnComplete;
-		_fxShakeDirection = Direction;
+		_fxShakeAxes = Axes;
 		_fxShakeOffset.set();
 	}
 	
@@ -1525,22 +1523,6 @@ class FlxCamera extends FlxBasic
 		}
 		return this.visible = visible;
 	}
-}
-
-enum FlxCameraShakeDirection
-{
-	/**
-	 * Shake camera on both the X and Y axes.
-	 */
-	BOTH_AXES;
-	/**
-	 * Shake camera on the X axis only.
-	 */
-	X_AXIS;
-	/**
-	 * Shake camera on the Y axis only.
-	 */
-	Y_AXIS;
 }
 
 enum FlxCameraFollowStyle

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -7,6 +7,7 @@ import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.math.FlxVelocity;
 import flixel.tile.FlxBaseTilemap;
+import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
@@ -846,16 +847,17 @@ class FlxObject extends FlxBasic
 	/**
 	 * Centers this FlxObject on the screen, either by the x axis, y axis, or both
 	 * 
-	 * @param	Horizontally	Boolean true if you want it centered horizontally
-	 * @param	Vertically		Boolean	true if you want it centered vertically
+	 * @param	axes	On what axes to center the object - default is XY / both.
 	 * @return 	This FlxObject for chaining
 	 */
-	public function screenCenter(xAxis:Bool = true, yAxis:Bool = true):FlxObject
+	public function screenCenter(?axes:FlxAxes):FlxObject
 	{
-		if (xAxis)
-			x = (FlxG.width / 2) - (width / 2);
+		if (axes == null)
+			axes = FlxAxes.XY;
 		
-		if (yAxis)
+		if (axes != FlxAxes.Y)
+			x = (FlxG.width / 2) - (width / 2);
+		if (axes != FlxAxes.X)
 			y = (FlxG.height / 2) - (height / 2);
 		
 		return this;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -844,6 +844,24 @@ class FlxObject extends FlxBasic
 	}
 	
 	/**
+	 * Centers this FlxObject on the screen, either by the x axis, y axis, or both
+	 * 
+	 * @param	Horizontally	Boolean true if you want it centered horizontally
+	 * @param	Vertically		Boolean	true if you want it centered vertically
+	 * @return 	This FlxObject for chaining
+	 */
+	public function screenCenter(xAxis:Bool = true, yAxis:Bool = true):FlxObject
+	{
+		if (xAxis)
+			x = (FlxG.width / 2) - (width / 2);
+		
+		if (yAxis)
+			y = (FlxG.height / 2) - (height / 2);
+		
+		return this;
+	}
+	
+	/**
 	 * Helper function to set the coordinates of this object.
 	 * Handy since it only requires one line of code.
 	 * 

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -3,6 +3,7 @@ package flixel.system.frontEnds;
 import flash.geom.Rectangle;
 import flixel.FlxCamera;
 import flixel.FlxG;
+import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 
 @:allow(flixel.FlxGame)
@@ -151,13 +152,13 @@ class CameraFrontEnd
 	 * @param	Duration	The length in seconds that the shaking effect should last.
 	 * @param	OnComplete	A function you want to run when the shake effect finishes.
 	 * @param	Force		Force the effect to reset (default = true, unlike flash() and fade()!).
-	 * @param	Direction	Whether to shake on both axes, just up and down, or just side to side. Default value is BOTH_AXES.
+	 * @param	Axes		On what axes to shake. Default value is XY / both.
 	 */
-	public function shake(Intensity:Float = 0.05, Duration:Float = 0.5, ?OnComplete:Void->Void, Force:Bool = true, ?Direction:FlxCameraShakeDirection):Void
+	public function shake(Intensity:Float = 0.05, Duration:Float = 0.5, ?OnComplete:Void->Void, Force:Bool = true, ?Axes:FlxAxes):Void
 	{
 		for (camera in list)
 		{
-			camera.shake(Intensity, Duration, OnComplete, Force, Direction);
+			camera.shake(Intensity, Duration, OnComplete, Force, Axes);
 		}
 	}
 	

--- a/flixel/util/FlxAxes.hx
+++ b/flixel/util/FlxAxes.hx
@@ -1,0 +1,8 @@
+package flixel.util;
+
+enum FlxAxes
+{
+	X;
+	Y;
+	XY;
+}

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -211,29 +211,6 @@ class FlxSpriteUtil
 	}
 	
 	/**
-	 * Centers the given FlxObject on the screen, either by the x axis, y axis, or both
-	 * 
-	 * @param	object			The FlxSprite to center
-	 * @param	Horizontally	Boolean true if you want it centered horizontally
-	 * @param	Vertically		Boolean	true if you want it centered vertically
-	 * @return 	The FlxObject for chaining
-	 */
-	public static function screenCenter(object:FlxObject, xAxis:Bool = true, yAxis:Bool = true):FlxObject
-	{
-		if (xAxis)
-		{
-			object.x = (FlxG.width / 2) - (object.width / 2);
-		}
-		
-		if (yAxis)
-		{
-			object.y = (FlxG.height / 2) - (object.height / 2);
-		}
-		
-		return object;
-	}
-	
-	/**
 	 * This function draws a line on a FlxSprite from position X1,Y1
 	 * to position X2,Y2 with the specified color.
 	 * 


### PR DESCRIPTION
This pull request

- Moves `FlxSpriteUtil.screenCenter()` to `FlxObject`
 - it was confusing to have it there, since it works on every `FlxObject`
 - it's useful enough to justify having it directly there (https://github.com/HaxeFlixel/haxeflixel-mechanics also uses it a lot in the demos, so this should help make that code simpler)

- Changes the function signature from `screenCenter(xAxis:Bool = true, yAxis:Bool = true)` to `screenCenter(?axes:FlxAxes)` This results in much more readable code on the call-site, compare:
 - `screenCenter(false)` (don't screen center!?) <=> `screenCenter(FlxAxes.Y)`
 - `screenCenter(true, false)` <=> `screenCenter(FlxAxes.X)`
 - `screenCenter(false, false)` - don't do anything, wtf? Not possible anymore with the enum.

(=> boolean arguments are bad)

- Turns the `FlxCameraShakeDirection` enum into a more generally useful `flixel.util.FlxAxes`. Also, the values are shorter now, compare `FlxCameraShakeDirection.BOTH_AXES` vs `FlxAxes.XY`

Breaking changes here, needs approval from @HaxeFlixel/owners.