### PR TITLE
Fix #1986

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -109,7 +109,7 @@ class FlxMouseEventManager extends FlxBasic
 	{
 		if (_registeredObjects != null)
 		{
-			for (reg in _registeredObjects)
+			for (reg in _registeredObjects.copy())
 			{
 				remove(reg.object);
 			}


### PR DESCRIPTION
Closes #1986

Iterating while removing, change taken from `Watch`. I'm not sure if copying is the best way vs iterating twice, but this makes it consistent with other parts of flixel.
