### PR TITLE
Tilemap DiagonalPolicy

### DIFF
--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -48,9 +48,6 @@ private enum HelperDefines
 	FLX_JOYSTICK_API;
 	FLX_GAMEINPUT_API;
 	
-	FLX_LINC_DIALOGS;
-	FLX_SYSTOOLS_DIALOGS;
-	
 	/**
 	 * Renders all cameras into a single BitmapData using draw() with
 	 * smoothing. Necessary to achieve non-blurry rendering with bitfive.
@@ -168,16 +165,6 @@ class FlxDefines
 		if (defined("cpp") || defined("neko"))
 		{
 			define(FLX_POST_PROCESS);
-		}
-		
-		if (defined("sys") && !defined("neko") && defined("linc_dialogs"))
-		{
-			define(FLX_LINC_DIALOGS);
-		}
-		
-		if (defined("sys") && !defined(FLX_LINC_DIALOGS) && defined("systools"))
-		{
-			define(FLX_SYSTOOLS_DIALOGS);
 		}
 	}
 	

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -48,6 +48,9 @@ private enum HelperDefines
 	FLX_JOYSTICK_API;
 	FLX_GAMEINPUT_API;
 	
+	FLX_LINC_DIALOGS;
+	FLX_SYSTOOLS_DIALOGS;
+	
 	/**
 	 * Renders all cameras into a single BitmapData using draw() with
 	 * smoothing. Necessary to achieve non-blurry rendering with bitfive.
@@ -165,6 +168,16 @@ class FlxDefines
 		if (defined("cpp") || defined("neko"))
 		{
 			define(FLX_POST_PROCESS);
+		}
+		
+		if (defined("sys") && !defined("neko") && defined("linc_dialogs"))
+		{
+			define(FLX_LINC_DIALOGS);
+		}
+		
+		if (defined("sys") && !defined(FLX_LINC_DIALOGS) && defined("systools"))
+		{
+			define(FLX_SYSTOOLS_DIALOGS);
 		}
 	}
 	

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -1255,18 +1255,18 @@ enum FlxTilemapAutoTiling
 }
 
 @:enum
-abstract FlxTilemapDiagonalPolicy(Null<Bool>)
+abstract FlxTilemapDiagonalPolicy(Int)
 {
 	/**
 	 * No diagonal movement allowed when calculating the path
 	 */
-	var NONE = null;
+	var NONE = 0;
 	/**
 	 * Diagonal movement costs the same as orthogonal movement
 	 */
-	var NORMAL = false;
+	var NORMAL = 1;
 	/**
 	 * Diagonal movement costs one more than orthogonal movement
 	 */
-	var WIDE = true;
+	var WIDE = 2;
 }

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -1255,18 +1255,18 @@ enum FlxTilemapAutoTiling
 }
 
 @:enum
-abstract FlxTilemapDiagonalPolicy(Int)
+abstract FlxTilemapDiagonalPolicy(Null<Bool>)
 {
 	/**
 	 * No diagonal movement allowed when calculating the path
 	 */
-	var NONE = 0;
+	var NONE = null;
 	/**
 	 * Diagonal movement costs the same as orthogonal movement
 	 */
-	var NORMAL = 1;
+	var NORMAL = false;
 	/**
 	 * Diagonal movement costs one more than orthogonal movement
 	 */
-	var WIDE = 2;
+	var WIDE = true;
 }

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -698,10 +698,10 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param	End			The end point in world coordinates.
 	 * @param	Simplify	Whether to run a basic simplification algorithm over the path data, removing extra points that are on the same line.  Default value is true.
 	 * @param	RaySimplify	Whether to run an extra raycasting simplification algorithm over the remaining path data.  This can result in some close corners being cut, and should be used with care if at all (yet).  Default value is false.
-	 * @param   WideDiagonal   Whether to require an additional tile to make diagonal movement. Default value is true;
+	 * @param	DiagonalPolicy	How to treat diagonal movement. (Default is WIDE, count +1 tile for diagonal movement)
 	 * @return	An Array of FlxPoints, containing all waypoints from the start to the end.  If no path could be found, then a null reference is returned.
 	 */
-	public function findPath(Start:FlxPoint, End:FlxPoint, Simplify:Bool = true, RaySimplify:Bool = false, WideDiagonal:Bool = true):Array<FlxPoint>
+	public function findPath(Start:FlxPoint, End:FlxPoint, Simplify:Bool = true, RaySimplify:Bool = false, DiagonalPolicy:FlxTilemapDiagonalPolicy = WIDE):Array<FlxPoint>
 	{
 		// Figure out what tile we are starting and ending on.
 		var startIndex:Int = getTileIndexByCoords(Start);
@@ -714,7 +714,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		}
 		
 		// Figure out how far each of the tiles is from the starting tile
