### PR TITLE
FlxMath: remove getDistance()

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -297,7 +297,7 @@ class FlxMath
 	{
 		return ax * bx + ay * by;
 	}
-	
+
 	/**
 	 * Finds the length of the given vector
 	 * 
@@ -307,23 +307,7 @@ class FlxMath
 	{
 		return Math.sqrt(dx * dx + dy * dy);
 	}
-	
-	/**
-	 * Calculate the distance between two points.
-	 * 
-	 * @param 	Point1		A FlxPoint object referring to the first location.
-	 * @param 	Point2		A FlxPoint object referring to the second location.
-	 * @return	The distance between the two points as a floating point Number object.
-	 */
-	public static inline function getDistance(Point1:FlxPoint, Point2:FlxPoint):Float
-	{
-		var dx:Float = Point1.x - Point2.x;
-		var dy:Float = Point1.y - Point2.y;
-		Point1.putWeak();
-		Point2.putWeak();
-		return vectorLength(dx, dy);
-	}
-	
+
 	/**
 	 * Find the distance (in pixels, rounded) between two FlxSprites, taking their origin into account
 	 * 
@@ -369,8 +353,8 @@ class FlxMath
 	 */
 	public static inline function distanceToPoint(Sprite:FlxSprite, Target:FlxPoint):Int
 	{
-		var dx:Float = (Sprite.x + Sprite.origin.x) - (Target.x);
-		var dy:Float = (Sprite.y + Sprite.origin.y) - (Target.y);
+		var dx:Float = (Sprite.x + Sprite.origin.x) - Target.x;
+		var dy:Float = (Sprite.y + Sprite.origin.y) - Target.y;
 		Target.putWeak();
 		return Std.int(FlxMath.vectorLength(dx, dy));
 	}

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -277,9 +277,12 @@ class FlxPoint implements IFlxPooled
 	 * @param 	AnotherPoint	A FlxPoint object to calculate the distance to.
 	 * @return	The distance between the two points as a Float.
 	 */
-	public inline function distanceTo(AnotherPoint:FlxPoint):Float
+	public inline function distanceTo(point:FlxPoint):Float
 	{
-		return FlxMath.getDistance(this, AnotherPoint);
+		var dx:Float = x - point.x;
+		var dy:Float = y - point.y;
+		point.putWeak();
+		return FlxMath.vectorLength(dx, dy);
 	}
 	
 	/**

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -229,7 +229,9 @@ class FlxSound extends FlxBasic
 		//Distance-based volume control
 		if (_target != null)
 		{
-			radialMultiplier = FlxMath.getDistance(FlxPoint.weak(_target.x, _target.y), FlxPoint.weak(x, y)) / _radius;
+			var targetPosition = _target.getPosition();
+			radialMultiplier = targetPosition.distanceTo(FlxPoint.weak(x, y)) / _radius;
+			targetPosition.put();
 			radialMultiplier = 1 - FlxMath.bound(radialMultiplier, 0, 1);
 			
 			if (_proximityPan)

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -435,7 +435,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	private function checkInput(pointer:FlxPointer, input:IFlxInput, justPressedPosition:FlxPoint, camera:FlxCamera):Bool
 	{
 		if (maxInputMovement != Math.POSITIVE_INFINITY &&
-			FlxMath.getDistance(justPressedPosition, pointer.getScreenPosition()) > maxInputMovement &&
+			justPressedPosition.distanceTo(pointer.getScreenPosition(FlxPoint.weak())) > maxInputMovement &&
 			input == currentInput)
 		{
 			currentInput == null;


### PR DESCRIPTION
It's pretty redundant since `FlxPoint` has a `distanceTo()`.

Technically it would be nicer if all distance-related functions in `FlxMath` were using that + `getPosition()`, but that might be bad for performance? Either way not an issue here, since you already have a `FlxPoint` object when calling `FlxMath.getDistance()`.