### PR TITLE
toPoint() -> getPosition(), toRect() -> getHitbox()

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -826,6 +826,11 @@ class FlxObject extends FlxBasic
 		return point.subtract(Camera.scroll.x * scrollFactor.x, Camera.scroll.y * scrollFactor.y);
 	}
 	
+	public inline function getPosition():FlxPoint
+	{
+		return FlxPoint.get(x, y);
+	}
+	
 	/**
 	 * Retrieve the midpoint of this object in world coordinates.
 	 * 
@@ -839,6 +844,11 @@ class FlxObject extends FlxBasic
 			point = FlxPoint.get();
 		}
 		return point.set(x + width * 0.5, y + height * 0.5);
+	}
+	
+	public inline function getHitbox():FlxRect
+	{
+		return FlxRect.get(x, y, width, height);
 	}
 	
 	/**
@@ -1080,16 +1090,6 @@ class FlxObject extends FlxBasic
 			LabelValuePair.weak("h", height), 
 			LabelValuePair.weak("visible", visible), 
 			LabelValuePair.weak("velocity", velocity)]);
-	}
-	
-	public inline function toPoint():FlxPoint
-	{
-		return FlxPoint.get(x, y);
-	}
-	
-	public inline function toRect():FlxRect
-	{
-		return FlxRect.get(x, y, width, height);
 	}
 	
 	private function set_x(NewX:Float):Float

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -826,9 +826,11 @@ class FlxObject extends FlxBasic
 		return point.subtract(Camera.scroll.x * scrollFactor.x, Camera.scroll.y * scrollFactor.y);
 	}
 	
-	public inline function getPosition():FlxPoint
+	public function getPosition(?point:FlxPoint):FlxPoint
 	{
-		return FlxPoint.get(x, y);
+		if (point == null)
+			point = FlxPoint.get();
+		return point.set(x, y);
 	}
 	
 	/**
@@ -846,9 +848,11 @@ class FlxObject extends FlxBasic
 		return point.set(x + width * 0.5, y + height * 0.5);
 	}
 	
-	public inline function getHitbox():FlxRect
+	public function getHitbox(?rect:FlxRect):FlxRect
 	{
-		return FlxRect.get(x, y, width, height);
+		if (rect == null)
+			rect = FlxRect.get();
+		return rect.set(x, y, width, height);
 	}
 	
 	/**

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -71,9 +71,11 @@ class FlxPointer
 	/**
 	 * Returns a FlxPoint with this input's x and y.
 	 */
-	public inline function getPosition():FlxPoint
+	public function getPosition(?point:FlxPoint):FlxPoint
 	{
-		return FlxPoint.get(x, y);
+		if (point == null)
+			point = FlxPoint.get();
+		return point.set(x, y);
 	}
 	
 	/**

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -71,7 +71,7 @@ class FlxPointer
 	/**
 	 * Returns a FlxPoint with this input's x and y.
 	 */
-	public inline function toPoint():FlxPoint
+	public inline function getPosition():FlxPoint
 	{
 		return FlxPoint.get(x, y);
 	}
@@ -103,7 +103,7 @@ class FlxPointer
 		}
 		else 
 		{
-			var point:FlxPoint = toPoint();
+			var point:FlxPoint = getPosition();
 			var object:FlxObject = cast ObjectOrGroup;
 			result = object.overlapsPoint(point, true, Camera);
 			point.put();

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -162,7 +162,7 @@ class FlxObjectTest extends FlxTest
 		
 		object1.velocity.set(100, 0);
 		
-		var lastPos = object1.toPoint();
+		var lastPos = object1.getPosition();
 		step(60, function()
 		{
 			Assert.isTrue(lastPos.x < object1.x);
@@ -176,7 +176,7 @@ class FlxObjectTest extends FlxTest
 		object1 = new OverridenReviveObject();
 		object1.reset(0, 0);
 		
-		Assert.isTrue(FlxPoint.get(10, 10).equals(object1.toPoint()));
+		Assert.isTrue(FlxPoint.get(10, 10).equals(object1.getPosition()));
 		Assert.isTrue(FlxPoint.get(10, 10).equals(object1.velocity));
 	}
 }


### PR DESCRIPTION
Not a fan of these names anymore. `sprite.toPoint()` doesn't "convert it" to a point, it just retrieves the position - which is also much more in line with `getScreenPosition()`.

`getHitbox()` I'm a bit less sure about, but it's in principle the same. However, the API only uses the term `hitbox` in docs, not actual method or variable names. Also not sure if we need to be concerned about people being confused that setting the rect's properties doesn't change the actual hitbox, but I suppose it's the same with `getPosition()` and it doesn't really seem like a concern there?

This is technically a breaking change, however these methods weren't part of an official release yet.