### PR TITLE
FlxSubState: fix close() if used in two different states

### DIFF
--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -112,10 +112,11 @@ class FlxState extends FlxGroup
 				FlxG.inputs.onStateSwitch();
 			}
 			
+			subState._parentState = this;
+			
 			if (!subState._created)
 			{
 				subState._created = true;
-				subState._parentState = this;
 				subState.create();
 			}
 		}

--- a/tests/unit/src/flixel/FlxSubStateTest.hx
+++ b/tests/unit/src/flixel/FlxSubStateTest.hx
@@ -37,4 +37,31 @@ class FlxSubStateTest extends FlxTest
 		
 		Assert.areEqual(subState2, FlxG.state.subState);
 	}
+	
+	@Test // #1971
+	function testOpenPersistentSubStateFromNewParent()
+	{
+		var state1 = new FlxState();
+		var state2 = new FlxState();
+		state1.destroySubStates = false;
+		FlxG.switchState(state1);
+		step();
+		FlxG.state.openSubState(subState1);
+		step();
+
+		Assert.areEqual(state1.subState, subState1);
+		subState1.close();
+		step();
+		Assert.isNull(state1.subState);
+
+		FlxG.switchState(state2);
+		step();
+		FlxG.state.openSubState(subState1);
+		step();
+
+		Assert.areEqual(state2.subState, subState1);
+		subState1.close();
+		step();
+		Assert.isNull(state2.subState);
+	}
 }


### PR DESCRIPTION
If you have persistent substates which you open from multiple parent states, you want the parent state of the substate to change even if the state has already been created, otherwise _parentState will be incorrect when you open the substate from a second location.