### PR TITLE
Make #1587 work in legacy mode.

### DIFF
--- a/flixel/graphics/tile/FlxDrawBaseItem.hx
+++ b/flixel/graphics/tile/FlxDrawBaseItem.hx
@@ -28,6 +28,7 @@ class FlxDrawBaseItem<T>
 				Tilesheet.TILE_BLEND_SCREEN;
 			case BlendMode.SUBTRACT:
 				Tilesheet.TILE_BLEND_SUBTRACT;
+			#if !lime_legacy
 			case BlendMode.DARKEN:
 				Tilesheet.TILE_BLEND_DARKEN;
 			case BlendMode.LIGHTEN:
@@ -40,6 +41,7 @@ class FlxDrawBaseItem<T>
 				Tilesheet.TILE_BLEND_DIFFERENCE;
 			case BlendMode.INVERT:
 				Tilesheet.TILE_BLEND_INVERT;
+			#end
 			#end
 			default:
 				Tilesheet.TILE_BLEND_NORMAL;


### PR DESCRIPTION
[Pull request 1587](https://github.com/HaxeFlixel/flixel/pull/1587) creates issues with lime legacy. This will allow games to be built without have to use `<set name="next" />` in Project.xml.

Fix was suggested [here](https://github.com/HaxeFlixel/flixel/commit/fd7b5da6f33646346c563fbbe63b148139b14438).