### PR TITLE
Add tooltips to FlxG.debugger

### DIFF
--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -121,6 +121,8 @@ class FlxDebugger extends Sprite
 		
 		visible = false;
 		
+		Tooltip.init(this);
+		
 		_topBar = new Sprite();
 		_topBar.graphics.beginFill(0x000000, 0xAA / 255);
 		_topBar.graphics.drawRect(0, 0, FlxG.stage.stageWidth, TOP_HEIGHT);

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -78,11 +78,11 @@ class TooltipOverlay extends Sprite
 	private static inline var MARGIN_Y:Float = 10;
 	
 	/**
-	 * Width of the window. Using Sprite.width is super unreliable for some reason!
+	 * Width of the tooltip. Using Sprite.width is super unreliable for some reason!
 	 */
 	private var _width:Int;
 	/**
-	 * Height of the window. Using Sprite.height is super unreliable for some reason!
+	 * Height of the tooltip. Using Sprite.height is super unreliable for some reason!
 	 */
 	private var _height:Int;
 	

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -7,10 +7,7 @@ import flash.events.MouseEvent;
 import flash.geom.Point;
 import flash.text.TextField;
 import flixel.FlxG;
-import flixel.system.debug.FlxDebugger.GraphicCloseButton;
-import flixel.system.ui.FlxSystemButton;
 import flixel.util.FlxColor;
-import flixel.util.FlxDestroyUtil;
 
 /**
  * Manages tooltips to be used within the debugger.

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -33,6 +33,16 @@ class Tooltip
 	 */
 	public static inline var TEXT_ALPHA:Float = 0.8;
 	
+	/**
+	 * How many pixels the tooltip should be away from the target in the x axis.
+	 */
+	public static inline var MARGIN_X:Int = 10;
+	
+	/**
+	 * How many pixels the tooltip should be away from the target in the y axis.
+	 */
+	public static inline var MARGIN_Y:Float = 10;
+	
 	
 	public static function init(container:Sprite):Void
 	{
@@ -222,8 +232,8 @@ class TooltipOverlay extends Sprite
 	{
 		if (event.type == MouseEvent.MOUSE_OVER && !visible)
 		{
-			x = event.stageX + event.target.width + 10;
-			y = event.stageY;
+			x = event.stageX + Tooltip.MARGIN_X;
+			y = event.stageY + Tooltip.MARGIN_Y;
 			
 			setVisible(true);
 		}

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -36,9 +36,22 @@ class Tooltip
 		_tooltips.push(tooltip);
 	}
 	
-	public static function remove(element:Sprite):Void
+	public static function remove(element:Sprite):Bool
 	{
-		// TODO: implement this
+		var removed:Bool = false;
+		
+		for (i in 0..._tooltips.length)
+		{
+			if (_tooltips[i] != null && _tooltips[i].owner == element)
+			{
+				var tooltip :TooltipOverlay = _tooltips.splice(i, 1)[0];
+				tooltip.destroy();
+				removed = true;
+				break;
+			}	
+		}
+		
+		return removed;
 	}
 }
 
@@ -82,7 +95,11 @@ class TooltipOverlay extends Sprite
 	private var _background:Bitmap;
 	private var _shadow:Bitmap;
 	private var _text:TextField;
-	private var _owner:Sprite;
+	
+	/**
+	 * The element the tooltip is attached to.
+	 */
+	public var owner(default, null):Sprite;
 	
 	/**
 	 * Maximum size allowed for the tooltip. A negative value (or zero) makes
@@ -93,16 +110,16 @@ class TooltipOverlay extends Sprite
 	/**
 	 * Creates a new tooltip.
 	 * 
-	 * @param	owner	Element where the tooltip will be attached to.
+	 * @param	target	Element where the tooltip will be attached to.
 	 * @param	text	Text displayed with this tooltip.
 	 * @param	width	Width of the tooltip.  If a negative value (or zero) is specified, the tooltip will adjust its width to properly accomodate the text.
 	 * @param	height	Height of the tooltip.  If a negative value (or zero) is specified, the tooltip will adjust its height to properly accomodate the text.
 	 */
