### PR TITLE
Include .mp3 sounds in HTML5 for Internet Explorer support

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -3,7 +3,7 @@
 	<icon path="assets/images/logo/HaxeFlixel.svg" />
 	
 	<assets path="assets/sounds" rename="flixel/sounds" include="*.ogg" if="html5" unless="unit-test" />
-	<assets path="assets/sounds" rename="flixel/sounds" include="*.mp3" if="flash" embed="true" />
+	<assets path="assets/sounds" rename="flixel/sounds" include="*.mp3" if="flash || html5" embed="true" />
 	<assets path="assets/sounds" rename="flixel/sounds" include="*.ogg" unless="flash || html5" embed="true" />
 	<assets path="assets/fonts/nokiafc22.ttf" rename="flixel/fonts/nokiafc22.ttf" embed="true" />
 	<assets path="assets/fonts/monsterrat.ttf" rename="flixel/fonts/monsterrat.ttf" embed="true" />


### PR DESCRIPTION
Currently, the html5 export won't run in Internet Explorer. This is because it expects mp3 versions of all audio files, and when those aren't found, it gets stuck on the loading screen.
Therefore, I simply modified include.xml so that mp3s are included in HTML5 as well as Flash. Ogg sounds are still included alongside; some browsers like Firefox depend on the OS for mp3 codecs, so ogg is preferred in those cases.