### PR TITLE
HTML5FrontEnd: Add platform and mobile detection

### DIFF
--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -1,6 +1,7 @@
 package flixel.system.frontEnds;
 
 import flixel.math.FlxPoint;
+import flixel.system.frontEnds.HTML5FrontEnd.IOSPlatform;
 import flixel.util.FlxStringUtil;
 
 #if js
@@ -9,16 +10,18 @@ import js.Browser;
 class HTML5FrontEnd
 {
 	public var browser(default, null):FlxBrowser;
+	public var ios(default, null):IOSPlatform;
+	public var platform(default, null):FlxPlatform;
+	public var isMobile(default, null):Bool;
 	public var browserWidth(get, null):Int;
 	public var browserHeight(get, null):Int;
 	public var browserPosition(get, null):FlxPoint;
-	public var platform(default, null):FlxPlatform;
-	public var isMobile(default, null):Bool;
 	
 	@:allow(flixel.FlxG)
 	private function new()
 	{
 		browser = getBrowser();
+		ios = getiOS();
 		platform = getPlatform();
 		isMobile = getIsMobile();
 	}
@@ -48,24 +51,21 @@ class HTML5FrontEnd
 		return FlxBrowser.UNKNOWN;
 	}
 	
-	private function get_browserPosition():FlxPoint
+	private function getiOS():IOSPlatform
 	{
-		if (browserPosition == null)
+		if (userAgentContains("iPhone"))
 		{
-			browserPosition = FlxPoint.get(0, 0);
+			return IPHONE;
 		}
-		browserPosition.set(Browser.window.screenX, Browser.window.screenY);
-		return browserPosition;
-	}
-	
-	private inline function get_browserWidth():Int
-	{
-		return Browser.window.innerWidth;
-	}
-	
-	private inline function get_browserHeight():Int
-	{
-		return Browser.window.innerHeight;
+		else if (userAgentContains("iPad"))
+		{
+			return IPAD;
+		}
+		else if (userAgentContains("iPod"))
+		{
+			return IPOD;
+		}
+		else return IOSPlatform.UNKNOWN;
 	}
 	
 	private function getPlatform():FlxPlatform
@@ -96,24 +96,16 @@ class HTML5FrontEnd
 		{
 			return BLACKBERRY;
 		}
-		else if (userAgentContains("iPhone"))
+		else if (ios != IOSPlatform.UNKNOWN)
 		{
-			return IPHONE;
-		}
-		else if (userAgentContains("iPad"))
-		{
-			return IPAD;
-		}
-		else if (userAgentContains("iPod"))
-		{
-			return IPOD;
+			return IOS;
 		}
 		else return FlxPlatform.UNKNOWN;
 	}
 	
 	private inline function getIsMobile():Bool 
 	{
-		var mobilePlatforms:Array<FlxPlatform> = [ANDROID, BLACKBERRY, WINDOWS_PHONE, IPHONE, IPAD, IPOD];
+		var mobilePlatforms:Array<FlxPlatform> = [ANDROID, BLACKBERRY, WINDOWS_PHONE, IOS];
 		return mobilePlatforms.indexOf(platform) != -1;
 	}
 	
@@ -123,6 +115,26 @@ class HTML5FrontEnd
 		if (toLowerCase)
 			userAgent = userAgent.toLowerCase();
 		return FlxStringUtil.contains(userAgent, substring);
+	}
+	
+	private function get_browserPosition():FlxPoint
+	{
+		if (browserPosition == null)
+		{
+			browserPosition = FlxPoint.get(0, 0);
+		}
+		browserPosition.set(Browser.window.screenX, Browser.window.screenY);
+		return browserPosition;
+	}
+	
+	private inline function get_browserWidth():Int
+	{
+		return Browser.window.innerWidth;
+	}
+	
+	private inline function get_browserHeight():Int
+	{
+		return Browser.window.innerHeight;
 	}
 }
 
@@ -144,6 +156,11 @@ enum FlxPlatform
 	ANDROID;
 	BLACKBERRY;
 	WINDOWS_PHONE;
