### PR TITLE
FlxBasePreloader: improve the sitelock failure notice

### DIFF
--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -50,16 +50,18 @@ class FlxBasePreloader extends NMEPreloader
 	 * The title text to display on the sitelock failure screen.
 	 * NOTE: This string should be reviewed for accuracy and may need to be localized.
 	 *
-	 * To customize this variable, create a class extending `FlxBasePreloader`, and override its value in the new function:
+	 * To customize this variable, create a class extending `FlxBasePreloader`, and override its value in the constructor:
 	 *
 	 * ```haxe
-	 * class Preloader extends FlxBasePreloader {
-	 *   public function new():Void {
-	 *     super(0, [ "http://placeholder.domain.test/path/document.html" ]);
+	 * class Preloader extends FlxBasePreloader
+	 * {
+	 *     public function new():Void
+	 *     {
+	 *         super(0, ["http://placeholder.domain.test/path/document.html"]);
 	 *
-	 *     siteLockTitleText = "Custom title text.";
-	 *     siteLockBodyText = "Custom body text.";
-	 *   }
+	 *         siteLockTitleText = "Custom title text.";
+	 *         siteLockBodyText = "Custom body text.";
+	 *     }
 	 * }
 	 * ```
 	 * @since 4.3.0
@@ -70,8 +72,8 @@ class FlxBasePreloader extends NMEPreloader
 	 * The body text to display on the sitelock failure screen.
 	 * NOTE: This string should be reviewed for accuracy and may need to be localized.
 	 *
-	 * To customize this variable, create a class extending `FlxBasePreloader`, and override its value in the new function.
-	 * @see siteLockTitleText
+	 * To customize this variable, create a class extending `FlxBasePreloader`, and override its value in the constructor.
+	 * @see `siteLockTitleText`
 	 * @since 4.3.0
 	 */
 	public var siteLockBodyText:String =
