### PR TITLE
FlxCamera: workaround for rendering edge case on Flash, closes #1838

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -390,7 +390,8 @@ class FlxCamera extends FlxBasic
 	
 	#if flash
 	/**
-	 * Internal helper for drawing pixels on the camera. Using this fixes some weird bugs with flash software renderer.
+	 * Internal helper for drawing pixels on the camera.
+	 Using this fixes some weird bugs with flash software renderer (see #1838).
 	 */
 	private var _bitmap:Bitmap;
 	#end

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -387,6 +387,13 @@ class FlxCamera extends FlxBasic
 	
 	private var _helperMatrix:FlxMatrix = new FlxMatrix();
 	
+	#if flash
+	/**
+	 * Internal helper for drawing pixels on the camera. Using this fixes some weird bugs with flash software renderer.
+	 */
+	private var _bitmap:Bitmap;
+	#end
+	
 	/**
 	 * Currently used draw stack item
 	 */
@@ -597,7 +604,12 @@ class FlxCamera extends FlxBasic
 	{
 		if (FlxG.renderBlit)
 		{
+			#if flash
+			_bitmap.bitmapData = pixels;
+			buffer.draw(_bitmap, matrix, null, blend, null, (smoothing || antialiasing));
+			#else
 			buffer.draw(pixels, matrix, null, blend, null, (smoothing || antialiasing));
+			#end
 		}
 		else
 		{
@@ -754,6 +766,10 @@ class FlxCamera extends FlxBasic
 			_flashBitmap = new Bitmap(buffer);
 			_scrollRect.addChild(_flashBitmap);
 			_fill = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
+			
+			#if flash
+			_bitmap = new Bitmap();
+			#end
 		}
 		else
 		{
@@ -794,6 +810,10 @@ class FlxCamera extends FlxBasic
 			buffer = null;
 			_flashBitmap = null;
 			_fill = FlxDestroyUtil.dispose(_fill);
+			
+			#if flash
+			_bitmap = null;
+			#end
 		}
 		else
 		{

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -391,7 +391,7 @@ class FlxCamera extends FlxBasic
 	#if flash
 	/**
 	 * Internal helper for drawing pixels on the camera.
-	 Using this fixes some weird bugs with flash software renderer (see #1838).
+	 * Using this fixes some weird bugs with flash software renderer (see #1838).
 	 */
 	private var _bitmap:Bitmap;
 	#end

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -2,6 +2,7 @@ package flixel;
 
 import flash.display.Bitmap;
 import flash.display.BitmapData;
+import flash.display.IBitmapDrawable;
 import flash.display.Graphics;
 import flash.display.Sprite;
 import flash.geom.ColorTransform;
@@ -604,12 +605,13 @@ class FlxCamera extends FlxBasic
 	{
 		if (FlxG.renderBlit)
 		{
+			var drawable:IBitmapDrawable = pixels;
 			#if flash
 			_bitmap.bitmapData = pixels;
-			buffer.draw(_bitmap, matrix, null, blend, null, (smoothing || antialiasing));
-			#else
-			buffer.draw(pixels, matrix, null, blend, null, (smoothing || antialiasing));
+			drawable = _bitmap;
 			#end
+			
+			buffer.draw(drawable, matrix, null, blend, null, (smoothing || antialiasing));
 		}
 		else
 		{


### PR DESCRIPTION
Using helper flash.display.Bitmap object for drawing pixels on camera's buffer fixes this weird bug on flash target and it shouldn't have negative perfomance effect (at least in BunnyMark test)