### PR TITLE
Getter / Setter fullscreen for NEXT

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -666,13 +666,21 @@ class FlxG
 	
 	private static function get_fullscreen():Bool
 	{
-		return (stage.displayState == StageDisplayState.FULL_SCREEN 
-			|| stage.displayState == StageDisplayState.FULL_SCREEN_INTERACTIVE);
+		#if (lime_legacy || flash)
+			return (stage.displayState == StageDisplayState.FULL_SCREEN 
+				|| stage.displayState == StageDisplayState.FULL_SCREEN_INTERACTIVE);
+		#else
+			return stage.window.fullscreen;
+		#end
 	}
 	
 	private static function set_fullscreen(Value:Bool):Bool
 	{
-		stage.displayState = Value ? StageDisplayState.FULL_SCREEN : StageDisplayState.NORMAL;
+		#if (lime_legacy || flash)
+			stage.displayState = Value ? StageDisplayState.FULL_SCREEN : StageDisplayState.NORMAL;
+		#else
+			stage.window.fullscreen = Value;
+		#end
 		return Value;
 	}
 	


### PR DESCRIPTION
FlxG.fullscreen getter is not working propertly on Next, because FlxG.displayState variable not changing, when you press [Alt] + [Enter]. But openfl next has nice new feature Lib.current.stage.window.fullscreen, which works correctly.

HaxeFlixel: dev, OpenFL: 3.5.3, Lime: 2.8.2, Haxe: 3.2.1

*My first pull request* :fearful: