### PR TITLE
Decrease FlxGroup.length in FlxGroup.remove()

### DIFF
--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -189,10 +189,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		{
 			members[index] = Object;
 			
-			if (index >= length)
-			{
-				length = index + 1;
-			}
+			length++;
 			
 			return Object;
 		}
@@ -363,6 +360,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		else
 			members[index] = null;
 		
+		length--;
+			
 		return Object;
 	}
 	


### PR DESCRIPTION
Note that `length` is always decremented, even when `Splice` is false. However, I also made it so the `add()` method increments `length` also when replacing a null entry—in other words, `FlxGroup.length` represents the number of actual flixel objects in the group, not the physical size of `FlxGroup.members`.