### PR TITLE
fixed  -DhscriptPos support in ConsoleUtil.hx

### DIFF
--- a/flixel/system/debug/console/ConsoleUtil.hx
+++ b/flixel/system/debug/console/ConsoleUtil.hx
@@ -165,15 +165,13 @@ private class Interp extends hscript.Interp
 	
 	override function get(o:Dynamic, f:String):Dynamic
 	{
-		if (o == null)
-			throw hscript.Expr.Error.EInvalidAccess(f);
+		if (o == null) error(EInvalidAccess(f));
 		return Reflect.getProperty(o, f);
 	}
 	
 	override function set(o:Dynamic, f:String, v:Dynamic):Dynamic
 	{
-		if (o == null)
-			throw hscript.Expr.Error.EInvalidAccess(f);
+		if (o == null) error(EInvalidAccess(f));
 		Reflect.setProperty(o, f, v);
 		return v;
 	}


### PR DESCRIPTION
With:
  haxeflixel version 4.0.1
  hscript version >= 2.0.5
...compiling on Neko at least with -DhscriptPos gives compilation error:

flixel/4,0,1/flixel/system/debug/console/ConsoleUtil.hx:156: characters 9-42 : Class<hscript.Error> has no field EInvalidAccess

The proposed fix uses the error() method now defined in hscript's Interp class (following usage in hscript's Interp.hx)