### PR TITLE
FlxTween: make start() public per docs

### DIFF
--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -477,7 +477,7 @@ class FlxTween implements IFlxDestroyable
 	/**
 	 * Starts the Tween, or restarts it if it's currently running.
 	 */
-	private function start():FlxTween
+	public function start():FlxTween
 	{
 		_waitingForRestart = false;
 		_secondsSinceStart = 0;

--- a/flixel/tweens/motion/LinearPath.hx
+++ b/flixel/tweens/motion/LinearPath.hx
@@ -94,7 +94,7 @@ class LinearPath extends Motion
 		return points[index % points.length];
 	}
 
-	override private function start():LinearPath
+	override public function start():LinearPath
 	{
 		_index = (backward) ? (points.length - 1) : 0;
 		super.start();

--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -96,7 +96,7 @@ class QuadPath extends Motion
 		return _points[index % _points.length];
 	}
 	
-	override private function start():QuadPath
+	override public function start():QuadPath
 	{
 		_index = (backward) ? (_numSegs - 1) : 0; 
 		super.start();


### PR DESCRIPTION
"FlxTween.PERSIST: stops when it finishes. Unlike ONESHOT, this type of tween stays attached to the core container when it finishes. This means you can keep a reference to this tween and call start() whenever you need it."

From this, I believe it was originally intended that start() be public.

- http://haxeflixel.com/documentation/flxtween/