### PR TITLE
Watch: avoid multiple Expr parses, closes #1886

### DIFF
--- a/flixel/system/debug/console/ConsoleUtil.hx
+++ b/flixel/system/debug/console/ConsoleUtil.hx
@@ -67,9 +67,9 @@ class ConsoleUtil
 	 * @param	Parsed	The parsed form of the user's input command.
 	 * @return	Whatever the input code evaluates to.
 	 */
-	public static function runExpr(ParsedInput:Expr):Dynamic
+	public static function runExpr(expr:Expr):Dynamic
 	{
-		return interp.expr(ParsedInput);
+		return interp.expr(expr);
 	}
 	
 	/**

--- a/flixel/system/debug/console/ConsoleUtil.hx
+++ b/flixel/system/debug/console/ConsoleUtil.hx
@@ -63,6 +63,16 @@ class ConsoleUtil
 	}
 	
 	/**
+	 * Runs the input expression.
+	 * @param	Parsed	The parsed form of the user's input command.
+	 * @return	Whatever the input code evaluates to.
+	 */
+	public static function runExpr(ParsedInput:Expr):Dynamic
+	{
+		return interp.expr(ParsedInput);
+	}
+	
+	/**
 	 * Register a new object to use in any command.
 	 * 
 	 * @param	ObjectAlias	The name with which you want to access the object.

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -60,8 +60,8 @@ class Watch extends Window
 				object == null || field == null;
 			case QUICK(value):
 				displayName.isNullOrEmpty();
-			case EXPRESSION(expression):
-				expression.isNullOrEmpty();
+			case EXPRESSION(command, _):
+				command.isNullOrEmpty();
 		}
 	}
 	
@@ -69,7 +69,7 @@ class Watch extends Window
 	{
 		for (entry in entries)
 		{
-			if (data.match(QUICK(_)))
+			if (data == null || data.match(QUICK(_)))
 			{
 				if (entry.displayName == displayName)
 					return entry;

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -60,8 +60,8 @@ class Watch extends Window
 				object == null || field == null;
 			case QUICK(value):
 				displayName.isNullOrEmpty();
-			case EXPRESSION(command, _):
-				command.isNullOrEmpty();
+			case EXPRESSION(expression, _):
+				expression.isNullOrEmpty();
 		}
 	}
 	

--- a/flixel/system/debug/watch/WatchEntry.hx
+++ b/flixel/system/debug/watch/WatchEntry.hx
@@ -57,7 +57,7 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 		{
 			case FIELD(_, _): 0xFFFFFF;
 			case QUICK(_): 0xA5F1ED;
-			case EXPRESSION(_): 0xC4FE83;
+			case EXPRESSION(_, _): 0xC4FE83;
 		}
 	}
 	
@@ -93,8 +93,8 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 		{
 			case FIELD(object, field):
 				setNameText(object.getClassName(true) + "." + field);
-			case EXPRESSION(expression):
-				setNameText(expression);
+			case EXPRESSION(command, _):
+				setNameText(command);
 			case QUICK(_):
 		}
 	}
@@ -112,9 +112,9 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 		{
 			case FIELD(object, field):
 				Reflect.getProperty(object, field);
-			case EXPRESSION(expression):
+			case EXPRESSION(_, expression):
 				#if hscript
-				ConsoleUtil.runCommand(expression);
+				ConsoleUtil.runExpr(expression);
 				#else
 				"hscript is not installed";
 				#end

--- a/flixel/system/debug/watch/WatchEntry.hx
+++ b/flixel/system/debug/watch/WatchEntry.hx
@@ -93,8 +93,8 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 		{
 			case FIELD(object, field):
 				setNameText(object.getClassName(true) + "." + field);
-			case EXPRESSION(command, _):
-				setNameText(command);
+			case EXPRESSION(expression, _):
+				setNameText(expression);
 			case QUICK(_):
 		}
 	}
@@ -112,9 +112,9 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 		{
 			case FIELD(object, field):
 				Reflect.getProperty(object, field);
-			case EXPRESSION(_, expression):
+			case EXPRESSION(_, parsedExpr):
 				#if hscript
-				ConsoleUtil.runExpr(expression);
+				ConsoleUtil.runExpr(parsedExpr);
 				#else
 				"hscript is not installed";
 				#end

--- a/flixel/system/debug/watch/WatchEntryData.hx
+++ b/flixel/system/debug/watch/WatchEntryData.hx
@@ -17,9 +17,5 @@ enum WatchEntryData
 	/**
 	 * Haxe expression evaluated with hscript.
 	 */
-	#if hscript
-	EXPRESSION(command:String, expression:Expr);
-	#else
-	EXPRESSION(command:String, expression:String);
-	#end
+	EXPRESSION(command:String, expression: #if hscript Expr #else String #end);
 }

--- a/flixel/system/debug/watch/WatchEntryData.hx
+++ b/flixel/system/debug/watch/WatchEntryData.hx
@@ -1,5 +1,9 @@
 package flixel.system.debug.watch;
 
