### PR TITLE
Update FlxAnimationController.hx

### DIFF
--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -719,7 +719,7 @@ class FlxAnimationController implements IFlxDestroyable
 	
 	private function set_frameIndex(Frame:Int):Int
 	{
-		if (_sprite.frames != null)
+		if (_sprite.frames != null && frames > 0)
 		{
 			Frame = Frame % frames;
 			_sprite.frame = _sprite.frames.frames[Frame];


### PR DESCRIPTION
Added a check for frames number to `set_frameIndex(Frame:Int):Int` so it wont throw "Invalid operation (%)" while doing Frame % frames if there are 0 frames.