### PR TITLE
Added filter support for FlxCamera and FlxGame

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -21,6 +21,7 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
 import openfl.display.BlendMode;
+import openfl.filters.BitmapFilter;
 import openfl.geom.Matrix;
 import openfl.Vector;
 
@@ -200,6 +201,10 @@ class FlxCamera extends FlxBasic
 	 * Used to force the camera to look ahead of the target.
 	 */
 	public var followLead(default, null):FlxPoint;
+	/**
+	 * Enables or disables the filters set via setFilters()
+	 */
+	public var enableFilters:Bool = true;
 	
 	/**
 	 * Internal, used to render buffer to screen space.
@@ -281,6 +286,10 @@ class FlxCamera extends FlxBasic
 	 * Internal, to help avoid costly allocations.
 	 */
 	private var _point:FlxPoint;
+	/**
+	 * Internal, the filters array to be applied to the camera.
+	 */
+	private var _filters:Array<BitmapFilter>;
 	
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.
@@ -786,6 +795,8 @@ class FlxCamera extends FlxBasic
 		updateFade(elapsed);
 		updateShake(elapsed);
 		
+		flashSprite.filters = enableFilters ? _filters : null;
+		
 		updateFlashSpritePosition();
 	}
 	
@@ -1187,6 +1198,16 @@ class FlxCamera extends FlxBasic
 		_fxFadeAlpha = 0.0;
 		_fxShakeDuration = 0;
 		updateFlashSpritePosition();
+	}
+	
+	/**
+	 * Sets the filter array to be applied to the camera.
+	 * 
+	 * @param	filters
+	 */
+	public function setFilters(filters:Array<BitmapFilter>):Void
+	{
+		_filters = filters;
 	}
 	
 	/**

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -20,6 +20,7 @@ import flixel.util.FlxArrayUtil;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import openfl.Assets;
+import openfl.filters.BitmapFilter;
 
 #if FLX_POST_PROCESS
 import openfl.display.OpenGLView;
@@ -80,6 +81,10 @@ class FlxGame extends Sprite
 	 * Time in milliseconds that has passed (amount of "ticks" passed) since the game has started.
 	 */
 	public var ticks(default, null):Int = 0;
+	/**
+	 * Enables or disables the filters set via setFilters()
+	 */
+	public var enableFilters:Bool = true;
 	
 	/**
 	 * A flag for triggering the onGameStart "event".
@@ -126,6 +131,11 @@ class FlxGame extends Sprite
 	 * Whether the game lost focus.
 	 */
 	private var _lostFocus:Bool = false;
+	
+	/**
+	 * The filters array to be applied to the game.
+	 */
+	private var _filters:Array<BitmapFilter>;
 	
 	#if (cpp || neko)
 	/**
@@ -256,6 +266,16 @@ class FlxGame extends Sprite
 		_initialState = (InitialState == null) ? FlxState : InitialState;
 		
 		addEventListener(Event.ADDED_TO_STAGE, create);
+	}
+	
+	/**
+	 * Sets the filter array to be applied to the game.
+	 * 
+	 * @param	filters
+	 */
+	public function setFilters(filters:Array<BitmapFilter>):Void
+	{
+		_filters = filters;
 	}
 	
 	/**
@@ -753,6 +773,8 @@ class FlxGame extends Sprite
 		}
 		FlxArrayUtil.clearArray(FlxG.swipes);
 		#end
+		
+		filters = enableFilters ? _filters : null;
 	}
 	
 	private function updateInput():Void

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -8,6 +8,7 @@ import openfl.Assets;
 import openfl.display.OpenGLView;
 import openfl.gl.*;
 import openfl.utils.Float32Array;
+import flixel.effects.postprocess.Shader in PShader;
 
 private class Uniform
 {
@@ -64,18 +65,18 @@ class PostProcess extends OpenGLView
 		GL.bufferData(GL.ARRAY_BUFFER, new Float32Array(cast vertices), GL.STATIC_DRAW);
 		GL.bindBuffer(GL.ARRAY_BUFFER, null);
 
-		shader = new Shader([
+		pshader = new PShader([
 			{ src: vertexShader, fragment: false },
 			{ src: Assets.getText(fragmentShader), fragment: true }
 		]);
 
 		// default shader variables
-		imageUniform = shader.uniform("uImage0");
-		timeUniform = shader.uniform("uTime");
-		resolutionUniform = shader.uniform("uResolution");
+		imageUniform = pshader.uniform("uImage0");
+		timeUniform = pshader.uniform("uTime");
+		resolutionUniform = pshader.uniform("uResolution");
 
-		vertexSlot = shader.attribute("aVertex");
-		texCoordSlot = shader.attribute("aTexCoord");
+		vertexSlot = pshader.attribute("aVertex");
+		texCoordSlot = pshader.attribute("aTexCoord");
 	}
 
 	/**
@@ -92,7 +93,7 @@ class PostProcess extends OpenGLView
 		}
 		else
 		{
-			var id:Int = shader.uniform(uniform);
+			var id:Int = pshader.uniform(uniform);
 			if (id != -1)
 			{
 				uniforms.set(uniform, new Uniform(id, value));
@@ -186,7 +187,7 @@ class PostProcess extends OpenGLView
 		GL.bindFramebuffer(GL.FRAMEBUFFER, renderTo);
 		GL.viewport(0, 0, screenWidth, screenHeight);
 		
-		shader.bind();
+		pshader.bind();
 
 		GL.enableVertexAttribArray(vertexSlot);
 		GL.enableVertexAttribArray(texCoordSlot);
@@ -233,7 +234,7 @@ class PostProcess extends OpenGLView
 	private var renderbuffer:GLRenderbuffer;
 	private var texture:GLTexture;
 
-	private var shader:Shader;
+	private var pshader:PShader;
 	private var buffer:GLBuffer;
 	private var renderTo:GLFramebuffer;
 	private var defaultFramebuffer:GLFramebuffer = null;

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -62,7 +62,7 @@ class PostProcess extends OpenGLView
 
 		buffer = GL.createBuffer();
 		GL.bindBuffer(GL.ARRAY_BUFFER, buffer);
-		GL.bufferData(GL.ARRAY_BUFFER, new Float32Array(cast vertices), GL.STATIC_DRAW);
+		GL.bufferData(GL.ARRAY_BUFFER, new Float32Array(#if !openfl_next cast #end vertices), GL.STATIC_DRAW);
 		GL.bindBuffer(GL.ARRAY_BUFFER, null);
 
 		pshader = new PShader([


### PR DESCRIPTION
This commit plus the latest release of OpenFL with custom shader support (so, using `next` not `legacy`) makes possible to have hardware accelerated filters (aka post-processes) per camera (`FlxCamera`) and a global filters support (`FlxGame`)

~~This deprecates the usage of `PostProcess`~~ This makes possible to use post process effects with `next`