### PR TITLE
FlxText - Prevent blurry lines

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -840,11 +840,41 @@ class FlxText extends FlxSprite
 			applyBorderTransparency();
 			applyFormats(_formatAdjusted, false);
 			
+			avoidBlurry();
+			
 			graphic.bitmap.draw(textField, _matrix);
 		}
 		
 		_regen = false;
 		dirty = true;
+	}
+	
+	/**
+	 * Internal function that insert an extra space in a line to prevent blurry lines.
+	 * Only work if wordWrap is not working, beacuse wordWrap seems to trim lines.
+	 */
+	private function avoidBlurry() 
+	{
+		var newText = "";
+		
+		for (i in 0...textField.numLines) 
+		{
+			var lineX = textField.getLineMetrics(i).x;
+			if (Math.floor(lineX) != lineX)
+			{
+				var space = textField.getLineText(i).indexOf(" ");
+				newText += textField.getLineText(i).substring(0, space) + " " + textField.getLineText(i).substring(space);
+			}
+			else
+			{
+				newText += textField.getLineText(i);
+			}
+		}
+		
+		if (newText != "")
+		{
+			textField.text = newText;
+		}
 	}
 	
 	override public function draw():Void 


### PR DESCRIPTION
Added a method in `FlxText` that insert an extra space to a line that is blurry. This is not a beautful solution, but it works.

Not work if:
If the font have a space character that width is not odd like the default font. (3 pixels)
If `wordWrap` is enabled and is applying a linebreak, because it seems to trim lines.

This solves https://github.com/HaxeFlixel/flixel/issues/1422