### PR TITLE
FlxGroup: fix recursion in forEachOfType(), closes #1876

### DIFF
--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -806,7 +806,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		{
 			basic = members[i++];
 			
-			if (basic != null &&  Std.is(basic, ObjectClass))
+			if (basic != null)
 			{
 				if (Recurse)
 				{
@@ -817,7 +817,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					}
 				}
 				
-				Function(cast basic);
+				if (Std.is(basic, ObjectClass))
+					Function(cast basic);
 			}
 		}
 	}

--- a/tests/unit/src/flixel/group/FlxGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxGroupTest.hx
@@ -60,6 +60,36 @@ class FlxGroupTest extends FlxTest
 	}
 	
 	@Test
+	function testForEachOfTypeRecurseTrue():Void
+	{
+		forEachOfTypeGroupSetup(group);
+		forEachOfTypeGroupSetup(subGroup);
+		
+		var timesCalled:Int = 0;
+		group.forEachOfType(FlxObject, function(_) timesCalled++, true);
+		
+		Assert.areEqual(6, timesCalled);
+	}
+	
+	@Test
+	function testForEachOfTypeRecurseFalse():Void
+	{
+		forEachOfTypeGroupSetup(group);
+		forEachOfTypeGroupSetup(subGroup);
+		
+		var timesCalled:Int = 0;
+		group.forEachOfType(FlxObject, function(_) timesCalled++, false);
+		
+		Assert.areEqual(3, timesCalled);
+	}
+	
+	function forEachOfTypeGroupSetup(group:FlxGroup):Void
+	{
+		for (i in 0...3)
+			group.add(new FlxObject());
+	}
+	
+	@Test
 	function testForEachExistsRecurseFalse():Void
 	{
 		forEachExistsGroupSetup(group);


### PR DESCRIPTION
Closes #1876 

Condition wasn't allowing groups to be traversed.