### PR TITLE
FlxButton: pull default graphic load out into a function so it can be…

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -200,7 +200,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		super(X, Y);
 		
-		loadGraphic(FlxGraphic.fromClass(GraphicButton), true, 80, 20);
+		loadDefaultGraphic();
 		
 		onUp = new FlxButtonEvent(OnClick);
 		onDown = new FlxButtonEvent();
@@ -231,6 +231,11 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		setupAnimation("normal", FlxButton.NORMAL);
 		setupAnimation("highlight", FlxButton.HIGHLIGHT);
 		setupAnimation("pressed", FlxButton.PRESSED);
+	}
+	
+	private function loadDefaultGraphic():Void
+	{
+		loadGraphic(FlxGraphic.fromClass(GraphicButton), true, 80, 20);
 	}
 	
 	private function setupAnimation(animationName:String, frameIndex:Int):Void


### PR DESCRIPTION
… overridden (and suppressed) in fancier button sub-classes

This helps with flixel-ui stuff in particular, since all those button sub-classes completely override the default button loading logic, this lets us skip that step entirely.

This should be a small in-place change that has zero effect on flixel itself but gives more flexibility down the line.