### PR TITLE
FlxTweenManager: check for active in completeAll()

### DIFF
--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -1141,7 +1141,7 @@ class FlxTweenManager extends FlxBasic
 	public function completeAll():Void
 	{
 		for (tween in _tweens)
-			if ((tween.type & FlxTween.LOOPING) == 0 && (tween.type & FlxTween.PINGPONG) == 0)
+			if ((tween.type & FlxTween.LOOPING) == 0 && (tween.type & FlxTween.PINGPONG) == 0 && tween.active)
 				tween.update(FlxMath.MAX_VALUE_FLOAT);
 	}
 

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -151,6 +151,25 @@ class FlxTweenTest extends FlxTest
 		};
 	}
 
+	@Test
+	function testCompleteAll()
+	{
+		var tween = makeTween(0.1, function(_) {});
+		FlxTween.globalManager.completeAll();
+
+		Assert.isTrue(tween.finished);
+	}
+
+	@Test // #1955
+	function testCompleteAllInactive()
+	{
+		var tween = makeTween(0.1, function(_) {});
+		tween.active = false;
+		FlxTween.globalManager.completeAll();
+
+		Assert.isFalse(tween.finished);
+	}
+
 	function makeTween(duration:Float, onComplete:TweenCallback):FlxTween
 	{
 		var foo = { f: 0 };


### PR DESCRIPTION
this patch adds check for tween's `active` value in `completeAll()` method od `FlxTweenManager` (just like in https://github.com/HaxeFlixel/flixel/pull/1954)
I think that we shouldn't finish tween if it's inactive.
Should we add this check in tween's `update()` method as well (like in `FlxTimer` class)?