### PR TITLE
Add FlxMath.fastFloor()

### DIFF
--- a/flixel/animation/FlxPrerotatedAnimation.hx
+++ b/flixel/animation/FlxPrerotatedAnimation.hx
@@ -1,6 +1,7 @@
 package flixel.animation;
 
 import flixel.animation.FlxBaseAnimation;
+import flixel.math.FlxMath;
 
 /**
  * ...
@@ -26,14 +27,14 @@ class FlxPrerotatedAnimation extends FlxBaseAnimation
 	private function set_angle(Value:Float):Float
 	{
 		var oldIndex:Int = curIndex;
-		var angleHelper:Int = Math.floor(Value % 360);
+		var angleHelper:Int = FlxMath.fastFloor(Value % 360);
 		
 		while (angleHelper < 0)
 		{
 			angleHelper += 360;
 		}
 		
-		var newIndex:Int = Math.floor(angleHelper / baked + 0.5);
+		var newIndex:Int = FlxMath.fastFloor(angleHelper / baked + 0.5);
 		newIndex = Std.int(newIndex % rotations);
 		if (oldIndex != newIndex)
 		{

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -201,7 +201,7 @@ class FlxMath
 		
 		if (useWorldCoords)
 		{
-			return pointInFlxRect(Math.floor(FlxG.mouse.x), Math.floor(FlxG.mouse.y), rect);
+			return pointInFlxRect(fastFloor(FlxG.mouse.x), fastFloor(FlxG.mouse.y), rect);
 		}
 		else
 		{

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -568,4 +568,12 @@ class FlxMath
 		return (a > 0) ? a : -a;
 	}
 	
+	/**
+	 * Floors the argument. Same as Math.floor, but faster.
+	 */
+	public static inline function fastFloor(f:Float):Int
+	{
+		return f >= 0 ? Std.int(f) : Std.int(f - 1);
+	}
+	
 }

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -570,6 +570,7 @@ class FlxMath
 	
 	/**
 	 * Floors the argument. Same as Math.floor, but faster.
+	 * WARNING: This will not work for NaN or numbers that are outside the bounds of a 32-bit integer.
 	 */
 	public static inline function fastFloor(f:Float):Int
 	{

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -281,12 +281,12 @@ class FlxPoint implements IFlxPooled
 	}
 	
 	/**
-	 * Rounds x and y using Math.floor()
+	 * Rounds x and y using FlxMath.fastFloor()
 	 */
 	public inline function floor():FlxPoint
 	{
-		x = Math.floor(x);
-		y = Math.floor(y);
+		x = FlxMath.fastFloor(x);
+		y = FlxMath.fastFloor(y);
 		return this;
 	}
 	

--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -82,7 +82,7 @@ class FlxRandom
 			
 			if (Excludes == null)
 			{
-				return Math.floor(Min + generate() / MODULUS * (Max - Min + 1));
+				return FlxMath.fastFloor(Min + generate() / MODULUS * (Max - Min + 1));
 			}
 			else
 			{
@@ -90,7 +90,7 @@ class FlxRandom
 				
 				do
 				{
-					result = Math.floor(Min + generate() / MODULUS * (Max - Min + 1));
+					result = FlxMath.fastFloor(Min + generate() / MODULUS * (Max - Min + 1));
 				}
 				while (Excludes.indexOf(result) >= 0);
 				

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -258,14 +258,14 @@ class FlxRect implements IFlxPooled
 	}
 	
 	/**
-	 * Rounds x, y, width and height using Math.floor()
+	 * Rounds x, y, width and height using FlxMath.fastFloor()
 	 */
 	public inline function floor():FlxRect
 	{
-		x = Math.floor(x);
-		y = Math.floor(y);
-		width = Math.floor(width);
-		height = Math.floor(height);
+		x = FlxMath.fastFloor(x);
+		y = FlxMath.fastFloor(y);
+		width = FlxMath.fastFloor(width);
+		height = FlxMath.fastFloor(height);
 		return this;
 	}
 	

