### PR TITLE
Calculate elapsed third

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -708,6 +708,19 @@ class FlxGame extends Sprite
 			return;
 		}
 		
+		if (FlxG.fixedTimestep)
+		{
+			FlxG.elapsed = FlxG.timeScale * _stepSeconds; // fixed timestep
+		}
+		else
+		{
+			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
+			
+			var max = FlxG.maxElapsed * FlxG.timeScale;
+			if (FlxG.elapsed > max) 
+				FlxG.elapsed = max;
+		}
+		
 		if (_state != _requestedState)
 		{
 			switchState();
@@ -721,19 +734,6 @@ class FlxGame extends Sprite
 		#end
 		
 		FlxG.signals.preUpdate.dispatch();
-		
-		if (FlxG.fixedTimestep)
-		{
-			FlxG.elapsed = FlxG.timeScale * _stepSeconds; // fixed timestep
-		}
-		else
-		{
-			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
-			
-			var max = FlxG.maxElapsed * FlxG.timeScale;
-			if (FlxG.elapsed > max) 
-				FlxG.elapsed = max;
-		}
 		
 		updateInput();
 		

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -708,19 +708,6 @@ class FlxGame extends Sprite
 			return;
 		}
 		
-		if (FlxG.fixedTimestep)
-		{
-			FlxG.elapsed = FlxG.timeScale * _stepSeconds; // fixed timestep
-		}
-		else
-		{
-			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
-			
-			var max = FlxG.maxElapsed * FlxG.timeScale;
-			if (FlxG.elapsed > max) 
-				FlxG.elapsed = max;
-		}
-		
 		if (_state != _requestedState)
 		{
 			switchState();
@@ -732,6 +719,8 @@ class FlxGame extends Sprite
 			ticks = getTimer(); // Lib.getTimer() is expensive, only do it if necessary
 		}
 		#end
+		
+		updateElapsed();
 		
 		FlxG.signals.preUpdate.dispatch();
 		
@@ -763,6 +752,22 @@ class FlxGame extends Sprite
 		#end
 		
 		filters = filtersEnabled ? _filters : null;
+	}
+	
+	private function updateElapsed():Void
+	{
+		if (FlxG.fixedTimestep)
+		{
+			FlxG.elapsed = FlxG.timeScale * _stepSeconds; // fixed timestep
+		}
+		else
+		{
+			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
+			
+			var max = FlxG.maxElapsed * FlxG.timeScale;
+			if (FlxG.elapsed > max) 
+				FlxG.elapsed = max;
+		}
 	}
 	
 	private function updateInput():Void


### PR DESCRIPTION
#1836 

So that `preUpdate` signals can have the current `elapsed`.