### PR TITLE
Add "flipX / flipY" property to animations

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -943,7 +943,7 @@ class FlxSprite extends FlxObject
 			}
 			else
 			{
-				framePixels = _frame.paintRotatedAndFlipped(framePixels, _flashPointZero, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY(), false, true);
+				framePixels = _frame.paintRotatedAndFlipped(framePixels, _flashPointZero, FlxFrameAngle.ANGLE_0, doFlipX, doFlipY, false, true);
 			}
 			
 			if (useColorTransform)
@@ -1361,26 +1361,26 @@ class FlxSprite extends FlxObject
 	
 	private inline function checkFlipX():Bool
 	{
-		var doFlipX:Bool = FlxMath.boolXOR(flipX, _frame.flipX);
-		
 		if (animation.curAnim != null)
 		{
-			doFlipX = FlxMath.boolXOR(flipX, animation.curAnim.flipX);
+			return ((flipX != _frame.flipX) != animation.curAnim.flipX);
 		}
-		
-		return doFlipX;
+		else
+		{
+			return (flipX != _frame.flipX);
+		}
 	}
 	
 	private inline function checkFlipY():Bool
 	{
-		var doFlipY:Bool = FlxMath.boolXOR(flipY, _frame.flipY);
-		
 		if (animation.curAnim != null)
 		{
-			doFlipY = FlxMath.boolXOR(flipY, animation.curAnim.flipY);
+			return ((flipY != _frame.flipY) != animation.curAnim.flipY);
 		}
-		
-		return doFlipY;
+		else
+		{
+			return (flipY != _frame.flipY);
+		}
 	}
 }
 

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -650,7 +650,7 @@ class FlxSprite extends FlxObject
 			}
 			else
 			{
-				_frame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, flipX, flipY);
+				_frame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY());
 				_matrix.translate( -origin.x, -origin.y);
 				_matrix.scale(scale.x, scale.y);
 				
@@ -934,15 +934,16 @@ class FlxSprite extends FlxObject
 			}
 			#end
 			
-			var doFlipX = flipX != _frame.flipX;
-			var doFlipY = flipY != _frame.flipY;
+			var doFlipX:Bool = checkFlipX();
+			var doFlipY:Bool = checkFlipY();
+			
 			if (!doFlipX && !doFlipY && _frame.type == FlxFrameType.REGULAR)
 			{
 				framePixels = _frame.paint(framePixels, _flashPointZero, false, true);
 			}
 			else
 			{
-				framePixels = _frame.paintRotatedAndFlipped(framePixels, _flashPointZero, FlxFrameAngle.ANGLE_0, flipX, flipY, false, true);
+				framePixels = _frame.paintRotatedAndFlipped(framePixels, _flashPointZero, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY(), false, true);
 			}
 			
 			if (useColorTransform)
@@ -1356,6 +1357,30 @@ class FlxSprite extends FlxObject
 	private function set_antialiasing(value:Bool):Bool
 	{
 		return antialiasing = value;
+	}
+	
+	private inline function checkFlipX():Bool
+	{
+		var doFlipX:Bool = FlxMath.boolXOR(flipX, _frame.flipX);
+		
+		if (animation.curAnim != null)
+		{
+			doFlipX = FlxMath.boolXOR(flipX, animation.curAnim.flipX);
+		}
+		
+		return doFlipX;
+	}
+	
+	private inline function checkFlipY():Bool
+	{
+		var doFlipY:Bool = FlxMath.boolXOR(flipY, _frame.flipY);
+		
+		if (animation.curAnim != null)
+		{
+			doFlipY = FlxMath.boolXOR(flipY, animation.curAnim.flipY);
+		}
+		
+		return doFlipY;
 	}
 }
 

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1361,26 +1361,22 @@ class FlxSprite extends FlxObject
 	
 	private inline function checkFlipX():Bool
 	{
+		var doFlipX = (flipX != _frame.flipX);
 		if (animation.curAnim != null)
 		{
-			return ((flipX != _frame.flipX) != animation.curAnim.flipX);
+			return (doFlipX != animation.curAnim.flipX);
 		}
-		else
-		{
-			return (flipX != _frame.flipX);
-		}
+		return doFlipX;
 	}
 	
 	private inline function checkFlipY():Bool
 	{
+		var doFlipY = (flipY != _frame.flipY);
 		if (animation.curAnim != null)
 		{
-			return ((flipY != _frame.flipY) != animation.curAnim.flipY);
+			return (doFlipY != animation.curAnim.flipY);
 		}
-		else
-		{
-			return (flipY != _frame.flipY);
-		}
+		return doFlipY;
 	}
 }
 

--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -49,6 +49,16 @@ class FlxAnimation extends FlxBaseAnimation
 	public var reversed(default, null):Bool = false;
 	
 	/**
+	 * Whether or not the frames of this animation are horizontally flipped
+	 */
+	public var flipX(default, null):Bool = false;
+	
+	/**
+	 * Whether or not the frames of this animation are vertically flipped
+	 */
+	public var flipY(default, null):Bool = false;
+	
+	/**
 	 * A list of frames stored as int objects
 	 */
 	@:allow(flixel.animation)
