### PR TITLE
FlxStringUtil.getDomain() fixes + improvements

### DIFF
--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -262,7 +262,7 @@ class FlxStringUtil
 	 */
 	public static function getDomain(url:String):String
 	{
-		var regex:EReg = ~/(?<=:\/\/)(?:[a-z0-9-]+\.)*([a-z0-9-]+\.[a-z0-9-]+)/i;
+		var regex:EReg = ~/(?:[a-x0-9.+-]+:\/\/)(?:[a-z0-9-]+\.)*([a-z0-9-]+\.[a-z0-9-]+)/i;
 		return regex.match(url) ? regex.matched(1).toLowerCase() : "local";
 	}
 	

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -262,14 +262,8 @@ class FlxStringUtil
 	 */
 	public static function getDomain(url:String):String
 	{
-		var urlStart:Int = url.indexOf("://") + 3;
-		var urlEnd:Int = url.indexOf("/", urlStart);
-		var home:String = url.substring(urlStart, urlEnd);
-		var lastDot:Int = home.lastIndexOf(".") - 1;
-		var domEnd:Int = home.lastIndexOf(".", lastDot) + 1;
-		home = home.substring(domEnd, home.length);
-		home = home.split(":")[0];
-		return (home == "") ? "local" : home;
+		var regex:EReg = ~/(?<=:\/\/)(?:[a-z0-9-]+\.)*([a-z0-9-]+\.[a-z0-9-]+)/i;
+		return regex.match(url) ? regex.matched(1).toLowerCase() : "local";
 	}
 	
 	/**

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -262,7 +262,7 @@ class FlxStringUtil
 	 */
 	public static function getDomain(url:String):String
 	{
-		var regex:EReg = ~/(?:[a-x0-9.+-]+:\/\/)(?:[a-z0-9-]+\.)*([a-z0-9-]+\.[a-z0-9-]+)/i;
+		var regex:EReg = ~/(?:[a-z0-9.+-]+:\/\/)(?:[a-z0-9-]+\.)*([a-z0-9-]+\.[a-z0-9-]+)/i;
 		return regex.match(url) ? regex.matched(1).toLowerCase() : "local";
 	}
 	

--- a/tests/unit/src/flixel/util/FlxStringUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxStringUtilTest.hx
@@ -105,10 +105,10 @@ class FlxStringUtilTest
 	{
 		var domain = "xn--eckwd4c7c.test";
 
-		// Examples of valid URI components. 
-		var schemes = [ "http", "https", "fake.but-valid+scheme" ];
-		var hosts = [ '$domain', 'www.$domain', 'aaa.bbb.ccc.$domain', ];
-		var paths = [ "", "/", "/index.html", "/path/to/file.extension?query=42" ];
+		// Examples of valid URI components.
+		var schemes = ["http", "https", "fake.but-valid+scheme"];
+		var hosts = ['$domain', 'www.$domain', 'aaa.bbb.ccc.$domain'];
+		var paths = ["", "/", "/index.html", "/path/to/file.extension?query=42"];
 
 		for (scheme in schemes) for (host in hosts) for (path in paths)
 		{
@@ -118,15 +118,15 @@ class FlxStringUtilTest
 	}
 
 	/**
-	 * Returns a string with a mixture of upper and lower case characters.  
+	 * Returns a string with a mixture of upper and lower case characters.
 	 */
 	function mixedCase(string:String):String
 	{
 		var result = "", upper = false;
-		for (index in 0...string.length)
+		for (i in 0...string.length)
 		{
-			var char = string.charAt(index);
-			result += ((upper = !upper) ? char.toUpperCase() : char.toLowerCase());
+			var char = string.charAt(i);
+			result += (upper = !upper) ? char.toUpperCase() : char.toLowerCase();
 		}
 		return result;
 	}
@@ -143,9 +143,10 @@ class FlxStringUtilTest
 			"D:\\folder\\file.extension:alternate_stream_name",
 			"D:file.extension",
 			"\\\\server\\folder\\file.extension",
-			"\\\\?\\D:\\folder\\file.extension",
+			"\\\\?\\D:\\folder\\file.extension"
 		];
 		
-		for (path in paths) Assert.areEqual("local", FlxStringUtil.getDomain(path));
+		for (path in paths)
+			Assert.areEqual("local", FlxStringUtil.getDomain(path));
 	}
 }

--- a/tests/unit/src/flixel/util/FlxStringUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxStringUtilTest.hx
@@ -99,4 +99,53 @@ class FlxStringUtilTest
 		Assert.isFalse(FlxStringUtil.isNullOrEmpty("."));
 		Assert.isFalse(FlxStringUtil.isNullOrEmpty("Hello World"));
 	}
+
+	@Test
+	function testGetDomainNonLocal()
+	{
+		var domain = "xn--eckwd4c7c.test";
+
+		// Examples of valid URI components. 
+		var schemes = [ "http", "https", "fake.but-valid+scheme" ];
+		var hosts = [ '$domain', 'www.$domain', 'aaa.bbb.ccc.$domain', ];
+		var paths = [ "", "/", "/index.html", "/path/to/file.extension?query=42" ];
+
+		for (scheme in schemes) for (host in hosts) for (path in paths)
+		{
+			var uri = mixedCase('$scheme://$host$path');
+			Assert.areEqual(domain, FlxStringUtil.getDomain(uri));
+		}
+	}
+
+	/**
+	 * Returns a string with a mixture of upper and lower case characters.  
+	 */
+	function mixedCase(string:String):String
+	{
+		var result = "", upper = false;
+		for (index in 0...string.length)
+		{
+			var char = string.charAt(index);
+			result += ((upper = !upper) ? char.toUpperCase() : char.toLowerCase());
+		}
+		return result;
+	}
+
+	@Test
+	function testGetDomainLocal()
+	{
+		// Examples of some Unix-style and Windows-style local file paths.
+		var paths = [
+			"/root/folder/file.extension",
+			"./folder/file.extension",
+			"~/.extension",
+			"D:\\folder\\file.extension",
+			"D:\\folder\\file.extension:alternate_stream_name",
+			"D:file.extension",
+			"\\\\server\\folder\\file.extension",
+			"\\\\?\\D:\\folder\\file.extension",
+		];
+		
+		for (path in paths) Assert.areEqual("local", FlxStringUtil.getDomain(path));
+	}
 }


### PR DESCRIPTION
I had encountered an issue with site-locking unexpectedly failing and traced the root cause to the helper function `FlxStringUtil.getDomain()` not accepting the URL that was passed in.

This pull request firstly introduces unit testing that was originally missing for the function in question and secondly replaces the existing logic with a singular regular expression that handles valid inputs.  Additionally, the function now supports case-insensitivity by forcing the extracted domain to lower case.