### PR TITLE
FlxMouseEventManager: fix pixel-perfect overlaps with offset

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -483,7 +483,7 @@ class FlxMouseEventManager extends FlxBasic
 	{
 		if (Sprite.angle != 0)
 		{
-			var pivot = FlxPoint.weak(Sprite.x + Sprite.origin.x, Sprite.y + Sprite.origin.y);
+			var pivot = FlxPoint.weak(Sprite.x + Sprite.origin.x - Sprite.offset.x, Sprite.y + Sprite.origin.y - Sprite.offset.y);
 			Point.rotate(pivot, -Sprite.angle);
 		}
 		return Sprite.pixelsOverlapPoint(Point, 0x01, Camera);


### PR DESCRIPTION
Updated logic in `FlxMouseEventManager.checkPixelPerfectOverlap` to account for a non-zero offset affecting the pivot point.