### PR TITLE
A few feature/UX enhancements for interaction pointer tool

### DIFF
--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -272,7 +272,7 @@ class Interaction extends Window
 			if (member != null && member.scrollFactor != null && member.isOnScreen())
 			{
 				// Render a red rectangle centered at the selected item
-				gfx.lineStyle(1.5, 0xff0000);
+				gfx.lineStyle(0.9, 0xff0000);
 				gfx.drawRect(member.x - FlxG.camera.scroll.x,
 					member.y - FlxG.camera.scroll.y,
 					member.width * 1.0, member.height * 1.0);

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -459,12 +459,13 @@ class Interaction extends Window
 	 * Find all items within an area. In order to improve performance and reduce temporary allocations,
 	 * the method has no return, you must pass an array where items will be placed. The method decides
 	 * if an item is within the searching area or not by checking if the item's hitbox (obtained from
-	 * <code>getHitbox()</code>) overlaps the area parameter.
+	 * `getHitbox()`) overlaps the area parameter.
 	 * 
 	 * @param	items		array where the method will place all found items. Any previous content in the array will be preserved.
 	 * @param	members		array where the method will recursively search for items.
 	 * @param	area		a rectangle that describes the area where the method should search within.
 	 */
+	@:access(flixel.group.FlxTypedGroup)
 	public function findItemsWithinArea(items:Array<FlxBasic>, members:Array<FlxBasic>, area:FlxRect):Void
 	{
 		// we iterate backwards to get the sprites on top first
@@ -476,8 +477,9 @@ class Interaction extends Window
 			if (member == null || !member.visible || !member.exists)
 				continue;
 
-			if (Std.is(member, FlxTypedGroup))
-				findItemsWithinArea(items, (cast member).members, area);
+			var group = FlxTypedGroup.resolveGroup(member);
+			if (group != null)
+				findItemsWithinArea(items, group.members, area);
 			else if (Std.is(member, FlxSprite) &&
 				area.overlaps(cast(member, FlxSprite).getHitbox()))
 				items.push(cast member);

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -450,6 +450,16 @@ class Interaction extends Window
 		return (_turn - value) == 1;
 	}
 	
+	/**
+	 * Find all items within an area. In order to improve performance and reduce temporary allocations,
+	 * the method has no return, you must pass an array where items will be placed. The method decides
+	 * if an item is within the searching area or not by checking if the item's hitbox (obtained from
+	 * <code>getHitbox()</code>) overlaps the area parameter.
+	 * 
+	 * @param	items		array where the method will place all found items. Any previous content in the array will be preserved.
+	 * @param	members		array where the method will recursively search for items.
+	 * @param	area		a rectangle that describes the area where the method should search within.
+	 */
 	public function findItemsWithinArea(items:Array<FlxBasic>, members:Array<FlxBasic>, area:FlxRect):Void
 	{
 		// we iterate backwards to get the sprites on top first

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -245,7 +245,7 @@ class Interaction extends Window
 		drawItemsSelection();
 	}
 	
