### PR TITLE
Fix completion problems when using OpenFL next

### DIFF
--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -469,7 +469,7 @@ class FlxGamepadManager implements IFlxInputManager
 	}
 	#end
 	
-	#if FLX_JOYSTICK_API
+	#if (FLX_JOYSTICK_API && openfl_legacy)
 	private function getModelFromJoystick(f:Float):FlxGamepadModel
 	{
 		//id "1" is PS3, but that is not supported as its PC drivers are terrible, and the most popular tools just turn it into a 360 controller


### PR DESCRIPTION
When using HaxeFlixel + OpenFL this completion error keeps popping up in FlashDevelop (and apparently other IDEs too):
```
flixel/flixel/input/gamepad/FlxGamepadManager.hx:486: lines 486-494 : Type not found : JoystickEvent
```

This simple check fixes it and probably solves #1655