### PR TITLE
Added timescale-independent version of FlxG.elapsed

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -118,6 +118,11 @@ class FlxG
 	 */
 	public static var elapsed(default, null):Float = 0;
 	/**
+	 * Represents the amount of time in seconds that passed since last frame, independent from timescale.
+	 * Useful for keeping track of time during slow-motion effects. If timescale is 1, this will be equal to elapsed. 
+	 */
+	public static var independentElapsed(default, null):Float = 0;
+	/**
 	 * Useful when the timestep is NOT fixed (i.e. variable), to prevent jerky movement or erratic behavior at very low fps.
 	 * Essentially locks the framerate to a minimum value - any slower and you'll get slowdown instead of frameskip; default is 1/10th of a second.
 	 */

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -713,10 +713,12 @@ class FlxGame extends Sprite
 		if (FlxG.fixedTimestep)
 		{
 			FlxG.elapsed = FlxG.timeScale * _stepSeconds; // fixed timestep
+			FlxG.independentElapsed = _stepSeconds;
 		}
 		else
 		{
 			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
+			FlxG.independentElapsed = (_elapsedMS / 1000);
 			
 			var max = FlxG.maxElapsed * FlxG.timeScale;
 			if (FlxG.elapsed > max) 


### PR DESCRIPTION
Added independentElapsed to FlxG, which works exactly like FlxG.elapsed,
but is independent from FlxG.timescale. This is very useful for keeping
things like UI and menus independent from slow-motion effects.