### PR TITLE
FlxTimerManager: fix array manipulation in onComplete

### DIFF
--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -175,14 +175,10 @@ class FlxTimer implements IFlxDestroyable
 	private function onLoopFinished():Void
 	{
 		if (onComplete != null)
-		{
 			onComplete(this);
-		}
 		
 		if (finished)
-		{
 			cancel();
-		}
 	}
 	
 	private inline function get_timeLeft():Float
@@ -312,9 +308,15 @@ class FlxTimerManager extends FlxBasic
 		for (timer in _timers)
 			if (timer.loops > 0)
 				timersToFinish.push(timer);
+
 		for (timer in timersToFinish)
+		{
 			while (!timer.finished)
+			{
 				timer.update(timer.timeLeft);
+				timer.onLoopFinished();
+			}
+		}
 	}
 
 	

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -311,7 +311,7 @@ class FlxTimerManager extends FlxBasic
 		var timersToFinish:Array<FlxTimer> = [];
 		
 		for (timer in _timers)
-            if (timer.loops > 0 && timer.active) // or should we activate timer and force it to finish?
+            if (timer.loops > 0 && timer.active)
 				timersToFinish.push(timer);
 		
 		if (timersToFinish.length == 0)

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -163,6 +163,11 @@ class FlxTimer implements IFlxDestroyable
 		{
 			_timeCounter -= time;
 			_loopsCounter++;
+			
+			if (loops > 0 && (_loopsCounter >= loops))
+			{
+				finished = true;
+			}
 		}
 	}
 	
@@ -174,9 +179,8 @@ class FlxTimer implements IFlxDestroyable
 			onComplete(this);
 		}
 		
-		if (loops > 0 && (_loopsCounter >= loops))
+		if (finished)
 		{
-			finished = true;
 			cancel();
 		}
 	}

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -309,36 +309,14 @@ class FlxTimerManager extends FlxBasic
 	public function completeAll():Void
 	{
 		var timersToFinish:Array<FlxTimer> = [];
-		
 		for (timer in _timers)
-            if (timer.loops > 0 && timer.active)
+			if (timer.loops > 0)
 				timersToFinish.push(timer);
-		
-		if (timersToFinish.length == 0)
-			return;
-		
-		var loopedTimers:Array<FlxTimer> = [];
-		
-		while (timersToFinish.length > 0)
-		{
-			for (timer in timersToFinish)
-			{
+		for (timer in timersToFinish)
+			while (!timer.finished)
 				timer.update(timer.timeLeft);
-				loopedTimers.push(timer);
-			}
-			
-			while (loopedTimers.length > 0)
-			{
-				var loopedTimer:FlxTimer = loopedTimers.shift();
-				loopedTimer.onLoopFinished();
-				
-				if (loopedTimer.finished)
-				{
-					timersToFinish.remove(loopedTimer);
-				}
-			}
-		}
 	}
+
 	
 	/**
 	 * Removes all the timers from the timer manager.
@@ -355,7 +333,7 @@ class FlxTimerManager extends FlxBasic
 	 */
 	public function forEach(Function:FlxTimer->Void)
 	{
-		for (timer in _timers)		
+		for (timer in _timers)
 			Function(timer);
 	}
 }

--- a/tests/unit/src/flixel/util/FlxTimerTest.hx
+++ b/tests/unit/src/flixel/util/FlxTimerTest.hx
@@ -43,7 +43,7 @@ class FlxTimerTest extends FlxTest
 		step();
 	}
 
-	@Test
+	@Test // #679
 	@:access(flixel.util.FlxTimerManager.remove)
 	function testManipuleListInCallback()
 	{

--- a/tests/unit/src/flixel/util/FlxTimerTest.hx
+++ b/tests/unit/src/flixel/util/FlxTimerTest.hx
@@ -40,7 +40,6 @@ class FlxTimerTest extends FlxTest
 		FlxTimer.globalManager.completeAll();
 		Assert.areEqual(0, timer.loopsLeft);
 		Assert.areEqual(2, loopsCompleted);
-		step();
 	}
 
 	@Test // #679

--- a/tests/unit/src/flixel/util/FlxTimerTest.hx
+++ b/tests/unit/src/flixel/util/FlxTimerTest.hx
@@ -42,4 +42,22 @@ class FlxTimerTest extends FlxTest
 		Assert.areEqual(2, loopsCompleted);
 		step();
 	}
+
+	@Test
+	@:access(flixel.util.FlxTimerManager.remove)
+	function testManipuleListInCallback()
+	{
+		var timer2 = new FlxTimer();
+		var timer1 = new FlxTimer().start(0.0001, function(_)
+			FlxTimer.globalManager.remove(timer2)
+		);
+		timer2.start(0.2);
+		var timer3 = new FlxTimer().start(0.2);
+
+		step();
+		Assert.isTrue(timer1.finished);
+		// make sure these timers were updated
+		Assert.isTrue(timer2.progress > 0);
+		Assert.isTrue(timer3.progress > 0);
+	}
 }


### PR DESCRIPTION
I've made mistake in my previous PR (inserted while loop in wrong place).
This PR request also changes `completeAll()` method. Previous version of this method doesn't take into account the value of `active` property of timer. This could lead to infinite loop (maybe i'm wrong about this), because without check of `active` value it adds inactive timers to `timersToFinish` array, which won't finish (there is check in timer's update method).
And thus i have a question: Do we need to activate paused timers and force them to finish or should we complete only active timers. I could add some parameter to `completeAll()` which will be responsible for this behavior, like `includeInactive:Bool = false`