+	IOS;
+	UNKNOWN;
+}
+enum IOSPlatform
+{
 	IPHONE;
 	IPAD;
 	IPOD;

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -1,7 +1,6 @@
 package flixel.system.frontEnds;
 
 import flixel.math.FlxPoint;
-import flixel.system.frontEnds.HTML5FrontEnd.IOSPlatform;
 import flixel.util.FlxStringUtil;
 
 #if js
@@ -10,7 +9,6 @@ import js.Browser;
 class HTML5FrontEnd
 {
 	public var browser(default, null):FlxBrowser;
-	public var ios(default, null):IOSPlatform;
 	public var platform(default, null):FlxPlatform;
 	public var isMobile(default, null):Bool;
 	public var browserWidth(get, null):Int;
@@ -21,7 +19,6 @@ class HTML5FrontEnd
 	private function new()
 	{
 		browser = getBrowser();
-		ios = getiOS();
 		platform = getPlatform();
 		isMobile = getIsMobile();
 	}
@@ -49,23 +46,6 @@ class HTML5FrontEnd
 			return SAFARI;
 		}
 		return FlxBrowser.UNKNOWN;
-	}
-	
-	private function getiOS():IOSPlatform
-	{
-		if (userAgentContains("iPhone"))
-		{
-			return IPHONE;
-		}
-		else if (userAgentContains("iPad"))
-		{
-			return IPAD;
-		}
-		else if (userAgentContains("iPod"))
-		{
-			return IPOD;
-		}
-		else return IOSPlatform.UNKNOWN;
 	}
 	
 	private function getPlatform():FlxPlatform
@@ -96,16 +76,24 @@ class HTML5FrontEnd
 		{
 			return BLACKBERRY;
 		}
-		else if (ios != IOSPlatform.UNKNOWN)
+		else if (userAgentContains("iPhone"))
 		{
-			return IOS;
+			return IOS(IPHONE);
+		}
+		else if (userAgentContains("iPad"))
+		{
+			return IOS(IPAD);
+		}
+		else if (userAgentContains("iPod"))
+		{
+			return IOS(IPOD);
 		}
 		else return FlxPlatform.UNKNOWN;
 	}
 	
 	private inline function getIsMobile():Bool 
 	{
-		var mobilePlatforms:Array<FlxPlatform> = [ANDROID, BLACKBERRY, WINDOWS_PHONE, IOS];
+		var mobilePlatforms:Array<FlxPlatform> = [ANDROID, BLACKBERRY, WINDOWS_PHONE, IOS(IPHONE), IOS(IPAD), IOS(IPOD)];
 		return mobilePlatforms.indexOf(platform) != -1;
 	}
 	
@@ -156,14 +144,13 @@ enum FlxPlatform
 	ANDROID;
 	BLACKBERRY;
 	WINDOWS_PHONE;
-	IOS;
+	IOS(device:FlxIOSDevice);
 	UNKNOWN;
 }
-enum IOSPlatform
+enum FlxIOSDevice
 {
 	IPHONE;
 	IPAD;
 	IPOD;
-	UNKNOWN;
 }
 #end

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -9,8 +9,8 @@ import js.Browser;
 class HTML5FrontEnd
 {
 	public var browser(default, null):FlxBrowser;
-	public var browserWidth(default, null):Int;
-	public var browserHeight(default, null):Int;
+	public var browserWidth(get, null):Int;
+	public var browserHeight(get, null):Int;
 	public var browserPosition(get, null):FlxPoint;
 	public var platform(default, null):FlxPlatform;
 	public var isMobile(default, null):Bool;
@@ -19,8 +19,6 @@ class HTML5FrontEnd
 	private function new()
 	{
 		browser = getBrowser();
-		browserWidth = getBrowserWidth();
-		browserHeight = getBrowserHeight();
 		platform = getPlatform();
 		isMobile = getIsMobile();
 	}
@@ -60,12 +58,12 @@ class HTML5FrontEnd
 		return browserPosition;
 	}
 	
-	private inline function getBrowserWidth():Int
+	private inline function get_browserWidth():Int
 	{
 		return Browser.window.innerWidth;
 	}
 	
-	private inline function getBrowserHeight():Int
+	private inline function get_browserHeight():Int
 	{
 		return Browser.window.innerHeight;
 	}
@@ -109,7 +107,6 @@ class HTML5FrontEnd
 	
 	private inline function getIsMobile():Bool 
 	{
-		var platform = this.platform;
 		return platform == ANDROID || platform == BLACKBERRY || platform == IOS || platform == WINDOWS_PHONE;
 	}
 	

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -11,6 +11,8 @@ class HTML5FrontEnd
 	public var browserWidth(get, never):Int;
 	public var browserHeight(get, never):Int;
 	public var browserPosition(get, null):FlxPoint;
+	public var platform(get, never):FlxPlatform;
+	public var isMobile(get, never):Bool;
 	
 	@:allow(flixel.FlxG)
 	private function new() {}
@@ -37,7 +39,7 @@ class HTML5FrontEnd
 		{
 			return SAFARI;
 		}
-		return UNKNOWN;
+		return FlxBrowser.UNKNOWN;
 	}
 	
 	private function get_browserPosition():FlxPoint
@@ -59,6 +61,49 @@ class HTML5FrontEnd
 	{
 		return Browser.window.innerHeight;
 	}