-	private function getDebugGraphics():Graphics
+	public function getDebugGraphics():Graphics
 	{
 		if (FlxG.renderBlit)
 		{

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -44,7 +44,7 @@ class Interaction extends Window
 	private var _customCursor:Sprite;
 	private var _tools:Array<Tool> = [];
 	private var _turn:Int = 2;
-	private var _keysDown:Map<Int, Int> = new Map();
+	private var _keysDown:Map<Int, Bool> = new Map();
 	private var _keysUp:Map<Int, Int> = new Map();
 	private var _wasMouseVisible:Bool;
 	private var _wasUsingSystemCursor:Bool;
@@ -152,9 +152,12 @@ class Interaction extends Window
 	private function handleKeyEvent(event:KeyboardEvent):Void
 	{
 		if (event.type == KeyboardEvent.KEY_DOWN)
-			_keysDown.set(event.keyCode, _turn);
+			_keysDown.set(event.keyCode, true);
 		else if (event.type == KeyboardEvent.KEY_UP)
+		{
+			_keysDown.set(event.keyCode, false);
 			_keysUp.set(event.keyCode, _turn);
+		}
 	}
 	
 	private function addTool(tool:Tool):Void
@@ -437,8 +440,7 @@ class Interaction extends Window
 	
 	public function keyPressed(key:Int):Bool
 	{
-		var value:Int = _keysDown.get(key) == null ? 0 : _keysDown.get(key);
-		return _turn <= value;
+		return _keysDown.get(key);
 	}
 	
 	public function keyJustPressed(key:Int):Bool

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -9,6 +9,7 @@ import flash.events.MouseEvent;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.input.FlxPointer;
 import flixel.math.FlxPoint;
+import flixel.math.FlxRect;
 import flixel.system.debug.FlxDebugger.GraphicInteractive;
 import flixel.system.debug.Window;
 import flixel.system.debug.interaction.tools.Eraser;
@@ -447,5 +448,24 @@ class Interaction extends Window
 	{
 		var value:Int = _keysUp.get(key) == null ? 0 : _keysUp.get(key);
 		return (_turn - value) == 1;
+	}
+	
+	public function findItemsWithinArea(items:Array<FlxBasic>, members:Array<FlxBasic>, area:FlxRect):Void
+	{
+		// we iterate backwards to get the sprites on top first
+		var i = members.length;
+		while (i-- > 0)
+		{
+			var member = members[i];
+			// Ignore invisible or non-existent entities
+			if (member == null || !member.visible || !member.exists)
+				continue;
+
+			if (Std.is(member, FlxTypedGroup))
+				findItemsWithinArea(items, (cast member).members, area);
+			else if (Std.is(member, FlxSprite) &&
+				area.overlaps(cast(member, FlxSprite).getHitbox()))
+				items.push(cast member);
+		}
 	}
 }

--- a/flixel/system/debug/interaction/tools/Mover.hx
+++ b/flixel/system/debug/interaction/tools/Mover.hx
@@ -39,14 +39,33 @@ class Mover extends Tool
 			return;
 		
 		if (_brain.pointerPressed && !_dragging)
-			_dragging = true;	
+			startDragging();	
 		else if (_brain.pointerPressed && _dragging)
 			doDragging();
 		else if (_brain.pointerJustReleased)
-			_dragging = false;
+			stopDragging();
 		
 		_lastCursorPosition.x = _brain.flixelPointer.x;
 		_lastCursorPosition.y = _brain.flixelPointer.y;
+	}
+	
+	private function stopDragging():Void
+	{
+		_dragging = false;
+	}
+	
+	private function startDragging():Void
+	{
+		if (_dragging)
+			return;
+			
+		_dragging = true;
+		
+		// If we are not active, it means things are being moved around using
+		// the mover's shortcut key. If the pointer is the active tool, it should
+		// not do any selection of items while things are being moved/dragged.
+		if (!isActive() && Std.is(_brain.activeTool, Pointer))
+			cast(_brain.activeTool, Pointer).stopSelection(false);
 	}
 	
 	private function doDragging():Void

--- a/flixel/system/debug/interaction/tools/Mover.hx
+++ b/flixel/system/debug/interaction/tools/Mover.hx
@@ -65,7 +65,7 @@ class Mover extends Tool
 		// the mover's shortcut key. If the pointer is the active tool, it should
 		// not do any selection of items while things are being moved/dragged.
 		if (!isActive() && Std.is(_brain.activeTool, Pointer))
-			cast(_brain.activeTool, Pointer).stopSelection(false);
+			cast(_brain.activeTool, Pointer).cancelSelection();
 	}
 	
 	private function doDragging():Void

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -37,13 +37,13 @@ class Pointer extends Tool
 			return;
 		
 		// Check clicks on the screen
-		if (!_brain.pointerJustPressed && !_brain.pointerJustReleased)
+		if (!_brain.pointerJustReleased)
 			return;
 
 		var item = pinpointItemInGroup(FlxG.state.members, _brain.flixelPointer);
 		if (item != null)
 			handleItemClick(item);
-		else if (_brain.pointerJustPressed && !_brain.keyPressed(Keyboard.CONTROL))
+		else if (!_brain.keyPressed(Keyboard.CONTROL))
 			// User clicked an empty space without holding the "add more items" key,
 			// so it's time to unselect everything.
 			_brain.clearSelection();
@@ -55,8 +55,13 @@ class Pointer extends Tool
 		var selectedItems = _brain.selectedItems;
 		if (selectedItems.length == 0 || _brain.keyPressed(Keyboard.CONTROL))
 		{
-			// Yeah, that's the case. Just add the new thing to the selection.
-			selectedItems.add(item);
+			// Yeah, that's the case. Is the item already in the selection?
+			if (selectedItems.members.contains(item))
+				// Yep, it's already there. Let's remove it then.
+				selectedItems.remove(item);
+			else
+				// No, so let's add it to the selection.
+				selectedItems.add(item);
 		}
 		else
 		{

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -120,7 +120,7 @@ class Pointer extends Tool
 		_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);	
 		calculateSelectionArea();
 
-		if(findItems)
+		if (findItems)
 			_brain.findItemsWithinArea(_itemsInSelectionArea, FlxG.state.members, _selectionArea);
 		
 		// Clear everything
@@ -144,7 +144,7 @@ class Pointer extends Tool
 				// it was the only selected item, otherwise the user is
 				// batch selecting things. In that case, everything should
 				// be included, no questions asked.
