### PR TITLE
Making FlxPoint and FlxRect use their pools

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -306,7 +306,7 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Helper rect for drawTriangles visibility checks
 	 */
-	private var _bounds:FlxRect = new FlxRect();
+	private var _bounds:FlxRect = FlxRect.get();
 	
 #if FLX_RENDER_TILE
 	/**

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -333,7 +333,7 @@ class FlxSprite extends FlxObject
 		
 		if (Animated)
 		{
-			frames = FlxTileFrames.fromGraphic(graph, new FlxPoint(Width, Height));
+			frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(Width, Height));
 		}
 		else
 		{
@@ -393,7 +393,7 @@ class FlxSprite extends FlxObject
 		var max:Int = (brush.height > brush.width) ? brush.height : brush.width;
 		max = (AutoBuffer) ? Std.int(max * 1.5) : max;
 		
-		frames = FlxTileFrames.fromGraphic(tempGraph, new FlxPoint(max, max));
+		frames = FlxTileFrames.fromGraphic(tempGraph, FlxPoint.get(max, max));
 		
 		if (AutoBuffer)
 		{

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -529,7 +529,7 @@ class FlxGraphic
 	{
 		var frame:FlxFrame = new FlxFrame(this);
 		frame.type = FlxFrameType.EMPTY;
-		frame.frame = new FlxRect();
+		frame.frame = FlxRect.get();
 		frame.sourceSize.copyFrom(size);
 		return frame;
 	}
@@ -620,7 +620,7 @@ class FlxGraphic
 	{
 		if (_imageFrame == null)
 		{
-			_imageFrame = FlxImageFrame.fromRectangle(this, new FlxRect(0, 0, bitmap.width, bitmap.height));
+			_imageFrame = FlxImageFrame.fromRectangle(this, FlxRect.get(0, 0, bitmap.width, bitmap.height));
 		}
 		
 		return _imageFrame;

--- a/flixel/graphics/atlas/FlxAtlas.hx
+++ b/flixel/graphics/atlas/FlxAtlas.hx
@@ -143,7 +143,7 @@ class FlxAtlas implements IFlxDestroyable
 			rootHeight = getNextPowerOfTwo(rootHeight);
 		}
 		
-		root = new FlxNode(new FlxRect(0, 0, rootWidth, rootHeight), this);
+		root = new FlxNode(FlxRect.get(0, 0, rootWidth, rootHeight), this);
 	}
 	
 	/**
@@ -199,7 +199,7 @@ class FlxAtlas implements IFlxDestroyable
 	private function wrapRoot():Void
 	{
 		var temp:FlxNode = root;
-		root = new FlxNode(new FlxRect(0, 0, temp.width, temp.height), this);
+		root = new FlxNode(FlxRect.get(0, 0, temp.width, temp.height), this);
 		root.left = temp;
 	}
 	
@@ -259,35 +259,35 @@ class FlxAtlas implements IFlxDestroyable
 			
 			if (divideHorizontally) // divide horizontally
 			{
-				firstChild = new FlxNode(new FlxRect(nodeToDivide.x, nodeToDivide.y, insertWidth, nodeToDivide.height), this);
+				firstChild = new FlxNode(FlxRect.get(nodeToDivide.x, nodeToDivide.y, insertWidth, nodeToDivide.height), this);
 				
 				if (nodeToDivide.width - insertWidth > 0)
 				{
-					secondChild = new FlxNode(new FlxRect(nodeToDivide.x + insertWidth, nodeToDivide.y, nodeToDivide.width - insertWidth, nodeToDivide.height), this);
+					secondChild = new FlxNode(FlxRect.get(nodeToDivide.x + insertWidth, nodeToDivide.y, nodeToDivide.width - insertWidth, nodeToDivide.height), this);
 				}
 				
-				firstGrandChild = new FlxNode(new FlxRect(firstChild.x, firstChild.y, insertWidth, insertHeight), this, firstGrandChildFilled, firstGrandChildKey, firstGrandChildRotated);
+				firstGrandChild = new FlxNode(FlxRect.get(firstChild.x, firstChild.y, insertWidth, insertHeight), this, firstGrandChildFilled, firstGrandChildKey, firstGrandChildRotated);
 				
 				if (firstChild.height - insertHeight > 0)
 				{
-					secondGrandChild = new FlxNode(new FlxRect(firstChild.x, firstChild.y + insertHeight, insertWidth, firstChild.height - insertHeight), this);
+					secondGrandChild = new FlxNode(FlxRect.get(firstChild.x, firstChild.y + insertHeight, insertWidth, firstChild.height - insertHeight), this);
 				}
 				
 			}
 			else // divide vertically
 			{
-				firstChild = new FlxNode(new FlxRect(nodeToDivide.x, nodeToDivide.y, nodeToDivide.width, insertHeight), this);
+				firstChild = new FlxNode(FlxRect.get(nodeToDivide.x, nodeToDivide.y, nodeToDivide.width, insertHeight), this);
 				
 				if (nodeToDivide.height - insertHeight > 0)
 				{
-					secondChild = new FlxNode(new FlxRect(nodeToDivide.x, nodeToDivide.y + insertHeight, nodeToDivide.width, nodeToDivide.height - insertHeight), this);
+					secondChild = new FlxNode(FlxRect.get(nodeToDivide.x, nodeToDivide.y + insertHeight, nodeToDivide.width, nodeToDivide.height - insertHeight), this);
 				}
 				
-				firstGrandChild = new FlxNode(new FlxRect(firstChild.x, firstChild.y, insertWidth, insertHeight), this, firstGrandChildFilled, firstGrandChildKey, firstGrandChildRotated);
+				firstGrandChild = new FlxNode(FlxRect.get(firstChild.x, firstChild.y, insertWidth, insertHeight), this, firstGrandChildFilled, firstGrandChildKey, firstGrandChildRotated);
 				
 				if (firstChild.width - insertWidth > 0)
 				{
-					secondGrandChild = new FlxNode(new FlxRect(firstChild.x + insertWidth, firstChild.y, firstChild.width - insertWidth, insertHeight), this);
+					secondGrandChild = new FlxNode(FlxRect.get(firstChild.x + insertWidth, firstChild.y, firstChild.width - insertWidth, insertHeight), this);
 				}
 			}
 			
@@ -525,7 +525,7 @@ class FlxAtlas implements IFlxDestroyable
 		if (newWidth> root.width || newHeight > root.height)
 		{
 			var temp:FlxNode = root;
-			root = new FlxNode(new FlxRect(0, 0, newWidth, newHeight), this);
+			root = new FlxNode(FlxRect.get(0, 0, newWidth, newHeight), this);
 			
 			divideHorizontally = decideHowToDivide ? needToDivideHorizontally(root, temp.width, temp.height) : divideHorizontally;
 			
@@ -655,7 +655,7 @@ class FlxAtlas implements IFlxDestroyable
 		
 		if (node.filled && !atlasFrames.framesHash.exists(node.key))
 		{
-			var frame:FlxRect = new FlxRect(node.x, node.y, node.width - border, node.height - border);
+			var frame:FlxRect = FlxRect.get(node.x, node.y, node.width - border, node.height - border);
 			var sourceSize:FlxPoint = node.rotated ? FlxPoint.get(node.height - border, node.width - border) : FlxPoint.get(node.width - border, node.height - border);
 			var offset:FlxPoint = FlxPoint.get(0, 0);
 			var angle:FlxFrameAngle = node.rotated ? FlxFrameAngle.ANGLE_NEG_90 : FlxFrameAngle.ANGLE_0;
@@ -1077,7 +1077,7 @@ class FlxAtlas implements IFlxDestroyable
 				}
 				
 				var temp:FlxNode = root;
-				root = new FlxNode(new FlxRect(0, 0, nextWidth, nextHeight), this);
+				root = new FlxNode(FlxRect.get(0, 0, nextWidth, nextHeight), this);
 				
 				if (temp.left != null) // this means that atlas isn't empty and we need to resize it's bitmapdata
 				{

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -88,12 +88,12 @@ class FlxAtlasFrames extends FlxFramesCollection
 		
 		if (rotated)
 		{
-			frameRect = new FlxRect(FrameData.frame.x, FrameData.frame.y, FrameData.frame.h, FrameData.frame.w);
+			frameRect = FlxRect.get(FrameData.frame.x, FrameData.frame.y, FrameData.frame.h, FrameData.frame.w);
 			angle = FlxFrameAngle.ANGLE_NEG_90;
 		}
 		else
 		{
-			frameRect = new FlxRect(FrameData.frame.x, FrameData.frame.y, FrameData.frame.w, FrameData.frame.h);
+			frameRect = FlxRect.get(FrameData.frame.x, FrameData.frame.y, FrameData.frame.w, FrameData.frame.h);
 		}
 		
 		Frames.addAtlasFrame(frameRect, sourceSize, offset, name, angle);
@@ -172,12 +172,12 @@ class FlxAtlasFrames extends FlxFramesCollection
 			rect = null;
 			if (rotated)
 			{
-				rect = new FlxRect(imageX, imageY, imageHeight, imageWidth);
+				rect = FlxRect.get(imageX, imageY, imageHeight, imageWidth);
 				angle = FlxFrameAngle.ANGLE_90;
 			}
 			else
 			{
-				rect = new FlxRect(imageX, imageY, imageWidth, imageHeight);
+				rect = FlxRect.get(imageX, imageY, imageWidth, imageHeight);
 			}
 			
 			tempString = lines[curIndex++];
@@ -261,7 +261,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 			flipX = (texture.has.flipX && texture.att.flipX == "true");
 			flipY = (texture.has.flipY && texture.att.flipY == "true");
 			
-			rect = new FlxRect(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat(texture.att.width), Std.parseFloat(texture.att.height));
+			rect = FlxRect.get(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat(texture.att.width), Std.parseFloat(texture.att.height));
 			
 			size = if (trimmed)
 			{
@@ -333,7 +333,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 			angle = (rotated) ? FlxFrameAngle.ANGLE_NEG_90 : FlxFrameAngle.ANGLE_0;
 			name = sprite.get("n");
 			offset = FlxPoint.get(0, 0);
-			rect = new FlxRect(Std.parseInt(sprite.get("x")), Std.parseInt(sprite.get("y")), Std.parseInt(sprite.get("w")), Std.parseInt(sprite.get("h")));
+			rect = FlxRect.get(Std.parseInt(sprite.get("x")), Std.parseInt(sprite.get("y")), Std.parseInt(sprite.get("w")), Std.parseInt(sprite.get("h")));
 			sourceSize = FlxPoint.get(rect.width, rect.height);
 			
 			if (trimmed)
@@ -394,9 +394,9 @@ class FlxAtlasFrames extends FlxFramesCollection
 			name = StringTools.trim(currImageData[0]);
 			currImageRegion = StringTools.trim(currImageData[1]).split(" ");
 			
-			rect = new FlxRect(Std.parseInt(currImageRegion[0]), Std.parseInt(currImageRegion[1]), Std.parseInt(currImageRegion[2]), Std.parseInt(currImageRegion[3]));
-			sourceSize = new FlxPoint(rect.width, rect.height);
-			offset = new FlxPoint();
+			rect = FlxRect.get(Std.parseInt(currImageRegion[0]), Std.parseInt(currImageRegion[1]), Std.parseInt(currImageRegion[2]), Std.parseInt(currImageRegion[3]));
+			sourceSize = FlxPoint.get(rect.width, rect.height);
+			offset = FlxPoint.get();
 			
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle);
 		}
@@ -433,7 +433,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 	
 	override public function addBorder(border:FlxPoint):FlxAtlasFrames
 	{
-		var resultBorder:FlxPoint = new FlxPoint().addPoint(this.border).addPoint(border);
+		var resultBorder:FlxPoint = FlxPoint.weak().addPoint(this.border).addPoint(border);
 		var atlasFrames:FlxAtlasFrames = FlxAtlasFrames.findFrame(parent, resultBorder);
 		if (atlasFrames != null)
 		{

--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -221,7 +221,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		
 		for (char in chars.nodes.char)
 		{
-			frame = new FlxRect();
+			frame = FlxRect.get();
 			frame.x = Std.parseInt(char.att.x); // X position within the bitmap image file.
 			frame.y = Std.parseInt(char.att.y); // Y position within the bitmap image file.
 			frame.width = Std.parseInt(char.att.width); // Width of the character in the image file.
@@ -382,7 +382,7 @@ class FlxBitmapFont extends FlxFramesCollection
 					gh = gy - cy;
 					
 					charCode = Utf8.charCodeAt(letters, letterIdx);
-					rect = new FlxRect(cx, cy, gw, gh);
+					rect = FlxRect.get(cx, cy, gw, gh);
 					offset = FlxPoint.get(0, 0);
 					xAdvance = gw;
 					
@@ -491,7 +491,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		
 		letters = (letters == null) ? DEFAULT_CHARS : letters;
 		region = (region == null) ? FlxRect.flxRect.set(0, 0, frame.sourceSize.x, frame.sourceSize.y) : region;
-		spacing = (spacing == null) ? new FlxPoint(0, 0) : spacing;
+		spacing = (spacing == null) ? FlxPoint.get(0, 0) : spacing;
 		
 		var bitmapWidth:Int = Std.int(region.width);
 		var bitmapHeight:Int = Std.int(region.height);
@@ -526,7 +526,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		{
 			for (i in 0...(numCols))
 			{
-				charRect = new FlxRect(startX + i * spacedWidth, startY + j * spacedHeight, charWidth, charHeight);
+				charRect = FlxRect.get(startX + i * spacedWidth, startY + j * spacedHeight, charWidth, charHeight);
 				offset = FlxPoint.get(0, 0);
 				font.addCharFrame(Utf8.charCodeAt(letters, letterIndex), charRect, offset, xAdvance);
 				letterIndex++;
@@ -620,7 +620,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	
 	override public function addBorder(border:FlxPoint):FlxBitmapFont 
 	{
-		var resultBorder:FlxPoint = new FlxPoint().addPoint(this.border).addPoint(border);
+		var resultBorder:FlxPoint = FlxPoint.weak().addPoint(this.border).addPoint(border);
 		
 		var font:FlxBitmapFont = FlxBitmapFont.findFont(frame, resultBorder);
 		if (font != null)

--- a/flixel/graphics/frames/FlxImageFrame.hx
+++ b/flixel/graphics/frames/FlxImageFrame.hx
@@ -70,7 +70,7 @@ class FlxImageFrame extends FlxFramesCollection
 		}
 		
 		imageFrame = new FlxImageFrame(graphic);
-		imageFrame.addSpriteSheetFrame(rect.copyTo(new FlxRect()));
+		imageFrame.addSpriteSheetFrame(rect.copyTo(FlxRect.get()));
 		return imageFrame;
 	}
 	
@@ -116,7 +116,7 @@ class FlxImageFrame extends FlxFramesCollection
 		
 		if (region == null)
 		{
-			region = new FlxRect(0, 0, graphic.width, graphic.height);
+			region = FlxRect.get(0, 0, graphic.width, graphic.height);
 		}
 		else
 		{
@@ -255,7 +255,7 @@ class FlxImageFrame extends FlxFramesCollection
 	
 	override public function addBorder(border:FlxPoint):FlxImageFrame 
 	{
-		var resultBorder:FlxPoint = new FlxPoint().addPoint(this.border).addPoint(border);
+		var resultBorder:FlxPoint = FlxPoint.weak().addPoint(this.border).addPoint(border);
 		
 		var imageFrame:FlxImageFrame = FlxImageFrame.findFrame(parent, frame.frame, resultBorder);
 		if (imageFrame != null)

--- a/flixel/graphics/frames/FlxTileFrames.hx
+++ b/flixel/graphics/frames/FlxTileFrames.hx
@@ -343,7 +343,7 @@ class FlxTileFrames extends FlxFramesCollection
 	 * @param	tileSize	the size of tiles (tilesets should have tiles of the same size)
 	 * @return	atlas frames collection, which you can load in tilemaps or sprites:
 	 * 
-	 * var combinedFrames = FlxTileFrames.combineTileSets(bitmaps, new FlxPoint(16, 16));
+	 * var combinedFrames = FlxTileFrames.combineTileSets(bitmaps, FlxPoint.get(16, 16));
 	 * tilemap.loadMapFromCSV(mapData, combinedFrames);
 	 * 
 	 * or
@@ -392,7 +392,7 @@ class FlxTileFrames extends FlxFramesCollection
 			for (frame in frames.frames)
 			{
 				frame.paint(combined, point, true);
-				result.addAtlasFrame(new FlxRect(point.x, point.y, tileSize.x, tileSize.y), new FlxPoint(tileSize.x, tileSize.y), new FlxPoint(0, 0));				
+				result.addAtlasFrame(FlxRect.get(point.x, point.y, tileSize.x, tileSize.y), FlxPoint.get(tileSize.x, tileSize.y), FlxPoint.get(0, 0));				
 				point.x += tileSize.x;
 				
 				if (point.x >= combined.width)
@@ -461,7 +461,7 @@ class FlxTileFrames extends FlxFramesCollection
 			for (frame in collection.frames)
 			{
 				frame.paint(combined, point, true);
-				result.addAtlasFrame(new FlxRect(point.x, point.y, tileWidth, tileHeight), new FlxPoint(tileWidth, tileHeight), new FlxPoint(0, 0));				
+				result.addAtlasFrame(FlxRect.get(point.x, point.y, tileWidth, tileHeight), FlxPoint.get(tileWidth, tileHeight), FlxPoint.get(0, 0));				
 				point.x += tileWidth;
 				
 				if (point.x >= combined.width)
@@ -537,7 +537,7 @@ class FlxTileFrames extends FlxFramesCollection
 	
 	override public function addBorder(border:FlxPoint):FlxTileFrames
 	{
-		var resultBorder:FlxPoint = new FlxPoint().addPoint(this.border).addPoint(border);
+		var resultBorder:FlxPoint = FlxPoint.get().addPoint(this.border).addPoint(border);
 		var resultSize:FlxPoint = FlxPoint.get().copyFrom(tileSize).subtract(2 * border.x, 2 * border.y);
 		var tileFrames:FlxTileFrames = FlxTileFrames.findFrame(parent, resultSize, region, atlasFrame, tileSpacing, resultBorder);
 		if (tileFrames != null)

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -47,7 +47,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		colors = new Array<Int>();
 		#end
 		
-		bounds = new FlxRect();
+		bounds = FlxRect.get();
 	}
 	
 	override public function render(camera:FlxCamera):Void 

--- a/flixel/tile/FlxTileblock.hx
+++ b/flixel/tile/FlxTileblock.hx
@@ -154,7 +154,7 @@ class FlxTileblock extends FlxSprite
 			TileHeight = (TileHeight > graph.height) ? graph.height : TileHeight;
 		}
 		
-		var tileFrames:FlxTileFrames = FlxTileFrames.fromGraphic(graph, new FlxPoint(TileWidth, TileHeight));
+		var tileFrames:FlxTileFrames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(TileWidth, TileHeight));
 		return this.loadFrames(tileFrames, Empties);
 	}
 	

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -260,7 +260,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			_tileHeight = _tileWidth;
 		}
 		
-		frames = FlxTileFrames.fromGraphic(graph, new FlxPoint(_tileWidth, _tileHeight));
+		frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(_tileWidth, _tileHeight));
 	}
 	
 	override private function initTileObjects():Void 

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -354,7 +354,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		if (buttonNode != null)
 		{
 			var buttonFrames:FlxTileFrames = cast frames;
-			var tileSize:FlxPoint = new FlxPoint(buttonFrames.tileSize.x, buttonFrames.tileSize.y);
+			var tileSize:FlxPoint = FlxPoint.get(buttonFrames.tileSize.x, buttonFrames.tileSize.y);
 			var tileFrames:FlxTileFrames = buttonNode.getTileFrames(tileSize);
 			this.frames = tileFrames;
 		}

--- a/flixel/ui/FlxVirtualPad.hx
+++ b/flixel/ui/FlxVirtualPad.hx
@@ -132,7 +132,7 @@ class FlxVirtualPad extends FlxSpriteGroup
 	{
 		var button = new FlxButton(X, Y);
 		var frame = FlxAssets.getVirtualInputFrames().getByName(Graphic);
-		button.frames = FlxTileFrames.fromFrame(frame, new FlxPoint(Width, Height));
+		button.frames = FlxTileFrames.fromFrame(frame, FlxPoint.get(Width, Height));
 		button.resetSizeFromFrame();
 		button.solid = false;
 		button.immovable = true;

--- a/flixel/util/FlxBitmapDataUtil.hx
+++ b/flixel/util/FlxBitmapDataUtil.hx
@@ -352,7 +352,7 @@ class FlxBitmapDataUtil
 	{
 		if (region == null)
 		{
-			region = new FlxRect(0, 0, bitmapData.width, bitmapData.height);
+			region = FlxRect.get(0, 0, bitmapData.width, bitmapData.height);
 		}
 		
 		var frameWidth:Int = Std.int(region.width);


### PR DESCRIPTION
- Updated code in some classes to get all `FlxPoint`s and `FlxRect`s through their pools instead of using `new`