+#if hscript
+import hscript.Expr;
+#end
+
 enum WatchEntryData
 {
 	/**
@@ -13,5 +17,9 @@ enum WatchEntryData
 	/**
 	 * Haxe expression evaluated with hscript.
 	 */
-	EXPRESSION(expression:String);
+	#if hscript
+	EXPRESSION(command:String, expression:Expr);
+	#else
+	EXPRESSION(command:String, expression:String);
+	#end
 }

--- a/flixel/system/debug/watch/WatchEntryData.hx
+++ b/flixel/system/debug/watch/WatchEntryData.hx
@@ -17,5 +17,5 @@ enum WatchEntryData
 	/**
 	 * Haxe expression evaluated with hscript.
 	 */
-	EXPRESSION(command:String, expression: #if hscript Expr #else String #end);
+	EXPRESSION(expression:String, parsedExpr: #if hscript Expr #else String #end);
 }

--- a/flixel/system/frontEnds/WatchFrontEnd.hx
+++ b/flixel/system/frontEnds/WatchFrontEnd.hx
@@ -73,14 +73,14 @@ class WatchFrontEnd
 	 * @param   displayName   Optional, display your own string instead of the expression string: e.g. "enemy count".
 	 * @since   4.1.0
 	 */
-	public function addExpression(command:String, ?displayName:String):Void
+	public function addExpression(expression:String, ?displayName:String):Void
 	{
 		#if FLX_DEBUG
-		var expression = null;
+		var parsedExpr = null;
 		#if hscript
-		expression = ConsoleUtil.parseCommand(command);
+		parsedExpr = ConsoleUtil.parseCommand(expression);
 		#end
-		FlxG.game.debugger.watch.add(displayName == null ? command : displayName, EXPRESSION(command, expression));
+		FlxG.game.debugger.watch.add(displayName == null ? expression : displayName, EXPRESSION(expression, parsedExpr));
 		#end
 	}
 	

--- a/flixel/system/frontEnds/WatchFrontEnd.hx
+++ b/flixel/system/frontEnds/WatchFrontEnd.hx
@@ -76,11 +76,11 @@ class WatchFrontEnd
 	public function addExpression(command:String, ?displayName:String):Void
 	{
 		#if FLX_DEBUG
+		var expression = null;
 		#if hscript
-		FlxG.game.debugger.watch.add(displayName == null ? command : displayName, EXPRESSION(command, ConsoleUtil.parseCommand(command)));
-		#else
-		FlxG.game.debugger.watch.add(displayName == null ? command : displayName, EXPRESSION(command, null));
+		expression = ConsoleUtil.parseCommand(command);
 		#end
+		FlxG.game.debugger.watch.add(displayName == null ? command : displayName, EXPRESSION(command, expression));
 		#end
 	}
 	

--- a/flixel/system/frontEnds/WatchFrontEnd.hx
+++ b/flixel/system/frontEnds/WatchFrontEnd.hx
@@ -2,6 +2,10 @@ package flixel.system.frontEnds;
 
 import flixel.FlxG;
 
+#if hscript
+import flixel.system.debug.console.ConsoleUtil;
+#end
+
 class WatchFrontEnd
 {
 	public function new() {}
@@ -69,23 +73,27 @@ class WatchFrontEnd
 	 * @param   displayName   Optional, display your own string instead of the expression string: e.g. "enemy count".
 	 * @since   4.1.0
 	 */
-	public function addExpression(expression:String, ?displayName:String):Void
+	public function addExpression(command:String, ?displayName:String):Void
 	{
 		#if FLX_DEBUG
-		FlxG.game.debugger.watch.add(displayName, EXPRESSION(expression));
+		#if hscript
+		FlxG.game.debugger.watch.add(displayName == null ? command : displayName, EXPRESSION(command, ConsoleUtil.parseCommand(command)));
+		#else
+		FlxG.game.debugger.watch.add(displayName == null ? command : displayName, EXPRESSION(command, null));
+		#end
 		#end
 	}
 	
 	/**
 	 * Remove an expression from the watch list in the debugger.
 	 * 
-	 * @param   expression   The Haxe expression that you want to remove.
+	 * @param   displayName   The display name of the registered expression, if you supplied one, or the Haxe expression that you want to remove, in string form.
 	 * @since   4.1.0
 	 */
-	public function removeExpression(expression:String):Void
+	public function removeExpression(displayName:String):Void
 	{
 		#if FLX_DEBUG
-		FlxG.game.debugger.watch.remove(null, EXPRESSION(expression));
+		FlxG.game.debugger.watch.remove(displayName, null);
 		#end
 	}
 	


### PR DESCRIPTION
Closes #1886 

I did this a bit hastily. I don't think I broke the other watch enums, but I only checked `EXPRESSION`. Also didn't check `!hscript`.