### PR TITLE
FlxObject: fix overlapsPoint() if overlap is at x or y = 0

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -781,7 +781,7 @@ class FlxObject extends FlxBasic
 	{
 		if (!InScreenSpace)
 		{
-			return (point.x > x) && (point.x < x + width) && (point.y > y) && (point.y < y + height);
+			return (point.x >= x) && (point.x < x + width) && (point.y >= y) && (point.y < y + height);
 		}
 		
 		if (Camera == null)
@@ -792,7 +792,7 @@ class FlxObject extends FlxBasic
 		var yPos:Float = point.y - Camera.scroll.y;
 		getScreenPosition(_point, Camera);
 		point.putWeak();
-		return (xPos > _point.x) && (xPos < _point.x + width) && (yPos > _point.y) && (yPos < _point.y + height);
+		return (xPos >= _point.x) && (xPos < _point.x + width) && (yPos >= _point.y) && (yPos < _point.y + height);
 	}
 	
 	/**

--- a/tests/unit/src/flixel/ui/FlxButtonTest.hx
+++ b/tests/unit/src/flixel/ui/FlxButtonTest.hx
@@ -12,7 +12,7 @@ class FlxButtonTest extends FlxTest
 	@Before
 	function before()
 	{
-		button = new FlxButton(1); // put it slightly to the right of the cursor so that it isn't highlighted by default
+		button = new FlxButton();
 		destroyable = button;
 	}
 	
@@ -66,10 +66,23 @@ class FlxButtonTest extends FlxTest
 	{
 		setAndAssertText(null);
 	}
+
+	@Test // #1818
+	function testHighlightStatusInUpperLeftCorner()
+	{
+		FlxG.state.add(button);
+
+		button.setPosition();
+		step(1);
+		Assert.areEqual(FlxButton.HIGHLIGHT, button.status);
+
+		FlxG.state.remove(button);
+	}
 	
 	@Test // #1365
 	function testTriggerAnimationOnce()
 	{
+		button.x = 1; // put it slightly to the right of the cursor so that it isn't highlighted by default
 		button.animation.add("normal", [for (i in 0...4) 0], 30, false);
 		FlxG.state.add(button);
 		step(2);
@@ -80,6 +93,7 @@ class FlxButtonTest extends FlxTest
 		step(10);
 		Assert.areEqual("normal", button.animation.curAnim.name);
 		Assert.areEqual(true, button.animation.finished);
+		FlxG.state.remove(button);
 	}
 	
 	function setAndAssertText(text:String)

--- a/tests/unit/src/flixel/ui/FlxButtonTest.hx
+++ b/tests/unit/src/flixel/ui/FlxButtonTest.hx
@@ -12,7 +12,7 @@ class FlxButtonTest extends FlxTest
 	@Before
 	function before()
 	{
-		button = new FlxButton();
+		button = new FlxButton(1); // put it slightly to the right of the cursor so that it isn't highlighted by default
 		destroyable = button;
 	}
 	


### PR DESCRIPTION
The top and left edges of checked objects were not registering as overlapping, when they should be.  (Consider the example of a single pixel at 0,0: the former could would never register an overlap with the mouse, always looking for your position to be > 0 and < 1.  Even though it's a float, it still gets updated to integer values when you move the mouse.)

May seem trivial, but when you have a button at the edge of a full-screen game, it becomes important.