### PR TITLE
Optional step after console command, closes #1884

### DIFF
--- a/flixel/system/debug/console/Console.hx
+++ b/flixel/system/debug/console/Console.hx
@@ -149,11 +149,9 @@ class Console extends Window
 		#end
 		
 		#if FLX_DEBUG
-		#if flash 
 		// Pause game
 		if (FlxG.console.autoPause)
 			FlxG.vcr.pause();
-		#end
 		
 		// Block keyboard input
 		#if FLX_KEYBOARD
@@ -174,11 +172,10 @@ class Console extends Window
 		#end
 		
 		#if FLX_DEBUG
-		#if flash
 		// Unpause game
 		if (FlxG.console.autoPause)
 			FlxG.vcr.resume();
-		#end
+		
 		// Unblock keyboard input
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = true;
@@ -246,8 +243,8 @@ class Console extends Window
 			history.addCommand(input.text);
 			
 			// Step forward one frame to see the results of the command
-			#if (flash && FLX_DEBUG)
-			if (FlxG.vcr.paused)
+			#if FLX_DEBUG
+			if (FlxG.vcr.paused && FlxG.console.stepAfterCommand)
 				FlxG.game.debugger.vcr.onStep();
 			#end
 			

--- a/flixel/system/debug/console/ConsoleCommands.hx
+++ b/flixel/system/debug/console/ConsoleCommands.hx
@@ -18,7 +18,6 @@ class ConsoleCommands
 	
 	public function new(console:Console):Void
 	{
-		#if FLX_DEBUG
 		_console = console;
 		
 		console.registerFunction("help", help, "Displays the help text of a registered object or function. See \"help\".");
@@ -32,6 +31,7 @@ class ConsoleCommands
 		console.registerFunction("listObjects", listObjects, "Lists the aliases of all registered objects.");
 		console.registerFunction("listFunctions", listFunctions, "Lists the aliases of all registered functions.");
 		
+		console.registerFunction("step", step, "Steps the game forward one frame if currently paused. No effect if unpaused.");
 		console.registerFunction("pause", pause, "Toggles the game between paused and unpaused.");
 		
 		console.registerFunction("clearBitmapLog", FlxG.bitmapLog.clear, "Clears the bitmapLog window.");
@@ -58,7 +58,6 @@ class ConsoleCommands
 		console.registerClass(FlxSprite);
 		console.registerClass(FlxMath);
 		console.registerClass(FlxTween);
-		#end
 	}
 	
 	private function help(?Alias:String):String
@@ -91,7 +90,6 @@ class ConsoleCommands
 		}
 	}
 	
-	#if FLX_DEBUG
 	private inline function close():Void
 	{
 		FlxG.debugger.visible = false;
@@ -172,6 +170,11 @@ class ConsoleCommands
 			ConsoleUtil.log("pause: Game paused");
 		}
 	}
-	#end
+	
+	private function step():Void
+	{
+		if (FlxG.vcr.paused)
+			FlxG.game.debugger.vcr.onStep();
+	}
 }
 #end

--- a/flixel/system/frontEnds/ConsoleFrontEnd.hx
+++ b/flixel/system/frontEnds/ConsoleFrontEnd.hx
@@ -10,6 +10,12 @@ class ConsoleFrontEnd
 	public var autoPause:Bool = true;
 	
 	/**
+	 * Whether the console should step() the game after a command is entered.
+	 * Setting this to false allows inputting multiple console commands within the same frame. Use the "step()" command to step the game from the console.
+	 */
+	public var stepAfterCommand:Bool = true;
+	
+	/**
 	 * Register a new function to use in any command.
 	 * 
 	 * @param 	FunctionAlias		The name with which you want to access the function.


### PR DESCRIPTION
Adds a boolean to see if the user wants to step after inputting a single console command (default behavior) or input multiple commands in a single frame. Adds the `step()` console command so you don't have to mouse over to the little stepper arrow each time you do want to advance. The boolean is regularly accessible from the console if it needs to be changed at runtime.

Cleaned up some defines that didn't seem to be relevant any longer. The entire `ConsoleCommands` class is wrapped in `#if FLX_DEBUG`, so there's no need to repeat those internally. Neko seemed fine with respect to taking out the `#if flash` defines.

![image](https://cloud.githubusercontent.com/assets/5033927/17839252/7921f358-67b0-11e6-9993-8f2c2854c2da.png)
Ugh, I'll get this right one day.