### PR TITLE
Fixed Bug

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -42,10 +42,10 @@ class GraphicAutoAlt extends BitmapData {}
 class FlxTilemap extends FlxBaseTilemap<FlxTile>
 {
 	/** 
-	 * A helper buffer for calculating number of columns and rows when the game size changed
+ 	 * A helper buffer for calculating number of columns and rows when the game size changed
 	 * We are only using its member functions that's why it is an empty instance
-	 */
-	private static var _helperBuffer:FlxTilemapBuffer = Type.createEmptyInstance(FlxTilemapBuffer);
+ 	 */
+ 	private static var _helperBuffer:FlxTilemapBuffer = Type.createEmptyInstance(FlxTilemapBuffer);
 	
 	// TODO: remove this hack and add docs about how to avoid tearing problem by preparing assets and some code...
 	/**
@@ -510,18 +510,18 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	{
 		var results:Bool = false;
 		
-		var xPos:Float = x;
-		var yPos:Float = y;
+		var X:Float = x;
+		var Y:Float = y;
 		
 		if (Position != null)
 		{
-			xPos = Position.x;
-			yPos = Position.y;
+			X = Position.x;
+			Y = Position.y;
 		}
 		
 		// Figure out what tiles we need to check against
-		var selectionX:Int = Math.floor((Object.x - xPos) / _scaledTileWidth);
-		var selectionY:Int = Math.floor((Object.y - yPos) / _scaledTileHeight);
+		var selectionX:Int = Math.floor((Object.x - X) / _scaledTileWidth);
+		var selectionY:Int = Math.floor((Object.y - Y) / _scaledTileHeight);
 		var selectionWidth:Int = selectionX + Math.ceil(Object.width / _scaledTileWidth) + 1;
 		var selectionHeight:Int = selectionY + Math.ceil(Object.height / _scaledTileHeight) + 1;
 		
@@ -536,8 +536,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		var column:Int;
 		var tile:FlxTile;
 		var overlapFound:Bool;
-		var deltaX:Float = xPos - last.x;
-		var deltaY:Float = yPos - last.y;
+		var deltaX:Float = X - last.x;
+		var deltaY:Float = Y - last.y;
 		
 		for (row in selectionY...selectionHeight)
 		{
@@ -562,14 +562,13 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				tile = _tileObjects[dataIndex];
 				tile.width = _scaledTileWidth;
 				tile.height = _scaledTileHeight;
-				tile.x = xPos + column * tile.width;
-				tile.y = yPos + row * tile.height;
+				tile.x = X + column * tile.width;
+				tile.y = Y + row * tile.height;
 				tile.last.x = tile.x - deltaX;
 				tile.last.y = tile.y - deltaY;
 				
-				overlapFound =
-					((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) && 
-					((Object.y + Object.height) > tile.y) && (Object.y < (tile.y + tile.height));
+				overlapFound = ((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) && 
+				               ((Object.y + Object.height) > tile.y) && (Object.y < (tile.y + tile.height));
 				
 				if (tile.allowCollisions != FlxObject.NONE)
 				{
@@ -636,7 +635,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 */
 	public function getTileCoords(Index:Int, Midpoint:Bool = true):Array<FlxPoint>
 	{
-		var array:Array<FlxPoint> = null;
+		var array:Array<FlxPoint> = new Array<FlxPoint>();
 		
 		var point:FlxPoint;
 		var l:Int = widthInTiles * heightInTiles;
@@ -653,10 +652,6 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					point.y += _scaledTileHeight * 0.5;
 				}
 				
-				if (array == null)
-				{
-					array = new Array<FlxPoint>();
-				}
 				array.push(point);
 			}
 		}
@@ -1057,7 +1052,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	/**
 	 * Signal listener for gameResize 
 	 */
-	private function onGameResize(_, _):Void
+	private function onGameResize(_,_):Void
 	{
 		if (graphic == null)
 			return;


### PR DESCRIPTION
Fixed Null Pointer Exception when used with FlxNapeTileMap.hx:103;
coords may be null before this fix, result in program halt.
This may cause problem in other places if they expect null.