### PR TITLE
New Tile Filter logic for `FlxTilemap`

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -5,6 +5,7 @@ import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxTilemapGraphicAsset;
+import flixel.tile.FlxTile.FlxTileFilter;
 import flixel.util.FlxArrayUtil;
 import openfl.Assets;
 
@@ -625,40 +626,80 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		
 		return ok;
 	}
-
+	
 	/**
-	 * Adjust collision settings and/or bind a callback function to a range of tiles.
-	 * This callback function, if present, is triggered by calls to overlap() or overlapsWithCallback().
+	 * Add a new Tile Filter to this tilemap which allows you to setup specific collision and/or callback based on class.
+	 * Use `removeTileFilter` to remove the filter.
 	 * 
-	 * @param	Tile				The tile or tiles you want to adjust.
-	 * @param	AllowCollisions		Modify the tile or tiles to only allow collisions from certain directions, use FlxObject constants NONE, ANY, LEFT, RIGHT, etc. Default is "ANY".
-	 * @param	Callback			The function to trigger, e.g. lavaCallback(Tile:FlxObject, Object:FlxObject).
-	 * @param	CallbackFilter		If you only want the callback to go off for certain classes or objects based on a certain class, set that class here.
-	 * @param	Range				If you want this callback to work for a bunch of different tiles, input the range here. Default value is 1.
+	 * @param	Tile		The tile id that this filter is for, or the first tile id in a range of tiles.
+	 * @param	Filter		Specify a class for this filter to work with, defaults to `FlxObject`
+	 * @param	Collisions	Specify Collision flags to be used for this tile. Defaults to ANY
+	 * @param	Callback	The function to trigger when overlap is detected. e.g. `tileCallback(Tile:FlxObject, Object:FlxObject)`
+	 * @param	ProcessCallback	This function, if set, will be called when overlap is detected, and will return true
+	 * @param	Range		If you want this filter to be applied to a range of different tiles, input the range here. Default is 1.
 	 */
-	public function setTileProperties(Tile:Int, AllowCollisions:Int = FlxObject.ANY, ?Callback:FlxObject->FlxObject->Void, ?CallbackFilter:Class<FlxObject>, Range:Int = 1):Void
+	public function addTileFilter(Tile:Int, ?Filter:Class<FlxObject>, ?Collisions:Int = FlxObject.ANY, ?Callback:FlxTile->FlxObject->Void, ?ProcessCallback:FlxTile->FlxObject->Bool, ?Range:Int = 1):Void
 	{
 		if (Range <= 0)
-		{
 			Range = 1;
-		}
-		
-		var tile:Tile;
+			
+		var tile:FlxTile;
 		var i:Int = Tile;
 		var l:Int = Tile + Range;
-		
-		var maxIndex = _tileObjects.length;
-		if (l > maxIndex) 
+		var maxIndex:Int = _tileObjects.length;
+		if (l > maxIndex)
 		{
-			throw 'Index $l exceeds the maximum tile index of $maxIndex. Please verfiy the Tile ($Tile) and Range ($Range) parameters.';
+			throw 'Index $l exceeds the maximum tile index of $maxIndex. Please verify the Tile ($Tile) and Range ($Range) parameters.';
 		}
 		
 		while (i < l)
 		{
-			tile = _tileObjects[i++];
-			tile.allowCollisions = AllowCollisions;
-			(cast tile).callbackFunction = Callback;
-			(cast tile).filter = CallbackFilter;
+			tile = cast(_tileObjects[i++]);
+			
+			if (tile.filters == null)
+			{
+				tile.filters = new Map<String, FlxTileFilter>();
+			}
+			tile.filters.set(Filter == null ? Type.getClassName(FlxObject) : Type.getClassName(Filter), new FlxTileFilter(Collisions, Callback, ProcessCallback));
+		}
+		
+	}
+	
+	/**
+	 * This will remove the filter from one or more tiles.
+	 * 
+	 * @param	Tile	The starting tile id of the range you want to remove the filter from
+	 * @param	Filter	The Class that the filter is for.
+	 * @param	Range	How many tiles starting from Tile that should have the filter removed. Defaults to 1
+	 */
+	public function removeTileFilter(Tile:Int, Filter:Class<FlxObject>, ?Range:Int = 1):Void
+	{
+		if (Range <= 0)
+			Range = 1;
+			
+		var tile:FlxTile;
+		var i:Int = Tile;
+		var l:Int = Tile + Range;
+		var maxIndex:Int = _tileObjects.length;
+		var className:String = "";
+		if (l > maxIndex)
+		{
+			throw 'Index $l exceeds the maximum tile index of $maxIndex. Please verify the Tile ($Tile) and Range ($Range) parameters.';
+		}
+		
+		while (i < l)
+		{
+			tile = cast(_tileObjects[i++]);
+			if (tile.filters != null)
+			{
+				className = Type.getClassName(Filter);
+				if (tile.filters.exists(className))
+				{
+					tile.filters.remove(className);
+				}
+			}
+			
+			
 		}
 	}
 

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -11,19 +11,6 @@ import flixel.graphics.frames.FlxFrame;
 class FlxTile extends FlxObject
 {
 	/**
-	 * This function is called whenever an object hits a tile of this type.
-	 * This function should take the form myFunction(Tile:FlxTile,Object:FlxObject):void.
-	 * Defaults to null, set through FlxTilemap.setTileProperties().
-	 */
-	public var callbackFunction:FlxObject->FlxObject->Void = null;
-	/**
-	 * Each tile can store its own filter class for their callback functions.
-	 * That is, the callback will only be triggered if an object with a class
-	 * type matching the filter touched it.
-	 * Defaults to null, set through FlxTilemap.setTileProperties().
-	 */
-	public var filter:Class<FlxObject>;
-	/**
 	 * A reference to the tilemap this tile object belongs to.
 	 */
 	public var tilemap:FlxTilemap;
@@ -39,6 +26,12 @@ class FlxTile extends FlxObject
 	 * This value is only reliable and useful if used from the callback function.
 	 */
 	public var mapIndex:Int = 0;
+	
+	/**
+	 * Filters used for overlap/collision vs different classes on this tile.
+	 * Use `FlxBaseTilemap.addTileFilter()` and `FlxBaseTilemap.removeTileFilter()`
+	 */
+	public var filters:Map<String, FlxTileFilter> = null;
 	
 	/**
 	 * Frame graphic for this tile.
@@ -73,10 +66,50 @@ class FlxTile extends FlxObject
 	 */
 	override public function destroy():Void
 	{
-		callbackFunction = null;
+		if (filters != null)
+		{
+			for (f in filters)
+			{
+				f.overlapCallback = null;
+				f.processCallback = null;
+				f = null;
+			}
+			filters = null;
+		}
+		
 		tilemap = null;
 		frame = null;
 		
 		super.destroy();
 	}
+}
+class FlxTileFilter
+{
+	/**
+	 * Collision flags for this filter.
+	 * Defaults to ANY
+	 */
+	public var collisions:Int = FlxObject.ANY;
+	
+	/**
+	 * This function is called whenever an object hits a tile of this type.
+	 * This function should take the form myFunction(Tile:FlxTile,Object:FlxObject):Void.
+	 * Defaults to null
+	 */
+	public var overlapCallback:FlxTile->FlxObject->Void = null;
+	
+	/**
+	 * This function, if set, will be called when overlap is detected, and `overlapCallback` will only be called if this returns `true`.
+	 * Should take the form of myFunction(Tile:FlxTile,Object:FlxObject):Bool
+	 * Use `FlxObject.seperate()` to allow collision on this tile.
+	 */
+	public var processCallback:FlxTile->FlxObject->Bool = null;
+	
+	public function new(?collisions:Int = FlxObject.ANY, ?overlapCallback:FlxTile->FlxObject->Void, ?processCallback:FlxTile->FlxObject->Bool)
+	{
+		this.collisions = collisions;
+		this.overlapCallback = overlapCallback;
+		this.processCallback = processCallback;
+	}
+	
 }

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -19,6 +19,7 @@ import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxTilemapGraphicAsset;
+import flixel.tile.FlxTile.FlxTileFilter;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
@@ -547,38 +548,65 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				tile.last.x = tile.x - deltaX;
 				tile.last.y = tile.y - deltaY;
 				
