### PR TITLE
PostProcess shader clashing with OpenFL

### DIFF
--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -64,18 +64,18 @@ class PostProcess extends OpenGLView
 		GL.bufferData(GL.ARRAY_BUFFER, new Float32Array(cast vertices), GL.STATIC_DRAW);
 		GL.bindBuffer(GL.ARRAY_BUFFER, null);
 
-		shader = new Shader([
+		postProcessShader = new Shader([
 			{ src: vertexShader, fragment: false },
 			{ src: Assets.getText(fragmentShader), fragment: true }
 		]);
 
 		// default shader variables
-		imageUniform = shader.uniform("uImage0");
-		timeUniform = shader.uniform("uTime");
-		resolutionUniform = shader.uniform("uResolution");
+		imageUniform = postProcessShader.uniform("uImage0");
+		timeUniform = postProcessShader.uniform("uTime");
+		resolutionUniform = postProcessShader.uniform("uResolution");
 
-		vertexSlot = shader.attribute("aVertex");
-		texCoordSlot = shader.attribute("aTexCoord");
+		vertexSlot = postProcessShader.attribute("aVertex");
+		texCoordSlot = postProcessShader.attribute("aTexCoord");
 	}
 
 	/**
@@ -92,7 +92,7 @@ class PostProcess extends OpenGLView
 		}
 		else
 		{
-			var id:Int = shader.uniform(uniform);
+			var id:Int = postProcessShader.uniform(uniform);
 			if (id != -1)
 			{
 				uniforms.set(uniform, new Uniform(id, value));
@@ -186,7 +186,7 @@ class PostProcess extends OpenGLView
 		GL.bindFramebuffer(GL.FRAMEBUFFER, renderTo);
 		GL.viewport(0, 0, screenWidth, screenHeight);
 		
-		shader.bind();
+		postProcessShader.bind();
 
 		GL.enableVertexAttribArray(vertexSlot);
 		GL.enableVertexAttribArray(texCoordSlot);
@@ -233,7 +233,7 @@ class PostProcess extends OpenGLView
 	private var renderbuffer:GLRenderbuffer;
 	private var texture:GLTexture;
 
-	private var shader:Shader;
+	private var postProcessShader:Shader;
 	private var buffer:GLBuffer;
 	private var renderTo:GLFramebuffer;
 	private var defaultFramebuffer:GLFramebuffer = null;

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -878,6 +878,7 @@ enum FlxGamepadModel
 	XInput;
 	MayflashWiiRemote;
 	WiiRemote;
+	MFi;
 }
 
 enum FlxGamepadModelAttachment

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -449,6 +449,7 @@ class FlxGamepadManager implements IFlxInputManager
 			else if (str.contains("nintendo rvlcnt01tr")) WiiRemote;                  //WiiRemote with motion plus
 			else if (str.contains("nintendo rvlcnt01")) WiiRemote;                    //WiiRemote w/o  motion plus
 			else if (str.contains("mayflash wiimote pc adapter")) MayflashWiiRemote;  //WiiRemote paired to MayFlash DolphinBar (with or w/o motion plus)
+			else if (str.contains("mfi")) MFi;
 			else XBox360; //default
 	}
 	

--- a/flixel/input/gamepad/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/FlxGamepadMapping.hx
@@ -11,6 +11,7 @@ import flixel.input.gamepad.id.MayflashWiiRemoteID;
 import flixel.input.gamepad.id.WiiRemoteID;
 import flixel.input.gamepad.id.XBox360ID;
 import flixel.input.gamepad.id.XInputID;
+import flixel.input.gamepad.id.MFiID;
 
 #if flash
 import openfl.system.Capabilities;
@@ -71,6 +72,7 @@ class FlxGamepadMapping
 					case WiiNunchuk: getRawWiiNunchuk(ID);
 					case None: getRawWiiRemote(ID);
 				}
+			case MFi: getRawMFi(ID);
 			default: -1;
 		}
 	}
@@ -103,6 +105,7 @@ class FlxGamepadMapping
 					case WiiNunchuk: getIDWiiNunchuk(RawID);
 					case None: getIDWiiRemote(RawID);
 				}
+			case MFi: getIDMFi(RawID);
 			default: NONE;
 		}
 	}
@@ -135,6 +138,7 @@ class FlxGamepadMapping
 						case WiiNunchuk, WiiClassicController: WiiRemoteID.LEFT_ANALOG_STICK;
 						case None: WiiRemoteID.REMOTE_DPAD;
 					}
+				case MFi: MFiID.LEFT_ANALOG_STICK;
 				default: null;
 			}
 		}
@@ -159,6 +163,7 @@ class FlxGamepadMapping
 						case WiiClassicController: WiiRemoteID.RIGHT_ANALOG_STICK;
 						default: null;
 					}
+				case MFi: MFiID.RIGHT_ANALOG_STICK;
 				default: null;
 			}
 		}
@@ -179,6 +184,7 @@ class FlxGamepadMapping
 			case XInput: XInputID.getFlipAxis(AxisID);
 			case MayflashWiiRemote: MayflashWiiRemoteID.getFlipAxis(AxisID, attachment);
 			case WiiRemote: WiiRemoteID.getFlipAxis(AxisID, attachment);
+			case MFi: MFiID.getFlipAxis(AxisID);
 			default: -1;
 		}
 	}
@@ -199,6 +205,7 @@ class FlxGamepadMapping
 			case XInput: XInputID.axisIndexToRawID(AxisID);
 			case MayflashWiiRemote: MayflashWiiRemoteID.axisIndexToRawID(AxisID, attachment);
 			case WiiRemote: WiiRemoteID.axisIndexToRawID(AxisID, attachment);
+			case MFiID: MFiID.axisIndexToRawID(AxisID);
 			default: -1;
 		}
 	}
@@ -226,6 +233,7 @@ class FlxGamepadMapping
 			case XInput: XInputID.isAxisForMotion(ID);
 			case MayflashWiiRemote: MayflashWiiRemoteID.isAxisForMotion(ID, attachment);
 			case WiiRemote: WiiRemoteID.isAxisForMotion(ID, attachment);
+			case MFi: MFiID.isAxisForMotion(ID);
 			default: false;
 		}
 	}
@@ -241,6 +249,7 @@ class FlxGamepadMapping
 			case XInput: XInputID.SUPPORTS_MOTION;
 			case MayflashWiiRemote: MayflashWiiRemoteID.SUPPORTS_MOTION;
 			case WiiRemote: WiiRemoteID.SUPPORTS_MOTION;
+			case MFi: MFiID.SUPPORTS_MOTION;
 			default: false;
 		}
 	}
@@ -256,6 +265,7 @@ class FlxGamepadMapping
 			case XInput: XInputID.SUPPORTS_POINTER;
 			case MayflashWiiRemote: MayflashWiiRemoteID.SUPPORTS_POINTER;
 			case WiiRemote: WiiRemoteID.SUPPORTS_POINTER;
+			case MFi: MFiID.SUPPORTS_POINTER;
 			default: false;
 		}
 	}
@@ -534,6 +544,36 @@ class FlxGamepadMapping
 			default: -1;
 		}
 	}
+
+	public function getRawMFi(ID:FlxGamepadInputID):Int
+	{
+		return switch (ID)
+		{
+			case A: MFiID.A;
+			case B: MFiID.B;
+			case X: MFiID.X;
+			case Y: MFiID.Y;
+			case BACK: MFiID.BACK;
+			case GUIDE: MFiID.GUIDE;
+			case START: MFiID.START;
+			case LEFT_STICK_CLICK: MFiID.LEFT_STICK_CLICK;
+			case RIGHT_STICK_CLICK: MFiID.RIGHT_STICK_CLICK;
+			case LEFT_SHOULDER: MFiID.LB;
+			case RIGHT_SHOULDER: MFiID.RB;
+			case DPAD_UP: MFiID.DPAD_UP;
+			case DPAD_DOWN: MFiID.DPAD_DOWN;
+			case DPAD_LEFT: MFiID.DPAD_LEFT;
+			case DPAD_RIGHT: MFiID.DPAD_RIGHT;
+			case LEFT_TRIGGER:  MFiID.LEFT_TRIGGER;
+			case RIGHT_TRIGGER: MFiID.RIGHT_TRIGGER;
+			#if FLX_JOYSTICK_API
+			case LEFT_TRIGGER_FAKE: MFiID.LEFT_TRIGGER_FAKE;
+			case RIGHT_TRIGGER_FAKE: MFiID.RIGHT_TRIGGER_FAKE;
+			#end
+			default: -1;
+		}
+	}
+
 	
 	public function getIDOUYA(rawID:Int):FlxGamepadInputID
 	{
@@ -781,6 +821,30 @@ class FlxGamepadMapping
 			default: NONE;
 		}
 	}
+
+	public function getIDMFi(rawID:Int):FlxGamepadInputID
+	{
+		return switch (rawID)
+		{
+			case MFiID.A: A;
+			case MFiID.B: B;
+			case MFiID.X: X;
+			case MFiID.Y: Y;
+			case MFiID.BACK: BACK;
+			case MFiID.GUIDE: GUIDE;
+			case MFiID.START: START;
+			case MFiID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
+			case MFiID.RIGHT_STICK_CLICK: RIGHT_STICK_CLICK;
+			case MFiID.LB: LEFT_SHOULDER;
+			case MFiID.RB: RIGHT_SHOULDER;
+			case MFiID.DPAD_UP: DPAD_UP;
+			case MFiID.DPAD_DOWN: DPAD_DOWN;
+			case MFiID.DPAD_LEFT: DPAD_LEFT;
+			case MFiID.DPAD_RIGHT: DPAD_RIGHT;
+			default: NONE;
+		}
+	}
+
 }
 
 enum Manufacturer

--- a/flixel/input/gamepad/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/FlxGamepadMapping.hx
@@ -205,7 +205,7 @@ class FlxGamepadMapping
 			case XInput: XInputID.axisIndexToRawID(AxisID);
 			case MayflashWiiRemote: MayflashWiiRemoteID.axisIndexToRawID(AxisID, attachment);
 			case WiiRemote: WiiRemoteID.axisIndexToRawID(AxisID, attachment);
-			case MFiID: MFiID.axisIndexToRawID(AxisID);
+			case MFi: MFiID.axisIndexToRawID(AxisID);
 			default: -1;
 		}
 	}

--- a/flixel/input/gamepad/id/MFiID.hx
+++ b/flixel/input/gamepad/id/MFiID.hx
@@ -1,0 +1,54 @@
+package flixel.input.gamepad.id;
+
+import flixel.input.gamepad.FlxGamepad;
+
+/**
+ * IDs for MFi controllers
+ */
+class MFiID
+{
+	public static inline var SUPPORTS_MOTION = false;
+	public static inline var SUPPORTS_POINTER = false;
+	
+	public static inline function getFlipAxis(AxisID:Int):Int { return 1; }
+	public static function isAxisForMotion(ID:FlxGamepadInputID):Bool { return false; }
+	
+	// Button IDs
+	public static inline var A:Int = 6;
+	public static inline var B:Int = 7;
+	public static inline var X:Int = 8;
+	public static inline var Y:Int = 9;
+	public static inline var LB:Int = 15;
+	public static inline var RB:Int = 16;
+	public static inline var BACK:Int = 10;
+	public static inline var START:Int = 12;
+	public static inline var LEFT_STICK_CLICK:Int = 13;
+	public static inline var RIGHT_STICK_CLICK:Int = 14;
+	
+	public static inline var GUIDE:Int = 11;
+	
+	// real dpad id's this time, no need for hats!
+	public static inline var DPAD_UP:Int = 17;
+	public static inline var DPAD_DOWN:Int = 18;
+	public static inline var DPAD_LEFT:Int = 19;
+	public static inline var DPAD_RIGHT:Int = 20;
+	
+	// Axis indices
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1);
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3);
+	
+	public static inline var LEFT_TRIGGER:Int = 4;
+	public static inline var RIGHT_TRIGGER:Int = 5;
+	
+	#if FLX_JOYSTICK_API
+	//the axis index values for this don't overlap with anything so we can just return the original values!
+	public static function axisIndexToRawID(index:Int):Int
+	{
+		return index;
+	}
+	
+	//Just pass back LEFT/RIGHT trigger
+	public static inline var LEFT_TRIGGER_FAKE:Int = LEFT_TRIGGER;
+	public static inline var RIGHT_TRIGGER_FAKE:Int = RIGHT_TRIGGER;
+	#end
+}


### PR DESCRIPTION
The PostProcess shader of Flixel uses a variable called shader. OpenFL's OpenGLView has another variable with the same name and the two clash with each other.
I renamed Flixel's one to overcome the problem.

I also added an initial support for MFi's controllers.