### PR TITLE
New signal (preStateCreate), dispatched with FlxState as parameter

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -611,6 +611,8 @@ class FlxGame extends Sprite
 		// Finally assign and create the new state
 		_state = _requestedState;
 		
+		FlxG.signals.preStateCreate.dispatch(_state);
+		
 		_state.create();
 		
 		if (_gameJustStarted)

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -9,6 +9,7 @@ class SignalFrontEnd
 	 * Gets dispatched when a state change occurs.
 	 */
 	public var stateSwitched(default, null):FlxSignal = new FlxSignal();
+	public var preStateCreate(default, null):FlxTypedSignal<FlxState->Void> = new FlxTypedSignal<FlxState->Void>();
 	/**
 	 * Gets dispatched when the game is resized. 
 	 * Passes the new window width and height to callback functions.


### PR DESCRIPTION
I found this useful while working on a game with dependency injection and would like to propose it for the main line. I wanted a single listener to detect every time the state has changed, and automatically inject dependencies into that state.

The solution was to create a new signal, `preStateCreate`, that includes the newly-change-to `FlxState` as the payload of the signal. This new signal is dispatched after the stateChange signal, and before the `.create()` method is called on the new state (hence, "pre state create").