### PR TITLE
Allow negative letterSpacing in FlxBitmapFont

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1547,11 +1547,9 @@ class FlxBitmapText extends FlxSprite
 	
 	private function set_letterSpacing(value:Int):Int
 	{
-		var tmp:Int = (value >= 0) ? value : -value;
-		
-		if (tmp != letterSpacing)
+		if (value != letterSpacing)
 		{
-			letterSpacing = tmp;
+			letterSpacing = value;
 			pendingTextChange = true;
 		}
 		


### PR DESCRIPTION
If you set the value to a negative value, it spaces the letters apart based on the positive value instead. Negative spacing is useful if you want your letters to blend together. It doesn't look like there's a technical reason to prohibit the value from being negative.

I implemented this fix for my Ludum Dare entry, and it is working there: https://github.com/schonstal/LudumDare33