### PR TITLE
FlxBaseTilemap: new optimized pathing method

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -720,7 +720,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param	DiagonalPolicy	How to treat diagonal movement. (Default is WIDE, count +1 tile for diagonal movement)
 	 * @return	An Array of FlxPoints, containing all waypoints from the start to the end.  If no path could be found, then a null reference is returned.
 	 */
-	public function findPath(Start:FlxPoint, End:FlxPoint, Simplify:Bool = true, RaySimplify:Bool = false, DiagonalPolicy:FlxTilemapDiagonalPolicy = WIDE, PathingMethod:FlxTilemapPathingMethod = null):Array<FlxPoint>
+	public function findPath(Start:FlxPoint, End:FlxPoint, Simplify:Bool = true, RaySimplify:Bool = false, DiagonalPolicy:FlxTilemapDiagonalPolicy = WIDE, ?PathingMethod:FlxTilemapPathingMethod):Array<FlxPoint>
 	{
 		if (PathingMethod == null) PathingMethod = FlxTilemapPathingMethod.BASIC;
 
@@ -790,7 +790,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		walkPath(distances, zone.indexEnd, pathIndexes, zone.sizeX, zone.sizeY);
 
 		// Translate back points from index within the zone array into original map coordinates
-		for (index in pathIndexes) {
+		for (index in pathIndexes)
+		{
 			var x = index % zone.sizeX;
 			var y = Math.floor(index / zone.sizeX);
 			var indexInMap = x + zone.x0 + (y + zone.y0) * widthInTiles;
@@ -845,13 +846,13 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		// Create a distance-based representation of the tilemap.
 		// All walls are flagged as -2, all open areas as -1.
 
-		var distances= new Array<Int>(/*zone.sizeX * zone.sizeY*/);
+		var distances = new Array<Int>(/*zone.sizeX * zone.sizeY*/);
 		FlxArrayUtil.setLength(distances, zone.sizeX * zone.sizeY);
 
 		var i:Int = 0;
-		for (yy in zone.y0...zone.y0+zone.sizeY)
+		for (yy in zone.y0...zone.y0 + zone.sizeY)
 		{
-			for (xx in zone.x0...zone.x0+zone.sizeX)
+			for (xx in zone.x0...zone.x0 + zone.sizeX)
 			{
 				if (_tileObjects[_data[xx + yy * widthInTiles]].allowCollisions != FlxObject.NONE)
 				{
@@ -1357,7 +1358,8 @@ abstract FlxTilemapDiagonalPolicy(Int)
 	var WIDE = 2;
 }
 
-enum FlxTilemapPathingMethod {
+enum FlxTilemapPathingMethod
+{
 	/**
 	 * Basic method is calculating distances using an array covering the whole map (was original solution)
 	*/
@@ -1370,7 +1372,8 @@ enum FlxTilemapPathingMethod {
 	BASIC_SCALED_HORIZON(scale:Float, minHorizonSize:Int);
 }
 
-typedef FlxTilemapZone = {
+typedef FlxTilemapZone =
+{
 	var x0:Int;
 	var y0:Int;
 	var sizeX:Int;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -734,13 +734,12 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			return null;
 		}
 
-		var zone:FlxTilemapZone = null;
-		switch (PathingMethod)
+		var zone:FlxTilemapZone = switch (PathingMethod)
 		{
 			// Basic pathing method where distances from starting point is calculated for all tiles
 			// until reaching the end point, and then path is found by backtracking from end point to starting point
 			case FlxTilemapPathingMethod.BASIC:
-				zone = {x0:0, y0:0, sizeX:widthInTiles, sizeY:heightInTiles, indexStart:startIndex, indexEnd:endIndex};
+				{x0:0, y0:0, sizeX:widthInTiles, sizeY:heightInTiles, indexStart:startIndex, indexEnd:endIndex};
 
 			// Scaled horizon method should be used with large maps:
 			// the basic pathing method is used over a small zone
@@ -774,7 +773,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 				var zoneSizeY = y1 - y0;
 				var startIndexInZone = (startX - x0) + (startY - y0) * zoneSizeX;
 				var endIndexInZone = (endX - x0) + (endY - y0) * zoneSizeX;
-				zone = {x0:x0, y0:y0, sizeX:zoneSizeX, sizeY:zoneSizeY, indexStart:startIndexInZone, indexEnd:endIndexInZone};
+				{x0:x0, y0:y0, sizeX:zoneSizeX, sizeY:zoneSizeY, indexStart:startIndexInZone, indexEnd:endIndexInZone};
 		}
 
 		// Figure out how far each of the tiles is from the starting tile

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -734,7 +734,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			return null;
 		}
 
-		var zone:FlxTilemapZone;
+		var zone:FlxTilemapZone = null;
 		switch (PathingMethod)
 		{
 			// Basic pathing method where distances from starting point is calculated for all tiles

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -777,7 +777,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		}
 
 		// Figure out how far each of the tiles is from the starting tile
-		var distances = computePathDistance(zone, DiagonalPolicy);
+		var distances = computePathDistanceZone(zone, DiagonalPolicy);
 		if (distances == null)
 		{
 			return null;
@@ -830,7 +830,23 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		
 		return path;
 	}
-	
+
+	/**
+	 * Pathfinding helper function, floods a grid with distance information until it finds the end point.
+	 * NOTE: Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
+	 *
+	 * @param	StartIndex		The starting tile's map index.
+	 * @param	EndIndex		The ending tile's map index.
+	 * @param	DiagonalPolicy	How to treat diagonal movement.
+	 * @param	StopOnEnd		Whether to stop at the end or not (default true)
+	 * @return	An array of FlxPoint nodes. If the end tile could not be found, then a null Array is returned instead.
+	 */
+	public function computePathDistance(StartIndex:Int, EndIndex:Int, DiagonalPolicy:FlxTilemapDiagonalPolicy, StopOnEnd:Bool = true):Array<Int>
+	{
+		var zone:FlxTilemapZone = {x0:0, y0:0, sizeX:widthInTiles, sizeY:heightInTiles, indexStart:StartIndex, indexEnd:EndIndex};
+		return computePathDistanceZone(zone, DiagonalPolicy, StopOnEnd);
+	}
+
 	/**
 	 * Pathfinding helper function, floods a grid with distance information until it finds the end point.
 	 * NOTE: Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
@@ -840,7 +856,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param	StopOnEnd		Whether to stop at the end or not (default true)
 	 * @return	An array of distances over the input zone. If the end tile could not be found, then a null Array is returned instead.
 	 */
-	public function computePathDistance(zone:FlxTilemapZone, DiagonalPolicy:FlxTilemapDiagonalPolicy, StopOnEnd:Bool = true):Array<Int>
+	public function computePathDistanceZone(zone:FlxTilemapZone, DiagonalPolicy:FlxTilemapDiagonalPolicy, StopOnEnd:Bool = true):Array<Int>
 	{
 		// Create a distance-based representation of the tilemap.
 		// All walls are flagged as -2, all open areas as -1.


### PR DESCRIPTION
Add new parameter to optional argument to findPath() to select a pathing
method. The default method remains unchanged. New parameter `PathingMethod` can be set to
`BASIC_SCALED_HORIZON(scale:Float, minHorizonSize:Int)` to constrain the pathing
algorithm into a zone `scale` times larger than the start tile-end tile
rectangle, with a minimum width and length of `minHorizonSize`.
