### PR TITLE
Add support for flipped FlxFrames

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -900,7 +900,9 @@ class FlxSprite extends FlxObject
 	{
 		if (_frame != null && dirty)
 		{
-			if (!flipX && !flipY && _frame.type == FlxFrameType.REGULAR)
+			var doFlipX = flipX != _frame.flipX;
+			var doFlipY = flipY != _frame.flipY;
+			if (!doFlipX && !doFlipY && _frame.type == FlxFrameType.REGULAR)
 			{
 				framePixels = _frame.paint(framePixels, _flashPointZero, false, true);
 			}

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -243,6 +243,8 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var data:Fast = new haxe.xml.Fast(Xml.parse(Description).firstElement());
 		
 		var angle:Int;
+		var flipX:Bool;
+		var flipY:Bool;
 		var name:String;
 		var trimmed:Bool;
 		var rotated:Bool;
@@ -256,6 +258,8 @@ class FlxAtlasFrames extends FlxFramesCollection
 			name = texture.att.name;
 			trimmed = texture.has.frameX;
 			rotated = (texture.has.rotated && texture.att.rotated == "true") ? true : false;
+			flipX = (texture.has.flipX && texture.att.flipX == "true") ? true : false;
+			flipY = (texture.has.flipY && texture.att.flipY == "true") ? true : false;
 			
 			rect = new FlxRect(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat(texture.att.width), Std.parseFloat(texture.att.height));
 			
@@ -278,7 +282,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 				sourceSize.set(size.height, size.width);
 			}
 			
-			frames.addAtlasFrame(rect, sourceSize, offset, name, angle);
+			frames.addAtlasFrame(rect, sourceSize, offset, name, angle, flipX, flipY);
 		}
 		
 		return frames;

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -257,9 +257,9 @@ class FlxAtlasFrames extends FlxFramesCollection
 		{
 			name = texture.att.name;
 			trimmed = texture.has.frameX;
-			rotated = (texture.has.rotated && texture.att.rotated == "true") ? true : false;
-			flipX = (texture.has.flipX && texture.att.flipX == "true") ? true : false;
-			flipY = (texture.has.flipY && texture.att.flipY == "true") ? true : false;
+			rotated = (texture.has.rotated && texture.att.rotated == "true");
+			flipX = (texture.has.flipX && texture.att.flipX == "true");
+			flipY = (texture.has.flipY && texture.att.flipY == "true");
 			
 			rect = new FlxRect(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat(texture.att.width), Std.parseFloat(texture.att.height));
 			

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -53,6 +53,9 @@ class FlxFrame implements IFlxDestroyable
 	 */
 	public var angle:FlxFrameAngle;
 	
+	public var flipX:Bool;
+	public var flipY:Bool;
+	
 	/**
 	 * Original (uncropped) image size.
 	 */
@@ -74,10 +77,18 @@ class FlxFrame implements IFlxDestroyable
 	private var blitMatrix:Vector<Float>;
 	
 	@:allow(flixel)
-	private function new(parent:FlxGraphic, angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0)
+	private function new(parent:FlxGraphic, angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false, flipY:Bool = false)
 	{
 		this.parent = parent;
 		this.angle = angle;
+		this.flipX = flipX;
+		this.flipY = flipY;
+		
+		if (flipX == true)
+		{
+			trace("BOINK");
+		}
+		
 		type = FlxFrameType.REGULAR;
 		
 		sourceSize = FlxPoint.get();
@@ -229,12 +240,15 @@ class FlxFrame implements IFlxDestroyable
 		mat.tx = tileMatrix[4];
 		mat.ty = tileMatrix[5];
 		
-		if (rotation == FlxFrameAngle.ANGLE_0 && !flipX && !flipY)
+		var doFlipX = flipX != this.flipX;
+		var doFlipY = flipY != this.flipY;
+		
+		if (rotation == FlxFrameAngle.ANGLE_0 && !doFlipX && !doFlipY)
 		{
 			return mat;
 		}
 		
-		return rotateAndFlip(mat, rotation, flipX, flipY);
+		return rotateAndFlip(mat, rotation, doFlipX, doFlipY);
 		#end
 	}
 	
@@ -324,8 +338,11 @@ class FlxFrame implements IFlxDestroyable
 			return bmd;
 		}
 		
+		var doFlipX = flipX != this.flipX;
+		var doFlipY = flipY != this.flipY;
+		
 		var matrix:FlxMatrix = FlxMatrix.matrix;
-		prepareTransformedBlitMatrix(matrix, rotation, flipX, flipY);
+		prepareTransformedBlitMatrix(matrix, rotation, doFlipX, doFlipY);
 		matrix.translate(point.x, point.y);
 		var rect:Rectangle = getDrawFrameRect(matrix);
 		bmd.draw(parent.bitmap, matrix, null, null, rect);
@@ -609,6 +626,8 @@ class FlxFrame implements IFlxDestroyable
 		}
 		
 		clone.offset.copyFrom(offset);
+		clone.flipX = flipX;
+		clone.flipY = flipY;
 		clone.sourceSize.copyFrom(sourceSize);
 		clone.frame = FlxRect.get().copyFrom(frame);
 		clone.type = type;

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -84,11 +84,6 @@ class FlxFrame implements IFlxDestroyable
 		this.flipX = flipX;
 		this.flipY = flipY;
 		
-		if (flipX == true)
-		{
-			trace("BOINK");
-		}
-		
 		type = FlxFrameType.REGULAR;
 		
 		sourceSize = FlxPoint.get();

--- a/flixel/graphics/frames/FlxFramesCollection.hx
+++ b/flixel/graphics/frames/FlxFramesCollection.hx
@@ -165,16 +165,18 @@ class FlxFramesCollection implements IFlxDestroyable
 	  * @param	offset			how frame region is located on original frame image (offset from top left corner of original image)
 	  * @param	name			name for this frame (name of packed image file)
 	  * @param	angle			rotation of packed image (can be 0, 90, -90).
+	  * @param	flipX			if packed image should be horizontally flipped
+	  * @param	flipY			if packed iamge should be vertically flipped
 	  * @return	Newly created and added frame object.
 	  */
-	public function addAtlasFrame(frame:FlxRect, sourceSize:FlxPoint, offset:FlxPoint, name:String = null, angle:FlxFrameAngle = 0):FlxFrame
+	public function addAtlasFrame(frame:FlxRect, sourceSize:FlxPoint, offset:FlxPoint, name:String = null, angle:FlxFrameAngle = 0, flipX:Bool=false, flipY:Bool=false):FlxFrame
 	{
 		if (name != null && framesHash.exists(name))
 		{
 			return framesHash.get(name);
 		}
 		
-		var texFrame:FlxFrame = new FlxFrame(parent, angle);
+		var texFrame:FlxFrame = new FlxFrame(parent, angle, flipX, flipY);
 		texFrame.name = name;
 		texFrame.sourceSize.set(sourceSize.x, sourceSize.y);
 		texFrame.offset.set(offset.x, offset.y);


### PR DESCRIPTION
Adding support for flipped FlxFrames. This lets you get your atlases packed even tighter by re-using mirror images.