-		var distances:Array<Int> = computePathDistance(startIndex, endIndex, WideDiagonal);
+		var distances:Array<Int> = computePathDistance(startIndex, endIndex, DiagonalPolicy);
 		
 		if (distances == null)
 		{
@@ -765,11 +765,11 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * 
 	 * @param	StartIndex		The starting tile's map index.
 	 * @param	EndIndex		The ending tile's map index.
-	 * @param	WideDiagonal	Whether to require an additional tile to make diagonal movement. Default value is true.
+	 * @param	DiagonalPolicy	How to treat diagonal movement.
 	 * @param	StopOnEnd		Whether to stop at the end or not (default true)
 	 * @return	A Flash Array of FlxPoint nodes.  If the end tile could not be found, then a null Array is returned instead.
 	 */
-	public function computePathDistance(StartIndex:Int, EndIndex:Int, WideDiagonal:Bool, StopOnEnd:Bool = true):Array<Int>
+	public function computePathDistance(StartIndex:Int, EndIndex:Int, DiagonalPolicy:FlxTilemapDiagonalPolicy, StopOnEnd:Bool = true):Array<Int>
 	{
 		// Create a distance-based representation of the tilemap.
 		// All walls are flagged as -2, all open areas as -1.
@@ -872,64 +872,69 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 						neighbors.push(index);
 					}
 				}
-				if (up && right)
+				
+				if (DiagonalPolicy != NONE)
 				{
-					index = currentIndex - widthInTiles + 1;
-					
-					if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex-widthInTiles] >= -1) && (distances[currentIndex+1] >= -1))
+					var WideDiagonal = DiagonalPolicy == WIDE;
+					if (up && right)
 					{
-						distances[index] = distance;
-						neighbors.push(index);
+						index = currentIndex - widthInTiles + 1;
+						
+						if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex-widthInTiles] >= -1) && (distances[currentIndex+1] >= -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
+						else if (!WideDiagonal && (distances[index] == -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
 					}
-					else if (!WideDiagonal && (distances[index] == -1))
+					if (right && down)
 					{
-						distances[index] = distance;
-						neighbors.push(index);
+						index = currentIndex + widthInTiles + 1;
+						
+						if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex+widthInTiles] >= -1) && (distances[currentIndex+1] >= -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
+						else if (!WideDiagonal && (distances[index] == -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
 					}
-				}
-				if (right && down)
-				{
-					index = currentIndex + widthInTiles + 1;
-					
-					if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex+widthInTiles] >= -1) && (distances[currentIndex+1] >= -1))
+					if (left && down)
 					{
-						distances[index] = distance;
-						neighbors.push(index);
+						index = currentIndex + widthInTiles - 1;
+						
+						if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex+widthInTiles] >= -1) && (distances[currentIndex-1] >= -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
+						else if (!WideDiagonal && (distances[index] == -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
 					}
-					else if (!WideDiagonal && (distances[index] == -1))
+					if (up && left)
 					{
-						distances[index] = distance;
-						neighbors.push(index);
-					}
-				}
-				if (left && down)
-				{
-					index = currentIndex + widthInTiles - 1;
-					
-					if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex+widthInTiles] >= -1) && (distances[currentIndex-1] >= -1))
-					{
-						distances[index] = distance;
-						neighbors.push(index);
-					}
-					else if (!WideDiagonal && (distances[index] == -1))
-					{
-						distances[index] = distance;
-						neighbors.push(index);
-					}
-				}
-				if (up && left)
-				{
-					index = currentIndex - widthInTiles - 1;
-					
-					if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex-widthInTiles] >= -1) && (distances[currentIndex-1] >= -1))
-					{
-						distances[index] = distance;
-						neighbors.push(index);
-					}
-					else if (!WideDiagonal && (distances[index] == -1))
-					{
-						distances[index] = distance;
-						neighbors.push(index);
+						index = currentIndex - widthInTiles - 1;
+						
+						if (WideDiagonal && (distances[index] == -1) && (distances[currentIndex-widthInTiles] >= -1) && (distances[currentIndex-1] >= -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
+						else if (!WideDiagonal && (distances[index] == -1))
+						{
+							distances[index] = distance;
+							neighbors.push(index);
+						}
 					}
 				}
 			}
@@ -1247,4 +1252,21 @@ enum FlxTilemapAutoTiling
 	 * Better for levels with thick walls that look better with interior corner art.
 	 */
 	ALT;
+}
+
+@:enum
+abstract FlxTilemapDiagonalPolicy(Int)
+{
+	/**
+	 * No diagonal movement allowed when calculating the path
+	 */
+	var NONE = 0;
+	/**
+	 * Diagonal movement costs the same as orthogonal movement
+	 */
+	var NORMAL = 1;
+	/**
+	 * Diagonal movement costs one more than orthogonal movement
+	 */
+	var WIDE = 2;
 }


### PR DESCRIPTION
I was debugging some pathfinding issues and noticed that FlxTilemap seems to always assume that diagonal movement is possible when it's calculating the distances during the A* / Dijkstra's algorithm step.

There was a parameter to modify this, but only to specify whether the diagonal was "wide" or not, ie, whether it would take an additional point to take the diagonal, or whether it was the same as an orthogonal step. There was no way I could see to disallow diagonals entirely.

So, this change swaps out the `WideDiagonal:Bool` for `DiagonalPolicy:FlxTilemapDiagonalPolicy`, which is an abstract enum.

Why an abstract enum and not a regular enum? Because the previous behavior is to set a default value of Wide Diagonals, and [you can't assign an enum as a default parameter because it's technically not a constant and the compiler complains](http://stackoverflow.com/questions/31307992/haxe-enum-default-parameters).

FlxTilemapDiagonalPolicy has three values -- NONE, NORMAL, and WIDE.

WIDE has the same behavior as previously setting the `WideDiagonal` value to true, and NORMAL has the same behavior as previously setting the `WideDiagonal` value to false.

NONE will make the calculator skip the `up && right`, `down && left`, etc, steps, and only consider orthogonal movement.