-	public function new(owner:Sprite, text:String, width:Float = 0, height:Float = 0)
+	public function new(target:Sprite, text:String, width:Float = 0, height:Float = 0)
 	{
 		super();
 		
-		_owner = owner;
+		owner = target;
 		
 		maxSize = new Point(width, height);
 		
@@ -121,8 +138,8 @@ class TooltipOverlay extends Sprite
 		updateSize();
 		setVisible(false);
 		
-		_owner.addEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
-		_owner.addEventListener(MouseEvent.MOUSE_OUT, handleMouseEvents);
+		owner.addEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
+		owner.addEventListener(MouseEvent.MOUSE_OUT, handleMouseEvents);
 	}
 	
 	/**
@@ -145,8 +162,11 @@ class TooltipOverlay extends Sprite
 			removeChild(_text);
 		}
 		_text = null;
-		_owner = null;
 		maxSize = null;
+		
+		owner.removeEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
+		owner.removeEventListener(MouseEvent.MOUSE_OUT, handleMouseEvents);
+		owner = null;
 	}
 	
 	/**

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -1,0 +1,196 @@
+package flixel.system.debug;
+
+import flash.display.Bitmap;
+import flash.display.BitmapData;
+import flash.display.Sprite;
+import flash.events.Event;
+import flash.events.MouseEvent;
+import flash.geom.Point;
+import flash.geom.Rectangle;
+import flash.text.TextField;
+import flixel.FlxG;
+import flixel.math.FlxMath;
+import flixel.system.debug.FlxDebugger.GraphicCloseButton;
+import flixel.system.ui.FlxSystemButton;
+import flixel.util.FlxColor;
+import flixel.util.FlxDestroyUtil;
+
+/**
+ * A generic, Flash-based tooltip class, created for use in FlxDebugger.
+ */
+class Tooltip extends Sprite
+{
+	private static var _tooltips:Array<Tooltip> = [];
+	private static var _container:Sprite;
+	private static var _activeElement:Sprite;
+	
+	/**
+	 * The background color of the window.
+	 */
+	public static inline var BG_COLOR:FlxColor = 0xFF3A3A3A;
+	public static inline var HEADER_ALPHA:Float = 0.8;
+	
+	public var maxSize:Point;
+	
+	/**
+	 * Width of the window. Using Sprite.width is super unreliable for some reason!
+	 */
+	private var _width:Int;
+	/**
+	 * Height of the window. Using Sprite.height is super unreliable for some reason!
+	 */
+	private var _height:Int;
+	
+	/**
+	 * Main elements
+	 */ 
+	private var _background:Bitmap;
+	private var _shadow:Bitmap;
+	private var _text:TextField;
+	private var _owner:Sprite;
+	
+	
+	public static function init(container:Sprite):Void
+	{
+		_container = container;
+	}
+	
+	public static function add(element:Sprite, text:String):Void
+	{
+		var tooltip = new Tooltip(element, text);
+		
+		_container.addChild(tooltip);
+		_tooltips.push(tooltip);
+	}
+	
+	public static function remove(element:Sprite):Void
+	{
+		// TODO: implement this
+	}
+	
+	public function new(owner:Sprite, text:String, width:Float = 0, height:Float = 0)
+	{
+		super();
+		
+		_owner = owner;
+		
+		maxSize = new Point(width, height);
+		
+		_shadow = new Bitmap(new BitmapData(1, 2, true, FlxColor.BLACK));
+		_background = new Bitmap(new BitmapData(1, 1, true, BG_COLOR));
+		
+		_text = DebuggerUtil.createTextField(2, 1);
+		_text.alpha = HEADER_ALPHA;
+		_text.text = text;
+		_text.wordWrap = true;
+		
+		addChild(_shadow);
+		addChild(_background);
+		addChild(_text);
+		
+		updateSize();
+		visible = false;
+		
+		_owner.addEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
+		_owner.addEventListener(MouseEvent.MOUSE_OUT, handleMouseEvents);
+	}
+	
+	/**
+	 * Clean up memory.
+	 */
+	public function destroy():Void
+	{
+		maxSize = null;
+
+		if (_shadow != null)
+		{
+			removeChild(_shadow);
+		}
+		_shadow = null;
+		if (_background != null)
+		{
+			removeChild(_background);
+		}
+		_background = null;
+		if (_text != null)
+		{
+			removeChild(_text);
+		}
+		_text = null;
+	}
+	
+	/**
+	 * Resize the window.  Subject to pre-specified minimums, maximums, and bounding rectangles.
+	 *
+	 * @param 	Width	How wide to make the window.
+	 * @param 	Height	How tall to make the window.
+	 */
+	public function resize(Width:Float, Height:Float):Void
+	{
+		maxSize.x = Std.int(Math.abs(Width));
+		maxSize.y = Std.int(Math.abs(Height));
+		updateSize();
+	}
+	
+	/**
+	 * Change the position of the window.  Subject to pre-specified bounding rectangles.
+	 * 
+	 * @param 	X	Desired X position of top left corner of the window.
+	 * @param 	Y	Desired Y position of top left corner of the window.
+	 */
+	public function reposition(X:Float, Y:Float):Void
+	{
+		x = X;
+		y = Y;
+	}
+	
+	public function setVisible(Value:Bool):Void
+	{
+		visible = Value;
+	
+		if (visible)
+			putOnTop();
+	}
+	
+	public function toggleVisible():Void
+	{
+		setVisible(!visible);
+	}
+	
+	public inline function putOnTop():Void
+	{
+		parent.addChild(this);
+	}
+	
+	public function update():Void {}
+	
+	/**
+	 * Update the Flash shapes to match the new size, and reposition the header, shadow, and handle accordingly.
+	 */
+	private function updateSize():Void
+	{
+		_width = Std.int(maxSize.x == 0 ? _text.textWidth : Math.abs(maxSize.x)) + 8;
+		_height = Std.int(maxSize.y == 0 ? _text.textHeight : Math.abs(maxSize.y)) + 8;
+		_background.scaleX = _width;
+		_background.scaleY = _height;
+		_shadow.scaleX = _width;
+		_shadow.y = _height;
+		_text.width = _width;
+	}
+	
+	private function handleMouseEvents(event:MouseEvent):Void
+	{
+		if (event.type == MouseEvent.MOUSE_OVER && !visible)
+		{
+			putOnTop();
+			x = event.stageX + event.target.width + 10;
+			y = event.stageY;
+			visible = true;
+			//FlxG.log.add("over " + event.target);
+		}
+		else if (event.type == MouseEvent.MOUSE_OUT)
+		{
+			visible = false;
+		}
+	}
+}

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -23,27 +23,6 @@ class Tooltip
 	private static var _tooltips:Array<TooltipOverlay> = [];
 	private static var _container:Sprite;
 	
