### PR TITLE
Fix for FlxTilemap with pixelPerfectRender.

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1538,12 +1538,12 @@ class FlxCamera extends FlxBasic
 	
 	public inline function floorX(x:Float):Float
 	{
-		return Math.floor(x * totalScaleX) / totalScaleX;
+		return FlxG.renderBlit ? Math.floor(x) : (Math.floor(x * totalScaleX) / totalScaleX);
 	}
 	
 	public inline function floorY(y:Float):Float
 	{
-		return Math.floor(y * totalScaleY) / totalScaleY;
+		return FlxG.renderBlit ? Math.floor(y) : (Math.floor(y * totalScaleY) / totalScaleY);
 	}
 	
 	private function set_followLerp(Value:Float):Float

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1525,6 +1525,27 @@ class FlxCamera extends FlxBasic
 		setScale(scaleX, scaleY);
 	}
 	
+	/**
+	 * Helper function to make sure a point will use integer coordinates after
+	 * applying scale.
+	 */
+	public inline function floorPoint(point:FlxPoint):FlxPoint
+	{
+		point.x = floorX(point.x);
+		point.y = floorY(point.y);
+		return point;
+	}
+	
+	public inline function floorX(x:Float):Float
+	{
+		return Math.floor(x * totalScaleX) / totalScaleX;
+	}
+	
+	public inline function floorY(y:Float):Float
+	{
+		return Math.floor(y * totalScaleY) / totalScaleY;
+	}
+	
 	private function set_followLerp(Value:Float):Float
 	{
 		return followLerp = FlxMath.bound(Value, 0, 60 / FlxG.updateFramerate);

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -810,28 +810,33 @@ class FlxObject extends FlxBasic
 	/**
 	 * Call this function to figure out the on-screen position of the object.
 	 * 
-	 * @param	Point		Takes a FlxPoint object and assigns the post-scrolled X and Y values of this object to it.
-	 * @param	Camera		Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
+	 * @param	point		Takes a FlxPoint object and assigns the post-scrolled X and Y values of this object to it.
+	 * @param	camera		Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
 	 * @return	The Point you passed in, or a new Point if you didn't pass one, containing the screen X and Y position of this object.
 	 */
-	public function getScreenPosition(?point:FlxPoint, ?Camera:FlxCamera):FlxPoint
+	public function getScreenPosition(?point:FlxPoint, ?camera:FlxCamera):FlxPoint
 	{
 		if (point == null)
 		{
 			point = FlxPoint.get();
 		}
-		if (Camera == null)
+		if (camera == null)
 		{
-			Camera = FlxG.camera;
+			camera = FlxG.camera;
 		}
 		
 		point.set(x, y);
 		if (pixelPerfectPosition)
 		{
-			point.floor();
+			camera.floorPoint(point);
+		}
+		point.subtract(camera.scroll.x * scrollFactor.x, camera.scroll.y * scrollFactor.y);
+		if (pixelPerfectPosition)
+		{
+			camera.floorPoint(point);
 		}
 		
-		return point.subtract(Camera.scroll.x * scrollFactor.x, Camera.scroll.y * scrollFactor.y);
+		return point;
 	}
 	
 	public function getPosition(?point:FlxPoint):FlxPoint

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -644,6 +644,8 @@ class FlxSprite extends FlxObject
 	
 	private function drawSimple(camera:FlxCamera):Void
 	{
+		if (isPixelPerfectRender(camera))
+			camera.floorPoint(_point);
 		_point.copyToFlash(_flashPoint);
 		camera.copyPixels(_frame, framePixels, _flashRect,
 			_flashPoint, colorTransform, blend, antialiasing);

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -644,9 +644,6 @@ class FlxSprite extends FlxObject
 	
 	private function drawSimple(camera:FlxCamera):Void
 	{
-		if (isPixelPerfectRender(camera))
-			_point.floor();
-		
 		_point.copyToFlash(_flashPoint);
 		camera.copyPixels(_frame, framePixels, _flashRect,
 			_flashPoint, colorTransform, blend, antialiasing);
@@ -666,14 +663,8 @@ class FlxSprite extends FlxObject
 				_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 		}
 		
-		_point.add(origin.x, origin.y);		
+		_point.add(origin.x, origin.y);
 		_matrix.translate(_point.x, _point.y);
-		
-		if (isPixelPerfectRender(camera))
-		{
-			_matrix.tx = Math.floor(_matrix.tx);
-			_matrix.ty = Math.floor(_matrix.ty);
-		}
 		
 		camera.drawPixels(_frame, framePixels, _matrix, colorTransform, blend, antialiasing, shader);
 	}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -863,12 +863,6 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		{
 			getScreenPosition(_point, Camera).subtractPoint(offset).copyToFlash(_helperPoint);
 			
-			if (isPixelPerfectRender(Camera))
-			{
-				_helperPoint.x = Camera.floorX(_helperPoint.x);
-				_helperPoint.y = Camera.floorY(_helperPoint.y);
-			}
-			
 			scaledWidth  = _scaledTileWidth;
 			scaledHeight = _scaledTileHeight;
 			
@@ -943,7 +937,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					}
 					else
 					{
-						if (isPixelPerfectRender(camera))
+						if (isPixelPerfectRender(Camera))
 						{
 							drawX = Camera.floorX((columnIndex % widthInTiles) * scaledWidth);
 							drawY = Camera.floorY(Math.floor(columnIndex / widthInTiles) * scaledHeight);
@@ -976,7 +970,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 							scaleX += 1 / (frame.sourceSize.x * Camera.totalScaleX);
 							scaleY += 1 / (frame.sourceSize.y * Camera.totalScaleY);
 						}
-						
+
 						_matrix.scale(scaleX, scaleY);
 						_matrix.translate(drawX, drawY);
 						


### PR DESCRIPTION
The goal is to make useScaleHack on FlxTilemap unnecessary, by adjusting tile widths/heights as needed to fill exactly the right amount of space. This totally eliminates gaps between tiles, and even works with tilesets that use alpha (useScaleHack causes tiles to overlap, which with alpha != 1 creates visible seams.) This also solves some issues when the camera \* screen are scaled at a non-integer value, and flooring coordinates doesn't actually result in integer positions after applying scale.

~~Would appreciate some more eyes on this. There's still one big issue, which is that a FlxSprite on top of a FlxTilemap using pixelPerfectRender appears to "jitter" as the camera moves, due to slightly different scrolling behavior. I'm guessing this is a difference in the order of flooring coordinates, and may be related to https://github.com/HaxeFlixel/flixel/issues/1951?~~ The camera jitter issue is fixed.
