### PR TITLE
Update URL parsing logic (again).

### DIFF
--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -19,7 +19,7 @@ class FlxBasePreloader extends NMEPreloader
 	/**
 	 * Add this string to allowedURLs array if you want to be able to test game with enabled site-locking on local machine 
 	 */
-	public static inline var LOCAL:String = #if flash "local" #else "localhost" #end;
+	public static inline var LOCAL:String = "localhost";
 	
 	/**
 	 * Change this if you want the flixel logo to show for more or less time.  Default value is 0 seconds (no delay).
@@ -250,21 +250,15 @@ class FlxBasePreloader extends NMEPreloader
 	private function isHostUrlAllowed():Bool
 	{
 		if (allowedURLs.length == 0)
-		{
 			return true;
-		}
-		
-		var homeDomain:String = FlxStringUtil.getDomain(#if flash loaderInfo.loaderURL #elseif js js.Browser.location.href #end);
+
+		var homeURL:String = #if flash loaderInfo.loaderURL #elseif js js.Browser.location.href #end;
+		var homeDomain:String = FlxStringUtil.getDomain(homeURL);
 		for (allowedURL in allowedURLs)
 		{
-			if (FlxStringUtil.getDomain(allowedURL) == homeDomain)
-			{
+			var allowedDomain = FlxStringUtil.getDomain(allowedURL);
+			if (allowedDomain == homeDomain)
 				return true;
-			}
-			else if (allowedURL == LOCAL && homeDomain == LOCAL)
-			{
-				return true;
-			}
 		}
 		return false;
 	}

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -256,14 +256,46 @@ class FlxStringUtil
 		}
 		return s;
 	}
+
+	/**
+	 * Returns the host from the specified URL.
+	 * The host is one of three parts that comprise the authority.  (User and port are the other two parts.)
+	 * For example, the host for "ftp://anonymous@ftp.domain.test:990/" is "ftp.domain.test".
+	 *
+	 * @return	The host from the URL; or the empty string ("") upon failure.
+	 */
+	public static function getHost(url:String):String
+	{
+		var hostFromURL:EReg = ~/^[a-z][a-z0-9+\-.]*:\/\/(?:[a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-f0-9:.]+\])?(?::[0-9]+)?/i;
+		if (hostFromURL.match(url))
+		{
+			var host = hostFromURL.matched(1);
+			return (host != null) ? host.urlDecode().toLowerCase() : "";
+		}
+
+		return "";
+	}
 	
 	/**
-	 * Returns the domain of a URL.
+	 * Returns the domain from the specified URL.
+	 * The domain, in this case, refers specifically to the first and second levels only.
+	 * For example, the domain for "api.haxe.org" is "haxe.org".
+	 *
+	 * @return	The domain from the URL; or the empty string ("") upon failure. 
 	 */
 	public static function getDomain(url:String):String
 	{
-		var regex:EReg = ~/(?:[a-z0-9.+-]+:\/\/)(?:[a-z0-9-]+\.)*([a-z0-9-]+\.[a-z0-9-]+)/i;
-		return regex.match(url) ? regex.matched(1).toLowerCase() : "local";
+		var host:String = getHost(url);
+
+		var isLocalhostOrIPaddress:EReg = ~/^(localhost|[0-9.]+|\[[a-f0-9:.]+\])$/i;
+		var domainFromHost:EReg = ~/^(?:[a-z0-9\-]+\.)*([a-z0-9\-]+\.[a-z0-9\-]+)$/i;
+		if (!isLocalhostOrIPaddress.match(host) && domainFromHost.match(host))
+		{
+			var domain = domainFromHost.matched(1);
+			return (domain != null) ? domain.toLowerCase() : "";
+		}
+
+		return "";
 	}
 	
 	/**


### PR DESCRIPTION
This improves upon a fix I submitted earlier regarding the `FlxStringUtil.getDomain()` function, addressing some concerns I brought up to @Gama11.  I wanted to submit this work now for greater visibility and general review, even though this is a fairly low priority item.

The main item is the introduction of a new public function, `FlxStringUtil.getHost()`, which takes care of proper URL parsing in a more robust manner.  It supports nearly all of RFC 3986, with the only notable exception being the "IPvFuture" extension to IPv6.  (I could not find any practical examples of the extension to use for testing, so I opted to omit it from the regex.)  This moves the URL parsing logic out of the existing `getDomain()` function, which now focuses only on extracting the first- and second-level domains from a host.

**Breaking change:** The `getDomain()` function used to return `"local"` upon failure.  This was _undocumented_ behavior carried over from when it was it part of the `FlxBasePreloader` class.  This PR changes the failure value to the empty string (`""`), which just feels like a better design for a public API.  The necessary changes have been made to `FlxBasePreloader`, cleaning up its logic in the process.

Finally, the unit tests I introduced for `getDomain()` have been expanded upon to test `getHost()` as well.