### PR TITLE
Fix a one-way collision bug in FlxTilemap, closes #1546

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -506,6 +506,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		var selectionHeight:Int = selectionY + Math.ceil(Object.height / _scaledTileHeight) + 1;
 		
 		// Then bound these coordinates by the map edges
+		selectionX = Std.int(FlxMath.bound(selectionX, 0, widthInTiles));
+		selectionY = Std.int(FlxMath.bound(selectionY, 0, heightInTiles));
 		selectionWidth = Std.int(FlxMath.bound(selectionWidth, 0, widthInTiles));
 		selectionHeight = Std.int(FlxMath.bound(selectionHeight, 0, heightInTiles));
 		


### PR DESCRIPTION
added bounds for `selectionX` and `selectionY` in `overlapsWithCallback`.
Fixes #1546