### PR TITLE
Render path set at runtime

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -120,8 +120,6 @@ class FlxCamera extends FlxBasic
 	 */
 	public var scroll:FlxPoint;
 	
-	//start renderBlit
-	
 	/**
 	* The actual bitmap data of the camera display itself.
 	*/
@@ -142,8 +140,6 @@ class FlxCamera extends FlxBasic
 	* This sprite reference will allow you to do exactly that.
 	*/
 	public var screen:FlxSprite;
-	
-	//end renderBlit
 	
 	/**
 	 * Whether to use alpha blending for camera's background fill or not. 
@@ -296,18 +292,14 @@ class FlxCamera extends FlxBasic
 	 */
 	public var initialZoom(default, null):Float = 1;
 	
-	//start FlxG.renderBlit
-		
-		/**
-		 * Internal helper variable for doing better wipes/fills between renders.
-		 */
-		private var _fill:BitmapData;
-		/**
-		 * Internal, used to render buffer to screen space.
-		 */
-		private var _flashBitmap:Bitmap;
-		
-	//end FlxG.renderBlit
+	/**
+	 * Internal helper variable for doing better wipes/fills between renders.
+	 */
+	private var _fill:BitmapData;
+	/**
+	 * Internal, used to render buffer to screen space.
+	 */
+	private var _flashBitmap:Bitmap;
 	
 	/**
 	 * Internal sprite, used for correct trimming of camera viewport.
@@ -318,8 +310,6 @@ class FlxCamera extends FlxBasic
 	 * Helper rect for drawTriangles visibility checks
 	 */
 	private var _bounds:FlxRect = FlxRect.get();
-	
-//Start FlxG.renderTile
 	
 	/**
 	 * Sprite for drawing (instead of _flashBitmap for blitting)
@@ -645,13 +635,7 @@ class FlxCamera extends FlxBasic
 		}
 	}
 
-	/**
-	 * Used for FlxG.renderBlit
-	 */
 	private static var drawVertices:Vector<Float> = new Vector<Float>();
-	/**
-	 * Used for FlxG.renderBlit
-	 */
 	private static var trianglesSprite:Sprite = new Sprite();
 	
 	/**

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -113,6 +113,11 @@ class FlxG
 	 */
 	public static var drawFramerate(default, set):Int;
 	
+	public static var renderMethod(default, null):FlxRenderMethod;
+	
+	public static var renderBlit(default, null):Bool;
+	public static var renderTile(default, null):Bool;
+	
 	/**
 	 * Represents the amount of time in seconds that passed since last frame.
 	 */
@@ -500,6 +505,8 @@ class FlxG
 		width = Std.int(Math.abs(Width));
 		height = Std.int(Math.abs(Height));
 		
+		initRenderMethod();
+		
 		BaseScaleMode.gWidth = width;
 		BaseScaleMode.gHeight = height;
 		
@@ -539,6 +546,38 @@ class FlxG
 		#if !FLX_NO_SOUND_SYSTEM
 		sound = new SoundFrontEnd();
 		#end
+	}
+	
+	private static function initRenderMethod():Void
+	{
+		renderMethod = BLIT;
+		
+		#if (!lime_legacy && !flash)
+			if (Lib.application.config.windows[0].hardware == false)
+			{
+				renderMethod = BLIT;
+			}
+			else
+			{
+				renderMethod = switch(stage.window.renderer.type)
+				{
+					case OPENGL, CONSOLE:      TILES;
+					case CANVAS, FLASH, CAIRO: BLIT;
+					default:                   BLIT;
+				}
+			}
+		#else
+			#if (flash || js)
+				renderMethod = BLIT;
+			#else
+				renderMethod = TILES;
+			#end
+		#end
+		
+		renderBlit = renderMethod == BLIT;
+		renderTile = renderMethod == TILES;
+		
+		FlxObject.defaultPixelPerfectPosition = renderBlit;
 	}
 	
 	/**
@@ -654,4 +693,10 @@ class FlxG
 	{
 		return game._state;
 	}
+}
+
+enum FlxRenderMethod 
+{
+	TILES;
+	BLIT;
 }

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -472,15 +472,12 @@ class FlxGame extends Sprite
 		FlxG.cameras.resize();
 		
 		#if FLX_RENDER_CRISP
-		if (FlxG.renderBlit)
-		{
-			FlxDestroyUtil.removeChild(this, _displayBitmap);
-			FlxDestroyUtil.dispose(_display);
-			
-			var index:Int = getChildIndex(_inputContainer);
-			_display = new BitmapData(width, height);
-			addChildAt(_displayBitmap = new Bitmap(_display), index);
-		}
+		FlxDestroyUtil.removeChild(this, _displayBitmap);
+		FlxDestroyUtil.dispose(_display);
+		
+		var index:Int = getChildIndex(_inputContainer);
+		_display = new BitmapData(width, height);
+		addChildAt(_displayBitmap = new Bitmap(_display), index);
 		#end
 		
 		#if !FLX_NO_DEBUG
@@ -890,27 +887,24 @@ class FlxGame extends Sprite
 		}
 		
 		#if FLX_RENDER_CRISP
-		if (FlxG.renderBlit)
+		_display.fillRect(_display.rect, FlxColor.TRANSPARENT);
+		
+		for (camera in FlxG.cameras.list)
 		{
-			_display.fillRect(_display.rect, FlxColor.TRANSPARENT);
+			_displayMatrix.identity();
+			_displayMatrix.scale(camera.zoom * FlxG.scaleMode.scale.x, camera.zoom * FlxG.scaleMode.scale.y);
+			_displayMatrix.translate(camera.x * FlxG.scaleMode.scale.x, camera.y * FlxG.scaleMode.scale.y);
 			
-			for (camera in FlxG.cameras.list)
+			// rotate around center
+			if (camera.angle != 0)
 			{
-				_displayMatrix.identity();
-				_displayMatrix.scale(camera.zoom * FlxG.scaleMode.scale.x, camera.zoom * FlxG.scaleMode.scale.y);
-				_displayMatrix.translate(camera.x * FlxG.scaleMode.scale.x, camera.y * FlxG.scaleMode.scale.y);
-				
-				// rotate around center
-				if (camera.angle != 0)
-				{
-					_displayMatrix.translate( - _display.width >> 1, - _display.height >> 1);
-					_displayMatrix.rotate(camera.angle * FlxAngle.TO_RAD);
-					_displayMatrix.translate(_display.width >> 1, _display.height >> 1);
-				}
-				
-				_displayColorTransform.alphaMultiplier = camera.alpha;
-				_display.draw(camera.buffer, _displayMatrix, _displayColorTransform, null, null, camera.antialiasing);
+				_displayMatrix.translate( - _display.width >> 1, - _display.height >> 1);
+				_displayMatrix.rotate(camera.angle * FlxAngle.TO_RAD);
+				_displayMatrix.translate(_display.width >> 1, _display.height >> 1);
 			}
+			
+			_displayColorTransform.alphaMultiplier = camera.alpha;
+			_display.draw(camera.buffer, _displayMatrix, _displayColorTransform, null, null, camera.antialiasing);
 		}
 		#end
 	

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -22,7 +22,7 @@ class FlxObject extends FlxBasic
 	/**
 	 * Default value for FlxObject's pixelPerfectPosition var.
 	 */
-	public static var defaultPixelPerfectPosition:Bool = #if FLX_RENDER_BLIT true #else false #end;
+	public static var defaultPixelPerfectPosition:Bool = false;
 	
 	/**
 	 * This value dictates the maximum number of pixels two objects have to intersect before collision stops trying to separate them.
@@ -1035,19 +1035,23 @@ class FlxObject extends FlxBasic
 
 	private inline function beginDrawDebug(camera:FlxCamera):Graphics
 	{
-		#if FLX_RENDER_BLIT
+		if (FlxG.renderBlit)
+		{
 			FlxSpriteUtil.flashGfx.clear();
 			return FlxSpriteUtil.flashGfx;
-		#else
+		}
+		else
+		{
 			return camera.debugLayer.graphics;
-		#end
+		}
 	}
 	
 	private inline function endDrawDebug(camera:FlxCamera)
 	{
-		#if FLX_RENDER_BLIT
+		if (FlxG.renderBlit)
+		{
 			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
-		#end
+		}
 	}
 #end
 

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -275,10 +275,7 @@ class FlxSprite extends FlxObject
 		
 		if (FlxG.renderTile)
 		{
-			if (_frame != null && frame != null && frame.parent != _frame.parent)
-			{
-				_frame.parent.destroy();
-			}
+			_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
 		}
 	}
 	
@@ -942,7 +939,7 @@ class FlxSprite extends FlxObject
 			{
 				// don't try to regenerate frame pixels if _frame already uses it as source of graphics
 				// if you'll try then it will clear framePixels and you won't see anything
-				if (_frame.parent.bitmap == framePixels)
+				if (_frameGraphic != null)
 				{
 					dirty = false;
 					return framePixels;
@@ -968,7 +965,10 @@ class FlxSprite extends FlxObject
 			
 			if (FlxG.renderTile)
 			{
+				//recreate _frame for native target, so it will use modified framePixels
 				_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
+				_frameGraphic = FlxGraphic.fromBitmapData(framePixels, false, null, false);
+				_frame = _frameGraphic.imageFrame.frame.copyTo(_frame);
 			}
 			
 			dirty = false;

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -161,15 +161,13 @@ class FlxSprite extends FlxObject
 	 */
 	private var _frame:FlxFrame;
 	
-	//start FlxG.renderTIle
 	/**
 	 * Graphic of _frame. Used in tile render mode, when useFramePixels is true.
 	 */
 	private var _frameGraphic:FlxGraphic;
 	
-		private var _facingHorizontalMult:Int = 1;
-		private var _facingVerticalMult:Int = 1;
-	//end FlxG.renderTile
+	private var _facingHorizontalMult:Int = 1;
+	private var _facingVerticalMult:Int = 1;
 	
 	/**
 	 * Internal, reused frequently during drawing and animating.
@@ -1199,10 +1197,7 @@ class FlxSprite extends FlxObject
 		
 		if (FlxG.renderTile)
 		{
-			if (_frame != null && _frame.parent.bitmap == framePixels)
-			{
-				_frame.parent.destroy();
-			}
+			_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
 		}
 		
 		if (clipRect != null)

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -970,13 +970,7 @@ class FlxSprite extends FlxObject
 			
 			if (FlxG.renderTile)
 			{
-				if(useFramePixels)
-				{
-					// recreate _frame for native target, so it will use modified framePixels
-					destroyInnerFrameGraphic();
-					var graph:FlxGraphic = FlxGraphic.fromBitmapData(framePixels, false, null, false);
-					_frame = graph.imageFrame.frame.copyTo(_frame);
-				}
+				_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
 			}
 			
 			dirty = false;

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -963,7 +963,7 @@ class FlxSprite extends FlxObject
 				framePixels.colorTransform(_flashRect, colorTransform);
 			}
 			
-			if (FlxG.renderTile)
+			if (FlxG.renderTile && useFramePixels)
 			{
 				//recreate _frame for native target, so it will use modified framePixels
 				_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -15,12 +15,14 @@ class FlxSubState extends FlxState
 	 */
 	public var closeCallback:Void->Void;
 	