@@ -64,14 +74,18 @@ class FlxAnimation extends FlxBaseAnimation
 	 * @param	Frames		An array of numbers indicating what frames to play in what order (e.g. 1, 2, 3)
 	 * @param	FrameRate	The speed in frames per second that the animation should play at (e.g. 40)
 	 * @param	Looped		Whether or not the animation is looped or just plays once
+	 * @param	FlipX		Whether or not the frames of this animation are horizontally flipped
+	 * @param	FlipY		Whether or not the frames of this animation are vertically flipped
 	 */
-	public function new(Parent:FlxAnimationController, Name:String, Frames:Array<Int>, FrameRate:Int = 0, Looped:Bool = true)
+	public function new(Parent:FlxAnimationController, Name:String, Frames:Array<Int>, FrameRate:Int = 0, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false)
 	{
 		super(Parent, Name);
 		
 		frameRate = FrameRate;
 		_frames = Frames;
 		looped = Looped;
+		flipX = FlipX;
+		flipY = FlipY;
 	}
 	
 	/**
@@ -212,7 +226,7 @@ class FlxAnimation extends FlxBaseAnimation
 	
 	override public function clone(Parent:FlxAnimationController):FlxAnimation
 	{
-		return new FlxAnimation(Parent, name, _frames, frameRate, looped);
+		return new FlxAnimation(Parent, name, _frames, frameRate, looped, flipX, flipY);
 	}
 	
 	private function set_frameRate(value:Int):Int

--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -51,12 +51,12 @@ class FlxAnimation extends FlxBaseAnimation
 	/**
 	 * Whether or not the frames of this animation are horizontally flipped
 	 */
-	public var flipX(default, null):Bool = false;
+	public var flipX:Bool = false;
 	
 	/**
 	 * Whether or not the frames of this animation are vertically flipped
 	 */
-	public var flipY(default, null):Bool = false;
+	public var flipY:Bool = false;
 	
 	/**
 	 * A list of frames stored as int objects

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -306,8 +306,10 @@ class FlxAnimationController implements IFlxDestroyable
 	 * @param	Postfix			Common ending of image names in atlas (e.g. ".png")
 	 * @param	FrameRate		The speed in frames per second that the animation should play at (e.g. 40 fps).
 	 * @param	Looped			Whether or not the animation is looped or just plays once.
+	 * @param	FlipX			Whether the frames should be horizontally flipped
+	 * @param	FlipY			Whether the frames should be vertically flipped
 	 */
