### PR TITLE
Disable controls if FLX_NO_SOUND_TRAY

### DIFF
--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -29,7 +29,7 @@ class SoundFrontEnd
 	 */
 	public var volumeHandler:Float->Void;
 	
-	#if !FLX_NO_KEYBOARD
+	#if (!FLX_NO_KEYBOARD && !FLX_NO_SOUND_TRAY)
 	/**
 	 * The key codes used to increase volume (see FlxG.keys for the keys available).
 	 * Default keys: + (and numpad +). Set to null to deactivate.
@@ -333,7 +333,7 @@ class SoundFrontEnd
 		if (list != null && list.active)
 			list.update(elapsed);
 		
-		#if !FLX_NO_KEYBOARD
+		#if (!FLX_NO_KEYBOARD && !FLX_NO_SOUND_TRAY)
 		if (FlxG.keys.anyJustReleased(muteKeys))
 			toggleMuted();
 		else if (FlxG.keys.anyJustReleased(volumeUpKeys))


### PR DESCRIPTION
I just noticed that even if you disable the sound tray by using the `FLX_NO_SOUND_TRAY` flag the controls will still work. This confused some users which thought it was a bug in the game.

Imho the controls should only work when you're using the sound tray.