### PR TITLE
FlxTween: add cancelChain()

### DIFF
--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -497,8 +497,10 @@ class FlxTween implements IFlxDestroyable
 	}
 	
 	/**
-	 * Immediately stops the Tween and removes it from the 
-	 * TweenManager without calling the complete callback.
+	 * Immediately stops the Tween and removes it from its 
+	 * `manager` without calling the `onComplete` callback.
+	 *
+	 * Yields control to the next chained Tween if one exists.
 	 */
 	public function cancel():Void
 	{
@@ -509,13 +511,16 @@ class FlxTween implements IFlxDestroyable
 	}
 
 	/**
-	 * Immediately stops this Tween and removes it from the TweenManager without calling the onComplete callback
+	 * Immediately stops the Tween and removes it from its
+	 * `manager` without calling the `onComplete` callback
 	 * or yielding control to the next chained Tween if one exists.
-	 * If control has already been passed on, forwards the cancellation request along the chain to the currently active Tween.   
+	 *
+	 * If control has already been passed on, forwards the cancellation
+	 * request along the chain to the currently active Tween.
 	 */
 	public function cancelChain():Void
 	{
-		// Pass along the cancellation request. 
+		// Pass along the cancellation request.
 		if (_nextTweenInChain != null)
 			_nextTweenInChain.cancelChain();
 

--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -373,6 +373,7 @@ class FlxTween implements IFlxDestroyable
 	private var _running:Bool = false;
 	private var _waitingForRestart:Bool = false;
 	private var _chainedTweens:Array<FlxTween>;
+	private var _nextTweenInChain:FlxTween;
 	
 	/**
 	 * This function is called when tween is created, or recycled.
@@ -409,6 +410,7 @@ class FlxTween implements IFlxDestroyable
 		ease = null;
 		manager = null;
 		_chainedTweens = null;
+		_nextTweenInChain = null;
 	}
 	
 	/**
@@ -505,6 +507,24 @@ class FlxTween implements IFlxDestroyable
 		if (manager != null)
 			manager.remove(this);
 	}
+
+	/**
+	 * Immediately stops this Tween and removes it from the TweenManager without calling the onComplete callback
+	 * or yielding control to the next chained Tween if one exists.
+	 * If control has already been passed on, forwards the cancellation request along the chain to the currently active Tween.   
+	 */
+	public function cancelChain():Void
+	{
+		// Pass along the cancellation request. 
+		if (_nextTweenInChain != null)
+			_nextTweenInChain.cancelChain();
+
+		// Prevent yielding control to any chained tweens.
+		if (_chainedTweens != null)
+			_chainedTweens = null;
+			
+		cancel();
+	}
 	
 	private function finish():Void
 	{
@@ -570,7 +590,10 @@ class FlxTween implements IFlxDestroyable
 		if (_chainedTweens == null || _chainedTweens.length <= 0)
 			return;
 		
-		doNextTween(_chainedTweens.shift());
+		// Remember next tween to enable cancellation of the chain.
+		_nextTweenInChain = _chainedTweens.shift();
+
+		doNextTween(_nextTweenInChain);
 		_chainedTweens = null;
 	}
 	

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -83,6 +83,45 @@ class FlxTweenTest extends FlxTest
 	}
 
 	@Test
