### PR TITLE
Null checks for FlxSpriteGroup width/height measurements

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -762,6 +762,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		
 		for (member in _sprites)
 		{
+			if (member == null) continue;
 			var minMemberX:Float = member.x;
 			var maxMemberX:Float = minMemberX + member.width;
 			
@@ -797,6 +798,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		
 		for (member in _sprites)
 		{
+			if (member == null) continue;
 			var minMemberY:Float = member.y;
 			var maxMemberY:Float = minMemberY + member.height;
 			


### PR DESCRIPTION
This was causing some weird bugs in some edge cases, this prevents rare null members that somehow make their way into a FlxSpriteGroup from interfering with an accurate width/height bounds calculation.