--- a/flixel/system/FlxQuadTree.hx
+++ b/flixel/system/FlxQuadTree.hx
@@ -3,6 +3,7 @@ package flixel.system;
 import flixel.FlxBasic;
 import flixel.FlxObject;
 import flixel.group.FlxGroup.FlxTypedGroup;
+import flixel.math.FlxMath;
 import flixel.math.FlxRect;
 import flixel.util.FlxDestroyUtil;
 
@@ -286,7 +287,7 @@ class FlxQuadTree extends FlxRect
 		}
 		else
 		{
-			_min = Math.floor((width + height) / (2 * divisions));
+			_min = FlxMath.fastFloor((width + height) / (2 * divisions));
 		}
 		_canSubdivide = (width > _min) || (height > _min);
 		

--- a/flixel/system/replay/FrameRecord.hx
+++ b/flixel/system/replay/FrameRecord.hx
@@ -1,4 +1,5 @@
 package flixel.system.replay;
+import flixel.math.FlxMath;
 
 /**
  * Helper class for the new replay system.  Represents all the game inputs for one "frame" or "step" of the game loop.
@@ -37,7 +38,7 @@ class FrameRecord
 	 */
 	public function create(Frame:Float, ?Keys:Array<CodeValuePair>, ?Mouse:MouseRecord):FrameRecord
 	{
-		frame = Math.floor(Frame);
+		frame = FlxMath.fastFloor(Frame);
 		keys = Keys;
 		mouse = Mouse;
 		

--- a/flixel/system/scaleModes/PixelPerfectScaleMode.hx
+++ b/flixel/system/scaleModes/PixelPerfectScaleMode.hx
@@ -1,6 +1,7 @@
 package flixel.system.scaleModes;
 
 import flixel.FlxG;
+import flixel.math.FlxMath;
 
 /**
  * A scale mode which scales up the game to the highest integer factor it can,
@@ -12,7 +13,7 @@ class PixelPerfectScaleMode extends BaseScaleMode
 	{
 		var scaleFactorX:Float = Width / FlxG.width;
 		var scaleFactorY:Float = Height / FlxG.height;
-		var scaleFactor:Int = Math.floor(Math.min(scaleFactorX, scaleFactorY));
+		var scaleFactor:Int = FlxMath.fastFloor(Math.min(scaleFactorX, scaleFactorY));
 		
 		// If the scale factor is less than zero, set it to one and crop
 		if (scaleFactor < 1)

--- a/flixel/system/scaleModes/RatioScaleMode.hx
+++ b/flixel/system/scaleModes/RatioScaleMode.hx
@@ -1,6 +1,7 @@
 package flixel.system.scaleModes;
 
 import flixel.FlxG;
+import flixel.math.FlxMath;
 
 class RatioScaleMode extends BaseScaleMode
 {
@@ -30,12 +31,12 @@ class RatioScaleMode extends BaseScaleMode
 		if (scaleY)
 		{
 			gameSize.x = Width;
-			gameSize.y = Math.floor(gameSize.x / ratio);
+			gameSize.y = FlxMath.fastFloor(gameSize.x / ratio);
 		}
 		else
 		{
 			gameSize.y = Height;
-			gameSize.x = Math.floor(gameSize.y * ratio);
+			gameSize.x = FlxMath.fastFloor(gameSize.y * ratio);
 		}
 	}
 }

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -367,8 +367,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		// Modified from getScreenPosition()
 		_point.x = (Camera.scroll.x * scrollFactor.x) - x; 
 		_point.y = (Camera.scroll.y * scrollFactor.y) - y;
-		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
-		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);
+		var screenXInTiles:Int = FlxMath.fastFloor(_point.x / _scaledTileWidth);
+		var screenYInTiles:Int = FlxMath.fastFloor(_point.y / _scaledTileHeight);
 		var screenRows:Int = buffer.rows;
 		var screenColumns:Int = buffer.columns;
 		
@@ -392,7 +392,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				if (tile != null && tile.visible)
 				{
 					drawX = _helperPoint.x + (columnIndex % widthInTiles) * rectWidth;
-					drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * rectHeight;
+					drawY = _helperPoint.y + FlxMath.fastFloor(columnIndex / widthInTiles) * rectHeight;
 					
 					if (tile.allowCollisions <= FlxObject.NONE)
 					{
@@ -520,8 +520,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		}
 		
 		// Figure out what tiles we need to check against
-		var selectionX:Int = Math.floor((Object.x - xPos) / _scaledTileWidth);
-		var selectionY:Int = Math.floor((Object.y - yPos) / _scaledTileHeight);
+		var selectionX:Int = FlxMath.fastFloor((Object.x - xPos) / _scaledTileWidth);
+		var selectionY:Int = FlxMath.fastFloor((Object.y - yPos) / _scaledTileHeight);
 		var selectionWidth:Int = selectionX + Math.ceil(Object.width / _scaledTileWidth) + 1;
 		var selectionHeight:Int = selectionY + Math.ceil(Object.height / _scaledTileHeight) + 1;
 		
@@ -727,8 +727,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				continue;
 			}
 			
-			tileX = Math.floor(curX / _scaledTileWidth);
-			tileY = Math.floor(curY / _scaledTileHeight);
+			tileX = FlxMath.fastFloor(curX / _scaledTileWidth);
+			tileY = FlxMath.fastFloor(curY / _scaledTileHeight);
 			
 			if (_tileObjects[_data[tileY * widthInTiles + tileX]].allowCollisions != FlxObject.NONE)
 			{
@@ -869,8 +869,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		{
 			getScreenPosition(_point, Camera).subtractPoint(offset).copyToFlash(_helperPoint);
 			
-			_helperPoint.x = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
-			_helperPoint.y = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;
+			_helperPoint.x = isPixelPerfectRender(Camera) ? FlxMath.fastFloor(_helperPoint.x) : _helperPoint.x;
+			_helperPoint.y = isPixelPerfectRender(Camera) ? FlxMath.fastFloor(_helperPoint.y) : _helperPoint.y;
 			
 			scaledWidth  = _scaledTileWidth;
 			scaledHeight = _scaledTileHeight;
@@ -883,8 +883,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_point.x = (Camera.scroll.x * scrollFactor.x) - x - offset.x; //modified from getScreenPosition()
 		_point.y = (Camera.scroll.y * scrollFactor.y) - y - offset.y;
 		
-		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
-		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);
+		var screenXInTiles:Int = FlxMath.fastFloor(_point.x / _scaledTileWidth);
+		var screenYInTiles:Int = FlxMath.fastFloor(_point.y / _scaledTileHeight);
 		var screenRows:Int = Buffer.rows;
 		var screenColumns:Int = Buffer.columns;
 		
@@ -947,7 +947,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					else
 					{
 						drawX = _helperPoint.x + (columnIndex % widthInTiles) * scaledWidth;
-						drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * scaledHeight;
+						drawY = _helperPoint.y + FlxMath.fastFloor(columnIndex / widthInTiles) * scaledHeight;
 						
 						_matrix.identity();
 						

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -6,6 +6,7 @@ import flash.geom.Point;
 import flash.geom.Rectangle;
 import flixel.FlxCamera;
 import flixel.FlxG;
+import flixel.math.FlxMath;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil.IFlxDestroyable;
 import openfl.display.BlendMode;
@@ -124,8 +125,8 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	{
 		if (isPixelPerfectRender(Camera))
 		{
-			FlashPoint.x = Math.floor(FlashPoint.x);
-			FlashPoint.y = Math.floor(FlashPoint.y);
+			FlashPoint.x = FlxMath.fastFloor(FlashPoint.x);
+			FlashPoint.y = FlxMath.fastFloor(FlashPoint.y);
 		}
 		
 		if (isPixelPerfectRender(Camera) && (ScaleX == 1.0 && ScaleY == 1.0) && blend == null)

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -12,6 +12,7 @@ import flixel.graphics.frames.FlxFrame;
 import flixel.graphics.frames.FlxFramesCollection;
 import flixel.graphics.frames.FlxImageFrame;
 import flixel.graphics.tile.FlxDrawTilesItem;
+import flixel.math.FlxMath;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.ui.FlxBar.FlxBarFillDirection;
 import flixel.math.FlxAngle;
@@ -891,7 +892,7 @@ class FlxBar extends FlxSprite
 			return 100;
 		}
 		
-		return Math.floor((value / range) * 100);
+		return FlxMath.fastFloor((value / range) * 100);
 	}
 
 	private function set_percent(newPct:Float):Float

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -477,8 +477,8 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		if (_spriteLabel != null) // Label positioning
 		{
-			_spriteLabel.x = (pixelPerfectPosition ? Math.floor(x) : x) + labelOffsets[status].x;
-			_spriteLabel.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status].y;
+			_spriteLabel.x = (pixelPerfectPosition ? FlxMath.fastFloor(x) : x) + labelOffsets[status].x;
+			_spriteLabel.y = (pixelPerfectPosition ? FlxMath.fastFloor(y) : y) + labelOffsets[status].y;
 		}
 	}
 	

--- a/flixel/util/FlxCollision.hx
+++ b/flixel/util/FlxCollision.hx
@@ -125,7 +125,7 @@ class FlxCollision
 			testMatrix.translate(boundsA.width / 2, boundsA.height / 2);
 			
 			// prepare an empty canvas
-			var testA2:BitmapData = FlxBitmapDataPool.get(Math.floor(boundsA.width), Math.floor(boundsA.height), true, FlxColor.TRANSPARENT, false);
+			var testA2:BitmapData = FlxBitmapDataPool.get(FlxMath.fastFloor(boundsA.width), FlxMath.fastFloor(boundsA.height), true, FlxColor.TRANSPARENT, false);
 			
 			// plot the sprite using the matrix
 			testA2.draw(testA, testMatrix, null, null, null, false);
@@ -137,7 +137,7 @@ class FlxCollision
 			testMatrix.rotate(Target.angle * FlxAngle.TO_RAD);
 			testMatrix.translate(boundsB.width / 2, boundsB.height / 2);
 			
-			var testB2:BitmapData = FlxBitmapDataPool.get(Math.floor(boundsB.width), Math.floor(boundsB.height), true, FlxColor.TRANSPARENT, false);
+			var testB2:BitmapData = FlxBitmapDataPool.get(FlxMath.fastFloor(boundsB.width), FlxMath.fastFloor(boundsB.height), true, FlxColor.TRANSPARENT, false);
 			testB2.draw(testB, testMatrix, null, null, null, false);
 			testB = testB2;
 		}
@@ -217,8 +217,8 @@ class FlxCollision
 	public static function pixelPerfectPointCheck(PointX:Int, PointY:Int, Target:FlxSprite, AlphaTolerance:Int = 1):Bool
 	{
 		// Intersect check
-		if (!FlxMath.pointInCoordinates(PointX, PointY, Math.floor(Target.x),
-			Math.floor(Target.y), Std.int(Target.width), Std.int(Target.height)))
+		if (!FlxMath.pointInCoordinates(PointX, PointY, FlxMath.fastFloor(Target.x),
+			FlxMath.fastFloor(Target.y), Std.int(Target.width), Std.int(Target.height)))
 		{
 			return false;
 		}
@@ -231,7 +231,7 @@ class FlxCollision
 		// How deep is pointX/Y within the rect?
 		var test:BitmapData = Target.framePixels;
 		
-		var pixelAlpha = FlxColor.fromInt(test.getPixel32(Math.floor(PointX - Target.x), Math.floor(PointY - Target.y))).alpha;
+		var pixelAlpha = FlxColor.fromInt(test.getPixel32(FlxMath.fastFloor(PointX - Target.x), FlxMath.fastFloor(PointY - Target.y))).alpha;
 		
 		if (FlxG.renderTile)
 		{
@@ -267,10 +267,10 @@ class FlxCollision
 		
 		if (PlaceOutside)
 		{
-			left = new FlxTileblock(Math.floor(Camera.x - Thickness), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
-			right = new FlxTileblock(Math.floor(Camera.x + Camera.width), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
-			top = new FlxTileblock(Math.floor(Camera.x - Thickness), Math.floor(Camera.y - Thickness), Camera.width + Thickness * 2, Thickness);
-			bottom = new FlxTileblock(Math.floor(Camera.x - Thickness), Camera.height, Camera.width + Thickness * 2, Thickness);
+			left = new FlxTileblock(FlxMath.fastFloor(Camera.x - Thickness), FlxMath.fastFloor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
+			right = new FlxTileblock(FlxMath.fastFloor(Camera.x + Camera.width), FlxMath.fastFloor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
+			top = new FlxTileblock(FlxMath.fastFloor(Camera.x - Thickness), FlxMath.fastFloor(Camera.y - Thickness), Camera.width + Thickness * 2, Thickness);
+			bottom = new FlxTileblock(FlxMath.fastFloor(Camera.x - Thickness), Camera.height, Camera.width + Thickness * 2, Thickness);
 			
 			if (AdjustWorldBounds)
 			{
@@ -279,10 +279,10 @@ class FlxCollision
 		}
 		else
 		{
-			left = new FlxTileblock(Math.floor(Camera.x), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
-			right = new FlxTileblock(Math.floor(Camera.x + Camera.width - Thickness), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
-			top = new FlxTileblock(Math.floor(Camera.x), Math.floor(Camera.y), Camera.width, Thickness);
-			bottom = new FlxTileblock(Math.floor(Camera.x), Camera.height - Thickness, Camera.width, Thickness);
+			left = new FlxTileblock(FlxMath.fastFloor(Camera.x), FlxMath.fastFloor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
+			right = new FlxTileblock(FlxMath.fastFloor(Camera.x + Camera.width - Thickness), FlxMath.fastFloor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
+			top = new FlxTileblock(FlxMath.fastFloor(Camera.x), FlxMath.fastFloor(Camera.y), Camera.width, Thickness);
+			bottom = new FlxTileblock(FlxMath.fastFloor(Camera.x), Camera.height - Thickness, Camera.width, Thickness);
 			
 			if (AdjustWorldBounds)
 			{

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -112,7 +112,7 @@ class FlxStringUtil
 	public static inline function formatMoney(Amount:Float, ShowDecimal:Bool = true, EnglishStyle:Bool = true):String
 	{
 		var helper:Int;
-		var amount:Int = Math.floor(Amount);
+		var amount:Int = FlxMath.fastFloor(Amount);
 		var string:String = "";
 		var comma:String = "";
 		var zeroes:String = "";
@@ -130,8 +130,8 @@ class FlxStringUtil
 				}
 			}
 			zeroes = "";
-			helper = amount - Math.floor(amount / 1000) * 1000;
-			amount = Math.floor(amount / 1000);
+			helper = amount - FlxMath.fastFloor(amount / 1000) * 1000;
+			amount = FlxMath.fastFloor(amount / 1000);
 			if (amount > 0)
 			{
 				if (helper < 100)


### PR DESCRIPTION
It kinda looks like the function call to `Math.floor` takes longer than actually flooring on js. `fastFloor` was about 20x faster in my little test suite with analyzer off.

Not sure if there's a `fastCeil`. I was also thinking about using `fastSin` and `fastCos` throughout the library, but that's technically a breaking change?