### PR TITLE
FlxText: fix blurry lines on Flash with center alignment

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -161,10 +161,12 @@ class FlxText extends FlxSprite
 	
 	private var _hasBorderAlpha = false;
 	
+	#if flash
 	/**
 	 * Helper to draw line by line used at drawTextFieldTo().
 	 */
 	private var _textFieldRect:Rectangle = new Rectangle();
+	#end
 	
 	/**
 	 * Creates a new FlxText object at the specified position.
@@ -821,10 +823,13 @@ class FlxText extends FlxSprite
 		resetFrame();
 	}
 	
+	/**
+	 * Internal function to draw textField to a bitmapData, if flash it calculates every line x to avoid blurry lines.
+	 */
 	private function drawTextFieldTo(graphic:BitmapData):Void
 	{
 		#if flash
-		if (alignment == FlxTextAlign.CENTER)
+		if (alignment == FlxTextAlign.CENTER && isTextBlurry())
 		{
 			var h:Int = 0;
 			var tx:Float = _matrix.tx;
@@ -852,6 +857,24 @@ class FlxText extends FlxSprite
 		
 		graphic.draw(textField, _matrix);
 	}
+	
+	#if flash
+	/**
+	 * Helper function for drawTextFieldTo(), this checks if thw workaround is needed to prevent blurry lines.
+	 */
+	private function isTextBlurry():Bool
+	{
+		for (i in 0...textField.numLines) 
+		{
+			var lineMetricsX = textField.getLineMetrics(i).x;
+			if (lineMetricsX - Std.int(lineMetricsX) != 0)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+	#end
 	
 	override public function draw():Void 
 	{

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -162,6 +162,11 @@ class FlxText extends FlxSprite
 	private var _hasBorderAlpha = false;
 	
 	/**
+	 * Helper to draw line by line used at drawTextFieldTo().
+	 */
+	private var _textFieldRect:Rectangle = new Rectangle();
+	
+	/**
 	 * Creates a new FlxText object at the specified position.
 	 * 
 	 * @param   X              The X position of the text.
@@ -821,23 +826,22 @@ class FlxText extends FlxSprite
 		#if flash
 		if (alignment == FlxTextAlign.CENTER)
 		{
-			// Prevents blurry lines.
 			var h:Int = 0;
-			var old_tx:Float = _matrix.tx;
-			var rect:Rectangle = new Rectangle();
+			var tx:Float = _matrix.tx;
 			for (i in 0...textField.numLines) 
 			{
 				var lineMetrics = textField.getLineMetrics(i);
+				
+				// Workaround for blurry lines caused by non-integer x positions on flash
 				if (lineMetrics.x != Std.int(lineMetrics.x))
 				{
-					_matrix.tx = old_tx + 0.5;
+					_matrix.tx = tx + 0.5;
 				}
+				_textFieldRect.setTo(0, h, textField.width, lineMetrics.height + lineMetrics.descent);
 				
-				rect.setTo(0, h, textField.width, lineMetrics.height + lineMetrics.descent);
+				graphic.draw(textField, _matrix, null, null, _textFieldRect, false);
 				
-				graphic.draw(textField, _matrix, null, null, rect, false);
-				
-				_matrix.tx = old_tx;
+				_matrix.tx = tx;
 				h += Std.int(lineMetrics.height);
 			}
 			

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -833,9 +833,10 @@ class FlxText extends FlxSprite
 				var lineMetrics = textField.getLineMetrics(i);
 				
 				// Workaround for blurry lines caused by non-integer x positions on flash
-				if (lineMetrics.x != Std.int(lineMetrics.x))
+				var diff:Float = lineMetrics.x - Std.int(lineMetrics.x);
+				if (diff != 0)
 				{
-					_matrix.tx = tx + 0.5;
+					_matrix.tx = tx + diff;
 				}
 				_textFieldRect.setTo(0, h, textField.width, lineMetrics.height + lineMetrics.descent);
 				

--- a/tests/unit/src/flixel/text/FlxTextTest.hx
+++ b/tests/unit/src/flixel/text/FlxTextTest.hx
@@ -3,6 +3,7 @@ package flixel.text;
 import flixel.system.FlxAssets;
 import flixel.text.FlxText;
 import flixel.text.FlxText.FlxTextAlign;
+import flixel.util.FlxColor;
 import massive.munit.Assert;
 
 class FlxTextTest extends FlxTest
@@ -39,5 +40,23 @@ class FlxTextTest extends FlxTest
 		Assert.isNotNull(text.graphic);
 		Assert.areNotEqual(0, text.frameWidth);
 		Assert.areNotEqual(0, text.frameHeight);
+	}
+	
+	@Test // #1422
+	function testBlurryLines()
+	{
+		text = new FlxText(0, 0, 120, "Text with some blur\none line without blur\nand another with blur");
+		text.alignment = FlxTextAlign.CENTER;
+		text.drawFrame();
+		
+		var graphic = text.updateFramePixels();
+		for (x in 0...graphic.width)
+		{
+			for (y in 0...graphic.height)
+			{
+				var color = graphic.getPixel32(x, y);
+				Assert.isFalse(color != FlxColor.WHITE && color != FlxColor.TRANSPARENT);
+			}
+		}
 	}
 }

--- a/tests/unit/src/flixel/text/FlxTextTest.hx
+++ b/tests/unit/src/flixel/text/FlxTextTest.hx
@@ -42,6 +42,7 @@ class FlxTextTest extends FlxTest
 		Assert.areNotEqual(0, text.frameHeight);
 	}
 	
+	#if !html5
 	@Test // #1422
 	function testBlurryLines()
 	{
@@ -59,4 +60,5 @@ class FlxTextTest extends FlxTest
 			}
 		}
 	}
+	#end
 }


### PR DESCRIPTION
This is a better fix for the old blurry lines bug on flash.

original issue: https://github.com/HaxeFlixel/flixel/issues/1422
last tricky to fix it: https://github.com/adrianulima/flixel/commit/cbbd73090b9ff6b2291e66e67d190f06cbdcdc70
remove commit: https://github.com/HaxeFlixel/flixel/commit/1040f3242caba8989fa3ba754c4c5f985d3b405a