-	#if FLX_RENDER_TILE
-	/**
-	 * Helper sprite object for non-flash targets. Draws background
-	 */
-	private var _bgSprite:FlxBGSprite;
-	#end
+	//start FlxG.renderTile
+	
+		/**
+		* Helper sprite object for non-flash targets. Draws background
+		*/
+		private var _bgSprite:FlxBGSprite;
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * Helper var for close() so closeSubState() can be called on the parent.
@@ -39,23 +41,27 @@ class FlxSubState extends FlxState
 		super();
 		closeCallback = null;
 		
-		#if FLX_RENDER_TILE
-		_bgSprite = new FlxBGSprite();
-		#end
+		if (FlxG.renderTile)
+		{
+			_bgSprite = new FlxBGSprite();
+		}
 		bgColor = BGColor;
 	}
 	
 	override public function draw():Void
 	{
 		//Draw background
-		#if FLX_RENDER_BLIT
-		for (camera in cameras)
+		if (FlxG.renderBlit)
 		{
-			camera.fill(bgColor);
+			for (camera in cameras)
+			{
+				camera.fill(bgColor);
+			}
 		}
-		#else
-		_bgSprite.draw();
-		#end
+		else
+		{
+			_bgSprite.draw();
+		}
 		
 		//Now draw all children
 		super.draw();
@@ -66,9 +72,10 @@ class FlxSubState extends FlxState
 		super.destroy();
 		closeCallback = null;
 		_parentState = null;
-		#if FLX_RENDER_TILE
-		_bgSprite = null;
-		#end
+		if (FlxG.renderTile)
+		{
+			_bgSprite = null;
+		}
 	}
 	
 	/**
@@ -89,12 +96,13 @@ class FlxSubState extends FlxState
 	
 	override private function set_bgColor(Value:Int):Int
 	{
-		#if FLX_RENDER_TILE
-		if (_bgSprite != null)
+		if (FlxG.renderTile)
 		{
-			_bgSprite.pixels.setPixel32(0, 0, Value);
+			if (_bgSprite != null)
+			{
+				_bgSprite.pixels.setPixel32(0, 0, Value);
+			}
 		}
-		#end
 		
 		return _bgColor = Value;
 	}

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -15,14 +15,10 @@ class FlxSubState extends FlxState
 	 */
 	public var closeCallback:Void->Void;
 	
-	//start FlxG.renderTile
-	
-		/**
-		* Helper sprite object for non-flash targets. Draws background
-		*/
-		private var _bgSprite:FlxBGSprite;
-	
-	//end FlxG.renderTile
+	/**
+	* Helper sprite object for non-flash targets. Draws background
+	*/
+	private var _bgSprite:FlxBGSprite;
 	
 	/**
 	 * Helper var for close() so closeSubState() can be called on the parent.

--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -268,11 +268,14 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 				
 				if (bakedRotationAngles > 0)
 				{
-					#if FLX_RENDER_BLIT
-					particle.loadRotatedGraphic(Graphics, bakedRotationAngles, randomFrame, false, AutoBuffer);
-					#else
+					if (FlxG.renderBlit)
+					{
+						particle.loadRotatedGraphic(Graphics, bakedRotationAngles, randomFrame, false, AutoBuffer);
+					}
+					else
+					{
 					particle.loadGraphic(Graphics, true);
-					#end
+					}
 				}
 				else
 				{
@@ -284,11 +287,14 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 			{
 				if (bakedRotationAngles > 0)
 				{
-					#if FLX_RENDER_BLIT
-					particle.loadRotatedGraphic(Graphics, bakedRotationAngles, -1, false, AutoBuffer);
-					#else
-					particle.loadGraphic(Graphics);
-					#end
+					if (FlxG.renderBlit)
+					{
+						particle.loadRotatedGraphic(Graphics, bakedRotationAngles, -1, false, AutoBuffer);
+					}
+					else
+					{
+						particle.loadGraphic(Graphics);
+					}
 				}
 				else
 				{

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -325,14 +325,10 @@ class FlxGraphic implements IFlxDestroyable
 	 */
 	public var canBeDumped(get, never):Bool;
 	
-	//start FlxG.renderTile
-	
 	/**
 	 * Tilesheet for this graphic object. It is used only for FlxG.renderTile mode
 	 */
 	public var tilesheet(get, null):Tilesheet;
-	
-	//end FlxG.renderTile
 	
 	/**
 	 * Usage counter for this FlxGraphic object.

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -325,12 +325,14 @@ class FlxGraphic implements IFlxDestroyable
 	 */
 	public var canBeDumped(get, never):Bool;
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	/**
-	 * Tilesheet for this graphic object. It is used only for FLX_RENDER_TILE mode
+	 * Tilesheet for this graphic object. It is used only for FlxG.renderTile mode
 	 */
 	public var tilesheet(get, null):Tilesheet;
-	#end
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * Usage counter for this FlxGraphic object.
@@ -374,13 +376,15 @@ class FlxGraphic implements IFlxDestroyable
 	 */
 	private var _imageFrame:FlxImageFrame;
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	/**
 	 * Internal var holding Tilesheet for bitmap of this graphic.
-	 * It is used only in FLX_RENDER_TILE mode
+	 * It is used only in FlxG.renderTile mode
 	 */
 	private var _tilesheet:Tilesheet;
-	#end
+	
+	//end FlxG.renderTile
 	
 	private var _useCount:Int = 0;
 	
@@ -409,11 +413,14 @@ class FlxGraphic implements IFlxDestroyable
 	public function dump():Void
 	{
 	#if lime_legacy	
-		#if (FLX_RENDER_TILE && !flash && !nme)
-		if (canBeDumped)
+		#if (!flash && !nme)
+		if (FlxG.renderTile)
 		{
-			bitmap.dumpBits();
-			isDumped = true;
+			if (canBeDumped)
+			{
+				bitmap.dumpBits();
+				isDumped = true;
+			}
 		}
 		#end
 	#end
@@ -467,9 +474,10 @@ class FlxGraphic implements IFlxDestroyable
 	public function destroy():Void
 	{
 		bitmap = FlxDestroyUtil.dispose(bitmap);
-		#if FLX_RENDER_TILE
-		_tilesheet = null;
-		#end
+		if (FlxG.renderTile)
+		{
+			_tilesheet = null;
+		}
 		key = null;
 		assetsKey = null;
 		assetsClass = null;
@@ -534,7 +542,8 @@ class FlxGraphic implements IFlxDestroyable
 		return frame;
 	}
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	/**
 	 * Tilesheet getter. Generates new one (and regenerates) if there is no tilesheet for this graphic yet.
 	 */
@@ -555,7 +564,8 @@ class FlxGraphic implements IFlxDestroyable
 		
 		return _tilesheet;
 	}
-	#end
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * Gets BitmapData for this graphic object from OpenFl.
@@ -638,10 +648,13 @@ class FlxGraphic implements IFlxDestroyable
 			bitmap = value;
 			width = bitmap.width;
 			height = bitmap.height;
-			#if (FLX_RENDER_TILE && !flash && !nme)
-			if (_tilesheet != null)
+			#if (!flash && !nme)
+			if (FlxG.renderTile)
 			{
-				_tilesheet = new Tilesheet(bitmap);
+				if (_tilesheet != null)
+				{
+					_tilesheet = new Tilesheet(bitmap);
+				}
 			}
 			#end
 		}

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -70,9 +70,7 @@ class FlxFrame implements IFlxDestroyable
 	 */
 	public var type:FlxFrameType;
 	
-	//start FlxG.renderTile
 	private var tileMatrix:Vector<Float>;
-	//end FlxG.renderTile
 	
 	private var blitMatrix:Vector<Float>;
 	

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -70,9 +70,9 @@ class FlxFrame implements IFlxDestroyable
 	 */
 	public var type:FlxFrameType;
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
 	private var tileMatrix:Vector<Float>;
-	#end
+	//end FlxG.renderTile
 	
 	private var blitMatrix:Vector<Float>;
 	
@@ -90,9 +90,10 @@ class FlxFrame implements IFlxDestroyable
 		offset = FlxPoint.get();
 		
 		blitMatrix = new Vector<Float>(6);
-		#if FLX_RENDER_TILE
-		tileMatrix = new Vector<Float>(6);
-		#end
+		if (FlxG.renderTile)
+		{
+			tileMatrix = new Vector<Float>(6);
+		}
 	}
 	
 	@:allow(flixel.graphics.frames)
@@ -107,15 +108,16 @@ class FlxFrame implements IFlxDestroyable
 		blitMatrix[4] = matrix.tx;
 		blitMatrix[5] = matrix.ty;
 		
-		#if FLX_RENDER_TILE
-		prepareBlitMatrix(matrix, false);
-		tileMatrix[0] = matrix.a;
-		tileMatrix[1] = matrix.b;
-		tileMatrix[2] = matrix.c;
-		tileMatrix[3] = matrix.d;
-		tileMatrix[4] = matrix.tx;
-		tileMatrix[5] = matrix.ty;
-		#end
+		if (FlxG.renderTile)
+		{
+			prepareBlitMatrix(matrix, false);
+			tileMatrix[0] = matrix.a;
+			tileMatrix[1] = matrix.b;
+			tileMatrix[2] = matrix.c;
+			tileMatrix[3] = matrix.d;
+			tileMatrix[4] = matrix.tx;
+			tileMatrix[5] = matrix.ty;
+		}
 	}
 	
 	/**
@@ -224,10 +226,12 @@ class FlxFrame implements IFlxDestroyable
 	 */
 	public function prepareMatrix(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false, flipY:Bool = false):FlxMatrix
 	{
-		#if FLX_RENDER_BLIT
-		mat.identity();
-		return mat;
-		#else
+		if (FlxG.renderBlit)
+		{
+			mat.identity();
+			return mat;
+		}
+		
 		mat.a = tileMatrix[0];
 		mat.b = tileMatrix[1];
 		mat.c = tileMatrix[2];
@@ -244,7 +248,6 @@ class FlxFrame implements IFlxDestroyable
 		}
 		
 		return rotateAndFlip(mat, rotation, doFlipX, doFlipY);
-		#end
 	}
 	
 	private inline function fillBlitMatrix(mat:FlxMatrix):FlxMatrix
@@ -640,9 +643,10 @@ class FlxFrame implements IFlxDestroyable
 		frame = FlxDestroyUtil.put(frame);
 		uv = FlxDestroyUtil.put(uv);
 		blitMatrix = null;
-		#if FLX_RENDER_TILE
-		tileMatrix = null;
-		#end
+		if (FlxG.renderTile)
+		{
+			tileMatrix = null;
+		}
 	}
 	
 	public function toString():String

