### PR TITLE
Frame Draw Changes

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -517,6 +517,11 @@ class FlxCamera extends FlxBasic
 	
 	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix, cr:Float = 1.0, cg:Float = 1.0, cb:Float = 1.0, ca:Float = 1.0, blend:BlendMode = null, smoothing:Bool = false):Void
 	{
+		if (pixels != null)
+		{
+			frame = frame.copyTo();
+			frame.parent.bitmap = pixels.clone();
+		}
 		var isColored:Bool = (cr != 1.0) || (cg != 1.0) || (cb != 1.0) || (ca != 1.0);
 		#if !FLX_RENDER_TRIANGLE
 		var drawItem:FlxDrawTilesItem = startQuadBatch(frame.parent, isColored, blend, smoothing);
@@ -528,6 +533,11 @@ class FlxCamera extends FlxBasic
 	
 	public function copyPixels(?frame:FlxFrame, ?pixels:BitmapData, ?sourceRect:Rectangle, destPoint:Point, cr:Float = 1.0, cg:Float = 1.0, cb:Float = 1.0, ca:Float = 1.0, blend:BlendMode = null, smoothing:Bool = false):Void
 	{
+		if (pixels != null)
+		{
+			frame = frame.copyTo();
+			frame.parent.bitmap = pixels.clone();
+		}
 		_helperMatrix.identity();
 		_helperMatrix.translate(destPoint.x + frame.offset.x, destPoint.y + frame.offset.y);
 		var isColored:Bool = (cr != 1.0) || (cg != 1.0) || (cb != 1.0) || (ca != 1.0);

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1120,6 +1120,8 @@ class FlxSprite extends FlxObject
 	private function set_frame(Value:FlxFrame):FlxFrame
 	{
 		frame = Value;
+		if (Value == null)
+			return null;
 		if (frame != null)
 		{
 			resetFrameSize();

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -648,4 +648,15 @@ class FlxGraphic
 		
 		return value;
 	}
+	
+	/**
+	 * Clones this FlxGraphic object
+	 */
+	public function clone():FlxGraphic
+	{
+		var toClone:FlxGraphic = new FlxGraphic(key, bitmap.clone(), persist);
+		toClone.frameCollections = frameCollections;
+		toClone.frameCollectionTypes = frameCollectionTypes;
+		return toClone;
+	}
 }

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -599,11 +599,11 @@ class FlxFrame implements IFlxDestroyable
 	{
 		if (clone == null)
 		{
-			clone = new FlxFrame(parent, angle);
+			clone = new FlxFrame(parent.clone(), angle);
 		}
 		else
 		{
-			clone.parent = parent;
+			clone.parent = parent.clone();
 			clone.angle = angle;
 			clone.frame = FlxDestroyUtil.put(clone.frame);
 		}


### PR DESCRIPTION
This is a change that allows you to use `framePixels` on native targets in order to change the current frame of a `FlxSprite` non-destructively.
This allows behavior that works the same between targets.

Before this change, doing something like this:
```
override function draw():Void
{
  if (putColor)
  {
    dirty = true;
    getFlxFrameBitmapData();
    framePixels.copyPixels(anotherBitmap, anotherBitmap.rect, _flashPointZero, framePixels, _flashPointZero, true);
  }  
  super.draw();
}
```
Would work on flash, but not on native targets.

This also includes a minor fix that caused a crash with this change, and would have been causing memory leakages before to `FlxFrame` - when `FlxSprite.destroy` is called, it says: `frame = null`, which calls `FlxSprite.set_frame` which was not checking if it was being passed a null or not, and would try to make `frame` be a new `FlxFrame`, etc.