+	function testCancelChainFirstTweenUnfinished()
+	{
+		var tweenCount = 4;
+		var tweenUpdated = [for (i in 0 ... tweenCount) false];
+		var tweenCompleted = [for (i in 0 ... tweenCount) false];
+		var tween = [for (i in 0 ... tweenCount) makeTween(0.1, function (_) tweenCompleted[i] = true, function (_) tweenUpdated[i] = true)];
+
+		for (i in 1 ... tweenCount) { tween[0].wait(0.1).then(tween[i]); }
+
+		while (!tweenUpdated[0]) step();
+		Assert.isFalse(tweenCompleted[0]);
+
+		tween[0].cancelChain();
+
+		for (i in 0 ... tweenCount) { finishTween(tween[i]); }
+		for (i in 1 ... tweenCount) { Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]); }
+	}
+
+	@Test
+	function testCancelChainFirstTweenFinished()
+	{
+		var tweenCount = 4;
+		var tweenUpdated = [for (i in 0 ... tweenCount) false];
+		var tweenCompleted = [for (i in 0 ... tweenCount) false];
+		var tween = [for (i in 0 ... tweenCount) makeTween(0.1, function (_) tweenCompleted[i] = true, function (_) tweenUpdated[i] = true)];
+		
+		for (i in 1 ... tweenCount) { tween[0].wait(0.1).then(tween[i]); }
+		
+		while (!tweenUpdated[1]) step();
+		Assert.isTrue(tweenUpdated[0] && tweenCompleted[0]);
+		Assert.isFalse(tweenCompleted[1]);
+		
+		tween[0].cancelChain();
+		
+		for (i in 1 ... tweenCount) { finishTween(tween[i]); }
+		for (i in 2 ... tweenCount) { Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]); }
+	}
+
+	@Test
 	function testLinearChain()
 	{
 		testChain(4, function(tweens)

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -85,40 +85,61 @@ class FlxTweenTest extends FlxTest
 	@Test
 	function testCancelChainFirstTweenUnfinished()
 	{
-		var tweenCount = 4;
-		var tweenUpdated = [for (i in 0 ... tweenCount) false];
-		var tweenCompleted = [for (i in 0 ... tweenCount) false];
-		var tween = [for (i in 0 ... tweenCount) makeTween(0.1, function (_) tweenCompleted[i] = true, function (_) tweenUpdated[i] = true)];
+		var chain = createChain(4);
 
-		for (i in 1 ... tweenCount) tween[0].wait(0.1).then(tween[i]);
+		while (!chain.updated[0])
+			step();
+		
+		Assert.isFalse(chain.completed[0]);
 
-		while (!tweenUpdated[0]) step();
-		Assert.isFalse(tweenCompleted[0]);
+		chain.tweens[0].cancelChain();
 
-		tween[0].cancelChain();
+		for (i in 0...chain.count)
+			finishTween(chain.tweens[i]);
 
-		for (i in 0 ... tweenCount) finishTween(tween[i]);
-		for (i in 1 ... tweenCount) Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]);
+		for (i in 1...chain.count)
+			Assert.isFalse(chain.updated[i] || chain.completed[i]);
 	}
 
 	@Test
 	function testCancelChainFirstTweenFinished()
 	{
-		var tweenCount = 4;
-		var tweenUpdated = [for (i in 0 ... tweenCount) false];
-		var tweenCompleted = [for (i in 0 ... tweenCount) false];
-		var tween = [for (i in 0 ... tweenCount) makeTween(0.1, function (_) tweenCompleted[i] = true, function (_) tweenUpdated[i] = true)];
+		var chain = createChain(4);
 		
-		for (i in 1 ... tweenCount) tween[0].wait(0.1).then(tween[i]);
+		while (!chain.updated[1])
+			step();
 		
-		while (!tweenUpdated[1]) step();
-		Assert.isTrue(tweenUpdated[0] && tweenCompleted[0]);
-		Assert.isFalse(tweenCompleted[1]);
+		Assert.isTrue(chain.updated[0] && chain.completed[0]);
+		Assert.isFalse(chain.completed[1]);
 		
-		tween[0].cancelChain();
+		chain.tweens[0].cancelChain();
 		
-		for (i in 1 ... tweenCount) finishTween(tween[i]);
-		for (i in 2 ... tweenCount) Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]);
+		for (i in 1...chain.count)
+			finishTween(chain.tweens[i]);
+		
+		for (i in 2...chain.count)
+			Assert.isFalse(chain.updated[i] || chain.completed[i]);
+	}
+
+	function createChain(count:Int)
+	{
+		var updated = [for (i in 0...count) false];
+		var completed = [for (i in 0...count) false];
+		var tweens = [for (i in 0...count)
+			makeTween(0.1,
+				function (_) completed[i] = true,
+				function (_) updated[i] = true
+		)];
+
+		for (i in 1...count)
+			tweens[0].wait(0.1).then(tweens[i]);
+
+		return {
+			count: count,
+			updated: updated,
+			completed: completed,
+			tweens: tweens
+		}
 	}
 
 	@Test

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -90,15 +90,15 @@ class FlxTweenTest extends FlxTest
 		var tweenCompleted = [for (i in 0 ... tweenCount) false];
 		var tween = [for (i in 0 ... tweenCount) makeTween(0.1, function (_) tweenCompleted[i] = true, function (_) tweenUpdated[i] = true)];
 
-		for (i in 1 ... tweenCount) { tween[0].wait(0.1).then(tween[i]); }
+		for (i in 1 ... tweenCount) tween[0].wait(0.1).then(tween[i]);
 
 		while (!tweenUpdated[0]) step();
 		Assert.isFalse(tweenCompleted[0]);
 
 		tween[0].cancelChain();
 
-		for (i in 0 ... tweenCount) { finishTween(tween[i]); }
-		for (i in 1 ... tweenCount) { Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]); }
+		for (i in 0 ... tweenCount) finishTween(tween[i]);
+		for (i in 1 ... tweenCount) Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]);
 	}
 
 	@Test
@@ -109,7 +109,7 @@ class FlxTweenTest extends FlxTest
 		var tweenCompleted = [for (i in 0 ... tweenCount) false];
 		var tween = [for (i in 0 ... tweenCount) makeTween(0.1, function (_) tweenCompleted[i] = true, function (_) tweenUpdated[i] = true)];
 		
-		for (i in 1 ... tweenCount) { tween[0].wait(0.1).then(tween[i]); }
+		for (i in 1 ... tweenCount) tween[0].wait(0.1).then(tween[i]);
 		
 		while (!tweenUpdated[1]) step();
 		Assert.isTrue(tweenUpdated[0] && tweenCompleted[0]);
@@ -117,8 +117,8 @@ class FlxTweenTest extends FlxTest
 		
 		tween[0].cancelChain();
 		
-		for (i in 1 ... tweenCount) { finishTween(tween[i]); }
-		for (i in 2 ... tweenCount) { Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]); }
+		for (i in 1 ... tweenCount) finishTween(tween[i]);
+		for (i in 2 ... tweenCount) Assert.isFalse(tweenUpdated[i] || tweenCompleted[i]);
 	}
 
 	@Test


### PR DESCRIPTION
The existing `FlxTween.cancel()` function works fine when you want to stop a tween that is currently active and have it yield to the next tween in the chain (if one exists).  However, the function does not help when you want to stop an entire tween chain, especially when the only reference you may hold is to the first tween in the chain.  (NOTE: Use of `FlxTween.wait()` results in the creation of hidden tweens that cannot be cancelled.)

This PR introduces `FlxTween.cancelChain()`, a new function whose purpose is to allow user code to cancel all subsequent tweens that may be chained to a particular tween, even when the root tween has already finished.  This helps simplify user code that relies on both chained tweening and the ability to cancel the animation at arbitrary times.