+	
+	private inline function get_platform():FlxPlatform
+	{
+		
+		if (Browser.navigator.userAgent.indexOf("Win") > -1)
+		{
+			return WINDOWS;
+		}
+		else if (Browser.navigator.userAgent.indexOf("Linux") > -1
+		&& Browser.navigator.userAgent.indexOf("Android") == -1)
+		{
+			return LINUX;
+		}
+		else if (Browser.navigator.userAgent.indexOf("X11") > -1)
+		{
+			return UNIX;
+		}
+		else if (Browser.navigator.userAgent.indexOf("Android") > -1)
+		{
+			return ANDROID;
+		}
+		else if (Browser.navigator.userAgent.indexOf("BlackBerry") > -1)
+		{
+			return BLACKBERRY;
+		}
+		else if (Browser.navigator.userAgent.indexOf("iPhone") > -1
+		|| Browser.navigator.userAgent.indexOf("iPad") > -1
+		|| Browser.navigator.userAgent.indexOf("iPod") > -1)
+		{
+			return IOS;
+		}
+		else if (Browser.navigator.userAgent.indexOf("IEMobile") > -1)
+		{
+			return WINDOWS_PHONE;
+		}
+		else return FlxPlatform.UNKNOWN;
+	}
+	
+	private inline function get_isMobile():Bool 
+	{
+		var platform = this.platform;
+		return platform == ANDROID || platform == BLACKBERRY || platform == IOS || platform == WINDOWS_PHONE;
+	}
 }
 
 enum FlxBrowser
@@ -68,6 +113,19 @@ enum FlxBrowser
 	FIREFOX;
 	SAFARI;
 	OPERA;
+	UNKNOWN;
+}
+
+enum FlxPlatform
+{
+	WINDOWS;
+	LINUX;
+	UNIX;
+	MAC;
+	ANDROID;
+	BLACKBERRY;
+	WINDOWS_PHONE;
+	IOS;
 	UNKNOWN;
 }
 #end

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -11,8 +11,8 @@ class HTML5FrontEnd
 	public var browser(default, null):FlxBrowser;
 	public var platform(default, null):FlxPlatform;
 	public var isMobile(default, null):Bool;
-	public var browserWidth(get, null):Int;
-	public var browserHeight(get, null):Int;
+	public var browserWidth(get, never):Int;
+	public var browserHeight(get, never):Int;
 	public var browserPosition(get, null):FlxPoint;
 	
 	@:allow(flixel.FlxG)

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -1,29 +1,37 @@
 package flixel.system.frontEnds;
 
 import flixel.math.FlxPoint;
+import flixel.util.FlxStringUtil;
 
 #if js
 import js.Browser;
 
 class HTML5FrontEnd
 {
-	public var browser(get, never):FlxBrowser;
-	public var browserWidth(get, never):Int;
-	public var browserHeight(get, never):Int;
+	public var browser(default, null):FlxBrowser;
+	public var browserWidth(default, null):Int;
+	public var browserHeight(default, null):Int;
 	public var browserPosition(get, null):FlxPoint;
-	public var platform(get, never):FlxPlatform;
-	public var isMobile(get, never):Bool;
+	public var platform(default, null):FlxPlatform;
+	public var isMobile(default, null):Bool;
 	
 	@:allow(flixel.FlxG)
-	private function new() {}
-	
-	private function get_browser():FlxBrowser
+	private function new()
 	{
-		if (Browser.navigator.userAgent.indexOf(" OPR/") > -1)
+		browser = getBrowser();
+		browserWidth = getBrowserWidth();
+		browserHeight = getBrowserHeight();
+		platform = getPlatform();
+		isMobile = getIsMobile();
+	}
+	
+	private function getBrowser():FlxBrowser
+	{
+		if (userAgentContains(" OPR/"))
 		{
 			return OPERA;
 		}
-		else if (Browser.navigator.userAgent.toLowerCase().indexOf("chrome") > -1)
+		else if (userAgentContains("chrome", true))
 		{
 			return CHROME;
 		}
@@ -52,57 +60,64 @@ class HTML5FrontEnd
 		return browserPosition;
 	}
 	
-	private inline function get_browserWidth():Int
+	private inline function getBrowserWidth():Int
 	{
 		return Browser.window.innerWidth;
 	}
 	
-	private inline function get_browserHeight():Int
+	private inline function getBrowserHeight():Int
 	{
 		return Browser.window.innerHeight;
 	}
 	
-	private inline function get_platform():FlxPlatform
+	private function getPlatform():FlxPlatform
 	{
 		
-		if (Browser.navigator.userAgent.indexOf("Win") > -1)
+		if (userAgentContains("Win"))
 		{
 			return WINDOWS;
 		}
-		else if (Browser.navigator.userAgent.indexOf("Linux") > -1
-		&& Browser.navigator.userAgent.indexOf("Android") == -1)
+		else if (userAgentContains("Linux")
+		&& !userAgentContains("Android"))
 		{
 			return LINUX;
 		}
-		else if (Browser.navigator.userAgent.indexOf("X11") > -1)
+		else if (userAgentContains("X11"))
 		{
 			return UNIX;
 		}
-		else if (Browser.navigator.userAgent.indexOf("Android") > -1)
+		else if (userAgentContains("Android"))
 		{
 			return ANDROID;
 		}
-		else if (Browser.navigator.userAgent.indexOf("BlackBerry") > -1)
+		else if (userAgentContains("BlackBerry"))
 		{
 			return BLACKBERRY;
 		}
-		else if (Browser.navigator.userAgent.indexOf("iPhone") > -1
-		|| Browser.navigator.userAgent.indexOf("iPad") > -1
-		|| Browser.navigator.userAgent.indexOf("iPod") > -1)
+		else if (userAgentContains("iPhone")
+		|| userAgentContains("iPad")
+		|| userAgentContains("iPod"))
 		{
 			return IOS;
 		}
-		else if (Browser.navigator.userAgent.indexOf("IEMobile") > -1)
+		else if (userAgentContains("IEMobile"))
 		{
 			return WINDOWS_PHONE;
 		}
 		else return FlxPlatform.UNKNOWN;
 	}
 	
-	private inline function get_isMobile():Bool 
+	private inline function getIsMobile():Bool 
 	{
 		var platform = this.platform;
 		return platform == ANDROID || platform == BLACKBERRY || platform == IOS || platform == WINDOWS_PHONE;
+	}
+	
+	private inline function userAgentContains(substring:String, toLowerCase:Bool = false) {
+		var userAgent = Browser.navigator.userAgent;
+		if (toLowerCase)
+			userAgent = userAgent.toLowerCase();
+		return FlxStringUtil.contains(userAgent, substring);
 	}
 }
 

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -113,7 +113,8 @@ class HTML5FrontEnd
 		return platform == ANDROID || platform == BLACKBERRY || platform == IOS || platform == WINDOWS_PHONE;
 	}
 	