--- a/flixel/graphics/tile/FlxDrawTilesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTilesItem.hx
@@ -62,7 +62,8 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 	
 	override public function render(camera:FlxCamera):Void
 	{
-		#if FLX_RENDER_TILE
+		if (!FlxG.renderTile) return;
+		
 		if (position > 0)
 		{
 			var tempFlags:Int = Tilesheet.TILE_TRANS_2x2 | Tilesheet.TILE_RECT | Tilesheet.TILE_ALPHA;
@@ -76,7 +77,6 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 			graphics.tilesheet.drawTiles(camera.canvas.graphics, drawData, (camera.antialiasing || antialiasing), tempFlags, position);
 			FlxTilesheet._DRAWCALLS++;
 		}
-		#end
 	}
 	
 	private function get_numTiles():Int

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -52,7 +52,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	
 	override public function render(camera:FlxCamera):Void 
 	{
-		#if FLX_RENDER_TILE
+		if (!FlxG.renderTile) return;
+		
 		if (numTriangles <= 0)
 		{
 			return;
@@ -75,7 +76,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		#end
 		
 		FlxTilesheet._DRAWCALLS++;
-		#end
 	}
 	
 	override public function reset():Void 

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -1,6 +1,7 @@
 package flixel.system;
 
-#if FLX_RENDER_TILE
+//start FlxG.renderTile
+
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
@@ -42,4 +43,5 @@ class FlxBGSprite extends FlxSprite
 		}
 	}
 }
-#end
+
+//end FlxG.renderTile

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -1,7 +1,5 @@
 package flixel.system;
 
-//start FlxG.renderTile
-
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
@@ -43,5 +41,3 @@ class FlxBGSprite extends FlxSprite
 		}
 	}
 }
-
-//end FlxG.renderTile

--- a/flixel/system/debug/Stats.hx
+++ b/flixel/system/debug/Stats.hx
@@ -87,13 +87,9 @@ class Stats extends Window
 	
 	private var _toggleSizeButton:FlxSystemButton;
 	
-	//start FlxG.renderTile
-	
 	private var drawCallsCount:Int = 0;
 	private var _drawCalls:Array<Int>;
 	private var _drawCallsMarker:Int = 0;
-	
-	//end FlxG.renderTile
 	
 	/**
 	 * Creates a new window with fps and memory graphs, as well as other useful stats for debugging.

--- a/flixel/system/debug/Stats.hx
+++ b/flixel/system/debug/Stats.hx
@@ -412,8 +412,6 @@ class Stats extends Window
 		_visibleObject[_visibleObjectMarker++] = Count;
 	}
 	
-	//start FlxG.renderTile
-	
 	/**
 	 * How many times drawTiles() method was called.
 	 * 
@@ -425,8 +423,6 @@ class Stats extends Window
 			return;
 		_drawCalls[_drawCallsMarker++] = Drawcalls;
 	}
-	
-	//end FlxG.renderTile
 	
 	/**
 	 * Re-enables tracking of the stats.

--- a/flixel/system/debug/Stats.hx
+++ b/flixel/system/debug/Stats.hx
@@ -37,7 +37,7 @@ class Stats extends Window
 	/**
 	 * The minimal height of the window.
 	 */
-	private static inline var MIN_HEIGHT:Int = #if !FLX_RENDER_TILE 185 #else 200 #end;
+	private static var MIN_HEIGHT:Int = 0;
 	
 	private static inline var FPS_COLOR:FlxColor = 0xff96ff00;
 	private static inline var MEMORY_COLOR:FlxColor = 0xff009cff;
@@ -87,11 +87,13 @@ class Stats extends Window
 	
 	private var _toggleSizeButton:FlxSystemButton;
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	private var drawCallsCount:Int = 0;
 	private var _drawCalls:Array<Int>;
 	private var _drawCallsMarker:Int = 0;
-	#end
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * Creates a new window with fps and memory graphs, as well as other useful stats for debugging.
@@ -99,6 +101,13 @@ class Stats extends Window
 	public function new()
 	{
 		super("Stats", new GraphicStats(0, 0), 0, 0, false);
+		
+		if (MIN_HEIGHT == 0) {
+			if (!FlxG.renderTile)
+				MIN_HEIGHT = 185;
+			else
+				MIN_HEIGHT = 200;
+		}
 		
 		minSize.y = MIN_HEIGHT;
 		resize(INITIAL_WIDTH, MIN_HEIGHT);
@@ -110,9 +119,10 @@ class Stats extends Window
 		_activeObject = [];
 		_visibleObject = [];
 		
-		#if FLX_RENDER_TILE
-		_drawCalls = [];
-		#end
+		if (FlxG.renderTile)
+		{
+			_drawCalls = [];
+		}
 		
 		var gutter:Int = 5;
 		var graphX:Int = gutter;
@@ -150,7 +160,7 @@ class Stats extends Window
 		_leftTextField.multiline = _rightTextField.multiline = true;
 		_leftTextField.wordWrap = _rightTextField.wordWrap = true;
 		
-		_leftTextField.text = "Update: \nDraw:" + #if FLX_RENDER_TILE "\nDrawTiles:" + #end "\nQuadTrees: \nLists:";
+		_leftTextField.text = "Update: \nDraw:" + (FlxG.renderTile ? "\nDrawTiles:" : "") + "\nQuadTrees: \nLists:";
 		
 		_toggleSizeButton = new FlxSystemButton(new GraphicMaximizeButton(0, 0), toggleSize);
 		_toggleSizeButton.alpha = Window.HEADER_ALPHA;
@@ -215,9 +225,10 @@ class Stats extends Window
 		_activeObject = null;
 		_visibleObject = null;
 		
-		#if FLX_RENDER_TILE
-		_drawCalls = null;
-		#end
+		if (FlxG.renderTile)
+		{
+			_drawCalls = null;
+		}
 		
 		super.destroy();
 	}
@@ -280,21 +291,23 @@ class Stats extends Window
 			}
 			visibleCount = Std.int(visibleCount / _visibleObjectMarker);
 			
-			#if FLX_RENDER_TILE
-			for (i in 0..._drawCallsMarker)
+			if (FlxG.renderTile)
 			{
-				drawCallsCount += _drawCalls[i];
+				for (i in 0..._drawCallsMarker)
+				{
+					drawCallsCount += _drawCalls[i];
+				}
+				drawCallsCount = Std.int(drawCallsCount / _drawCallsMarker);
 			}
-			drawCallsCount = Std.int(drawCallsCount / _drawCallsMarker);
-			#end
 			
 			_updateMarker = 0;
 			_drawMarker = 0;
 			_activeObjectMarker = 0;
 			_visibleObjectMarker = 0;
-			#if FLX_RENDER_TILE
-			_drawCallsMarker = 0;
-			#end
+			if (FlxG.renderTile)
+			{
+				_drawCallsMarker = 0;
+			}
 			
 			_updateTimer -= UPDATE_DELAY;
 		}
@@ -309,10 +322,8 @@ class Stats extends Window
 		updateTimeGraph.update(updTime);
 		
 		_rightTextField.text = 	activeCount + " (" + updTime + "ms)\n"
-								+ visibleCount + " (" + drwTime + "ms)\n" 
-								#if FLX_RENDER_TILE
-								+ drawCallsCount + "\n"
-								#end 
+								+ visibleCount + " (" + drwTime + "ms)\n"
+								+ (FlxG.renderTile ? (drawCallsCount + "\n") : "")
 								+ FlxQuadTree._NUM_CACHED_QUAD_TREES + "\n"
 								+ FlxLinkedList._NUM_CACHED_FLX_LIST;
 	}
@@ -405,7 +416,8 @@ class Stats extends Window
 		_visibleObject[_visibleObjectMarker++] = Count;
 	}
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	/**
 	 * How many times drawTiles() method was called.
 	 * 
@@ -417,7 +429,8 @@ class Stats extends Window
 			return;
 		_drawCalls[_drawCallsMarker++] = Drawcalls;
 	}
-	#end
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * Re-enables tracking of the stats.

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -47,10 +47,11 @@ class BitmapFrontEnd
 		}
 	}
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	/**
 	 * Helper FlxFrame object. Containing only one frame.
-	 * Useful for drawing colored rectangles of all sizes in FLX_RENDER_TILE mode.
+	 * Useful for drawing colored rectangles of all sizes in FlxG.renderTile mode.
 	 */
 	public var whitePixel(get, never):FlxFrame;
 	
@@ -89,7 +90,8 @@ class BitmapFrontEnd
 			}
 		}
 	}