-	public function addByStringIndices(Name:String, Prefix:String, Indices:Array<String>, Postfix:String, FrameRate:Int = 30, Looped:Bool = true):Void
+	public function addByStringIndices(Name:String, Prefix:String, Indices:Array<String>, Postfix:String, FrameRate:Int = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
 	{
 		if (_sprite.frames != null)
 		{
@@ -316,7 +318,7 @@ class FlxAnimationController implements IFlxDestroyable
 			
 			if (frameIndices.length > 0)
 			{
-				var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped);
+				var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
 				_animations.set(Name, anim);
 			}
 		}
@@ -355,8 +357,10 @@ class FlxAnimationController implements IFlxDestroyable
 	 * @param	Postfix			Common ending of image names in atlas (e.g. ".png")
 	 * @param	FrameRate		The speed in frames per second that the _animations should play at (e.g. 40 fps).
 	 * @param	Looped			Whether or not the animation is looped or just plays once.
+	 * @param	FlipX			Whether the frames should be horizontally flipped
+	 * @param	FlipY			Whether the frames should be vertically flipped
 	 */
-	public function addByIndices(Name:String, Prefix:String, Indices:Array<Int>, Postfix:String, FrameRate:Int = 30, Looped:Bool = true):Void
+	public function addByIndices(Name:String, Prefix:String, Indices:Array<Int>, Postfix:String, FrameRate:Int = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
 	{
 		if (_sprite.frames != null)
 		{
@@ -365,7 +369,7 @@ class FlxAnimationController implements IFlxDestroyable
 			
 			if (frameIndices.length > 0)
 			{
-				var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped);
+				var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
 				_animations.set(Name, anim);
 			}
 		}
@@ -428,8 +432,10 @@ class FlxAnimationController implements IFlxDestroyable
 	 * @param	Prefix			Common beginning of image names in atlas (e.g. "tiles-")
 	 * @param	FrameRate		The speed in frames per second that the animation should play at (e.g. 40 fps).
 	 * @param	Looped			Whether or not the animation is looped or just plays once.
+	 * @param	FlipX			Whether the frames should be horizontally flipped
+	 * @param	FlipY			Whether the frames should be vertically flipped
 	*/
-	public function addByPrefix(Name:String, Prefix:String, FrameRate:Int = 30, Looped:Bool = true):Void
+	public function addByPrefix(Name:String, Prefix:String, FrameRate:Int = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
 	{
 		if (_sprite.frames != null)
 		{
@@ -443,7 +449,7 @@ class FlxAnimationController implements IFlxDestroyable
 				
 				if (frameIndices.length > 0)
 				{
-					var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped);
+					var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
 					_animations.set(Name, anim);
 				}
 			}

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -199,7 +199,7 @@ class FlxAnimationController implements IFlxDestroyable
 		
 		if (framesToAdd.length > 0)
 		{
-			var anim = new FlxAnimation(this, Name, framesToAdd, FrameRate, Looped);
+			var anim = new FlxAnimation(this, Name, framesToAdd, FrameRate, Looped, FlipX, FlipY);
 			_animations.set(Name, anim);
 		}
 	}

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -172,8 +172,10 @@ class FlxAnimationController implements IFlxDestroyable
 	 * @param	Frames		An array of numbers indicating what frames to play in what order (e.g. 1, 2, 3).
 	 * @param	FrameRate	The speed in frames per second that the animation should play at (e.g. 40 fps).
 	 * @param	Looped		Whether or not the animation is looped or just plays once.
+	 * @param	FlipX		Whether the frames should be horizontally flipped
+	 * @param	FlipY		Whether the frames should be vertically flipped
 	 */
-	public function add(Name:String, Frames:Array<Int>, FrameRate:Int = 30, Looped:Bool = true):Void
+	public function add(Name:String, Frames:Array<Int>, FrameRate:Int = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
 	{
 		// Check _animations frames
 		var framesToAdd:Array<Int> = Frames;
@@ -255,8 +257,10 @@ class FlxAnimationController implements IFlxDestroyable
 	 * @param	FrameNames		An array of image names from atlas indicating what frames to play in what order.
 	 * @param	FrameRate		The speed in frames per second that the animation should play at (e.g. 40 fps).
 	 * @param	Looped			Whether or not the animation is looped or just plays once.
+	 * @param	FlipX			Whether the frames should be horizontally flipped
+	 * @param	FlipY			Whether the frames should be vertically flipped
 	 */
-	public function addByNames(Name:String, FrameNames:Array<String>, FrameRate:Int = 30, Looped:Bool = true):Void
+	public function addByNames(Name:String, FrameNames:Array<String>, FrameRate:Int = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
 	{
 		if (_sprite.frames != null)
 		{
@@ -265,7 +269,7 @@ class FlxAnimationController implements IFlxDestroyable
 			
 			if (indices.length > 0)
 			{
-				var anim = new FlxAnimation(this, Name, indices, FrameRate, Looped);
+				var anim = new FlxAnimation(this, Name, indices, FrameRate, Looped, FlipX, FlipY);
 				_animations.set(Name, anim);
 			}
 		}
@@ -502,12 +506,22 @@ class FlxAnimationController implements IFlxDestroyable
 			return;
 		}
 		
+		var oldFlipX:Bool = false;
+		var oldFlipY:Bool = false;
+		
 		if (_curAnim != null && AnimName != _curAnim.name)
 		{
+			oldFlipX = _curAnim.flipX;
+			oldFlipY = _curAnim.flipY;
 			_curAnim.stop();
 		}
 		_curAnim = _animations.get(AnimName);
 		_curAnim.play(Force, Reversed, Frame);
+		
+		if (oldFlipX != _curAnim.flipX || oldFlipY != _curAnim.flipY)
+		{
+			_sprite.dirty = true;
+		}
 	}
 	
 	/**

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -589,4 +589,15 @@ class FlxMath
 	{
 		return (a > 0) ? a : -a;
 	}
+	
+	/**
+	 * Returns the result of a "boolean exclusive or" comparison
+	 * @param	a
+	 * @param	b
+	 * @return
+	 */
+	public static inline function boolXOR(a:Bool, b:Bool):Bool
+	{
+		return (a && !b) || (b && !a);
+	}
 }

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -590,14 +590,4 @@ class FlxMath
 		return (a > 0) ? a : -a;
 	}
 	
-	/**
-	 * Returns the result of a "boolean exclusive or" comparison
-	 * @param	a
-	 * @param	b
-	 * @return
-	 */
-	public static inline function boolXOR(a:Bool, b:Bool):Bool
-	{
-		return (a && !b) || (b && !a);
-	}
 }


### PR DESCRIPTION
...and also make it interact properly with FlxSprite's own flipX / flipY.

Rationale: for games with big sprite sheets, it can save a lot of memory to re-use frames in animations by vertically flipping them. So if I can re-use a walk cycle and just tell it to flip the frames right in the animation call, that's extremely convenient. Much easier to do than messing around with individual frames in the atlas.

Before this pull, we have had the ability to apply flipX/flipY to individual flxFrames (such as those loaded from an atlas) -- so this means the user can now set flipX/flipY in three places:

1) On the sprite itself
2) On an individual frame (e.g. tagging the metadata as part of atlas loading)
3) On an individual animation

The effect should cascade properly. So you can have a particular frame in an animation that has flipX=true, used in an animation that has flipX=true, and then the sprite itself has flipX=true, which will resolve to true because (true XOR true XOR true) == true.