### PR TITLE
Implementing FlxTIleFilter logic

### DIFF
--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -11,18 +11,10 @@ import flixel.graphics.frames.FlxFrame;
 class FlxTile extends FlxObject
 {
 	/**
-	 * This function is called whenever an object hits a tile of this type.
-	 * This function should take the form myFunction(Tile:FlxTile,Object:FlxObject):void.
-	 * Defaults to null, set through FlxTilemap.setTileProperties().
+	 * Filters used for overlap/collision vs different classes on this tile.
+	 * Use `FlxBaseTilemap.addTileFilter()` and `FlxBaseTilemap.removeTileFilter()`
 	 */
-	public var callbackFunction:FlxObject->FlxObject->Void = null;
-	/**
-	 * Each tile can store its own filter class for their callback functions.
-	 * That is, the callback will only be triggered if an object with a class
-	 * type matching the filter touched it.
-	 * Defaults to null, set through FlxTilemap.setTileProperties().
-	 */
-	public var filter:Class<FlxObject>;
+	public var filters:Map<String, FlxTileFilter> = null;
 	/**
 	 * A reference to the tilemap this tile object belongs to.
 	 */
@@ -73,10 +65,49 @@ class FlxTile extends FlxObject
 	 */
 	override public function destroy():Void
 	{
-		callbackFunction = null;
+		if (filters != null)
+		{
+			for (f in filters)
+			{
+				f.overlapCallback = null;
+				f.processCallback = null;
+				f = null;
+			}
+			filters = null;
+		}
 		tilemap = null;
 		frame = null;
 		
 		super.destroy();
 	}
+}
+class FlxTileFilter
+{
+	/**
+	 * Collision flags for this filter.
+	 * Defaults to ANY
+	 */
+	public var collisions:Int = FlxObject.ANY;
+	
+	/**
+	 * This function is called whenever an object hits a tile of this type.
+	 * This function should take the form myFunction(Tile:FlxTile,Object:FlxObject):Void.
+	 * Defaults to null
+	 */
+	public var overlapCallback:FlxTile->FlxObject->Void = null;
+	
+	/**
+	 * This function, if set, will be called when overlap is detected, and `overlapCallback` will only be called if this returns `true`.
+	 * Should take the form of myFunction(Tile:FlxTile,Object:FlxObject):Bool
+	 * Use `FlxObject.seperate()` to allow collision on this tile.
+	 */
+	public var processCallback:FlxTile->FlxObject->Bool = null;
+	
+	public function new(?collisions:Int = FlxObject.ANY, ?overlapCallback:FlxTile->FlxObject->Void, ?processCallback:FlxTile->FlxObject->Bool)
+	{
+		this.collisions = collisions;
+		this.overlapCallback = overlapCallback;
+		this.processCallback = processCallback;
+	}
+	
 }

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -19,6 +19,7 @@ import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxTilemapGraphicAsset;
+import flixel.tile.FlxTile.FlxTileFilter;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
@@ -571,33 +572,63 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) && 
 					((Object.y + Object.height) > tile.y) && (Object.y < (tile.y + tile.height));
 				
-				if (tile.allowCollisions != FlxObject.NONE)
-				{
-					if (Callback != null)
-					{
-						if (FlipCallbackParams)
-						{
-							overlapFound = Callback(Object, tile);
-						}
-						else
-						{
-							overlapFound = Callback(tile, Object);
-						}
-					}
-				}
-				
 				if (overlapFound)
 				{
-					if ((tile.callbackFunction != null) && ((tile.filter == null) || Std.is(Object, tile.filter)))
+					var tileFilter:FlxTileFilter = null;
+					var tmpCollisions:Int = FlxObject.ANY;
+					var classType:String = "";
+					if (tile.filters != null)
 					{
-						tile.mapIndex = rowStart + column;
-						tile.callbackFunction(tile, Object);
+						classType = Type.getClassName(Type.getClass(Object));
+						if (tile.filters.exists(classType))
+						{
+							tileFilter = tile.filters.get(classType);
+							tmpCollisions = tile.allowCollisions;
+							tile.allowCollisions = tileFilter.collisions;
+							if (tileFilter.processCallback != null)
+							{
+								overlapFound = tileFilter.processCallback(tile, Object);							
+							}
+						}
+					}
+					if (tile.allowCollisions != FlxObject.NONE && overlapFound)
+					{
+						if (Callback != null)
+						{
+							if (FlipCallbackParams)
+							{
+								overlapFound = Callback(Object, tile);
+							}
+							else
+							{
+								overlapFound = Callback(tile, Object);
+							}
+						}
 					}
 					
-					if (tile.allowCollisions != FlxObject.NONE)
+					if (overlapFound)
 					{
-						results = true;
+						if (tileFilter != null && tileFilter.overlapCallback != null)
+						{
+							tile.mapIndex = rowStart + column;
+							tileFilter.overlapCallback(tile, Object);
+ 
+						}
+						
+						if (tile.allowCollisions != FlxObject.NONE)
+                        {
+                            results = true;
+                        }
+						
+						if (tileFilter != null)
+                        {
+							tile.allowCollisions = tmpCollisions;
+							tileFilter = null;
+							classType = null;
+						}
+						
 					}
+					
 				}
 				
 				column++;


### PR DESCRIPTION
I tried to implement this before, but, there was something wrong with my repo and I never figured out how to fix it - and then promptly forgot about it.

So, here it is again, hopefully better than before: FlxTileFilter.

Instead of setting a single callback for a tile/range of tiles in a FlxTilemap, you can now set multiple filters to be triggered by different Classes.

You can set it up so that your Enemy class can pass through certain tiles, while your Player cannot, and much more.

Usage is `myTilemap.addTileFilter(5, MyPlayerObject, FlxObject.UP, collisionCallback, processCallback, 2);`

This will set tiles 5 and 6 to have the `MyPlayerObject` collide with the top of the tile only, call `processCallback` to do some pre-collision checks, and then `collisionCallback` if the `processCallback` returns `true`.

You can use multiple `addTileFilter`s on the same Tilemap.

Use `removeTileFilter` to remove a specific filter.