### PR TITLE
Fix FlxText applyMarkup for markers with length > 1.

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -299,12 +299,13 @@ class FlxText extends FlxSprite
 			if (rule.marker != null && rule.format != null)
 			{
 				var start:Bool = false;
+				var markerLength:Int = Utf8.length(rule.marker);
 				if (input.indexOf(rule.marker) != -1)   //if this marker is present
 				{
 					for (charIndex in 0...Utf8.length(input))   //inspect each character
 					{
 						var charCode = Utf8.charCodeAt(input, charIndex);
-						if (charCode == rule.marker.charCodeAt(0))   //it's one of the markers
+						if (Utf8.compare(Utf8.sub(input, charIndex, markerLength), rule.marker) == 0)   //it's one of the markers
 						{
 							if (!start)   //we're outside of a format block
 							{ 
@@ -344,7 +345,7 @@ class FlxText extends FlxSprite
 			//Consider each range start
 			var delIndex:Int = rangeStarts[i];
 			
-			var markerLength:Int = rulesToApply[i].marker.length;
+			var markerLength:Int = Utf8.length(rulesToApply[i].marker);
 			
 			//Any start or end index that is HIGHER than this must be subtracted by one markerLength
 			for (j in 0...rangeStarts.length)


### PR DESCRIPTION
I tried using applyMarkup with some colored text tags, using multi-character markers which all start with the same character, like [red], [blue], [green]. The current implementation only looks at the first character of the marker, so each left brace matches every marker, resulting in the positions of the format ranges being off. Doing a full comparison against the marker fixes this issue.

Before:

<img width="800" alt="screen shot 2016-08-20 at 11 08 31 pm" src="https://cloud.githubusercontent.com/assets/544977/17835656/76361f32-672b-11e6-9e4f-ce56d066ce03.png">

After (correct):

<img width="800" alt="screen shot 2016-08-20 at 11 07 43 pm" src="https://cloud.githubusercontent.com/assets/544977/17835657/79512c66-672b-11e6-9dbd-f842a538aa1e.png">