### PR TITLE
Fix bug in accelerateFromAngle, and add comment

### DIFF
--- a/flixel/math/FlxVelocity.hx
+++ b/flixel/math/FlxVelocity.hx
@@ -265,16 +265,26 @@ class FlxVelocity
 		}
 		return Velocity;
 	}
-	
+
+	/**
+	 * Sets the x/y acceleration on the source FlxSprite so it will accelerate in the direction of the specified angle.
+	 * You must give a maximum speed value (in pixels per second), beyond which the FlxSprite won't go any faster.
+	 * 
+	 * @param	Source			The FlxSprite on which the acceleration will be set
+	 * @param	Radians			The angle in which the FlxPoint will be set to accelerate
+	 * @param	Acceleration	The speed it will accelerate in pixels per second
+	 * @param	MaxSpeed		The maximum speed in pixels per second in which the sprite can move
+	 * @param	ResetVelocity	Whether to reset the FlxSprite velocity to 0 each time
+	 */
 	public static inline function accelerateFromAngle(source:FlxSprite, radians:Float, acceleration:Float, maxSpeed:Float, resetVelocity:Bool = true):Void
 	{
-		var sin = Math.sin(radians);
-		var cos = Math.cos(radians);
+		var sinA = Math.sin(radians);
+		var cosA = Math.cos(radians);
 		
 		if (resetVelocity)
 			source.velocity.set(0, 0);
 		
-		source.acceleration.set(cos * acceleration, sin * acceleration);
-		source.maxVelocity.set(cos * maxSpeed, sin * maxSpeed);		
+		source.acceleration.set(cosA * acceleration, sinA * acceleration);
+		source.maxVelocity.set(Math.abs(cosA * maxSpeed), Math.abs(sinA * maxSpeed));		
 	}
 }


### PR DESCRIPTION
(Sorry I sent the previous version of this suggestion to the wrong branch, hopefully this is ok…)

The accelerateFromAngle function has a problem in that if sine or cosine of the angle is negative, then the maximum velocity will end up being negative, which it's never supposed to be.

For example, If your current velocity was 10, and you wanted a limit of 100; depending on the angle of rotation you can suddenly end up with a maximum velocity of -100. This makes your velocity of 10 look to be 110 over the maximum. Then you get an extreme change of velocity. In the app I was working on I ended up with a constant oscillation between -100 and +100 from one frame to the next. Adding the Math.abs functions inside accelerateFromAngle, fixes this.