### PR TITLE
FlxG.cameras: fix reset() not removing all cameras

### DIFF
--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -97,10 +97,9 @@ class CameraFrontEnd
 	 */
 	public function reset(?NewCamera:FlxCamera):Void
 	{
-		while (list.length > 0) {
+		while (list.length > 0)
 			remove(list[0]);
-		}
-		
+
 		if (NewCamera == null)
 			NewCamera = new FlxCamera(0, 0, FlxG.width, FlxG.height);
 		

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -97,10 +97,9 @@ class CameraFrontEnd
 	 */
 	public function reset(?NewCamera:FlxCamera):Void
 	{
-		for (camera in list)
-			remove(camera);
-		
-		list.splice(0, list.length);
+		while (list.length > 0) {
+			remove(list[0]);
+		}
 		
 		if (NewCamera == null)
 			NewCamera = new FlxCamera(0, 0, FlxG.width, FlxG.height);

--- a/tests/unit/src/FlxTest.hx
+++ b/tests/unit/src/FlxTest.hx
@@ -17,9 +17,9 @@ class FlxTest
 	
 	public function new() {}
 	
+	@After
 	@:access(flixel)
-	@AfterClass
-	function afterClass()
+	function after()
 	{
 		FlxG.game.getTimer = function()
 		{

--- a/tests/unit/src/flixel/system/frontEnds/CameraFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/CameraFrontEndTest.hx
@@ -3,7 +3,7 @@ package flixel.system.frontEnds;
 import flixel.FlxCamera;
 import massive.munit.Assert;
 
-class CameraFrontEndTest
+class CameraFrontEndTest extends FlxTest
 {
 	@Test
 	public function testCameraAdded()
@@ -49,5 +49,17 @@ class CameraFrontEndTest
 		Assert.isTrue(success);
 		
 		FlxG.cameras.cameraResized.removeAll();
+	}
+
+	@Test
+	function testResetCameras()
+	{
+		Assert.areEqual(1, FlxG.cameras.list.length);
+
+		FlxG.cameras.add(new FlxCamera());
+		Assert.areEqual(2, FlxG.cameras.list.length);
+
+		FlxG.cameras.reset();
+		Assert.areEqual(1, FlxG.cameras.list.length);
 	}
 }


### PR DESCRIPTION
The problem is that `FlxG.cameras.reset()` tries to remove elements of an `Array` while iterating over it. 
This fails to `.destroy()` half of all cameras, leading to the memory leak.

________________________________

- **Flixel version:** 4.2.0
- **OpenFL version:** 3.6.1
- **Lime version:** 2.9.1
- **Affected targets:** at least Neko, likely more
- **Observed behavior:** Process memory usage steadily goes up.
- **Expected behavior:** It should not.

________________________________

**Code snippet reproducing the issue**:

```haxe
package;
import flixel.FlxG;
import flixel.FlxState;
import flixel.FlxCamera;

class PlayState extends FlxState
{
	override public function create():Void
	{
		FlxG.cameras.add(new FlxCamera());
	}

	override public function update(elapsed: Float):Void
	{
		super.update(elapsed);
		FlxG.switchState(new PlayState());
	}
}
```