### PR TITLE
FlxRandom: add shuffle(), deprecate shuffleArray()

### DIFF
--- a/checkstyle.json
+++ b/checkstyle.json
@@ -19,6 +19,9 @@
 	"exclude": {
 		"all": [
 			"TestSuite"
+		],
+		"AvoidStarImport": [
+			"flixel.math.FlxRandomTest"
 		]
 	},
 	"checks": [

--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -304,9 +304,7 @@ class FlxRandom
 	 * @return  The newly shuffled array.
 	 */
 	@:generic
-	@:deprecated(
-		"Unless you rely on reproducing the exact output of shuffleArray, you should use shuffle instead," +
-		"which is both faster and higher quality.")
+	@:deprecated("Unless you rely on reproducing the exact output of shuffleArray(), you should use shuffle() instead, which is both faster and higher quality.")
 	public function shuffleArray<T>(Objects:Array<T>, HowManyTimes:Int):Array<T>
 	{
 		HowManyTimes = Std.int(Math.max(HowManyTimes, 0));

--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -304,6 +304,9 @@ class FlxRandom
 	 * @return  The newly shuffled array.
 	 */
 	@:generic
+	@:deprecated(
+		"Unless you rely on reproducing the exact output of shuffleArray, you should use shuffle instead," +
+		"which is both faster and higher quality.")
 	public function shuffleArray<T>(Objects:Array<T>, HowManyTimes:Int):Array<T>
 	{
 		HowManyTimes = Std.int(Math.max(HowManyTimes, 0));
@@ -321,6 +324,25 @@ class FlxRandom
 		}
 		
 		return Objects;
+	}
+
+	/**
+	 * Shuffles the entries in an array in-place into a new pseudorandom order,
+	 * using the standard Fisher-Yates shuffle algorithm.
+	 *
+	 * @param  array  The array to shuffle.
+	 */
+	@:generic
+	public function shuffle<T>(array:Array<T>):Void
+	{
+		var maxValidIndex = array.length - 1;
+		for (i in 0...array.length)
+		{
+			var j = int(i, maxValidIndex);
+			var tmp = array[i];
+			array[i] = array[j];
+			array[j] = tmp;
+		}
 	}
 	
 	/**

--- a/tests/unit/src/flixel/math/FlxRandomTest.hx
+++ b/tests/unit/src/flixel/math/FlxRandomTest.hx
@@ -2,6 +2,7 @@ package flixel.math;
 
 import flixel.util.FlxColor;
 import massive.munit.Assert;
+import org.hamcrest.Matchers.*;
 
 class FlxRandomTest extends FlxTest
 {
@@ -10,7 +11,8 @@ class FlxRandomTest extends FlxTest
 	@Before
 	function before()
 	{
-		random = new FlxRandom();
+		// Use a constant seed for reproducible test results.
+		random = new FlxRandom(1);
 	}
 	
 	@Test // #1172
@@ -33,5 +35,39 @@ class FlxRandomTest extends FlxTest
 		random.color(FlxColor.GRAY, null, null);
 		random.color(null, FlxColor.GRAY, null);
 		random.color(FlxColor.RED, FlxColor.GRAY, null);
+	}
+
+	@Test
+	function testShuffleWithEmptyArray()
+	{
+		var array:Array<Int> = [];
+		random.shuffle(array);
+		assertThat(array, is([]));
+	}
+
+	@Test
+	function testShuffleWithSingleElementArray()
+	{
+		var array = [42];
+		random.shuffle(array);
+		assertThat(array, is([42]));
+	}
+
+	@Test
+	function testShuffleWithThreeElementArray()
+	{
+		var seen = new Map<String, Bool>();
+		// The probability of this failing is (5/6)^20 = 2.6%. But because we use
+		// a fixed seed, once it passes, it will always pass, so there is no need
+		// for more iterations.
+		for (i in 0...20) {
+			var array = [1, 2, 3];
+			random.shuffle(array);
+			seen[array.join(",")] = true;
+		}
+		// We have to turn the Iterator returned by keys() back into an Iterable to
+		// make Hamcrest happy.
+		var keys = [for (key in seen.keys()) key];
+		assertThat(keys, containsInAnyOrder("1,2,3", "1,3,2", "2,1,3", "2,3,1", "3,1,2", "3,2,1"));
 	}
 }

--- a/tests/unit/src/flixel/math/FlxRandomTest.hx
+++ b/tests/unit/src/flixel/math/FlxRandomTest.hx
@@ -60,7 +60,8 @@ class FlxRandomTest extends FlxTest
 		// The probability of this failing is (5/6)^20 = 2.6%. But because we use
 		// a fixed seed, once it passes, it will always pass, so there is no need
 		// for more iterations.
-		for (i in 0...20) {
+		for (i in 0...20)
+		{
 			var array = [1, 2, 3];
 			random.shuffle(array);
 			seen[array.join(",")] = true;


### PR DESCRIPTION
Deprecate FlxRandom#shuffleArray() in favour of this.

Fixes #1914.

Unlike `shuffleArray()`, I decided not to return the shuffled array, to make it crystal clear from the API that the array is modified in place rather than cloned.