-				overlapFound = ((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) && 
-				               ((Object.y + Object.height) > tile.y) && (Object.y < (tile.y + tile.height));
-				
-				if (tile.allowCollisions != FlxObject.NONE)
-				{
-					if (Callback != null)
-					{
-						if (FlipCallbackParams)
-						{
-							overlapFound = Callback(Object, tile);
-						}
-						else
-						{
-							overlapFound = Callback(tile, Object);
-						}
-					}
-				}
+				overlapFound = 	((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) && 
+								((Object.y + Object.height) > tile.y) && (Object.y < (tile.y + tile.height));
 				
 				if (overlapFound)
 				{
-					if ((tile.callbackFunction != null) && ((tile.filter == null) || Std.is(Object, tile.filter)))
+					var tileFilter:FlxTileFilter = null;
+					var tmpCollisions:Int = FlxObject.ANY;
+					var classType:String = "";
+					if (tile.filters != null)
 					{
-						tile.mapIndex = rowStart + column;
-						tile.callbackFunction(tile, Object);
+						classType = Type.getClassName(Type.getClass(Object));
+						if (tile.filters.exists(classType))
+						{
+							tileFilter = tile.filters.get(classType);
+							tmpCollisions = tile.allowCollisions;
+							tile.allowCollisions = tileFilter.collisions;
+							if (tileFilter.processCallback != null)
+							{
+								overlapFound = tileFilter.processCallback(tile, Object);
+							}
+						}
+					}
+
+					if (tile.allowCollisions != FlxObject.NONE && overlapFound)
+					{
+						if (Callback != null)
+						{
+							if (FlipCallbackParams)
+							{
+								overlapFound = Callback(Object, tile);
+							}
+							else
+							{
+								overlapFound = Callback(tile, Object);
+							}
+						}
 					}
 					
-					if (tile.allowCollisions != FlxObject.NONE)
+					if (overlapFound)
 					{
-						results = true;
+						if (tileFilter != null && tileFilter.overlapCallback != null)
+						{
+							tile.mapIndex = rowStart + column;
+							tileFilter.overlapCallback(tile, Object);
+						}
+						
+						if (tile.allowCollisions != FlxObject.NONE)
+						{
+							results = true;
+						}
+						
+						if (tileFilter != null)
+						{
+							tile.allowCollisions = tmpCollisions;
+							tileFilter = null;
+							classType = null;
+						}
 					}
 				}
-				
 				column++;
 			}
 			


### PR DESCRIPTION
Changed `FlxTile`, `FlxTilemap`, and `FlxBaseTilemap` to allow multiple filters to be specified for each tile.

Use `FlxBaseTilemap.addTileFilter()` to add a new filter. You can specify a Class to use as the filter, Collisions, Callback, and ProcessCallback which will all work within `FlxTilemap.overlapWithCallback()` to have your class(es) collide/not collide, and trigger callbacks properly.