-	#end
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * Dumps bits of all graphics in the cache. This frees some memory, but you can't read/write pixels on those graphics anymore.

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -41,10 +41,7 @@ class CameraFrontEnd
 	public inline function add<T:FlxCamera>(NewCamera:T):T
 	{
 		#if !FLX_RENDER_CRISP
-		if (!FlxG.renderBlit)
-		{
-			FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
-		}
+		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
 		#end
 		FlxG.cameras.list.push(NewCamera);
 		NewCamera.ID = FlxG.cameras.list.length - 1;
@@ -63,10 +60,7 @@ class CameraFrontEnd
 		if ((Camera != null) && index != -1)
 		{
 			#if !FLX_RENDER_CRISP
-			if (!FlxG.renderBlit)
-			{
-				FlxG.game.removeChild(Camera.flashSprite);
-			}
+			FlxG.game.removeChild(Camera.flashSprite);
 			#end
 			
 			list.splice(index, 1);
@@ -99,13 +93,10 @@ class CameraFrontEnd
 	public function reset(?NewCamera:FlxCamera):Void
 	{
 		#if !FLX_RENDER_CRISP
-		if (!FlxG.renderBlit)
+		for (camera in list)
 		{
-			for (camera in list)
-			{
-				FlxG.game.removeChild(camera.flashSprite);
-				camera.destroy();
-			}
+			FlxG.game.removeChild(camera.flashSprite);
+			camera.destroy();
 		}
 		#end
 		

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -41,7 +41,10 @@ class CameraFrontEnd
 	public inline function add<T:FlxCamera>(NewCamera:T):T
 	{
 		#if !FLX_RENDER_CRISP
-		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
+		if (!FlxG.renderBlit)
+		{
+			FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
+		}
 		#end
 		FlxG.cameras.list.push(NewCamera);
 		NewCamera.ID = FlxG.cameras.list.length - 1;
@@ -60,7 +63,10 @@ class CameraFrontEnd
 		if ((Camera != null) && index != -1)
 		{
 			#if !FLX_RENDER_CRISP
-			FlxG.game.removeChild(Camera.flashSprite);
+			if (!FlxG.renderBlit)
+			{
+				FlxG.game.removeChild(Camera.flashSprite);
+			}
 			#end
 			
 			list.splice(index, 1);
@@ -70,12 +76,13 @@ class CameraFrontEnd
 			FlxG.log.warn("FlxG.cameras.remove(): The camera you attemped to remove is not a part of the game.");
 		}
 		
-		#if FLX_RENDER_TILE
-		for (i in 0...list.length)
+		if (FlxG.renderTile)
 		{
-			list[i].ID = i;
+			for (i in 0...list.length)
+			{
+				list[i].ID = i;
+			}
 		}
-		#end
 		
 		if (Destroy)
 		{
@@ -92,16 +99,19 @@ class CameraFrontEnd
 	public function reset(?NewCamera:FlxCamera):Void
 	{
 		#if !FLX_RENDER_CRISP
-		for (camera in list)
+		if (!FlxG.renderBlit)
 		{
-			FlxG.game.removeChild(camera.flashSprite);
-			camera.destroy();
+			for (camera in list)
+			{
+				FlxG.game.removeChild(camera.flashSprite);
+				camera.destroy();
+			}
 		}
 		#end
 		
 		list.splice(0, list.length);
 		
-		if (NewCamera == null)	
+		if (NewCamera == null)
 		{
 			NewCamera = new FlxCamera(0, 0, FlxG.width, FlxG.height);
 		}
@@ -180,45 +190,51 @@ class CameraFrontEnd
 				continue;
 			}
 			
-			#if FLX_RENDER_BLIT
-			camera.checkResize();
-			
-			if (useBufferLocking)
+			if (FlxG.renderBlit)
 			{
-				camera.buffer.lock();
+				camera.checkResize();
+				
+				if (useBufferLocking)
+				{
+					camera.buffer.lock();
+				}
 			}
-			#end
 			
-		#if FLX_RENDER_TILE
-			camera.clearDrawStack();
-			camera.canvas.graphics.clear();
-			// Clearing camera's debug sprite
-			#if !FLX_NO_DEBUG
-			camera.debugLayer.graphics.clear();
-			#end
-		#end
+			if (FlxG.renderTile)
+			{
+				camera.clearDrawStack();
+				camera.canvas.graphics.clear();
+				// Clearing camera's debug sprite
+				#if !FLX_NO_DEBUG
+				camera.debugLayer.graphics.clear();
+				#end
+			}
 			
-			#if FLX_RENDER_BLIT
-			camera.fill(camera.bgColor, camera.useBgAlphaBlending);
-			camera.screen.dirty = true;
-			#else
-			camera.fill((camera.bgColor & 0x00ffffff), camera.useBgAlphaBlending, ((camera.bgColor >> 24) & 255) / 255);
-			#end
+			if (FlxG.renderBlit)
+			{
+				camera.fill(camera.bgColor, camera.useBgAlphaBlending);
+				camera.screen.dirty = true;
+			}
+			else
+			{
+				camera.fill((camera.bgColor & 0x00ffffff), camera.useBgAlphaBlending, ((camera.bgColor >> 24) & 255) / 255);
+			}
 		}
 	}
 	
-	#if FLX_RENDER_TILE
 	private inline function render():Void
 	{
-		for (camera in list)
+		if (FlxG.renderTile)
 		{
-			if ((camera != null) && camera.exists && camera.visible)
+			for (camera in list)
 			{
-				camera.render();
+				if ((camera != null) && camera.exists && camera.visible)
+				{
+					camera.render();
+				}
 			}
 		}
 	}
-	#end
 	
 	/**
 	 * Called by the game object to draw the special FX and unlock all the camera buffers.
@@ -234,14 +250,15 @@ class CameraFrontEnd
 			
 			camera.drawFX();
 			
-			#if FLX_RENDER_BLIT
-			if (useBufferLocking)
+			if (FlxG.renderBlit)
 			{
-				camera.buffer.unlock();
+				if (useBufferLocking)
+				{
+					camera.buffer.unlock();
+				}
+				
+				camera.screen.dirty = true;
 			}
-			
-			camera.screen.dirty = true;
-			#end
 		}
 	}
 	

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -25,9 +25,6 @@ private enum UserDefines
 	 */
 	FLX_HAXE_BUILD;
 	FLX_UNIT_TEST;
-	/** only one of these two may be defined */
-	FLX_RENDER_TILE;
-	FLX_RENDER_BLIT;
 	/* additional rendering define */
 	FLX_RENDER_TRIANGLE;
 }
@@ -72,7 +69,6 @@ class FlxDefines
 		#end
 		
 		checkDefines();
-		defineRenderingDefine();
 		defineHelperDefines();
 		
 		if (defined("flash"))
@@ -83,11 +79,6 @@ class FlxDefines
 	
 	private static function checkDefines()
 	{
-		if (defined(FLX_RENDER_BLIT) && defined(FLX_RENDER_TILE))
-		{
-			abort('You cannot define both $FLX_RENDER_BLIT and $FLX_RENDER_TILE.', FlxMacroUtil.here());
-		}
-		
 		for (define in HelperDefines.getConstructors())
 		{
 			abortIfDefined(define);
@@ -110,21 +101,6 @@ class FlxDefines
 		if (defined(define))
 		{
 			abort('$define can only be defined by flixel.', FlxMacroUtil.here());
-		}
-	}
-	
-	private static function defineRenderingDefine()
-	{
-		if (!defined(FLX_RENDER_BLIT) && !defined(FLX_RENDER_TILE))
-		{
-			if (defined("flash") || defined("js"))
-			{
-				define(FLX_RENDER_BLIT);
-			}
-			else
-			{
-				define(FLX_RENDER_TILE);
-			}
 		}
 	}
 	
@@ -164,7 +140,7 @@ class FlxDefines
 			define("bitfive_gamepads");
 		}
 		
-		if (defined("js") && defined("bitfive") && defined(FLX_RENDER_BLIT))
+		if (defined("js") && defined("bitfive"))
 		{
 			define(FLX_RENDER_CRISP);
 		}

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -180,11 +180,11 @@ class FlxBitmapText extends FlxSprite
 	private var pendingTextBitmapChange:Bool = true;
 	private var pendingPixelsChange:Bool = true;
 	
-	#if FLX_RENDER_TILE
-	private var textData:Array<Float>;
-	private var textDrawData:Array<Float>;
-	private var borderDrawData:Array<Float>;
-	#end
+	//start FlxG.renderTile
+		private var textData:Array<Float>;
+		private var textDrawData:Array<Float>;
+		private var borderDrawData:Array<Float>;
+	//end FlxG.renderTile
 	
 	/**
 	 * Helper bitmap buffer for text pixels but without any color transformations
@@ -206,14 +206,17 @@ class FlxBitmapText extends FlxSprite
 		
 		shadowOffset = FlxPoint.get(1, 1);
 		
-		#if FLX_RENDER_BLIT
-		pixels = new BitmapData(1, 1, true, FlxColor.TRANSPARENT);
-		#else
-		textData = [];
-		
-		textDrawData = [];
-		borderDrawData = [];
-		#end
+		if (FlxG.renderBlit)
+		{
+			pixels = new BitmapData(1, 1, true, FlxColor.TRANSPARENT);
+		}
+		else
+		{
+			textData = [];
+			
+			textDrawData = [];
+			borderDrawData = [];
+		}
 	}
 	
 	/**
@@ -229,11 +232,12 @@ class FlxBitmapText extends FlxSprite
 		shadowOffset = FlxDestroyUtil.put(shadowOffset);
 		textBitmap = FlxDestroyUtil.dispose(textBitmap);
 		
-		#if FLX_RENDER_TILE
-		textData = null;
-		textDrawData = null;
-		borderDrawData = null;
-		#end
+		if (FlxG.renderTile)
+		{
+			textData = null;
+			textDrawData = null;
+			borderDrawData = null;
+		}
 		super.destroy();
 	}
 	
@@ -242,21 +246,24 @@ class FlxBitmapText extends FlxSprite
 	 */
 	override public function drawFrame(Force:Bool = false):Void 
 	{
-		#if FLX_RENDER_TILE
-		Force = true;
-		#end
+		if (FlxG.renderTile)
+		{
+			Force = true;
+		}
 		pendingTextBitmapChange = pendingTextBitmapChange || Force;
 		checkPendingChanges(false);
-		#if FLX_RENDER_BLIT
-		super.drawFrame(Force);
-		#end
+		if (FlxG.renderBlit)
+		{
+			super.drawFrame(Force);
+		}
 	}
 	
 	inline private function checkPendingChanges(useTiles:Bool = false):Void
 	{
-		#if FLX_RENDER_BLIT
-		useTiles = false;
-		#end
+		if (FlxG.renderBlit)
+		{
+			useTiles = false;
+		}
 		
 		if (pendingTextChange)
 		{
@@ -276,196 +283,199 @@ class FlxBitmapText extends FlxSprite
 		}
 	}
 	
-	#if FLX_RENDER_BLIT
 	override public function draw():Void 
 	{
-		checkPendingChanges(false);
-		super.draw();
-	}
-	#else
-	override public function draw():Void 
-	{
-		checkPendingChanges(true);
-		
-		var textLength:Int = Std.int(textDrawData.length / 3);
-		var borderLength:Int = Std.int(borderDrawData.length / 3);
-		
-		var dataPos:Int;
-		
-		var cr:Float = color.redFloat;
-		var cg:Float = color.greenFloat;
-		var cb:Float = color.blueFloat;
-		
-		var borderRed:Float = borderColor.redFloat * cr;
-		var borderGreen:Float = borderColor.greenFloat * cg;
-		var borderBlue:Float = borderColor.blueFloat * cb;
-		var bAlpha:Float = borderColor.alphaFloat * alpha;
-		
-		var textRed:Float = cr;
-		var textGreen:Float = cg;
-		var textBlue:Float = cb;
-		var tAlpha:Float = alpha;
-		
-		if (useTextColor)
+		if (FlxG.renderBlit)
 		{
-			textRed *= textColor.redFloat;
-			textGreen *= textColor.greenFloat;
-			textBlue *= textColor.blueFloat;
-			tAlpha *= textColor.alpha;		
+			checkPendingChanges(false);
+			super.draw();
 		}
-		
-		var bgRed:Float = cr;
-		var bgGreen:Float = cg;
-		var bgBlue:Float = cb;
-		var bgAlpha:Float = alpha;
-		
-		if (background)
+		else
 		{
-			bgRed *= backgroundColor.redFloat;
-			bgGreen *= backgroundColor.greenFloat;
-			bgBlue *= backgroundColor.blueFloat;
-			bgAlpha *= backgroundColor.alphaFloat;
-		}
-		
-		var drawItem;
-		var currFrame:FlxFrame = null;
-		var currTileX:Float = 0;
-		var currTileY:Float = 0;
-		var sx:Float = scale.x * _facingHorizontalMult;
-		var sy:Float = scale.y * _facingVerticalMult;
-		
-		var ox:Float = origin.x;
-		var oy:Float = origin.y;
-		
-		if (_facingHorizontalMult != 1)
-		{
-			ox = frameWidth - ox;
-		}
-		if (_facingVerticalMult != 1)
-		{
-			oy = frameHeight - oy;
-		}
-		
-		for (camera in cameras)
-		{
-			if (!camera.visible || !camera.exists || !isOnScreen(camera))
+			checkPendingChanges(true);
+			
+			var textLength:Int = Std.int(textDrawData.length / 3);
+			var borderLength:Int = Std.int(borderDrawData.length / 3);
+			
+			var dataPos:Int;
+			
+			var cr:Float = color.redFloat;
+			var cg:Float = color.greenFloat;
+			var cb:Float = color.blueFloat;
+			
+			var borderRed:Float = borderColor.redFloat * cr;
+			var borderGreen:Float = borderColor.greenFloat * cg;
+			var borderBlue:Float = borderColor.blueFloat * cb;
+			var bAlpha:Float = borderColor.alphaFloat * alpha;
+			
+			var textRed:Float = cr;
+			var textGreen:Float = cg;
+			var textBlue:Float = cb;
+			var tAlpha:Float = alpha;
+			
+			if (useTextColor)
 			{
-				continue;
+				textRed *= textColor.redFloat;
+				textGreen *= textColor.greenFloat;
+				textBlue *= textColor.blueFloat;
+				tAlpha *= textColor.alpha;
 			}
 			
-			getScreenPosition(_point, camera).subtractPoint(offset);
-			
-			if (isPixelPerfectRender(camera))
-			{
-				_point.floor();
-			}
-			
-			updateTrig();
+			var bgRed:Float = cr;
+			var bgGreen:Float = cg;
+			var bgBlue:Float = cb;
+			var bgAlpha:Float = alpha;
 			
 			if (background)
 			{
-				// backround tile transformations
-				currFrame = FlxG.bitmap.whitePixel;
-				_matrix.identity();
-				_matrix.scale(0.1 * frameWidth, 0.1 * frameHeight);
-				_matrix.translate(-ox, -oy);
-				_matrix.scale(sx, sy);
-				
-				if (angle != 0)
-				{
-					_matrix.rotateWithTrig(_cosAngle, _sinAngle);
-				}
-				
-				_matrix.translate(_point.x + ox, _point.y + oy);
-				camera.drawPixels(currFrame, null, _matrix, bgRed, bgGreen, bgBlue, bgAlpha, blend, antialiasing);
+				bgRed *= backgroundColor.redFloat;
+				bgGreen *= backgroundColor.greenFloat;
+				bgBlue *= backgroundColor.blueFloat;
+				bgAlpha *= backgroundColor.alphaFloat;
 			}
 			
-			drawItem = camera.startQuadBatch(font.parent, true, blend, antialiasing);
+			var drawItem;
+			var currFrame:FlxFrame = null;
+			var currTileX:Float = 0;
+			var currTileY:Float = 0;
+			var sx:Float = scale.x * _facingHorizontalMult;
+			var sy:Float = scale.y * _facingVerticalMult;
 			
-			for (j in 0...borderLength)
+			var ox:Float = origin.x;
+			var oy:Float = origin.y;
+			
+			if (_facingHorizontalMult != 1)
 			{
-				dataPos = j * 3;
-				
-				currFrame = font.getCharFrame(Std.int(borderDrawData[dataPos]));
-				
-				currTileX = borderDrawData[dataPos + 1];
-				currTileY = borderDrawData[dataPos + 2];
-				
-				currFrame.prepareMatrix(_matrix);
-				_matrix.translate(currTileX - ox, currTileY - oy);
-				_matrix.scale(sx, sy);
-				if (angle != 0)
-				{
-					_matrix.rotateWithTrig(_cosAngle, _sinAngle);
-				}
-				
-				_matrix.translate(_point.x + ox, _point.y + oy);
-				
-				drawItem.addQuad(currFrame, _matrix, borderRed, borderGreen, borderBlue, bAlpha);
+				ox = frameWidth - ox;
+			}
+			if (_facingVerticalMult != 1)
+			{
+				oy = frameHeight - oy;
 			}
 			
-			for (j in 0...textLength)
+			for (camera in cameras)
 			{
-				dataPos = j * 3;
-				
-				currFrame = font.getCharFrame(Std.int(textDrawData[dataPos]));
-				
-				currTileX = textDrawData[dataPos + 1];
-				currTileY = textDrawData[dataPos + 2];
-				
-				currFrame.prepareMatrix(_matrix);
-				_matrix.translate(currTileX - ox, currTileY - oy);
-				_matrix.scale(sx, sy);
-				if (angle != 0)
+				if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				{
-					_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+					continue;
 				}
 				
-				_matrix.translate(_point.x + ox, _point.y + oy);
+				getScreenPosition(_point, camera).subtractPoint(offset);
 				
-				drawItem.addQuad(currFrame, _matrix, textRed, textGreen, textBlue, tAlpha);
+				if (isPixelPerfectRender(camera))
+				{
+					_point.floor();
+				}
+				
+				updateTrig();
+				
+				if (background)
+				{
+					// backround tile transformations
+					currFrame = FlxG.bitmap.whitePixel;
+					_matrix.identity();
+					_matrix.scale(0.1 * frameWidth, 0.1 * frameHeight);
+					_matrix.translate(-ox, -oy);
+					_matrix.scale(sx, sy);
+					
+					if (angle != 0)
+					{
+						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+					}
+					
+					_matrix.translate(_point.x + ox, _point.y + oy);
+					camera.drawPixels(currFrame, null, _matrix, bgRed, bgGreen, bgBlue, bgAlpha, blend, antialiasing);
+				}
+				
+				drawItem = camera.startQuadBatch(font.parent, true, blend, antialiasing);
+				
+				for (j in 0...borderLength)
+				{
+					dataPos = j * 3;
+					
+					currFrame = font.getCharFrame(Std.int(borderDrawData[dataPos]));
+					
+					currTileX = borderDrawData[dataPos + 1];
+					currTileY = borderDrawData[dataPos + 2];
+					
+					currFrame.prepareMatrix(_matrix);
+					_matrix.translate(currTileX - ox, currTileY - oy);
+					_matrix.scale(sx, sy);
+					if (angle != 0)
+					{
+						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+					}
+					
+					_matrix.translate(_point.x + ox, _point.y + oy);
+					
+					drawItem.addQuad(currFrame, _matrix, borderRed, borderGreen, borderBlue, bAlpha);
+				}
+				
+				for (j in 0...textLength)
+				{
+					dataPos = j * 3;
+					
+					currFrame = font.getCharFrame(Std.int(textDrawData[dataPos]));
+					
+					currTileX = textDrawData[dataPos + 1];
+					currTileY = textDrawData[dataPos + 2];
+					
+					currFrame.prepareMatrix(_matrix);
+					_matrix.translate(currTileX - ox, currTileY - oy);
+					_matrix.scale(sx, sy);
+					if (angle != 0)
+					{
+						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+					}
+					
+					_matrix.translate(_point.x + ox, _point.y + oy);
+					
+					drawItem.addQuad(currFrame, _matrix, textRed, textGreen, textBlue, tAlpha);
+				}
+				
+				#if !FLX_NO_DEBUG
+				FlxBasic.visibleCount++;
+				#end
 			}
 			
 			#if !FLX_NO_DEBUG
-			FlxBasic.visibleCount++;
+			if (FlxG.debugger.drawDebug)
+			{
+				drawDebug();
+			}
 			#end
 		}
-		
-		#if !FLX_NO_DEBUG
-		if (FlxG.debugger.drawDebug)
-		{
-			drawDebug();
-		}
-		#end
 	}
 	
 	override private function set_color(Color:FlxColor):FlxColor
 	{
 		super.set_color(Color);
-		#if FLX_RENDER_BLIT
-		pendingTextBitmapChange = true;
-		#end
+		if (FlxG.renderBlit)
+		{
+			pendingTextBitmapChange = true;
+		}
 		return color;
 	}
 	
 	override private function set_alpha(value:Float):Float
 	{
 		alpha = value;
-		#if FLX_RENDER_BLIT
-		pendingTextBitmapChange = true;
-		#end
+		if (FlxG.renderBlit)
+		{
+			pendingTextBitmapChange = true;
+		}
 		return value;
 	}
-	#end
 	
 	private function set_textColor(value:FlxColor):FlxColor 
 	{
 		if (textColor != value)
 		{
 			textColor = value;
-			#if FLX_RENDER_BLIT
-			pendingPixelsChange = true;
-			#end
+			if (FlxG.renderBlit)
+			{
+				pendingPixelsChange = true;
+			}
 		}
 		
 		return value;
@@ -476,20 +486,22 @@ class FlxBitmapText extends FlxSprite
 		if (useTextColor != value)
 		{
 			useTextColor = value;
-			#if FLX_RENDER_BLIT
-			pendingPixelsChange = true;
-			#end
+			if (FlxG.renderBlit)
+			{
+				pendingPixelsChange = true;
+			}
 		}
 		
 		return value;
 	}
 	
-	#if FLX_RENDER_TILE
 	override private function calcFrame(RunOnCpp:Bool = false):Void 
 	{
-		drawFrame(RunOnCpp);
+		if (FlxG.renderTile)
+		{
+			drawFrame(RunOnCpp);
+		}
 	}
-	#end
 	
 	private function set_text(value:String):String 
 	{
@@ -1025,9 +1037,10 @@ class FlxBitmapText extends FlxSprite
 	{
 		computeTextSize();
 		
-		#if FLX_RENDER_BLIT
-		useTiles = false;
-		#end
+		if (FlxG.renderBlit)
+		{
+			useTiles = false;
+		}
 		
 		if (!useTiles)
 		{
@@ -1044,12 +1057,10 @@ class FlxBitmapText extends FlxSprite
 			
 			textBitmap.lock();
 		}
-		#if FLX_RENDER_TILE
-		else
+		else if(FlxG.renderTile)
 		{
 			textData.splice(0, textData.length);
 		}
-		#end
 		
 		_fieldWidth = frameWidth;
 		
@@ -1094,9 +1105,10 @@ class FlxBitmapText extends FlxSprite
 	
 	private function drawLine(lineIndex:Int, posX:Int, posY:Int, useTiles:Bool = false):Void
 	{
-		#if FLX_RENDER_BLIT
-		useTiles = false;
-		#end
+		if (FlxG.renderBlit)
+		{
+			useTiles = false;
+		}
 		
 		if (useTiles)
 		{
@@ -1176,7 +1188,8 @@ class FlxBitmapText extends FlxSprite
 	
 	private function tileLine(lineIndex:Int, startX:Int, startY:Int):Void
 	{
-		#if FLX_RENDER_TILE
+		if (!FlxG.renderTile) return;
+		
 		var charFrame:FlxFrame;
 		var pos:Int = textData.length;
 		
@@ -1240,7 +1253,6 @@ class FlxBitmapText extends FlxSprite
 			
 			curX += letterSpacing;
 		}
-		#end
 	}
 	
 	private function updatePixels(useTiles:Bool = false):Void
@@ -1248,44 +1260,47 @@ class FlxBitmapText extends FlxSprite
 		var colorForFill:Int = background ? backgroundColor : FlxColor.TRANSPARENT;
 		var bitmap:BitmapData = null;
 		
-		#if FLX_RENDER_BLIT
-		if (pixels == null || (frameWidth != pixels.width || frameHeight != pixels.height))
+		if (FlxG.renderBlit)
 		{
-			pixels = new BitmapData(frameWidth, frameHeight, true, colorForFill);
-		}
-		else
-		{
-			pixels.fillRect(graphic.bitmap.rect, colorForFill);
-		}
-		
-		bitmap = pixels;
-		#else
-		if (!useTiles)
-		{
-			if (framePixels == null || (frameWidth != framePixels.width || frameHeight != framePixels.height))
+			if (pixels == null || (frameWidth != pixels.width || frameHeight != pixels.height))
 			{
-				framePixels = FlxDestroyUtil.dispose(framePixels);
-				framePixels = new BitmapData(frameWidth, frameHeight, true, colorForFill);
+				pixels = new BitmapData(frameWidth, frameHeight, true, colorForFill);
 			}
 			else
 			{
-				framePixels.fillRect(framePixels.rect, colorForFill);
+				pixels.fillRect(graphic.bitmap.rect, colorForFill);
 			}
 			
-			bitmap = framePixels;
+			bitmap = pixels;
 		}
 		else
 		{
-			textDrawData.splice(0, textDrawData.length);
-			borderDrawData.splice(0, borderDrawData.length);
+			if (!useTiles)
+			{
+				if (framePixels == null || (frameWidth != framePixels.width || frameHeight != framePixels.height))
+				{
+					framePixels = FlxDestroyUtil.dispose(framePixels);
+					framePixels = new BitmapData(frameWidth, frameHeight, true, colorForFill);
+				}
+				else
+				{
+					framePixels.fillRect(framePixels.rect, colorForFill);
+				}
+				
+				bitmap = framePixels;
+			}
+			else
+			{
+				textDrawData.splice(0, textDrawData.length);
+				borderDrawData.splice(0, borderDrawData.length);
+			}
+			
+			width = frameWidth;
+			height = frameHeight;
+			
+			origin.x = frameWidth * 0.5;
+			origin.y = frameHeight * 0.5;
 		}
-		
-		width = frameWidth;
-		height = frameHeight;
-		
-		origin.x = frameWidth * 0.5;
-		origin.y = frameHeight * 0.5;
-		#end
 		
 		if (!useTiles)
 		{
@@ -1379,18 +1394,20 @@ class FlxBitmapText extends FlxSprite
 			bitmap.unlock();
 		}
 		
-		#if FLX_RENDER_BLIT
-		dirty = true;
-		#end
+		if (FlxG.renderBlit)
+		{
+			dirty = true;
+		}
 		
 		pendingPixelsChange = false;
 	}
 	
 	private function drawText(posX:Int, posY:Int, isFront:Bool = true, bitmap:BitmapData = null, useTiles:Bool = false):Void
 	{
-		#if FLX_RENDER_BLIT
-		useTiles = false;
-		#end
+		if (FlxG.renderBlit)
+		{
+			useTiles = false;
+		}
 		
 		if (useTiles)
 		{
@@ -1437,7 +1454,8 @@ class FlxBitmapText extends FlxSprite
 	
 	private function tileText(posX:Int, posY:Int, isFront:Bool = true):Void
 	{
-		#if FLX_RENDER_TILE
+		if (!FlxG.renderTile) return;
+		
 		var data:Array<Float> = isFront ? textDrawData : borderDrawData;
 		
 		var pos:Int = data.length;
@@ -1451,7 +1469,6 @@ class FlxBitmapText extends FlxSprite
 			data[pos++] = textData[textPos + 1] + posX;
 			data[pos++] = textData[textPos + 2] + posY;
 		}
-		#end
 	}
 	
 	/**
@@ -1627,9 +1644,10 @@ class FlxBitmapText extends FlxSprite
 		if (background != value)
 		{
 			background = value;
-			#if FLX_RENDER_BLIT
-			pendingPixelsChange = true;
-			#end
+			if (FlxG.renderBlit)
+			{
+				pendingPixelsChange = true;
+			}
 		}
 		
 		return value;
@@ -1640,9 +1658,10 @@ class FlxBitmapText extends FlxSprite
 		if (backgroundColor != value)
 		{
 			backgroundColor = value;
-			#if FLX_RENDER_BLIT
-			pendingPixelsChange = true;
-			#end
+			if (FlxG.renderBlit)
+			{
+				pendingPixelsChange = true;
+			}
 		}
 		
 		return value;
@@ -1664,9 +1683,10 @@ class FlxBitmapText extends FlxSprite
 		if (borderColor != value)
 		{
 			borderColor = value;
-			#if FLX_RENDER_BLIT
-			pendingPixelsChange = true;
-			#end
+			if (FlxG.renderBlit)
+			{
+				pendingPixelsChange = true;
+			}
 		}
 		
 		return value;

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -180,11 +180,9 @@ class FlxBitmapText extends FlxSprite
 	private var pendingTextBitmapChange:Bool = true;
 	private var pendingPixelsChange:Bool = true;
 	
-	//start FlxG.renderTile
-		private var textData:Array<Float>;
-		private var textDrawData:Array<Float>;
-		private var borderDrawData:Array<Float>;
-	//end FlxG.renderTile
+	private var textData:Array<Float>;
+	private var textDrawData:Array<Float>;
+	private var borderDrawData:Array<Float>;
 	
 	/**
 	 * Helper bitmap buffer for text pixels but without any color transformations

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -865,11 +865,12 @@ class FlxText extends FlxSprite
 		if (textField == null)
 			return;
 		
-		#if FLX_RENDER_TILE
-		if (!RunOnCpp)
-			return;
-		#end
-			
+		if (FlxG.renderTile)
+		{
+			if (!RunOnCpp)
+				return;
+		}
+		
 		if (_regen)
 			regenGraphics();
 		

--- a/flixel/text/FlxTextField.hx
+++ b/flixel/text/FlxTextField.hx
@@ -126,18 +126,21 @@ class FlxTextField extends FlxText
 	 */
 	override public function draw():Void
 	{
-		if (_camera == null)	
+		if (_camera == null)
 		{
 			return;
 		}
 		
 		if (!_addedToDisplay)
 		{
-			#if FLX_RENDER_TILE
-			_camera.canvas.addChild(textField);
-			#else
-			_camera.flashSprite.addChild(textField);
-			#end
+			if (FlxG.renderTile)
+			{
+				_camera.canvas.addChild(textField);
+			}
+			else 
+			{
+				_camera.flashSprite.addChild(textField);
+			}
 			
 			_addedToDisplay = true;
 			updateDefaultFormat();
@@ -155,13 +158,16 @@ class FlxTextField extends FlxText
 		_point.x = x - (_camera.scroll.x * scrollFactor.x) - (offset.x);
 		_point.y = y - (_camera.scroll.y * scrollFactor.y) - (offset.y);
 		
-		#if FLX_RENDER_TILE
-		textField.x = _point.x;
-		textField.y = _point.y;
-		#else
-		textField.x = (_point.x - 0.5 * _camera.width);
-		textField.y = (_point.y - 0.5 * _camera.height);
-		#end
+		if (FlxG.renderTile)
+		{
+			textField.x = _point.x;
+			textField.y = _point.y;
+		}
+		else
+		{
+			textField.x = (_point.x - 0.5 * _camera.width);
+			textField.y = (_point.y - 0.5 * _camera.height);
+		}
 		
 		#if !FLX_NO_DEBUG
 		FlxBasic.visibleCount++;
@@ -179,11 +185,14 @@ class FlxTextField extends FlxText
 		{
 			if (Value != null)
 			{
-				#if FLX_RENDER_TILE
-				Value.canvas.addChild(textField);
-				#else
-				Value.flashSprite.addChild(textField);
-				#end
+				if (FlxG.renderTile)
+				{
+					Value.canvas.addChild(textField);
+				}
+				else
+				{
+					Value.flashSprite.addChild(textField);
+				}
 				
 				_addedToDisplay = true;
 			}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -113,26 +113,33 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	private var _scaledTileWidth:Float = 0;
 	private var _scaledTileHeight:Float = 0;
 	
-	#if (FLX_RENDER_BLIT && !FLX_NO_DEBUG)
-	/**
-	 * Internal, used for rendering the debug bounding box display.
-	 */
-	private var _debugTileNotSolid:BitmapData;
-	/**
-	 * Internal, used for rendering the debug bounding box display.
-	 */
-	private var _debugTilePartial:BitmapData;
-	/**
-	 * Internal, used for rendering the debug bounding box display.
-	 */
-	private var _debugTileSolid:BitmapData;
-	/**
-	 * Internal, used for rendering the debug bounding box display.
-	 */
-	private var _debugRect:Rectangle;
+	#if (!FLX_NO_DEBUG)
+	
+	//start FlxG.renderBlit
+	
+		/**
+		* Internal, used for rendering the debug bounding box display.
+		*/
+		private var _debugTileNotSolid:BitmapData;
+		/**
+		* Internal, used for rendering the debug bounding box display.
+		*/
+		private var _debugTilePartial:BitmapData;
+		/**
+		* Internal, used for rendering the debug bounding box display.
+		*/
+		private var _debugTileSolid:BitmapData;
+		/**
+		* Internal, used for rendering the debug bounding box display.
+		*/
+		private var _debugRect:Rectangle;
+	
+	//end FlxG.renderBlit
+	
 	#end
 	
-	#if FLX_RENDER_TILE
+	//start FlxG.renderTile
+	
 	/**
 	 * Rendering helper, minimize new object instantiation on repetitive methods. Used only in tile rendering mode
 	 */
@@ -142,7 +149,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * Rendering helper, used for tile's frame transoformations (only in tile rendering mode).
 	 */
 	private var _matrix:FlxMatrix;
-	#end
+	
+	//end FlxG.renderTile
 	
 	/**
 	 * The tilemap constructor just initializes some basic variables.
@@ -155,10 +163,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_flashPoint = new Point();
 		_flashRect = new Rectangle();
 		
-		#if FLX_RENDER_TILE
-		_helperPoint = new Point();
-		_matrix = new FlxMatrix();
-		#end
+		if (FlxG.renderTile)
+		{
+			_helperPoint = new Point();
+			_matrix = new FlxMatrix();
+		}
 		
 		colorTransform = new ColorTransform();
 		
@@ -168,8 +177,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		offset = FlxPoint.get();
 		
 		FlxG.signals.gameResized.add(onGameResize);
-		#if (FLX_RENDER_BLIT && !FLX_NO_DEBUG)
-		FlxG.debugger.drawDebugChanged.add(onDrawDebugChanged);
+		#if (!FLX_NO_DEBUG)
+		if (FlxG.renderBlit)
+		{
+			FlxG.debugger.drawDebugChanged.add(onDrawDebugChanged);
+		}
 		#end
 	}
 	
@@ -186,17 +198,20 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
 		_buffers = FlxDestroyUtil.destroyArray(_buffers);
 		
-		#if FLX_RENDER_BLIT
-		#if !FLX_NO_DEBUG
-		_debugRect = null;
-		_debugTileNotSolid = null;
-		_debugTilePartial = null;
-		_debugTileSolid = null;
-		#end
-		#else
-		_helperPoint = null;
-		_matrix = null;
-		#end
+		if (FlxG.renderBlit)
+		{
+			#if !FLX_NO_DEBUG
+			_debugRect = null;
+			_debugTileNotSolid = null;
+			_debugTilePartial = null;
+			_debugTileSolid = null;
+			#end
+		}
+		else
+		{
+			_helperPoint = null;
+			_matrix = null;
+		}
 		
 		frames = null;
 		graphic = null;
@@ -209,8 +224,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		colorTransform = null;
 		
 		FlxG.signals.gameResized.remove(onGameResize);
-		#if (FLX_RENDER_BLIT && !FLX_NO_DEBUG)
-		FlxG.debugger.drawDebugChanged.remove(onDrawDebugChanged);
+		#if (!FLX_NO_DEBUG)
+		if (FlxG.renderBlit)
+		{
+			FlxG.debugger.drawDebugChanged.remove(onDrawDebugChanged);
+		}
 		#end
 		
 		super.destroy();
@@ -283,10 +301,13 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		}
 		
 		// Create debug tiles for rendering bounding boxes on demand
-		#if (FLX_RENDER_BLIT && !FLX_NO_DEBUG)
-		_debugTileNotSolid = makeDebugTile(FlxColor.BLUE);
-		_debugTilePartial = makeDebugTile(FlxColor.PINK);
-		_debugTileSolid = makeDebugTile(FlxColor.GREEN);
+		#if (!FLX_NO_DEBUG)
+		if (FlxG.renderBlit)
+		{
+			_debugTileNotSolid = makeDebugTile(FlxColor.BLUE);
+			_debugTilePartial = makeDebugTile(FlxColor.PINK);
+			_debugTileSolid = makeDebugTile(FlxColor.GREEN);
+		}
 		#end
 	}
 	
@@ -302,8 +323,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	
 	override private function updateMap():Void 
 	{
-		#if (!FLX_NO_DEBUG && FLX_RENDER_BLIT)
-		_debugRect = new Rectangle(0, 0, _tileWidth, _tileHeight);
+		#if (!FLX_NO_DEBUG)
+		if (FlxG.renderBlit)
+		{
+			_debugRect = new Rectangle(0, 0, _tileWidth, _tileHeight);
+		}
 		#end
 		
 		var numTiles:Int = _tileObjects.length;
@@ -316,7 +340,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	#if !FLX_NO_DEBUG
 	override public function drawDebugOnCamera(Camera:FlxCamera):Void
 	{
-		#if FLX_RENDER_TILE
+		if (!FlxG.renderTile) return;
+		
 		var buffer:FlxTilemapBuffer = null;
 		var l:Int = FlxG.cameras.list.length;
 		
@@ -400,7 +425,6 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			
 			rowIndex += widthInTiles;
 		}
-		#end
 	}
 	#end
 	
@@ -435,20 +459,23 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			
 			buffer = _buffers[i];
 			
-			#if FLX_RENDER_BLIT
-			getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y);
-			buffer.dirty = buffer.dirty || _point.x > 0 || (_point.y > 0) || (_point.x + buffer.width < camera.width) || (_point.y + buffer.height < camera.height);
-			
-			if (buffer.dirty)
+			if (FlxG.renderBlit)
+			{
+				getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y);
+				buffer.dirty = buffer.dirty || _point.x > 0 || (_point.y > 0) || (_point.x + buffer.width < camera.width) || (_point.y + buffer.height < camera.height);
+				
+				if (buffer.dirty)
+				{
+					drawTilemap(buffer, camera);
+				}
+				
+				getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y).copyToFlash(_flashPoint);
+				buffer.draw(camera, _flashPoint, scale.x, scale.y);
+			}
+			else
 			{
 				drawTilemap(buffer, camera);
 			}
-			
-			getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y).copyToFlash(_flashPoint);
-			buffer.draw(camera, _flashPoint, scale.x, scale.y);
-			#else			
-			drawTilemap(buffer, camera);
-			#end
 			
 			#if !FLX_NO_DEBUG
 			FlxBasic.visibleCount++;
@@ -833,22 +860,29 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	{
 		var isColored:Bool = ((alpha != 1) || (color != 0xffffff));
 		
-	#if FLX_RENDER_BLIT
-		Buffer.fill();
-	#else
-		getScreenPosition(_point, Camera).subtractPoint(offset).copyToFlash(_helperPoint);
+		//only used for renderTile
+		var drawX:Float = 0;
+		var drawY:Float = 0;
+		var scaledWidth:Float = 0;
+		var scaledHeight:Float = 0;
+		var drawItem = null;
 		
-		_helperPoint.x = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
-		_helperPoint.y = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;
-		
-		var drawX:Float;
-		var drawY:Float;
-		
-		var scaledWidth:Float = _scaledTileWidth;
-		var scaledHeight:Float = _scaledTileHeight;
-		
-		var drawItem = Camera.startQuadBatch(graphic, isColored, blend);
-	#end
+		if (FlxG.renderBlit)
+		{
+			Buffer.fill();
+		}
+		else
+		{
+			getScreenPosition(_point, Camera).subtractPoint(offset).copyToFlash(_helperPoint);
+			
+			_helperPoint.x = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
+			_helperPoint.y = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;
+			
+			scaledWidth  = _scaledTileWidth;
+			scaledHeight = _scaledTileHeight;
+			
+			drawItem = Camera.startQuadBatch(graphic, isColored, blend);
+		}
 		
 		// Copy tile images into the tile buffer
 		_point.x = (Camera.scroll.x * scrollFactor.x) - x - offset.x; //modified from getScreenPosition()
@@ -886,82 +920,88 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				{
 					frame = tile.frame;
 					
-				#if FLX_RENDER_BLIT
-					frame.paint(Buffer.pixels, _flashPoint, true);
-					
-					#if !FLX_NO_DEBUG
-					if (FlxG.debugger.drawDebug && !ignoreDrawDebug) 
+					if (FlxG.renderBlit)
 					{
-						if (tile.allowCollisions <= FlxObject.NONE)
+						frame.paint(Buffer.pixels, _flashPoint, true);
+						
+						#if !FLX_NO_DEBUG
+						if (FlxG.debugger.drawDebug && !ignoreDrawDebug) 
 						{
-							// Blue
-							debugTile = _debugTileNotSolid; 
+							if (tile.allowCollisions <= FlxObject.NONE)
+							{
+								// Blue
+								debugTile = _debugTileNotSolid; 
+							}
+							else if (tile.allowCollisions != FlxObject.ANY)
+							{
+								// Pink
+								debugTile = _debugTilePartial; 
+							}
+							else
+							{
+								// Green
+								debugTile = _debugTileSolid; 
+							}
+							
+							offset.addToFlash(_flashPoint);
+							Buffer.pixels.copyPixels(debugTile, _debugRect, _flashPoint, null, null, true);
+							offset.subtractFromFlash(_flashPoint);
 						}
-						else if (tile.allowCollisions != FlxObject.ANY)
+						#end
+					}
+					else
+					{
+						drawX = _helperPoint.x + (columnIndex % widthInTiles) * scaledWidth;
+						drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * scaledHeight;
+						
+						_matrix.identity();
+						
+						if (frame.angle != FlxFrameAngle.ANGLE_0)
 						{
-							// Pink
-							debugTile = _debugTilePartial; 
-						}
-						else
-						{
-							// Green
-							debugTile = _debugTileSolid; 
+							frame.prepareMatrix(_matrix);
 						}
 						
-						offset.addToFlash(_flashPoint);
-						Buffer.pixels.copyPixels(debugTile, _debugRect, _flashPoint, null, null, true);
-						offset.subtractFromFlash(_flashPoint);
+						var scaleX:Float = scale.x;
+						var scaleY:Float = scale.y;
+						
+						if (useScaleHack)
+						{
+							scaleX += 1 / (frame.sourceSize.x * Camera.totalScaleX);
+							scaleY += 1 / (frame.sourceSize.y * Camera.totalScaleY);
+						}
+						
+						_matrix.scale(scaleX, scaleY);
+						_matrix.translate(drawX, drawY);
+						
+						drawItem.addQuad(frame, _matrix, color.redFloat, color.greenFloat, color.blueFloat, alpha);
 					}
-					#end
-				#else
-					drawX = _helperPoint.x + (columnIndex % widthInTiles) * scaledWidth;
-					drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * scaledHeight;
-					
-					_matrix.identity();
-					
-					if (frame.angle != FlxFrameAngle.ANGLE_0)
-					{
-						frame.prepareMatrix(_matrix);
-					}
-					
-					var scaleX:Float = scale.x;
-					var scaleY:Float = scale.y;
-					
-					if (useScaleHack)
-					{
-						scaleX += 1 / (frame.sourceSize.x * Camera.totalScaleX);
-						scaleY += 1 / (frame.sourceSize.y * Camera.totalScaleY);
-					}
-					
-					_matrix.scale(scaleX, scaleY);
-					_matrix.translate(drawX, drawY);
-					
-					drawItem.addQuad(frame, _matrix, color.redFloat, color.greenFloat, color.blueFloat, alpha);
-				#end
 				}
 				
-				#if FLX_RENDER_BLIT
-				_flashPoint.x += _tileWidth;
-				#end
+				if (FlxG.renderBlit)
+				{
+					_flashPoint.x += _tileWidth;
+				}
 				columnIndex++;
 			}
 			
-			#if FLX_RENDER_BLIT
-			_flashPoint.y += _tileHeight;
-			#end
+			if (FlxG.renderBlit)
+			{
+				_flashPoint.y += _tileHeight;
+			}
 			rowIndex += widthInTiles;
 		}
 		
 		Buffer.x = screenXInTiles * _scaledTileWidth;
 		Buffer.y = screenYInTiles * _scaledTileHeight;
 		
-		#if FLX_RENDER_BLIT
-		if (isColored)
+		if (FlxG.renderBlit)
 		{
-			Buffer.colorTransform(colorTransform);
+			if (isColored)
+			{
+				Buffer.colorTransform(colorTransform);
+			}
+			Buffer.blend = blend;
 		}
-		Buffer.blend = blend;
-		#end
 		
 		Buffer.dirty = false;
 	}
@@ -970,24 +1010,28 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * Internal function to clean up the map loading code.
 	 * Just generates a wireframe box the size of a tile with the specified color.
 	 */
-	#if (FLX_RENDER_BLIT && !FLX_NO_DEBUG)
+	#if (!FLX_NO_DEBUG)
 	private function makeDebugTile(Color:FlxColor):BitmapData
 	{
-		var debugTile:BitmapData;
-		debugTile = new BitmapData(_tileWidth, _tileHeight, true, 0);
-		
-		var gfx:Graphics = FlxSpriteUtil.flashGfx;
-		gfx.clear();
-		gfx.moveTo(0, 0);
-		gfx.lineStyle(1, Color, 0.5);
-		gfx.lineTo(_tileWidth - 1, 0);
-		gfx.lineTo(_tileWidth - 1, _tileHeight - 1);
-		gfx.lineTo(0, _tileHeight - 1);
-		gfx.lineTo(0, 0);
-		
-		debugTile.draw(FlxSpriteUtil.flashGfxSprite);
-		
-		return debugTile;
+		if (FlxG.renderBlit)
+		{
+			var debugTile:BitmapData;
+			debugTile = new BitmapData(_tileWidth, _tileHeight, true, 0);
+			
+			var gfx:Graphics = FlxSpriteUtil.flashGfx;
+			gfx.clear();
+			gfx.moveTo(0, 0);
+			gfx.lineStyle(1, Color, 0.5);
+			gfx.lineTo(_tileWidth - 1, 0);
+			gfx.lineTo(_tileWidth - 1, _tileHeight - 1);
+			gfx.lineTo(0, _tileHeight - 1);
+			gfx.lineTo(0, 0);
+			
+			debugTile.draw(FlxSpriteUtil.flashGfxSprite);
+			
+			return debugTile;
+		}
+		return null;
 	}
 	#end
 
@@ -1043,13 +1087,16 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		}
 	}
 	
-	#if (FLX_RENDER_BLIT && !FLX_NO_DEBUG)
+	#if (!FLX_NO_DEBUG)
 	private function onDrawDebugChanged():Void
 	{
-		for (buffer in _buffers)
+		if (FlxG.renderBlit)
 		{
-			if (buffer != null)
-				buffer.dirty = true;
+			for (buffer in _buffers)
+			{
+				if (buffer != null)
+					buffer.dirty = true;
+			}
 		}
 	}
 	#end
@@ -1129,16 +1176,18 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			colorTransform.alphaMultiplier = 1;
 		}
 		
-		#if FLX_RENDER_BLIT
-		setDirty();
-		#end
+		if (FlxG.renderBlit)
+		{
+			setDirty();
+		}
 	}
 	
 	private function set_blend(Value:BlendMode):BlendMode 
 	{
-		#if FLX_RENDER_BLIT
-		setDirty();
-		#end
+		if (FlxG.renderBlit)
+		{
+			setDirty();
+		}
 		return blend = Value;
 	}
 	

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -115,30 +115,24 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	
 	#if (!FLX_NO_DEBUG)
 	
-	//start FlxG.renderBlit
-	
-		/**
-		* Internal, used for rendering the debug bounding box display.
-		*/
-		private var _debugTileNotSolid:BitmapData;
-		/**
-		* Internal, used for rendering the debug bounding box display.
-		*/
-		private var _debugTilePartial:BitmapData;
-		/**
-		* Internal, used for rendering the debug bounding box display.
-		*/
-		private var _debugTileSolid:BitmapData;
-		/**
-		* Internal, used for rendering the debug bounding box display.
-		*/
-		private var _debugRect:Rectangle;
-	
-	//end FlxG.renderBlit
+	/**
+	* Internal, used for rendering the debug bounding box display.
+	*/
+	private var _debugTileNotSolid:BitmapData;
+	/**
+	* Internal, used for rendering the debug bounding box display.
+	*/
+	private var _debugTilePartial:BitmapData;
+	/**
+	* Internal, used for rendering the debug bounding box display.
+	*/
+	private var _debugTileSolid:BitmapData;
+	/**
+	* Internal, used for rendering the debug bounding box display.
+	*/
+	private var _debugRect:Rectangle;
 	
 	#end
-	
-	//start FlxG.renderTile
 	
 	/**
 	 * Rendering helper, minimize new object instantiation on repetitive methods. Used only in tile rendering mode
@@ -149,8 +143,6 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * Rendering helper, used for tile's frame transoformations (only in tile rendering mode).
 	 */
 	private var _matrix:FlxMatrix;
-	
-	//end FlxG.renderTile
 	
 	/**
 	 * The tilemap constructor just initializes some basic variables.

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -52,9 +52,8 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public var pixelPerfectRender:Null<Bool>;
 	
-	#if FLX_RENDER_BLIT
 	/**
-	 * The actual buffer BitmapData.
+	 * The actual buffer BitmapData. (Only used if FlxG.renderBlit == true)
 	 */ 
 	public var pixels(default, null):BitmapData;
 	
@@ -62,8 +61,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	
 	private var _flashRect:Rectangle;
 	private var _matrix:Matrix;
-	#end
-
+	
 	/**
 	 * Instantiates a new camera-specific buffer for storing the visual tilemap data.
 	 * 
@@ -79,11 +77,12 @@ class FlxTilemapBuffer implements IFlxDestroyable
 		updateColumns(TileWidth, WidthInTiles, ScaleX, Camera);
 		updateRows(TileHeight, HeightInTiles, ScaleY, Camera);
 		
-		#if FLX_RENDER_BLIT
-		pixels = new BitmapData(Std.int(columns * TileWidth), Std.int(rows * TileHeight), true, 0);
-		_flashRect = new Rectangle(0, 0, pixels.width, pixels.height);
-		_matrix = new Matrix();
-		#end
+		if (FlxG.renderBlit)
+		{
+			pixels = new BitmapData(Std.int(columns * TileWidth), Std.int(rows * TileHeight), true, 0);
+			_flashRect = new Rectangle(0, 0, pixels.width, pixels.height);
+			_matrix = new Matrix();
+		}
 		
 		dirty = true;
 	}
@@ -93,12 +92,15 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public function destroy():Void
 	{
-		#if FLX_RENDER_BLIT
-		pixels = null;
-		blend = null;
-		_matrix = null;
-		#end
+		if (FlxG.renderBlit)
+		{
+			pixels = null;
+			blend = null;
+			_matrix = null;
+		}
 	}
+	
+	//start FlxG.renderBlit
 	
 	/**
 	 * Fill the buffer with the specified color.
@@ -106,10 +108,12 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 * 
 	 * @param	Color	What color to fill with, in 0xAARRGGBB hex format.
 	 */
-	#if FLX_RENDER_BLIT
 	public function fill(Color:FlxColor = FlxColor.TRANSPARENT):Void
 	{
-		pixels.fillRect(_flashRect, Color);
+		if (FlxG.renderBlit)
+		{
+			pixels.fillRect(_flashRect, Color);
+		}
 	}
 	
 	/**
@@ -143,7 +147,8 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	{
 		pixels.colorTransform(_flashRect, Transform);
 	}
-	#end
+	
+	//end FlxG.renderBlit
 	
 	public function updateColumns(TileWidth:Int, WidthInTiles:Int, ScaleX:Float = 1.0, ?Camera:FlxCamera):Void
 	{

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -100,8 +100,6 @@ class FlxTilemapBuffer implements IFlxDestroyable
 		}
 	}
 	
-	//start FlxG.renderBlit
-	
 	/**
 	 * Fill the buffer with the specified color.
 	 * Default value is transparent.
@@ -147,8 +145,6 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	{
 		pixels.colorTransform(_flashRect, Transform);
 	}
-	
-	//end FlxG.renderBlit
 	
 	public function updateColumns(TileWidth:Int, WidthInTiles:Int, ScaleX:Float = 1.0, ?Camera:FlxCamera):Void
 	{

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -112,15 +112,11 @@ class FlxBar extends FlxSprite
 	public var fillDirection(default, set):FlxBarFillDirection;	
 	private var _fillHorizontal:Bool;
 	
-	//start FlxG.renderTile
-	
 	/**
 	 * FlxSprite which is used for rendering front graphics of bar (showing value) in tile render mode.
 	 */
 	private var _frontFrame:FlxFrame;
 	private var _filledFlxRect:FlxRect;
-	
-	//else (FlxG.renderBlit)
 	
 	private var _emptyBar:BitmapData;
 	private var _emptyBarRect:Rectangle;
@@ -128,8 +124,6 @@ class FlxBar extends FlxSprite
 	private var _filledBar:BitmapData;
 	
 	private var _zeroOffset:Point;
-	
-	//end FlxG.renderBlit
 	
 	private var _filledBarRect:Rectangle;
 	private var _filledBarPoint:Point;

--- a/flixel/util/FlxCollision.hx
+++ b/flixel/util/FlxCollision.hx
@@ -58,7 +58,7 @@ class FlxCollision
 		{
 			// find the center of both sprites
 			Contact.origin.copyToFlash(centerA);
-			Target.origin.copyToFlash(centerB);			
+			Target.origin.copyToFlash(centerB);
 			
 			// now make a bounding box that allows for the sprite to be rotated in 360 degrees
 			boundsA.x = (pointA.x + centerA.x - centerA.length);
@@ -98,10 +98,11 @@ class FlxCollision
 		matrixB.identity();
 		matrixB.translate(-(intersect.x - boundsB.x), -(intersect.y - boundsB.y));
 		
-	#if FLX_RENDER_TILE
-		Contact.drawFrame();
-		Target.drawFrame();
-	#end
+		if (FlxG.renderTile)
+		{
+			Contact.drawFrame();
+			Target.drawFrame();
+		}
 		
 		var testA:BitmapData = Contact.framePixels;
 		var testB:BitmapData = Target.framePixels;
@@ -221,18 +222,20 @@ class FlxCollision
 			return false;
 		}
 		
-		#if FLX_RENDER_TILE
-		Target.drawFrame();
-		#end
+		if (FlxG.renderTile)
+		{
+			Target.drawFrame();
+		}
 		
 		// How deep is pointX/Y within the rect?
 		var test:BitmapData = Target.framePixels;
 		
 		var pixelAlpha = FlxColor.fromInt(test.getPixel32(Math.floor(PointX - Target.x), Math.floor(PointY - Target.y))).alpha;
 		
-		#if FLX_RENDER_TILE
-		pixelAlpha = Std.int(pixelAlpha * Target.alpha);
-		#end
+		if (FlxG.renderTile)
+		{
+			pixelAlpha = Std.int(pixelAlpha * Target.alpha);
+		}
 		
 		// How deep is pointX/Y within the rect?
 		if (pixelAlpha >= AlphaTolerance)

--- a/flixel/util/FlxPath.hx
+++ b/flixel/util/FlxPath.hx
@@ -631,13 +631,18 @@ class FlxPath implements IFlxDestroyable
 			Camera = FlxG.camera;
 		}
 		
+		var gfx:Graphics = null;
+		
 		//Set up our global flash graphics object to draw out the path
-		#if FLX_RENDER_BLIT
-		var gfx:Graphics = FlxSpriteUtil.flashGfx;
-		gfx.clear();
-		#else
-		var gfx:Graphics = Camera.debugLayer.graphics;
-		#end
+		if (FlxG.renderBlit)
+		{
+			gfx = FlxSpriteUtil.flashGfx;
+			gfx.clear();
+		}
+		else
+		{
+			gfx = Camera.debugLayer.graphics;
+		}
 		
 		//Then fill up the object with node and path graphics
 		var node:FlxPoint;
@@ -699,10 +704,11 @@ class FlxPath implements IFlxDestroyable
 			i++;
 		}
 		
-		#if FLX_RENDER_BLIT
-		//then stamp the path down onto the game buffer
-		Camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
-		#end
+		if (FlxG.renderBlit)
+		{
+			//then stamp the path down onto the game buffer
+			Camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
+		}
 	}
 	#end
 }