-				if(_itemsInSelectionArea.length == 1)
+				if (_itemsInSelectionArea.length == 1)
 					selectedItems.remove(item);
 			}
 			else

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -39,12 +39,13 @@ class Pointer extends Tool
 		// Check clicks on the screen
 		if (!_brain.pointerJustPressed && !_brain.pointerJustReleased)
 			return;
-		
+
 		var item = pinpointItemInGroup(FlxG.state.members, _brain.flixelPointer);
 		if (item != null)
 			handleItemClick(item);
-		else if (_brain.pointerJustPressed)
-			// User clicked an empty space, so it's time to unselect everything.
+		else if (_brain.pointerJustPressed && !_brain.keyPressed(Keyboard.CONTROL))
+			// User clicked an empty space without holding the "add more items" key,
+			// so it's time to unselect everything.
 			_brain.clearSelection();
 	}
 	

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -110,7 +110,7 @@ class Pointer extends Tool
 	/**
 	 * Stop any selection activity that is happening. 
 	 * 
-	 * @param	findItems	If <code>true</code> (default), all items within the (stopped) selection area will be included in the list of selected items of the tool.
+	 * @param	findItems	If `true` (default), all items within the (stopped) selection area will be included in the list of selected items of the tool.
 	 */
 	public function stopSelection(findItems:Bool = true):Void
 	{	
@@ -159,34 +159,7 @@ class Pointer extends Tool
 			selectedItems.add(item);
 		}
 	}
-	
-	@:access(flixel.group.FlxTypedGroup)
-	private function pinpointItemInGroup(members:Array<FlxBasic>, cursor:FlxPoint):FlxObject
-	{
-		var target:FlxObject = null;
-
-		// we iterate backwards to get the sprites on top first
-		var i = members.length;
-		while (i-- > 0)
-		{
-			var member = members[i];
-			// Ignore invisible or non-existent entities
-			if (member == null || !member.visible || !member.exists)
-				continue;
-
-			var group = FlxTypedGroup.resolveGroup(member);
-			if (group != null)
-				target = pinpointItemInGroup(group.members, cursor);
-			else if (Std.is(member, FlxSprite) &&
-				(cast(member, FlxSprite).overlapsPoint(cursor, true)))
-				target = cast member;
-			
-			if (target != null)
-				break;
-		}
-		return target;
-	}
-	
+		
 	override public function draw():Void 
 	{
 		var gfx:Graphics = _brain.getDebugGraphics();

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -96,21 +96,32 @@ class Pointer extends Tool
 		}
 	}
 	
-	private function startSelection():Void
+	/**
+	 * Start a selection area. A selection area is a rectangular shaped area
+	 * whose boundaries will be used to select game elements.
+	 */
+	public function startSelection():Void
 	{
 		_selectionHappening = true;
 		_selectionStartPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);
 		_itemsInSelectionArea.clearArray();
 	}
 	
-	private function stopSelection():Void
-	{
-		_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);
+	/**
+	 * Stop any selection activity that is happening. 
+	 * 
+	 * @param	findItems	If <code>true</code> (default), all items within the (stopped) selection area will be included in the list of selected items of the tool.
+	 */
+	public function stopSelection(findItems:Bool = true):Void
+	{	
+		if (!_selectionHappening)
+			return;
 		
+		_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);	
 		calculateSelectionArea();
 
-		// Find all items within the selection area
-		_brain.findItemsWithinArea(_itemsInSelectionArea, FlxG.state.members, _selectionArea);
+		if(findItems)
+			_brain.findItemsWithinArea(_itemsInSelectionArea, FlxG.state.members, _selectionArea);
 		
 		// Clear everything
 		_selectionHappening = false;
@@ -149,6 +160,7 @@ class Pointer extends Tool
 		}
 	}
 	
+	// TODO: move this method to brain
 	private function pinpointItemInGroup(members:Array<FlxBasic>, cursor:FlxPoint):FlxObject
 	{
 		var target:FlxObject = null;

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -5,7 +5,6 @@ import flash.display.Graphics;
 import flash.ui.Keyboard;
 import flixel.FlxBasic;
 import flixel.FlxObject;
-import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.debug.interaction.Interaction;

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -4,7 +4,6 @@ import flash.display.BitmapData;
 import flash.display.Graphics;
 import flash.ui.Keyboard;
 import flixel.FlxBasic;
-import flixel.FlxObject;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.debug.interaction.Interaction;


### PR DESCRIPTION
This PR does the following:

- Prevent users from de-selecting already selected items if the cursor clicks an empty area when CTRL is pressed (it's a lot easier to select items now);
- UI tweak regarding selected items in `FlxG.debug.interaction` (selection line is thinner) 
- Allow users to select items using a selection area:

![haxeflixel-interaction-selection](https://cloud.githubusercontent.com/assets/512405/20036803/fd8d2754-a412-11e6-9732-5993c5ec762d.gif)
 