### PR TITLE
HTML5FrontEnd: Fix iPad check and iOS isMobile

### DIFF
--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -55,7 +55,7 @@ class HTML5FrontEnd
 		{
 			return WINDOWS;
 		}
-		else if (userAgentContains("Mac"))
+		else if (userAgentContains("Mac") && !userAgentContains("iPad"))
 		{
 			return MAC;
 		}
@@ -92,8 +92,7 @@ class HTML5FrontEnd
 	
 	private function getIsMobile():Bool 
 	{
-		return [ANDROID, BLACKBERRY, WINDOWS_PHONE,
-			IOS(IPHONE), IOS(IPAD), IOS(IPOD)].contains(platform);
+		return Type.enumConstructor(platform) == "IOS" || [ANDROID, BLACKBERRY, WINDOWS_PHONE].contains(platform);
 	}
 	
 	private function userAgentContains(substring:String, toLowerCase:Bool = false)

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -92,7 +92,13 @@ class HTML5FrontEnd
 	
 	private function getIsMobile():Bool 
 	{
-		return Type.enumConstructor(platform) == "IOS" || [ANDROID, BLACKBERRY, WINDOWS_PHONE].contains(platform);
+		return
+		switch (platform) {
+			case ANDROID, BLACKBERRY, WINDOWS_PHONE, IOS(_):
+				true;
+			default:
+				false;
+		};
 	}
 	
 	private function userAgentContains(substring:String, toLowerCase:Bool = false)

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -93,7 +93,8 @@ class HTML5FrontEnd
 	private function getIsMobile():Bool 
 	{
 		return
-		switch (platform) {
+		switch (platform)
+		{
 			case ANDROID, BLACKBERRY, WINDOWS_PHONE, IOS(_):
 				true;
 			default:


### PR DESCRIPTION
 - On an iPad, user agent contains "Mac"
 - For some reason, `[IOS(IPHONE), IOS(IPAD), IOS(IPOD)].contains(IOS(IPAD)) == false` so that's my workaround