### PR DESCRIPTION
This changes the FLX_RENDER_BLIT and FLX_RENDER_TILE into runtime flags (FlxG.renderTile and FlxG.renderBlit).

I think this change is necessary because there are situations in which you can't know ahead of time whether the user's system will need software rendering (for which BLIT is optimized) or hardware rendering (for which TILE is optimized).

I've identified two such scenarios already:

**1. Windows  -- ANGLE on Vista/7/8/10, SOFTWARE on XP**

In a recent bit of refactoring for OpenFL, we were able to get ANGLE up and running, and it's now going to be the default rendering system for Windows, this increases compatibility across the board and virtually eliminates issues with bad OpenGL drivers. However, ANGLE does now work with Windows XP. Doing some testing, the *only* way I could get reliable, works close to 100% of the time results with XP was to force software rendering -- this hasn't been pushed through quite yet, but I believe Joshua agrees with me. However, the system cannot know at compile time which version of windows the user will use, so it has to be able to switch between hardware and software at runtime.

**2. HTML5 -- WebGL with CANVAS fallback**

This one's more important IMHO. If we want a really good web compatibility experience, we need to target WebGL with an automatic Canvas fallback. For best results this would require us to detect WebGL compatibility at runtime and then pick the right render method then.

This is a big refactor so it deserves a lot of scrutiny, I've been using it myself and it seems stable but I definitely need input and feedback on this.

Hope this is useful.


