### PR TITLE
Fixes to make the preloader work on HTML5

### DIFF
--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -163,20 +163,17 @@ class FlxBasePreloader extends NMEPreloader
 	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new Bitmap instance is passed as an argument.
 	 * @return  The Bitmap instance that was created.
 	 */
-	private function createBitmap(bitmapDataClass:Class<BitmapData>, ?onLoad:Bitmap->Void):Bitmap
+	private function createBitmap(bitmapDataClass:Class<BitmapData>, onLoad:Bitmap->Void):Bitmap
 	{
 		#if html5
-		if (onLoad != null && Type.getClassFields(bitmapDataClass).indexOf("preload") != -1)
-		{
-			var bmp = new Bitmap();
-			bmp.bitmapData = Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, function(_) onLoad(bmp)]);
-			return bmp;
-		}
-		#end
-		var bmp = new Bitmap(Type.createInstance(bitmapDataClass, [0, 0]));
-		if (onLoad != null)
-			onLoad(bmp);
+		var bmp = new Bitmap();
+		bmp.bitmapData = Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, function(_) onLoad(bmp)]);
 		return bmp;
+		#else
+		var bmp = new Bitmap(Type.createInstance(bitmapDataClass, [0, 0]));
+		onLoad(bmp);
+		return bmp;
+		#end
 	}
 	
 	/**
@@ -193,15 +190,12 @@ class FlxBasePreloader extends NMEPreloader
 	private function loadBitmapData(bitmapDataClass:Class<BitmapData>, onLoad:BitmapData->Void):BitmapData
 	{
 		#if html5
-		if (onLoad != null && Type.getClassFields(bitmapDataClass).indexOf("preload") != -1)
-		{
-			return Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, onLoad]);
-		}
-		#end
+		return Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, onLoad]);
+		#else
 		var bmpData = Type.createInstance(bitmapDataClass, [0, 0]);
-		if (onLoad != null)
-			onLoad(bmpData);
+		onLoad(bmpData);
 		return bmpData;
+		#end
 	}
 	
 	/**

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -52,7 +52,7 @@ class FlxBasePreloader extends NMEPreloader
 	 * @param	MinDisplayTime	Minimum time (in seconds) the preloader should be shown. (Default = 0)
 	 * @param	AllowedURLs		Allowed URLs used for Site-locking. If the game is run anywhere else, a message will be displayed on the screen (Default = [])
 	 */
-	public function new(?MinDisplayTime:Float = 0, ?AllowedURLs:Array<String>)
+	public function new(MinDisplayTime:Float = 0, ?AllowedURLs:Array<String>)
 	{
 		super();
 		

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -154,6 +154,57 @@ class FlxBasePreloader extends NMEPreloader
 	}
 	
 	/**
+	 * This should be used whenever you want to create a Bitmap that uses BitmapData embedded with the
+	 * @:bitmap metadata, if you want to support both Flash and HTML5. Because the embedded data is loaded
+	 * asynchronously in HTML5, any code that depends on the pixel data or size of the bitmap should be
+	 * in the onLoad function; any such code executed before it is called will fail on the HTML5 target.
+	 * 
+	 * @param	bitmapDataClass		A reference to the BitmapData child class that contains the embedded data which is to be used.
+	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new Bitmap instance is passed as an argument.
+	 * @return  The Bitmap instance that was created.
+	 */
+	private function createBitmap(bitmapDataClass:Class<BitmapData>, ?onLoad:Bitmap->Void):Bitmap
+	{
+		#if html5
+		if (onLoad != null && Type.getClassFields(bitmapDataClass).indexOf("preload") != -1)
+		{
+			var bmp = new Bitmap();
+			bmp.bitmapData = Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, function(_) onLoad(bmp)]);
+			return bmp;
+		}
+		#end
+		var bmp = new Bitmap(Type.createInstance(bitmapDataClass, [0, 0]));
+		if (onLoad != null)
+			onLoad(bmp);
+		return bmp;
+	}
+	
+	/**
+	 * This should be used whenever you want to create a BitmapData object from a class containing data embedded with
+	 * the @:bitmap metadata. Often, you'll want to use the BitmapData in a Bitmap object; in this case, createBitmap()
+	 * can should be used instead. Because the embedded data is loaded asynchronously in HTML5, any code that depends on
+	 * the pixel data or size of the bitmap should be in the onLoad function; any such code executed before it is called
+	 * will fail on the HTML5 target.
+	 * 
+	 * @param	bitmapDataClass		A reference to the BitmapData child class that contains the embedded data which is to be used.
+	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new BitmapData instance is passed as an argument.
+	 * @return  The BitmapData instance that was created.
+	 */
+	private function loadBitmapData(bitmapDataClass:Class<BitmapData>, onLoad:BitmapData->Void):BitmapData
+	{
+		#if html5
+		if (onLoad != null && Type.getClassFields(bitmapDataClass).indexOf("preload") != -1)
+		{
+			return Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, onLoad]);
+		}
+		#end
+		var bmpData = Type.createInstance(bitmapDataClass, [0, 0]);
+		if (onLoad != null)
+			onLoad(bmpData);
+		return bmpData;
+	}
+	
+	/**
 	 * Site-locking Functionality
 	 */
 	private function checkSiteLock():Void

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -19,7 +19,7 @@ class FlxBasePreloader extends NMEPreloader
 	/**
 	 * Add this string to allowedURLs array if you want to be able to test game with enabled site-locking on local machine 
 	 */
