### PR TITLE
FlxSprite: fix position discrepancy between simple and complex render

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -666,11 +666,15 @@ class FlxSprite extends FlxObject
 				_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 		}
 		
-		_point.add(origin.x, origin.y);
-		if (isPixelPerfectRender(camera))
-			_point.floor();
-		
+		_point.add(origin.x, origin.y);		
 		_matrix.translate(_point.x, _point.y);
+		
+		if (isPixelPerfectRender(camera))
+		{
+			_matrix.tx = Math.floor(_matrix.tx);
+			_matrix.ty = Math.floor(_matrix.ty);
+		}
+		
 		camera.drawPixels(_frame, framePixels, _matrix, colorTransform, blend, antialiasing, shader);
 	}
 	


### PR DESCRIPTION
See #1917

Before for sprites with an odd width of height, the initial translation (using the offset) would be at a .5.

I'm not completely sure that this is correct, so it would be good to get a second opinion from @beeblerox.