### PR TITLE
FlxPool & FlxTypedButton: optimization that removes dynamic casting in c++

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -313,10 +313,10 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		super.draw();
 		
-		if (label != null && label.visible)
+		if (_spriteLabel != null && _spriteLabel.visible)
 		{
-			label.cameras = cameras;
-			label.draw();
+			_spriteLabel.cameras = cameras;
+			_spriteLabel.draw();
 		}
 	}
 	
@@ -328,9 +328,9 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		super.drawDebug();
 		
-		if (label != null) 
+		if (_spriteLabel != null) 
 		{
-			label.drawDebug();
+			_spriteLabel.drawDebug();
 		}
 	}
 #end

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -177,6 +177,8 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	public var pressed(get, never):Bool;
 	public var justPressed(get, never):Bool;
 	
+	private var _labelAsSprite:FlxSprite;
+	
 	/** 
 	 * We don't need an ID here, so let's just use Int as the type.
 	 */
@@ -251,6 +253,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	override public function destroy():Void
 	{
 		label = FlxDestroyUtil.destroy(label);
+		_labelAsSprite = null;
 		
 		onUp = FlxDestroyUtil.destroy(onUp);
 		onDown = FlxDestroyUtil.destroy(onDown);
@@ -456,18 +459,18 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	
 	private function updateLabelPosition()
 	{
-		if (label != null) // Label positioning
+		if (_labelAsSprite != null) // Label positioning
 		{
-			label.x = (pixelPerfectPosition ? Math.floor(x) : x) + labelOffsets[status].x;
-			label.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status].y;
+			_labelAsSprite.x = (pixelPerfectPosition ? Math.floor(x) : x) + labelOffsets[status].x;
+			_labelAsSprite.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status].y;
 		}
 	}
 	
 	private function updateLabelAlpha()
 	{
-		if (label != null && labelAlphas.length > status) 
+		if (_labelAsSprite != null && labelAlphas.length > status) 
 		{
-			label.alpha = alpha * labelAlphas[status];
+			_labelAsSprite.alpha = alpha * labelAlphas[status];
 		}
 	}
 	
@@ -539,6 +542,8 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		}
 		
 		label = Value;
+		_labelAsSprite = label;
+		
 		updateLabelPosition();
 		
 		return Value;

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -113,6 +113,9 @@ class FlxButton extends FlxTypedButton<FlxText>
 /**
  * A simple button class that calls a function when clicked by the mouse.
  */
+#if !display
+@:generic
+#end
 class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 {
 	/**

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -177,7 +177,10 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	public var pressed(get, never):Bool;
 	public var justPressed(get, never):Bool;
 	
-	private var _labelAsSprite:FlxSprite;
+	/**
+	 * We cast label to a FlxSprite for internal operations to avoid Dynamic casts in C++
+	 */
+	private var _spriteLabel:FlxSprite;
 	
 	/** 
 	 * We don't need an ID here, so let's just use Int as the type.
@@ -253,7 +256,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	override public function destroy():Void
 	{
 		label = FlxDestroyUtil.destroy(label);
-		_labelAsSprite = null;
+		_spriteLabel = null;
 		
 		onUp = FlxDestroyUtil.destroy(onUp);
 		onDown = FlxDestroyUtil.destroy(onDown);
@@ -459,18 +462,18 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	
 	private function updateLabelPosition()
 	{
-		if (_labelAsSprite != null) // Label positioning
+		if (_spriteLabel != null) // Label positioning
 		{
-			_labelAsSprite.x = (pixelPerfectPosition ? Math.floor(x) : x) + labelOffsets[status].x;
-			_labelAsSprite.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status].y;
+			_spriteLabel.x = (pixelPerfectPosition ? Math.floor(x) : x) + labelOffsets[status].x;
+			_spriteLabel.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status].y;
 		}
 	}
 	
 	private function updateLabelAlpha()
 	{
-		if (_labelAsSprite != null && labelAlphas.length > status) 
+		if (_spriteLabel != null && labelAlphas.length > status) 
 		{
-			_labelAsSprite.alpha = alpha * labelAlphas[status];
+			_spriteLabel.alpha = alpha * labelAlphas[status];
 		}
 	}
 	
@@ -542,7 +545,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		}
 		
 		label = Value;
-		_labelAsSprite = label;
+		_spriteLabel = label;
 		
 		updateLabelPosition();
 		

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -6,7 +6,10 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
  * A generic container that facilitates pooling and recycling of objects.
  * WARNING: Pooled objects must have parameterless constructors: function new()
  */
-@:generic class FlxPool<T:IFlxDestroyable>
+#if !display
+@:generic 
+#end
+class FlxPool<T:IFlxDestroyable>
 {
 	public var length(get, never):Int;
 	

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -6,7 +6,7 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
  * A generic container that facilitates pooling and recycling of objects.
  * WARNING: Pooled objects must have parameterless constructors: function new()
  */
-class FlxPool<T:IFlxDestroyable>
+@:generic class FlxPool<T:IFlxDestroyable>
 {
 	public var length(get, never):Int;
 	


### PR DESCRIPTION
AFAIK, this has no external changes to the API or the behavior, and from inspecting the generated CPP and hxscout, removes the dynamic cast entirely.

before:
```cpp
Dynamic tmp = this->label;
```

after:
```cpp
::flixel::FlxSprite tmp = this->_labelAsSprite;
```

UPDATE: I also added the @:generic meta to FlxPool to properly generate the generic variants the avoid the dynamic casting.