@@ -241,7 +243,8 @@ class FlxBasePreloader extends NMEPreloader
 	private function checkSiteLock():Void
 	{
 		#if web
-		if (_urlChecked) return;
+		if (_urlChecked)
+			return;
 
 		if (!isHostUrlAllowed())
 		{
@@ -295,13 +298,13 @@ class FlxBasePreloader extends NMEPreloader
 
 		graphics.beginFill(color);
 		graphics.drawPath(
-			[ 1, 6, 2, 2, 2, 6, 6, 2, 2, 2, 6, 1, 6, 2, 6, 2, 6, 2, 6, 1, 6, 6, 2, 2, 2, 6, 6 ],
-			[ 120.0, 0, 164, 0, 200, 35, 200, 79, 200, 130, 160, 130, 160, 79, 160, 57, 142, 40,
+			[1, 6, 2, 2, 2, 6, 6, 2, 2, 2, 6, 1, 6, 2, 6, 2, 6, 2, 6, 1, 6, 6, 2, 2, 2, 6, 6],
+			[120.0, 0, 164, 0, 200, 35, 200, 79, 200, 130, 160, 130, 160, 79, 160, 57, 142, 40,
 				120, 40, 97, 40, 79, 57, 79, 79, 80, 130, 40, 130, 40, 79, 40, 35, 75, 0, 120, 0,
 				220, 140, 231, 140, 240, 148, 240, 160, 240, 300, 240, 311, 231, 320, 220, 320,
 				20, 320, 8, 320, 0, 311, 0, 300, 0, 160, 0, 148, 8, 140, 20, 140, 120, 190, 108,
 				190, 100, 198, 100, 210, 100, 217, 104, 223, 110, 227, 110, 270, 130, 270, 130,
-				227, 135, 223, 140, 217, 140, 210, 140, 198, 131, 190, 120, 190 ],
+				227, 135, 223, 140, 217, 140, 210, 140, 198, 131, 190, 120, 190],
 			GraphicsPathWinding.NON_ZERO
 		);
 		graphics.endFill();
@@ -370,8 +373,7 @@ class FlxBasePreloader extends NMEPreloader
 	 * When overridden, allows the customization of the text fields in the sitelock failure screen.
 	 * @since 4.3.0
 	 */
-	private function adjustSiteLockTextFields(titleText:TextField, bodyText:TextField, hyperlinkText:TextField):Void
-	{}
+	private function adjustSiteLockTextFields(titleText:TextField, bodyText:TextField, hyperlinkText:TextField):Void {}
 
 	private function goToMyURL(?e:MouseEvent):Void
 	{

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -2,10 +2,16 @@ package flixel.system;
 
 import flash.display.Bitmap;
 import flash.display.BitmapData;
+import flash.display.GradientType;
+import flash.display.GraphicsPathWinding;
+import flash.display.Shape;
+import flash.display.Sprite;
 import flash.display.StageAlign;
 import flash.display.StageScaleMode;
 import flash.events.Event;
 import flash.events.MouseEvent;
+import flash.geom.Matrix;
+import flash.geom.Rectangle;
 import flash.Lib;
 import flash.net.URLRequest;
 import flash.text.TextField;
@@ -17,15 +23,15 @@ import flixel.util.FlxStringUtil;
 class FlxBasePreloader extends NMEPreloader
 {
 	/**
-	 * Add this string to allowedURLs array if you want to be able to test game with enabled site-locking on local machine 
+	 * Add this string to allowedURLs array if you want to be able to test game with enabled site-locking on local machine
 	 */
 	public static inline var LOCAL:String = "localhost";
-	
+
 	/**
 	 * Change this if you want the flixel logo to show for more or less time.  Default value is 0 seconds (no delay).
 	 */
 	public var minDisplayTime:Float = 0;
-	
+
 	/**
 	 * List of allowed URLs for built-in site-locking.
 	 * Set it in FlxPreloader's constructor as: `['http://adamatomic.com/canabalt/', FlxPreloader.LOCAL]`;
@@ -39,14 +45,49 @@ class FlxBasePreloader extends NMEPreloader
 	 * Defaults to 0.
 	 */
 	public var siteLockURLIndex:Int = 0;
-	
+
+	/**
+	 * The title text to display on the sitelock failure screen.
+	 * NOTE: This string should be reviewed for accuracy and may need to be localized.
+	 *
+	 * To customize this variable, create a class extending `FlxBasePreloader`, and override its value in the new function:
+	 *
+	 * ```haxe
+	 * class Preloader extends FlxBasePreloader {
+	 *   public function new():Void {
+	 *     super(0, [ "http://placeholder.domain.test/path/document.html" ]);
+	 *
+	 *     siteLockTitleText = "Custom title text.";
+	 *     siteLockBodyText = "Custom body text.";
+	 *   }
+	 * }
+	 * ```
+	 * @since 4.3.0
+	 */
+	public var siteLockTitleText:String = "Sorry.";
+
+	/**
+	 * The body text to display on the sitelock failure screen.
+	 * NOTE: This string should be reviewed for accuracy and may need to be localized.
+	 *
+	 * To customize this variable, create a class extending `FlxBasePreloader`, and override its value in the new function.
+	 * @see siteLockTitleText
+	 * @since 4.3.0
+	 */
+	public var siteLockBodyText:String =
+		"It appears the website you are using is hosting an unauthorized copy of this game. "
+		+ "Storage or redistribution of this content, without the express permission of the "
+		+ "developer or other copyright holder, is prohibited under copyright law.\n\n"
+		+ "Thank you for your interest in this game! Please support the developer by "
+		+ "visiting the following website to play the game:";
+
 	private var _percent:Float = 0;
 	private var _width:Int;
 	private var _height:Int;
 	private var _loaded:Bool = false;
 	private var _urlChecked:Bool = false;
 	private var _startTime:Float;
-	
+
 	/**
 	 * FlxBasePreloader Constructor.
 	 * @param	MinDisplayTime	Minimum time (in seconds) the preloader should be shown. (Default = 0)
@@ -55,56 +96,56 @@ class FlxBasePreloader extends NMEPreloader
 	public function new(MinDisplayTime:Float = 0, ?AllowedURLs:Array<String>)
 	{
 		super();
-		
+
 		removeChild(progress);
 		removeChild(outline);
-		
+
 		minDisplayTime = MinDisplayTime;
 		if (AllowedURLs != null)
 			allowedURLs = AllowedURLs;
 		else
 			allowedURLs = [];
-			
+
 		_startTime = Date.now().getTime();
 	}
-	
+
 	/**
 	 * Override this to create your own preloader objects.
 	 */
 	private function create():Void {}
-	
+
 	/**
 	 * This function is called externally to initialize the Preloader.
 	 */
-	override public function onInit() 
+	override public function onInit()
 	{
 		super.onInit();
-		
+
 		Lib.current.stage.scaleMode = StageScaleMode.NO_SCALE;
 		Lib.current.stage.align = StageAlign.TOP_LEFT;
 		create();
 		addEventListener(Event.ENTER_FRAME, onEnterFrame);
 		checkSiteLock();
 	}
-	
+
 	/**
-	 * This function is called each update to check the load status of the project. 
+	 * This function is called each update to check the load status of the project.
 	 * It is highly recommended that you do NOT override this.
 	 */
-	override public function onUpdate(bytesLoaded:Int, bytesTotal:Int) 
+	override public function onUpdate(bytesLoaded:Int, bytesTotal:Int)
 	{
 		#if flash
 		if (root.loaderInfo.bytesTotal == 0)
 			bytesTotal = 50000;
 		#end
-		
+
 		#if web
 		_percent = (bytesTotal != 0) ? bytesLoaded / bytesTotal : 0;
 		#else
 		super.onUpdate(bytesLoaded, bytesTotal);
 		#end
 	}
-	
+
 	/**
 	 * This function is triggered on each 'frame'.
 	 * It is highly recommended that you do NOT override this.
@@ -117,7 +158,7 @@ class FlxBasePreloader extends NMEPreloader
 		if ((min > 0) && (_percent > time / min))
 			percent = time / min;
 		update(percent);
-		
+
 		if (_loaded && (min <= 0 || time / min >= 1))
 		{
 			removeEventListener(Event.ENTER_FRAME, onEnterFrame);
@@ -125,36 +166,36 @@ class FlxBasePreloader extends NMEPreloader
 			destroy();
 		}
 	}
-	
+
 	/**
 	 * This function is called when the project has finished loading.
 	 * Override it to remove all of your objects.
 	 */
 	private function destroy():Void {}
-	
+
 	/**
 	 * Override to draw your preloader objects in response to the Percent
-	 * 
+	 *
 	 * @param	Percent		How much of the program has loaded.
 	 */
 	private function update(Percent:Float):Void {}
-	
+
 	/**
-	 * This function is called EXTERNALLY once the movie has actually finished being loaded. 
+	 * This function is called EXTERNALLY once the movie has actually finished being loaded.
 	 * Highly recommended you DO NO override.
 	 */
-	override public function onLoaded() 
+	override public function onLoaded()
 	{
 		_loaded = true;
 		_percent = 1;
 	}
-	
+
 	/**
 	 * This should be used whenever you want to create a Bitmap that uses BitmapData embedded with the
 	 * @:bitmap metadata, if you want to support both Flash and HTML5. Because the embedded data is loaded
 	 * asynchronously in HTML5, any code that depends on the pixel data or size of the bitmap should be
 	 * in the onLoad function; any such code executed before it is called will fail on the HTML5 target.
-	 * 
+	 *
 	 * @param	bitmapDataClass		A reference to the BitmapData child class that contains the embedded data which is to be used.
 	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new Bitmap instance is passed as an argument.
 	 * @return  The Bitmap instance that was created.
@@ -171,14 +212,14 @@ class FlxBasePreloader extends NMEPreloader
 		return bmp;
 		#end
 	}
-	
+
 	/**
 	 * This should be used whenever you want to create a BitmapData object from a class containing data embedded with
 	 * the @:bitmap metadata. Often, you'll want to use the BitmapData in a Bitmap object; in this case, createBitmap()
 	 * can should be used instead. Because the embedded data is loaded asynchronously in HTML5, any code that depends on
 	 * the pixel data or size of the bitmap should be in the onLoad function; any such code executed before it is called
 	 * will fail on the HTML5 target.
-	 * 
+	 *
 	 * @param	bitmapDataClass		A reference to the BitmapData child class that contains the embedded data which is to be used.
 	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new BitmapData instance is passed as an argument.
 	 * @return  The BitmapData instance that was created.
@@ -193,51 +234,145 @@ class FlxBasePreloader extends NMEPreloader
 		return bmpData;
 		#end
 	}
-	
+
 	/**
 	 * Site-locking Functionality
 	 */
 	private function checkSiteLock():Void
 	{
 		#if web
-		if (!_urlChecked && (allowedURLs != null))
+		if (_urlChecked) return;
+
+		if (!isHostUrlAllowed())
 		{
-			if (!isHostUrlAllowed())
-			{
-				var tmp = new Bitmap(new BitmapData(stage.stageWidth, stage.stageHeight, true, FlxColor.WHITE));
-				addChild(tmp);
-				
-				var format = new TextFormat();
-				format.color = 0x000000;
-				format.size = 16;
-				format.align = TextFormatAlign.CENTER;
-				format.bold = true;
-				format.font = "system";
-				
-				var textField = new TextField();
-				textField.width = tmp.width - 16;
-				textField.height = tmp.height - 16;
-				textField.y = 8;
-				textField.multiline = true;
-				textField.wordWrap = true;
-				textField.defaultTextFormat = format;
-				textField.text = "Hi there!  It looks like somebody copied this game without my permission.  Just click anywhere, or copy-paste this URL into your browser.\n\n" + allowedURLs[0] + "\n\nto play the game at my site.  Thanks, and have fun!";
-				addChild(textField);
-				
-				textField.addEventListener(MouseEvent.CLICK, goToMyURL);
-				tmp.addEventListener(MouseEvent.CLICK, goToMyURL);
-				
-				removeEventListener(Event.ENTER_FRAME, onEnterFrame);
-			}
-			else
-			{
-				_urlChecked = true;
-			}
+			removeChildren();
+			removeEventListener(Event.ENTER_FRAME, onEnterFrame);
+
+			createSiteLockFailureScreen();
+		}
+		else
+		{
+			_urlChecked = true;
 		}
 		#end
 	}
-	
+
 	#if web
+	/**
+	 * When overridden, allows the customized creation of the sitelock failure screen.
+	 * @since 4.3.0
+	 */
+	private function createSiteLockFailureScreen():Void
+	{
+		addChild(createSiteLockFailureBackground(0xffffff, 0xe5e5e5));
+		addChild(createSiteLockFailureIcon(0xe5e5e5, 0.9));
+		addChild(createSiteLockFailureText(30));
+	}
+
+	private function createSiteLockFailureBackground(innerColor:FlxColor, outerColor:FlxColor):Shape
+	{
+		var shape = new Shape();
+		var graphics = shape.graphics;
+		graphics.clear();
+
+		var fillMatrix = new Matrix();
+		fillMatrix.createGradientBox(1, 1, 0, -0.5, -0.5);
+		var scaling = Math.max(stage.stageWidth, stage.stageHeight);
+		fillMatrix.scale(scaling, scaling);
+		fillMatrix.translate(0.5 * stage.stageWidth, 0.5 * stage.stageHeight);
+
+		graphics.beginGradientFill(GradientType.RADIAL, [innerColor, outerColor], [1, 1], [0, 255], fillMatrix);
+		graphics.drawRect(0, 0, stage.stageWidth, stage.stageHeight);
+		graphics.endFill();
+		return shape;
+	}
+
+	private function createSiteLockFailureIcon(color:FlxColor, scale:Float):Shape
+	{
+		var shape = new Shape();
+		var graphics = shape.graphics;
+		graphics.clear();
+
+		graphics.beginFill(color);
+		graphics.drawPath(
+			[ 1, 6, 2, 2, 2, 6, 6, 2, 2, 2, 6, 1, 6, 2, 6, 2, 6, 2, 6, 1, 6, 6, 2, 2, 2, 6, 6 ],
+			[ 120.0, 0, 164, 0, 200, 35, 200, 79, 200, 130, 160, 130, 160, 79, 160, 57, 142, 40,
+				120, 40, 97, 40, 79, 57, 79, 79, 80, 130, 40, 130, 40, 79, 40, 35, 75, 0, 120, 0,
+				220, 140, 231, 140, 240, 148, 240, 160, 240, 300, 240, 311, 231, 320, 220, 320,
+				20, 320, 8, 320, 0, 311, 0, 300, 0, 160, 0, 148, 8, 140, 20, 140, 120, 190, 108,
+				190, 100, 198, 100, 210, 100, 217, 104, 223, 110, 227, 110, 270, 130, 270, 130,
+				227, 135, 223, 140, 217, 140, 210, 140, 198, 131, 190, 120, 190 ],
+			GraphicsPathWinding.NON_ZERO
+		);
+		graphics.endFill();
+
+		var transformMatrix = new Matrix();
+		transformMatrix.translate(-0.5 * shape.width, -0.5 * shape.height);
+		var scaling = scale * Math.min(stage.stageWidth / shape.width, stage.stageHeight / shape.height);
+		transformMatrix.scale(scaling, scaling);
+		transformMatrix.translate(0.5 * stage.stageWidth, 0.5 * stage.stageHeight);
+		shape.transform.matrix = transformMatrix;
+		return shape;
+	}
+
+	private function createSiteLockFailureText(margin:Float):Sprite
+	{
+		var sprite = new Sprite();
+		var bounds = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
+		bounds.inflate(-margin, -margin);
+
+		var titleText = new TextField();
+		var titleTextFormat = new TextFormat("_sans", 33, 0x333333, true);
+		titleTextFormat.align = TextFormatAlign.LEFT;
+		titleText.defaultTextFormat = titleTextFormat;
+		titleText.selectable = false;
+		titleText.width = bounds.width;
+		titleText.text = siteLockTitleText;
+
+		var bodyText = new TextField();
+		var bodyTextFormat = new TextFormat("_sans", 22, 0x333333);
+		bodyTextFormat.align = TextFormatAlign.JUSTIFY;
+		bodyText.defaultTextFormat = bodyTextFormat;
+		bodyText.multiline = true;
+		bodyText.wordWrap = true;
+		bodyText.selectable = false;
+		bodyText.width = bounds.width;
+		bodyText.text = siteLockBodyText;
+
+		var hyperlinkText = new TextField();
+		var hyperlinkTextFormat = new TextFormat("_sans", 22, 0x6e97cc, true, false, true);
+		hyperlinkTextFormat.align = TextFormatAlign.CENTER;
+		hyperlinkTextFormat.url = allowedURLs[siteLockURLIndex];
+		hyperlinkText.defaultTextFormat = hyperlinkTextFormat;
+		hyperlinkText.selectable = true;
+		hyperlinkText.width = bounds.width;
+		hyperlinkText.text = allowedURLs[siteLockURLIndex];
+
+		// Do customization before final layout.
+		adjustSiteLockTextFields(titleText, bodyText, hyperlinkText);
+
+		var gutterSize = 4;
+		titleText.height = titleText.textHeight + gutterSize;
+		bodyText.height = bodyText.textHeight + gutterSize;
+		hyperlinkText.height = hyperlinkText.textHeight + gutterSize;
+		titleText.x = bodyText.x = hyperlinkText.x = bounds.left;
+		titleText.y = bounds.top;
+		bodyText.y = titleText.y + 2.0 * titleText.height;
+		hyperlinkText.y = bodyText.y + bodyText.height + hyperlinkText.height;
+
+		sprite.addChild(titleText);
+		sprite.addChild(bodyText);
+		sprite.addChild(hyperlinkText);
+		return sprite;
+	}
+
+	/**
+	 * When overridden, allows the customization of the text fields in the sitelock failure screen.
+	 * @since 4.3.0
+	 */
+	private function adjustSiteLockTextFields(titleText:TextField, bodyText:TextField, hyperlinkText:TextField):Void
+	{}
+
 	private function goToMyURL(?e:MouseEvent):Void
 	{
 		//if the chosen URL isn't "local", use FlxG's openURL() function.
@@ -246,7 +381,7 @@ class FlxBasePreloader extends NMEPreloader
 		else
 			Lib.getURL(new URLRequest(allowedURLs[siteLockURLIndex]));
 	}
-	
+
 	private function isHostUrlAllowed():Bool
 	{
 		if (allowedURLs.length == 0)


### PR DESCRIPTION
The existing sitelock failure notice is, well, a little lackluster.  Unfortunately, the sitelock functionality within the `FlxBasePreloader` class is not as easily modified, requiring the programmer to duplicate parts of the logic not dealing with the visuals.

I decided the improvements I made for my own uses should be shared with the world, so here is a PR for including an updated version of the sitelock failure notice.  And as pictures are nice, here is how the new default failure notice looks:

![haxeflixel-sitelockfailurenotice-default](https://cloud.githubusercontent.com/assets/20533271/20034878/4cf643fc-a38c-11e6-872f-7ad50f53048f.png)

As the underlying logic has been reorganized to address the issues mentioned above and several helper functions have been added to aid in the creation of the visual elements, here is a code snippet showing a sample customization in action:

```haxe
class Preloader extends FlxBasePreloader
{
    public function new():Void {
        super(0, [ "http://placeholder.domain.test/path/document.html" ]);

        siteLockTitleText = "Oops!";
        siteLockBodyText = "Well, it looks like somebody went and did a very bad and naughty thing.\n\n"
            + "Why not try heading over to the following website to play this game?";
    }

    override private function createSiteLockFailureScreen():Void {
        addChild(createSiteLockFailureBackground(0xeeaa33, 0xbb5533));
        addChild(createSiteLockFailureIcon(0xffcc33, 0.5));
        addChild(createSiteLockFailureText(60));
    }

    override private function adjustSiteLockTextFields(titleText:TextField, bodyText:TextField, hyperlinkText:TextField):Void {
        titleText.setTextFormat(new TextFormat("Cambria", 40, 0xffcc33, true, true));
        bodyText.setTextFormat(new TextFormat("Cambria", 25, 0x112244));
        hyperlinkText.setTextFormat(new TextFormat("Consolas", 20, 0xffcc33));
        hyperlinkText.background = true;
        hyperlinkText.backgroundColor = 0x112244;
    }

    // . . .
}
```

![haxeflixel-sitelockfailurenotice-customized](https://cloud.githubusercontent.com/assets/20533271/20034889/ba109866-a38c-11e6-838e-19e59c1cdd5c.png)