### PR TITLE
Adjust camera scroll bounds to account for zoom

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -872,9 +872,15 @@ class FlxCamera extends FlxBasic
 	 */
 	public function updateScroll():Void
 	{
-		//Make sure we didn't go outside the camera's bounds
-		scroll.x = FlxMath.bound(scroll.x, minScrollX, (maxScrollX != null) ? maxScrollX - width : null);
-		scroll.y = FlxMath.bound(scroll.y, minScrollY, (maxScrollY != null) ? maxScrollY - height : null);
+		// Adjust bounds to account for zoom
+		var minX:Null<Float> = minScrollX == null ? null : minScrollX - (zoom - 1) * width / (2 * zoom);
+		var maxX:Null<Float> = maxScrollX == null ? null : maxScrollX + (zoom - 1) * width / (2 * zoom);
+		var minY:Null<Float> = minScrollY == null ? null : minScrollY - (zoom - 1) * height / (2 * zoom);
+		var maxY:Null<Float> = maxScrollY == null ? null : maxScrollY + (zoom - 1) * height / (2 * zoom);
+		
+		// Make sure we didn't go outside the camera's bounds
+		scroll.x = FlxMath.bound(scroll.x, minX, (maxX != null) ? maxX - width : null);
+		scroll.y = FlxMath.bound(scroll.y, minY, (maxY != null) ? maxY - height : null);
 	}
 	
 	/**


### PR DESCRIPTION
Currently there is an issue with FlxCamera's scroll bounds if you zoom. If you are zoomed then move to the edge of the scroll bounds, you will not be able to see a part of the side of the map, because the scroll bounds are only correct at a zoom of 1.

For example, if your camera is targeting a player, and your player is right beside the scroll bounds, then you attempt to zoom on the player, the player will go off-screen in spite of it being your camera's target.

This pull request adds the required adjustments to correctly apply the scroll bounds irrespective of the current zoom. When you are zoomed, your camera's size is effectively shrunk, and it is this shrunk camera that is prevented from passing the scroll bounds, rather than the camera's size at a zoom of 1.