### PR TITLE
Dispatch RESIZE signals later

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -461,9 +461,9 @@ class FlxGame extends Sprite
 		FlxG.resizeGame(width, height);
 		
 		_state.onResize(width, height);
-		FlxG.signals.gameResized.dispatch(width, height);
 		
 		FlxG.cameras.resize();
+		FlxG.signals.gameResized.dispatch(width, height);
 		
 		#if FLX_DEBUG
 		debugger.onResize(width, height);


### PR DESCRIPTION
If you're trying to scale something onResize, `FlxG.camera.totalScaleX` is currently not the value you want. I'm not sure what you'd want to independently scale within flixel, but I'm scaling nape's debug display to adjust to fullscreening.