-	private inline function userAgentContains(substring:String, toLowerCase:Bool = false) {
+	private inline function userAgentContains(substring:String, toLowerCase:Bool = false)
+	{
 		var userAgent = Browser.navigator.userAgent;
 		if (toLowerCase)
 			userAgent = userAgent.toLowerCase();

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -75,14 +75,18 @@ class HTML5FrontEnd
 		{
 			return WINDOWS;
 		}
+		else if (userAgentContains("Mac"))
+		{
+			return MAC;
+		}
 		else if (userAgentContains("Linux")
 		&& !userAgentContains("Android"))
 		{
 			return LINUX;
 		}
-		else if (userAgentContains("X11"))
+		else if (userAgentContains("IEMobile"))
 		{
-			return UNIX;
+			return WINDOWS_PHONE;
 		}
 		else if (userAgentContains("Android"))
 		{
@@ -92,22 +96,25 @@ class HTML5FrontEnd
 		{
 			return BLACKBERRY;
 		}
-		else if (userAgentContains("iPhone")
-		|| userAgentContains("iPad")
-		|| userAgentContains("iPod"))
+		else if (userAgentContains("iPhone"))
 		{
-			return IOS;
+			return IPHONE;
 		}
-		else if (userAgentContains("IEMobile"))
+		else if (userAgentContains("iPad"))
 		{
-			return WINDOWS_PHONE;
+			return IPAD;
+		}
+		else if (userAgentContains("iPod"))
+		{
+			return IPOD;
 		}
 		else return FlxPlatform.UNKNOWN;
 	}
 	
 	private inline function getIsMobile():Bool 
 	{
-		return platform == ANDROID || platform == BLACKBERRY || platform == IOS || platform == WINDOWS_PHONE;
+		var mobilePlatforms:Array<FlxPlatform> = [ANDROID, BLACKBERRY, WINDOWS_PHONE, IPHONE, IPAD, IPOD];
+		return mobilePlatforms.indexOf(platform) != -1;
 	}
 	
 	private inline function userAgentContains(substring:String, toLowerCase:Bool = false)
@@ -133,12 +140,13 @@ enum FlxPlatform
 {
 	WINDOWS;
 	LINUX;
-	UNIX;
 	MAC;
 	ANDROID;
 	BLACKBERRY;
 	WINDOWS_PHONE;
-	IOS;
+	IPHONE;
+	IPAD;
+	IPOD;
 	UNKNOWN;
 }
 #end


### PR DESCRIPTION
I added `platform` and `isMobile` variables to `FlxG.html5`.
Tested on Windows and Android. Not sure about the others. Here's a [test](https://dleanjeans.github.io/flixel-html5-platform-test/) (https://github.com/DleanJeans/flixel-html5-platform-test).