### PR TITLE
FlxMouseEventManager: check objects for camera overlap

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1524,6 +1524,15 @@ class FlxCamera extends FlxBasic
 		updateFlashOffset();
 		setScale(scaleX, scaleY);
 	}
+
+	/**
+	 * Checks whether this camera contains a given point or rectangle, in
+	 * screen coordinates.
+	 */
+	public inline function containsPoint(point:FlxPoint, width:Float = 0, height:Float = 0):Bool
+	{
+		return (point.x + width > 0) && (point.x < this.width) && (point.y + height > 0) && (point.y < this.height);
+	}
 	
 	private function set_followLerp(Value:Float):Float
 	{

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -904,7 +904,7 @@ class FlxObject extends FlxBasic
 			Camera = FlxG.camera;
 		}
 		getScreenPosition(_point, Camera);
-		return (_point.x + width > 0) && (_point.x < Camera.width) && (_point.y + height > 0) && (_point.y < Camera.height);
+		return Camera.containsPoint(_point, width, height);
 	}
 	
 	/**

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -69,6 +69,27 @@ class FlxPointer
 	}
 	
 	/**
+	 * Fetch the screen position of the pointer relative to given camera's viewport.
+	 * 
+	 * @param 	Camera		If unspecified, first/main global camera is used instead.
+	 * @param 	point		An existing point object to store the results (if you don't want a new one created). 
+	 * @return 	The touch point's location relative to camera's viewport.
+	 */
+	public function getCameraViewPosition(?Camera:FlxCamera, ?point:FlxPoint):FlxPoint
+	{
+		if (Camera == null)
+			Camera = FlxG.camera;
+		
+		if (point == null)
+			point = FlxPoint.get();
+		
+		point.x = (_globalScreenX - Camera.x) / Camera.zoom;
+		point.y = (_globalScreenY - Camera.y) / Camera.zoom;
+		
+		return point;
+	}
+	
+	/**
 	 * Returns a FlxPoint with this input's x and y.
 	 */
 	public function getPosition(?point:FlxPoint):FlxPoint

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -75,7 +75,7 @@ class FlxPointer
 	 * @param 	point		An existing point object to store the results (if you don't want a new one created). 
 	 * @return 	The touch point's location relative to camera's viewport.
 	 */
-	public function getCameraViewPosition(?Camera:FlxCamera, ?point:FlxPoint):FlxPoint
+	public function getPositionInCameraView(?Camera:FlxCamera, ?point:FlxPoint):FlxPoint
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -443,7 +443,7 @@ class FlxMouseEventManager extends FlxBasic
 		for (camera in Register.object.cameras)
 		{
 			#if FLX_MOUSE
-			_point = FlxG.mouse.getScreenPosition(camera, _point);
+			_point = FlxG.mouse.getPositionInCameraView(camera, _point);
 			if (camera.containsPoint(_point))
 			{
 				_point = FlxG.mouse.getWorldPosition(camera, _point);
@@ -458,7 +458,7 @@ class FlxMouseEventManager extends FlxBasic
 			#if FLX_TOUCH
 			for (touch in FlxG.touches.list)
 			{
-				_point = touch.getScreenPosition(camera, _point);
+				_point = touch.getPositionInCameraView(camera, _point);
 				if (camera.containsPoint(_point))
 				{
 					_point = touch.getWorldPosition(camera, _point);

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -103,7 +103,7 @@ class FlxMouseEventManager extends FlxBasic
 	}
 
 	/**
-	 * Removes all registerd objects from the registry.
+	 * Removes all registered objects from the registry.
 	 */
 	public static function removeAll():Void
 	{
@@ -443,22 +443,30 @@ class FlxMouseEventManager extends FlxBasic
 		for (camera in Register.object.cameras)
 		{
 			#if FLX_MOUSE
-			_point = FlxG.mouse.getWorldPosition(camera, _point);
-			
-			if (checkOverlapWithPoint(Register, _point, camera))
+			_point = FlxG.mouse.getScreenPosition(camera, _point);
+			if (camera.containsPoint(_point))
 			{
-				return true;
+				_point = FlxG.mouse.getWorldPosition(camera, _point);
+				
+				if (checkOverlapWithPoint(Register, _point, camera))
+				{
+					return true;
+				}
 			}
 			#end
 			
 			#if FLX_TOUCH
 			for (touch in FlxG.touches.list)
 			{
-				_point = touch.getWorldPosition(camera, _point);
-				
-				if (checkOverlapWithPoint(Register, _point, camera))
+				_point = touch.getScreenPosition(camera, _point);
+				if (camera.containsPoint(_point))
 				{
-					return true;
+					_point = touch.getWorldPosition(camera, _point);
+					
+					if (checkOverlapWithPoint(Register, _point, camera))
+					{
+						return true;
+					}
 				}
 			}
 			#end


### PR DESCRIPTION
The problem: when using FlxCameras that don't cover the whole screen, mouse events can be generated by FlxMouseEventManager when the mouse isn't within the camera's visible area.

Example: this scrolling button menu has its own FlxCamera. The top button is highlighted by an onMouseOver callback, even though the overlapping part is above the camera's visible area:

<img width="367" alt="screen shot 2016-09-28 at 8 32 09 am" src="https://cloud.githubusercontent.com/assets/544977/18920399/1d6864c0-8556-11e6-9f7e-ea939c240017.png">

With this change, FlxMouseEventManager first checks that the screen coordinates are within the camera's bounds before checking if the object overlaps the mouse position.

<img width="381" alt="screen shot 2016-09-28 at 8 34 15 am" src="https://cloud.githubusercontent.com/assets/544977/18920501/6713ffe4-8556-11e6-8823-04786dc3f0a5.png">