-	/**
-	 * The background color of all tooltips.
-	 */
-	public static inline var BG_COLOR:FlxColor = 0xFF3A3A3A;
-	
-	/**
-	 * Alpha applied to the tooltips text.
-	 */
-	public static inline var TEXT_ALPHA:Float = 0.8;
-	
-	/**
-	 * How many pixels the tooltip should be away from the target in the x axis.
-	 */
-	public static inline var MARGIN_X:Int = 10;
-	
-	/**
-	 * How many pixels the tooltip should be away from the target in the y axis.
-	 */
-	public static inline var MARGIN_Y:Float = 10;
-	
-	
 	public static function init(container:Sprite):Void
 	{
 		_container = container;
@@ -68,6 +47,26 @@ class Tooltip
  */
 class TooltipOverlay extends Sprite
 {
+	/**
+	 * The background color of all tooltips.
+	 */
+	private static inline var BG_COLOR:FlxColor = 0xFF3A3A3A;
+	
+	/**
+	 * Alpha applied to the tooltips text.
+	 */
+	private static inline var TEXT_ALPHA:Float = 0.8;
+	
+	/**
+	 * How many pixels the tooltip should be away from the target in the x axis.
+	 */
+	private static inline var MARGIN_X:Int = 10;
+	
+	/**
+	 * How many pixels the tooltip should be away from the target in the y axis.
+	 */
+	private static inline var MARGIN_Y:Float = 10;
+	
 	/**
 	 * Width of the window. Using Sprite.width is super unreliable for some reason!
 	 */
@@ -108,10 +107,10 @@ class TooltipOverlay extends Sprite
 		maxSize = new Point(width, height);
 		
 		_shadow = new Bitmap(new BitmapData(1, 2, true, FlxColor.BLACK));
-		_background = new Bitmap(new BitmapData(1, 1, true, Tooltip.BG_COLOR));
+		_background = new Bitmap(new BitmapData(1, 1, true, BG_COLOR));
 		
 		_text = DebuggerUtil.createTextField(2, 1);
-		_text.alpha = Tooltip.TEXT_ALPHA;
+		_text.alpha = TEXT_ALPHA;
 		_text.text = text;
 		_text.wordWrap = true;
 		
@@ -232,8 +231,8 @@ class TooltipOverlay extends Sprite
 	{
 		if (event.type == MouseEvent.MOUSE_OVER && !visible)
 		{
-			x = event.stageX + Tooltip.MARGIN_X;
-			y = event.stageY + Tooltip.MARGIN_Y;
+			x = event.stageX + MARGIN_X;
+			y = event.stageY + MARGIN_Y;
 			
 			setVisible(true);
 		}

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -3,13 +3,10 @@ package flixel.system.debug;
 import flash.display.Bitmap;
 import flash.display.BitmapData;
 import flash.display.Sprite;
-import flash.events.Event;
 import flash.events.MouseEvent;
 import flash.geom.Point;
-import flash.geom.Rectangle;
 import flash.text.TextField;
 import flixel.FlxG;
-import flixel.math.FlxMath;
 import flixel.system.debug.FlxDebugger.GraphicCloseButton;
 import flixel.system.ui.FlxSystemButton;
 import flixel.util.FlxColor;
@@ -199,7 +196,8 @@ class TooltipOverlay extends Sprite
 	{
 		visible = Value;
 	
-		if (visible) {
+		if (visible)
+		{
 			putOnTop();
 			ensureOnScreen();
 		}

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -8,6 +8,7 @@ import flash.geom.Point;
 import flash.text.TextField;
 import flixel.FlxG;
 import flixel.util.FlxColor;
+import flixel.util.FlxDestroyUtil;
 
 /**
  * Manages tooltips to be used within the debugger.
@@ -23,7 +24,7 @@ class Tooltip
 	}
 	
 	public static function add(element:Sprite, text:String):Void
-	{		
+	{
 		var tooltip = new TooltipOverlay(element, text);
 		
 		_container.addChild(tooltip);
@@ -38,11 +39,11 @@ class Tooltip
 		{
 			if (_tooltips[i] != null && _tooltips[i].owner == element)
 			{
-				var tooltip :TooltipOverlay = _tooltips.splice(i, 1)[0];
+				var tooltip:TooltipOverlay = _tooltips.splice(i, 1)[0];
 				tooltip.destroy();
 				removed = true;
 				break;
-			}	
+			}
 		}
 		
 		return removed;
@@ -141,21 +142,9 @@ class TooltipOverlay extends Sprite
 	 */
 	public function destroy():Void
 	{
-		if (_shadow != null)
-		{
-			removeChild(_shadow);
-		}
-		_shadow = null;
-		if (_background != null)
-		{
-			removeChild(_background);
-		}
-		_background = null;
-		if (_text != null)
-		{
-			removeChild(_text);
-		}
-		_text = null;
+		_shadow = FlxDestroyUtil.removeChild(this, _shadow);
+		_background = FlxDestroyUtil.removeChild(this, _background);
+		_text = FlxDestroyUtil.removeChild(this, _text);
 		maxSize = null;
 		
 		owner.removeEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
@@ -164,7 +153,7 @@ class TooltipOverlay extends Sprite
 	}
 	
 	/**
-	 * Resize the tooltip.  Subject to pre-specified minimums, maximums, and bounding rectangles.
+	 * Resize the tooltip. Subject to pre-specified minimums, maximums, and bounding rectangles.
 	 *
 	 * @param 	Width	How wide to make the tooltip. If zero is specified, the tooltip will adjust its size to properly accomodate the text.
 	 * @param 	Height	How tall to make the tooltip. If zero is specified, the tooltip will adjust its size to properly accomodate the text.

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -56,7 +56,7 @@ class Tooltip extends Sprite
 	}
 	
 	public static function add(element:Sprite, text:String):Void
-	{
+	{		
 		var tooltip = new Tooltip(element, text);
 		
 		_container.addChild(tooltip);
@@ -148,8 +148,21 @@ class Tooltip extends Sprite
 	{
 		visible = Value;
 	
-		if (visible)
+		if (visible) {
 			putOnTop();
+			
+			// Move the tooltip back to the screen if top-left corner
+			// is out of the screen.
+			x = x < 0 ? 0 : x;
+			y = y < 0 ? 0 : y;
+			
+			// Calculate any adjustments to ensure that part of the
+			// tooltip is not outside of the screen.
+			var offsetX = x + width >= FlxG.stage.stageWidth ? FlxG.stage.stageWidth - (x + width) : 0;
+			var offsetY = y + height >= FlxG.stage.stageHeight ? FlxG.stage.stageHeight - (y + height) : 0;
+			x += offsetX;
+			y += offsetY;
+		}
 	}
 	
 	public function toggleVisible():Void
@@ -182,15 +195,12 @@ class Tooltip extends Sprite
 	{
 		if (event.type == MouseEvent.MOUSE_OVER && !visible)
 		{
-			putOnTop();
 			x = event.stageX + event.target.width + 10;
 			y = event.stageY;
-			visible = true;
-			//FlxG.log.add("over " + event.target);
+			
+			setVisible(true);
 		}
 		else if (event.type == MouseEvent.MOUSE_OUT)
-		{
-			visible = false;
-		}
+			setVisible(false);
 	}
 }

--- a/flixel/system/debug/interaction/tools/Mover.hx
+++ b/flixel/system/debug/interaction/tools/Mover.hx
@@ -25,6 +25,7 @@ class Mover extends Tool
 		_lastCursorPosition = new FlxPoint(brain.flixelPointer.x, brain.flixelPointer.x);
 
 		_name = "Mover";
+		_shortcut = "Shift";
 		setButton(GraphicMoverTool);
 		setCursor(new GraphicMoverTool(0, 0));
 

--- a/flixel/system/debug/interaction/tools/Tool.hx
+++ b/flixel/system/debug/interaction/tools/Tool.hx
@@ -17,6 +17,7 @@ class Tool extends Sprite implements IFlxDestroyable
 	public var cursor(default, null):BitmapData;
 	
 	private var _name:String = "(Unknown tool)";
+	private var _shortcut:String;
 	private var _brain:Interaction;
 	
 	public function init(brain:Interaction):Tool
@@ -45,7 +46,10 @@ class Tool extends Sprite implements IFlxDestroyable
 		button = new FlxSystemButton(Type.createInstance(Icon, [0, 0]), onButtonClicked, true);
 		button.toggled = true;
 		
-		Tooltip.add(button, _name);
+		var tooltip = _name;
+		if (_shortcut != null)
+			tooltip += ' ($_shortcut)';
+		Tooltip.add(button, tooltip);
 	}
 	
 	private function setCursor(Icon:BitmapData):Void

--- a/flixel/system/debug/interaction/tools/Tool.hx
+++ b/flixel/system/debug/interaction/tools/Tool.hx
@@ -44,6 +44,8 @@ class Tool extends Sprite implements IFlxDestroyable
 	{
 		button = new FlxSystemButton(Type.createInstance(Icon, [0, 0]), onButtonClicked, true);
 		button.toggled = true;
+		
+		Tooltip.add(button, _name);
 	}
 	
 	private function setCursor(Icon:BitmapData):Void


### PR DESCRIPTION
![debugger-overlay](https://cloud.githubusercontent.com/assets/512405/20652240/e878ea4e-b4f5-11e6-9adf-48509d63c433.gif)

This PR allows the use of tooltips in the debugger. Any `Sprite` element child of `FlxG.debugger` can receive a tooltip using the call `Tooltip.add(element, text)`. I decided for a static method in the `Tooltip` class instead of something like `FlxG.debugger.tooltip.add()` to keep the API internal and hidden from HaxeFlixel users.

I also added tooltips to the tools in `FlxG.debugger.interaction`.