### PR TITLE
Fix updateHitbox() description

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -552,7 +552,7 @@ class FlxSprite extends FlxObject
 	
 	/**
 	 * Updates the sprite's hitbox (width, height, offset) according to the current scale. 
-	 * Also calls setOriginToCenter(). Called by setGraphicSize().
+	 * Also calls centerOrigin().
 	 */
 	public function updateHitbox():Void
 	{


### PR DESCRIPTION
setOriginToCenter() was renamed to centerOrigin() in https://github.com/HaxeFlixel/flixel/commit/1bec99ec93e1fd83abe78cd1e4bef0cc1f7d4ef9
call to updateHitbox() was removed from SetGraphicSize() in https://github.com/HaxeFlixel/flixel/commit/977a9d21502f72f63740b8fd6dd7dabf19707bba