### PR TITLE
FlxStringUtil: bugfix on formatMoney

### DIFF
--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -144,9 +144,10 @@ class FlxStringUtil
 		if (ShowDecimal)
 		{
 			amount = Math.floor(Amount * 100) - (Math.floor(Amount) * 100);
-			string += (EnglishStyle ? "." : ",") + amount;
+			string += (EnglishStyle ? "." : ",");
 			if (amount < 10)
 				string += "0";
+			string += amount;
 		}
 		
 		if (isNegative)


### PR DESCRIPTION
The current behavior add a "0" if decimal part is inferior to 10, but append it after the decimal part. It should be appended before the decimal part.
Example: when using on numbers like 4.0312, formatMoney returned "4.30". The expected value was "4.03".