### PR TITLE
Add visibilityChanged signal to debugger

### DIFF
--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -159,9 +159,9 @@ class DebuggerFrontEnd
 			FlxG.stage.stageFocusRect = false; // don't show yellow focus rect on flash
 			FlxG.stage.focus = FlxG.game;
 		}
-		#end
 		
 		visibilityChanged.dispatch(Value);
+		#end
 		
 		return visible = Value;
 	}

--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -159,10 +159,16 @@ class DebuggerFrontEnd
 			FlxG.stage.stageFocusRect = false; // don't show yellow focus rect on flash
 			FlxG.stage.focus = FlxG.game;
 		}
-		
-		visible = Value;
-		visibilityChanged.dispatch();
 		#end
+		
+		if (Value != visible)
+		{
+			visible = Value;
+			
+			#if FLX_DEBUG
+			visibilityChanged.dispatch();
+			#end
+		}
 		
 		return visible;
 	}

--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -38,7 +38,7 @@ class DebuggerFrontEnd
 	/**
 	 * Dispatched when visibility is changed.
 	 */
-	public var visibilityChanged(default, null):FlxTypedSignal<Bool->Void> = new FlxTypedSignal<Bool->Void>();
+	public var visibilityChanged(default, null):FlxSignal = new FlxSignal();
 	
 	public var visible(default, set):Bool = false;
 	
@@ -160,9 +160,10 @@ class DebuggerFrontEnd
 			FlxG.stage.focus = FlxG.game;
 		}
 		
-		visibilityChanged.dispatch(Value);
+		visible = Value;
+		visibilityChanged.dispatch();
 		#end
 		
-		return visible = Value;
+		return visible;
 	}
 }

--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -35,6 +35,10 @@ class DebuggerFrontEnd
 	 * Dispatched when drawDebug is changed.
 	 */
 	public var drawDebugChanged(default, null):FlxSignal = new FlxSignal();
+	/**
+	 * Dispatched when visibility is changed.
+	 */
+	public var visibilityChanged(default, null):FlxTypedSignal<Bool->Void> = new FlxTypedSignal<Bool->Void>();
 	
 	public var visible(default, set):Bool = false;
 	
@@ -156,6 +160,8 @@ class DebuggerFrontEnd
 			FlxG.stage.focus = FlxG.game;
 		}
 		#end
+		
+		visibilityChanged.dispatch(Value);
 		
 		return visible = Value;
 	}


### PR DESCRIPTION
Add the `visibilityChanged` signal to the `DebuggerFrontEnd` following the same convention/idea of the already existing `drawDebugChanged` signal.