-	public static inline var LOCAL:String = "local";
+	public static inline var LOCAL:String = #if flash "local" #else "localhost" #end;
 	
 	/**
 	 * Change this if you want the flixel logo to show for more or less time.  Default value is 0 seconds (no delay).
@@ -45,17 +45,17 @@ class FlxBasePreloader extends NMEPreloader
 	private var _height:Int;
 	private var _loaded:Bool = false;
 	private var _urlChecked:Bool = false;
+	private var _startTime:Float;
 	
 	/**
 	 * FlxBasePreloader Constructor.
-	 * @param	MinDisplayTime	Minimum time the preloader should be shown. (Default = 0)
+	 * @param	MinDisplayTime	Minimum time (in seconds) the preloader should be shown. (Default = 0)
 	 * @param	AllowedURLs		Allowed URLs used for Site-locking. If the game is run anywhere else, a message will be displayed on the screen (Default = [])
 	 */
 	public function new(MinDisplayTime:Float = 0, ?AllowedURLs:Array<String>)
 	{
 		super();
 		
-		#if !js
 		removeChild(progress);
 		removeChild(outline);
 		
@@ -64,7 +64,8 @@ class FlxBasePreloader extends NMEPreloader
 			allowedURLs = AllowedURLs;
 		else
 			allowedURLs = [];
-		#end
+			
+		_startTime = Date.now().getTime();
 	}
 	
 	/**
@@ -79,13 +80,11 @@ class FlxBasePreloader extends NMEPreloader
 	{
 		super.onInit();
 		
-		#if !js
 		Lib.current.stage.scaleMode = StageScaleMode.NO_SCALE;
 		Lib.current.stage.align = StageAlign.TOP_LEFT;
 		create();
-		checkSiteLock();
 		addEventListener(Event.ENTER_FRAME, onEnterFrame);
-		#end
+		checkSiteLock();
 	}
 	
 	/**
@@ -97,6 +96,9 @@ class FlxBasePreloader extends NMEPreloader
 		#if flash
 		if (root.loaderInfo.bytesTotal == 0)
 			bytesTotal = 50000;
+		#end
+		
+		#if web
 		_percent = (bytesTotal != 0) ? bytesLoaded / bytesTotal : 0;
 		#else
 		super.onUpdate(bytesLoaded, bytesTotal);
@@ -109,8 +111,8 @@ class FlxBasePreloader extends NMEPreloader
 	 */
 	private function onEnterFrame(E:Event):Void
 	{
-		var time:Int = Lib.getTimer();
-		var min:Int = Std.int(minDisplayTime * 1000);
+		var time = Date.now().getTime() - _startTime;
+		var min = minDisplayTime * 1000;
 		var percent:Float = _percent;
 		if ((min > 0) && (_percent > time / min))
 			percent = time / min;
@@ -143,7 +145,7 @@ class FlxBasePreloader extends NMEPreloader
 	 */
 	override public function onLoaded() 
 	{
-		#if flash
+		#if web
 		_loaded = true;
 		_percent = 1;
 		#else
@@ -156,7 +158,7 @@ class FlxBasePreloader extends NMEPreloader
 	 */
 	private function checkSiteLock():Void
 	{
-		#if flash
+		#if web
 		if (!_urlChecked && (allowedURLs != null))
 		{
 			if (!isHostUrlAllowed())
@@ -194,7 +196,7 @@ class FlxBasePreloader extends NMEPreloader
 		#end
 	}
 	
-	#if flash
+	#if web
 	private function goToMyURL(?e:MouseEvent):Void
 	{
 		//if the chosen URL isn't "local", use FlxG's openURL() function.
@@ -211,7 +213,7 @@ class FlxBasePreloader extends NMEPreloader
 			return true;
 		}
 		
-		var homeDomain:String = FlxStringUtil.getDomain(loaderInfo.loaderURL);
+		var homeDomain:String = FlxStringUtil.getDomain(#if flash loaderInfo.loaderURL #elseif js js.Browser.location.href #end);
 		for (allowedURL in allowedURLs)
 		{
 			if (FlxStringUtil.getDomain(allowedURL) == homeDomain)

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -57,16 +57,16 @@ class FlxPreloader extends FlxBasePreloader
 		_height = Std.int(Lib.current.stage.stageHeight / _buffer.scaleY);
 		_buffer.addChild(new Bitmap(new BitmapData(_width, _height, false, 0x00345e)));
 		
-		// On html5, access to an embedded bitmap's dimensions or scale must be done in a function passed to the onLoad (5th) constructor parameter.
-		// Anything executed before that will be ignored. But to make things harder, there is no such
-		// parameter on any other targets.
-		// The onLoad function takes one parameter, which is a reference to the BitmapData instance that was loaded.
+		// On html5, access to an embedded bitmap's dimensions or scale must be done in a function passed to the last constructor argument
+		// That function will be called once the bitmap is finished loading, and any access to the size before that will fail.
+		// But to make things harder, there is no such parameter on any other targets.
+		// The function should take one argument, which is a reference to the BitmapData instance that was loaded.
 		var setSize = function(_)
 		{
 			_logoLight.width = _logoLight.height = _height;
 			_logoLight.x = (_width - _logoLight.width) / 2;
 		}
-		_logoLight = new Bitmap(new GraphicLogoLight(0, 0, true, null #if html5 ,setSize #end));
+		_logoLight = new Bitmap(new GraphicLogoLight(0, 0 #if html5 ,setSize #end));
 		#if !html5 setSize(null); #end
 		_logoLight.smoothing = true;
 		_buffer.addChild(_logoLight);
@@ -103,7 +103,7 @@ class FlxPreloader extends FlxBasePreloader
 			_corners.width = _width;
 			_corners.height = _height;
 		}
-		_corners = new Bitmap(new GraphicLogoCorners(0, 0, true, null #if html5 ,setSize #end));
+		_corners = new Bitmap(new GraphicLogoCorners(0, 0 #if html5 ,setSize #end));
 		#if !html5 setSize(null); #end
 		_corners.smoothing = true;
 		_buffer.addChild(_corners);

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -151,11 +151,6 @@ class FlxPreloader extends FlxBasePreloader
 	 */
 	override public function update(Percent:Float):Void
 	{
-		#if html5
-		// in html5, we need to trigger the textfield's __dirty flag every step for the correct font to be used
-		_text.defaultTextFormat = _text.defaultTextFormat;
-		#end
-
 		_bmpBar.scaleX = Percent * (_width - 8);
 		_text.text = Std.string(FlxG.VERSION) + " " + Std.int(Percent * 100) + "%";
 		

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -27,6 +27,8 @@ class FlxPreloader extends FlxBasePreloader
 	private var _text:TextField;
 	private var _logo:Sprite;
 	private var _logoGlow:Sprite;
+	private var _logoLight:Bitmap;
+	private var _corners:Bitmap;
 	
 	/**
 	 * Initialize your preloader here.
@@ -48,18 +50,17 @@ class FlxPreloader extends FlxBasePreloader
 	 */
 	override private function create():Void
 	{
-		#if !js
 		_buffer = new Sprite();
 		_buffer.scaleX = _buffer.scaleY = 2;
 		addChild(_buffer);
 		_width = Std.int(Lib.current.stage.stageWidth / _buffer.scaleX);
 		_height = Std.int(Lib.current.stage.stageHeight / _buffer.scaleY);
 		_buffer.addChild(new Bitmap(new BitmapData(_width, _height, false, 0x00345e)));
-		var bitmap = new Bitmap(new GraphicLogoLight(0, 0));
-		bitmap.smoothing = true;
-		bitmap.width = bitmap.height = _height;
-		bitmap.x = (_width - bitmap.width) / 2;
-		_buffer.addChild(bitmap);
+		_logoLight = new Bitmap(new GraphicLogoLight(0, 0));
+		_logoLight.smoothing = true;
+		_logoLight.width = _logoLight.height = _height;
+		_logoLight.x = (_width - _logoLight.width) / 2;
+		_buffer.addChild(_logoLight);
 		_bmpBar = new Bitmap(new BitmapData(1, 7, false, 0x5f6aff));
 		_bmpBar.x = 4;
 		_bmpBar.y = _height - 11;
@@ -88,12 +89,13 @@ class FlxPreloader extends FlxBasePreloader
 		_logoGlow.x = (_width - _logoGlow.width) / 2;
 		_logoGlow.y = (_height - _logoGlow.height) / 2;
 		_buffer.addChild(_logoGlow);
-		bitmap = new Bitmap(new GraphicLogoCorners(0, 0));
-		bitmap.smoothing = true;
-		bitmap.width = _width;
-		bitmap.height = _height;
-		_buffer.addChild(bitmap);
-		bitmap = new Bitmap(new BitmapData(_width, _height, false, 0xffffff));
+		_corners = new Bitmap(new GraphicLogoCorners(0, 0));
+		_corners.smoothing = true;
+		_corners.width = _width;
+		_corners.height = _height;
+		_buffer.addChild(_corners);
+		
+		var bitmap = new Bitmap(new BitmapData(_width, _height, false, 0xffffff));
 		var i:Int = 0;
 		var j:Int = 0;
 		while (i < _height)
@@ -108,7 +110,6 @@ class FlxPreloader extends FlxBasePreloader
 		bitmap.blendMode = BlendMode.OVERLAY;
 		bitmap.alpha = 0.25;
 		_buffer.addChild(bitmap);
-		#end
 		
 		super.create();
 	}
@@ -119,7 +120,6 @@ class FlxPreloader extends FlxBasePreloader
 	 */
 	override private function destroy():Void
 	{
-		#if !js
 		if (_buffer != null)	
 		{
 			removeChild(_buffer);
@@ -130,7 +130,6 @@ class FlxPreloader extends FlxBasePreloader
 		_logo = null;
 		_logoGlow = null;
 		super.destroy();
-		#end
 	}
 	
 	/**
@@ -139,7 +138,22 @@ class FlxPreloader extends FlxBasePreloader
 	 */
 	override public function update(Percent:Float):Void
 	{
-		#if !js
+		#if html5
+		// size can't be set immediately in html5 (probably because of asynchronous loading...)
+		if (!Math.isFinite(_logoLight.width))
+		{
+			_logoLight.width = _logoLight.height = _height;
+			_logoLight.x = (_width - _logoLight.width) / 2;
+		}
+		if (!Math.isFinite(_corners.width))
+		{		
+			_corners.width = _width;
+			_corners.height = _height;
+		}
+		// in html5, we need to trigger the textfield's __dirty flag every step for the correct font to be used
+		_text.defaultTextFormat = _text.defaultTextFormat;
+		#end
+		
 		_bmpBar.scaleX = Percent * (_width - 8);
 		_text.text = Std.string(FlxG.VERSION) + " " + Std.int(Percent * 100) + "%";
 		
@@ -177,6 +191,5 @@ class FlxPreloader extends FlxBasePreloader
 		{
 			_buffer.alpha = 1 - (Percent - 0.9) / 0.1;
 		}
-		#end
 	}
 }

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -56,10 +56,16 @@ class FlxPreloader extends FlxBasePreloader
 		_width = Std.int(Lib.current.stage.stageWidth / _buffer.scaleX);
 		_height = Std.int(Lib.current.stage.stageHeight / _buffer.scaleY);
 		_buffer.addChild(new Bitmap(new BitmapData(_width, _height, false, 0x00345e)));
-		_logoLight = new Bitmap(new GraphicLogoLight(0, 0));
+		
+		// Access to an embedded bitmap's dimensions or scale should be done in a function passed to the onLoad (5th) constructor parameter.
+		// Anything executed before that will be ignored on html5.
+		// The onLoad function takes one parameter, which is a reference to the BitmapData instance that was loaded.
+		_logoLight = new Bitmap(new GraphicLogoLight(0, 0, true, null, function(_)
+		{
+			_logoLight.width = _logoLight.height = _height;
+			_logoLight.x = (_width - _logoLight.width) / 2;
+		}));
 		_logoLight.smoothing = true;
-		_logoLight.width = _logoLight.height = _height;
-		_logoLight.x = (_width - _logoLight.width) / 2;
 		_buffer.addChild(_logoLight);
 		_bmpBar = new Bitmap(new BitmapData(1, 7, false, 0x5f6aff));
 		_bmpBar.x = 4;
@@ -89,10 +95,12 @@ class FlxPreloader extends FlxBasePreloader
 		_logoGlow.x = (_width - _logoGlow.width) / 2;
 		_logoGlow.y = (_height - _logoGlow.height) / 2;
 		_buffer.addChild(_logoGlow);
-		_corners = new Bitmap(new GraphicLogoCorners(0, 0));
+		_corners = new Bitmap(new GraphicLogoCorners(0, 0, true, null, function(_)
+		{
+			_corners.width = _width;
+			_corners.height = _height;
+		}));
 		_corners.smoothing = true;
-		_corners.width = _width;
-		_corners.height = _height;
 		_buffer.addChild(_corners);
 		
 		var bitmap = new Bitmap(new BitmapData(_width, _height, false, 0xffffff));
@@ -139,18 +147,7 @@ class FlxPreloader extends FlxBasePreloader
 	override public function update(Percent:Float):Void
 	{
 		#if html5
-		// size can't be set immediately in html5 (probably because of asynchronous loading...)
-		if (!Math.isFinite(_logoLight.width))
-		{
-			_logoLight.width = _logoLight.height = _height;
-			_logoLight.x = (_width - _logoLight.width) / 2;
-		}
-		if (!Math.isFinite(_corners.width))
-		{		
-			_corners.width = _width;
-			_corners.height = _height;
-		}
-		// in html5, we need to trigger the textfield's __dirty flag every step for the correct font to be used
+		// in html5, we need to somehow trigger the textfield's __dirty flag every frame for the correct font to be used
 		_text.defaultTextFormat = _text.defaultTextFormat;
 		#end
 		

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -57,14 +57,17 @@ class FlxPreloader extends FlxBasePreloader
 		_height = Std.int(Lib.current.stage.stageHeight / _buffer.scaleY);
 		_buffer.addChild(new Bitmap(new BitmapData(_width, _height, false, 0x00345e)));
 		
-		// Access to an embedded bitmap's dimensions or scale should be done in a function passed to the onLoad (5th) constructor parameter.
-		// Anything executed before that will be ignored on html5.
+		// On html5, access to an embedded bitmap's dimensions or scale must be done in a function passed to the onLoad (5th) constructor parameter.
+		// Anything executed before that will be ignored. But to make things harder, there is no such
+		// parameter on any other targets.
 		// The onLoad function takes one parameter, which is a reference to the BitmapData instance that was loaded.
-		_logoLight = new Bitmap(new GraphicLogoLight(0, 0, true, null, function(_)
+		var setSize = function(_)
 		{
 			_logoLight.width = _logoLight.height = _height;
 			_logoLight.x = (_width - _logoLight.width) / 2;
-		}));
+		}
+		_logoLight = new Bitmap(new GraphicLogoLight(0, 0, true, null #if html5 ,setSize #end));
+		#if !html5 setSize(null); #end
 		_logoLight.smoothing = true;
 		_buffer.addChild(_logoLight);
 		_bmpBar = new Bitmap(new BitmapData(1, 7, false, 0x5f6aff));
@@ -95,11 +98,13 @@ class FlxPreloader extends FlxBasePreloader
 		_logoGlow.x = (_width - _logoGlow.width) / 2;
 		_logoGlow.y = (_height - _logoGlow.height) / 2;
 		_buffer.addChild(_logoGlow);
-		_corners = new Bitmap(new GraphicLogoCorners(0, 0, true, null, function(_)
+		setSize = function(_)
 		{
 			_corners.width = _width;
 			_corners.height = _height;
-		}));
+		}
+		_corners = new Bitmap(new GraphicLogoCorners(0, 0, true, null #if html5 ,setSize #end));
+		#if !html5 setSize(null); #end
 		_corners.smoothing = true;
 		_buffer.addChild(_corners);
 		
@@ -147,10 +152,10 @@ class FlxPreloader extends FlxBasePreloader
 	override public function update(Percent:Float):Void
 	{
 		#if html5
-		// in html5, we need to somehow trigger the textfield's __dirty flag every frame for the correct font to be used
+		// in html5, we need to trigger the textfield's __dirty flag every step for the correct font to be used
 		_text.defaultTextFormat = _text.defaultTextFormat;
 		#end
-		
+
 		_bmpBar.scaleX = Percent * (_width - 8);
 		_text.text = Std.string(FlxG.VERSION) + " " + Std.int(Percent * 100) + "%";
 		

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -27,8 +27,6 @@ class FlxPreloader extends FlxBasePreloader
 	private var _text:TextField;
 	private var _logo:Sprite;
 	private var _logoGlow:Sprite;
-	private var _logoLight:Bitmap;
-	private var _corners:Bitmap;
 	
 	/**
 	 * Initialize your preloader here.
@@ -57,19 +55,13 @@ class FlxPreloader extends FlxBasePreloader
 		_height = Std.int(Lib.current.stage.stageHeight / _buffer.scaleY);
 		_buffer.addChild(new Bitmap(new BitmapData(_width, _height, false, 0x00345e)));
 		
-		// On html5, access to an embedded bitmap's dimensions or scale must be done in a function passed to the last constructor argument
-		// That function will be called once the bitmap is finished loading, and any access to the size before that will fail.
-		// But to make things harder, there is no such parameter on any other targets.
-		// The function should take one argument, which is a reference to the BitmapData instance that was loaded.
-		var setSize = function(_)
+		var logoLight = createBitmap(GraphicLogoLight, function(logoLight:Bitmap)
 		{
-			_logoLight.width = _logoLight.height = _height;
-			_logoLight.x = (_width - _logoLight.width) / 2;
-		}
-		_logoLight = new Bitmap(new GraphicLogoLight(0, 0 #if html5 ,setSize #end));
-		#if !html5 setSize(null); #end
-		_logoLight.smoothing = true;
-		_buffer.addChild(_logoLight);
+			logoLight.width = logoLight.height = _height;
+			logoLight.x = (_width - logoLight.width) / 2;
+		});
+		logoLight.smoothing = true;
+		_buffer.addChild(logoLight);
 		_bmpBar = new Bitmap(new BitmapData(1, 7, false, 0x5f6aff));
 		_bmpBar.x = 4;
 		_bmpBar.y = _height - 11;
@@ -98,15 +90,13 @@ class FlxPreloader extends FlxBasePreloader
 		_logoGlow.x = (_width - _logoGlow.width) / 2;
 		_logoGlow.y = (_height - _logoGlow.height) / 2;
 		_buffer.addChild(_logoGlow);
-		setSize = function(_)
+		var corners = createBitmap(GraphicLogoCorners, function(corners)
 		{
-			_corners.width = _width;
-			_corners.height = _height;
-		}
-		_corners = new Bitmap(new GraphicLogoCorners(0, 0 #if html5 ,setSize #end));
-		#if !html5 setSize(null); #end
-		_corners.smoothing = true;
-		_buffer.addChild(_corners);
+			corners.width = _width;
+			corners.height = height;
+		});
+		corners.smoothing = true;
+		_buffer.addChild(corners);
 		
 		var bitmap = new Bitmap(new BitmapData(_width, _height, false, 0xffffff));
 		var i:Int = 0;


### PR DESCRIPTION
This modifies FlxPreloader and FlxBasePreloader to work on the HTML5 target. Because blend modes don't work on html5, the default preloader doesn't look quite as good as in Flash... but it runs. More importantly, FlxBasePreloader works fine, so custom preloaders can be made (which don't use blend modes :))
There are some quirks to be aware of with regard to embedded BitmapData and TextFields with custom fonts (and probably other things I haven't encountered yet) – this is documented to some extent in the comments in FlxPreloader.hx. Unfortunately, it inevitably leads to somewhat messier code, but I've tried to keep it as clean as possible.

Fixes #1804.