### PR TITLE
Add two new signals: debuggerShowed and debuggerHid

### DIFF
--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -444,6 +444,29 @@ class FlxDebugger extends Sprite
 		return result;
 	}
 	
+	#if flash @:setter(visible) #else override #end
+	public function set_visible(Value:Bool): #if flash Void #else Bool #end
+	{
+		#if flash
+		super.visible = Value;
+		#else
+		super.set_visible(Value);
+		#end
+        
+		if (Value)
+		{
+			FlxG.signals.debuggerShowed.dispatch();
+		}
+		else
+		{
+			FlxG.signals.debuggerHid.dispatch();
+		}
+		
+		#if !flash
+		return Value;
+		#end
+	}
+	
 	/**
 	 * Mouse handler that helps with fake "mouse focus" type behavior.
 	 */

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -26,6 +26,18 @@ class SignalFrontEnd
 	public var postDraw(default, null):FlxSignal = new FlxSignal();
 	public var focusGained(default, null):FlxSignal = new FlxSignal();
 	public var focusLost(default, null):FlxSignal = new FlxSignal();
+	#if FLX_DEBUG
+	/**
+	 * Gets dispatched when the debugger is showed (usually by
+	 * pressing the key below ESC)
+	 */
+	public var debuggerShowed(default, null):FlxSignal = new FlxSignal();
+	/**
+	 * Gets dispatched when the debugger is hid (usually by
+	 * pressing the key below ESC)
+	 */
+	public var debuggerHid(default, null):FlxSignal = new FlxSignal();
+	#end
 	
 	@:allow(flixel.FlxG)
 	private function new() {}


### PR DESCRIPTION
Those signals are dispatched when the debugger is showed/hid (usually by pressing the key below ESC). The change was implemented by overriding the setter of the `visible` property in the `FlxDebugger` class. As a consequence, ***there is no API changes/breaks***.

The new signals are useful for classes interested in monitoring any changes in the debugger visibility; they can now use the (reliable) signals instead of making checks in the update method, for instance.

Those signals are essential to implement custom cursors in #972 without introducing a lot of hacky code all over the place.  