### PR TITLE
Fixed bug with diagonally-cast FlxTilemap.ray()

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -731,7 +731,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				rx = q;
 				ry = ly + stepY * ((q - lx) / stepX);
 				
-				if ((ry > tileY) && (ry < tileY + _scaledTileHeight))
+				if ((ry >= tileY) && (ry <= tileY + _scaledTileHeight))
 				{
 					if (Result == null)
 					{
@@ -753,7 +753,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				rx = lx + stepX * ((q - ly) / stepY);
 				ry = q;
 				
-				if ((rx > tileX) && (rx < tileX + _scaledTileWidth))
+				if ((rx >= tileX) && (rx <= tileX + _scaledTileWidth))
 				{
 					if (Result == null)
 					{

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -3,6 +3,7 @@ package flixel.tile;
 import flash.display.BitmapData;
 import flash.errors.ArgumentError;
 import flixel.graphics.FlxGraphic;
+import flixel.math.FlxPoint;
 import flixel.tile.FlxTilemap;
 import massive.munit.Assert;
 using flixel.util.FlxArrayUtil;
@@ -113,6 +114,42 @@ class FlxTilemapTest extends FlxTest
 		Assert.areEqual(4, tilemap.widthInTiles);
 		Assert.areEqual(3, tilemap.heightInTiles);
 		Assert.isTrue(sampleMapArray.equals(tilemap.getData()));
+	}
+	
+	@Test //#1617
+	function testRayEmpty()
+	{
+		var mapData = [0, 0, 0]; //3x1 
+		tilemap.loadMapFromArray(mapData, 3, 1, getBitmapData(), 8, 8);
+		
+		Assert.isTrue(tilemap.ray(new FlxPoint(0, tilemap.height/2), new FlxPoint(tilemap.width, tilemap.height/2)));
+	}
+	
+	@Test //#1617
+	function testRayStraight()
+	{
+		var mapData = [0, 1, 0]; //3x1 with a solid block in the middle
+		tilemap.loadMapFromArray(mapData, 3, 1, getBitmapData(), 8, 8);
+		
+		Assert.isFalse(tilemap.ray(new FlxPoint(0, tilemap.height/2), new FlxPoint(tilemap.width, tilemap.height/2)));
+	}
+	
+	@Test //#1617
+	function testRayImperfectDiagonal()
+	{
+		var mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; //3x3 with a solid block in the middle
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		
+		Assert.isFalse(tilemap.ray(new FlxPoint(0, 0), new FlxPoint(tilemap.width-tilemap.width/8, tilemap.height)));
+	}
+	
+	@Test //#1617
+	function testRayPerfectDiagonal()
+	{
+		var mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; //3x3 with a solid block in the middle
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		
+		Assert.isFalse(tilemap.ray(new FlxPoint(0, 0), new FlxPoint(tilemap.width, tilemap.height)));
 	}
 	
 	function getBitmapData()


### PR DESCRIPTION
If your start and end points were perfectly diagonal, FlxTilemap.ray() would fail to detect a collision. This was caused by the ray assuming that whenever it checked a position within a tile it would fall *inside* the bounds, rather than exactly on one of the tile's corners.