### PR TITLE
FlxSpriteGroup: add insert()

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -257,6 +257,24 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	}
 	
 	/**
+	 * Inserts a new `FlxSprite` subclass to the group at the specified position.
+	 * 
+	 * @param   Position The position that the new sprite or sprite group should be inserted at.
+	 * @param   Sprite   The sprite or sprite group you want to insert into the group.
+	 * @return  The same object that was passed in.
+	 */
+	public function insert(Position:Int, Sprite:T):T
+	{
+		var sprite:FlxSprite = cast Sprite;
+		sprite.x += x;
+		sprite.y += y;
+		sprite.alpha *= alpha;
+		sprite.scrollFactor.copyFrom(scrollFactor);
+		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
+		return group.insert(Position, Sprite);
+	}
+	
+	/**
 	 * Recycling is designed to help you reuse game objects without always re-allocating or "newing" them.
 	 * It behaves differently depending on whether `maxSize` equals `0` or is bigger than `0`.
 	 * 

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -247,12 +247,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	public function add(Sprite:T):T
 	{
-		var sprite:FlxSprite = cast Sprite;
-		sprite.x += x;
-		sprite.y += y;
-		sprite.alpha *= alpha;
-		sprite.scrollFactor.copyFrom(scrollFactor);
-		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
+		preAdd(Sprite);
 		return group.add(Sprite);
 	}
 	
@@ -265,13 +260,24 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	public function insert(Position:Int, Sprite:T):T
 	{
+		preAdd(Sprite);
+		return group.insert(Position, Sprite);
+	}
+	
+	/**
+	 * Adjusts the position and other properties of the soon-to-be child of this sprite group.
+	 * Private helper to avoid duplicate code in `add()` and `insert()`.
+	 * 
+	 * @param	Sprite	The sprite or sprite group that is about to be added or inserted into the group.
+	 */
+	private function preAdd(Sprite:T):Void
+	{
 		var sprite:FlxSprite = cast Sprite;
 		sprite.x += x;
 		sprite.y += y;
 		sprite.alpha *= alpha;
 		sprite.scrollFactor.copyFrom(scrollFactor);
 		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
-		return group.insert(Position, Sprite);
 	}
 	
 	/**


### PR DESCRIPTION
Basically just `add` with a bit more control over positioning, or a more useful `group.insert()`. May or may not need it for haxeui.