### PR TITLE
FlxAtlasFrames.fromTexturePackerJson(): allow passing a parsed description

### DIFF
--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -50,8 +50,8 @@ class FlxAtlasFrames extends FlxFramesCollection
 		
 		var data:Dynamic;
 		
-		if (Std.is(Description, String)) {
-			
+		if (Std.is(Description, String))
+		{
 			var json:String = Description;
 			
 			if (Assets.exists(json))
@@ -60,7 +60,8 @@ class FlxAtlasFrames extends FlxFramesCollection
 			data = Json.parse(json);
 		}
 		
-		else {
+		else
+		{
 			data = Description;
 		}
 		

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -2,11 +2,13 @@ package flixel.graphics.frames;
 
 import flash.geom.Rectangle;
 import flixel.graphics.FlxGraphic;
+import flixel.graphics.frames.FlxAtlasFrames.TexturePackerObject;
 import flixel.graphics.frames.FlxFrame.FlxFrameAngle;
 import flixel.graphics.frames.FlxFramesCollection.FlxFrameCollectionType;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxGraphicAsset;
+import flixel.system.FlxAssets.FlxTexturePackerSource;
 import haxe.Json;
 import haxe.xml.Fast;
 import openfl.Assets;
@@ -32,7 +34,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 *                        You can also directly pass in the parsed object.
 	 * @return  Newly created `FlxAtlasFrames` collection.
 	 */
-	public static function fromTexturePackerJson(Source:FlxGraphicAsset, Description:Dynamic):FlxAtlasFrames
+	public static function fromTexturePackerJson(Source:FlxGraphicAsset, Description:FlxTexturePackerSource):FlxAtlasFrames
 	{
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source, false);
 		if (graphic == null)
@@ -48,7 +50,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		
 		frames = new FlxAtlasFrames(graphic);
 		
-		var data:Dynamic;
+		var data:TexturePackerObject;
 		
 		if (Std.is(Description, String))
 		{
@@ -423,4 +425,9 @@ class FlxAtlasFrames extends FlxFramesCollection
 		
 		return atlasFrames;
 	}
+}
+
+typedef TexturePackerObject = 
+{
+	frames : Dynamic
 }

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -29,9 +29,10 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 * @param   Description   Contents of JSON file with atlas description.
 	 *                        You can get it with `Assets.getText(path/to/description.json)`.
 	 *                        Or you can just a pass path to the JSON file in the assets directory.
+	 *                        You can also directly pass in the parsed object.
 	 * @return  Newly created `FlxAtlasFrames` collection.
 	 */
-	public static function fromTexturePackerJson(Source:FlxGraphicAsset, Description:String):FlxAtlasFrames
+	public static function fromTexturePackerJson(Source:FlxGraphicAsset, Description:Dynamic):FlxAtlasFrames
 	{
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source, false);
 		if (graphic == null)
@@ -47,10 +48,21 @@ class FlxAtlasFrames extends FlxFramesCollection
 		
 		frames = new FlxAtlasFrames(graphic);
 		
-		if (Assets.exists(Description))
-			Description = Assets.getText(Description);
+		var data:Dynamic;
 		
-		var data:Dynamic = Json.parse(Description);
+		if (Std.is(Description, String)) {
+			
+			var json:String = Description;
+			
+			if (Assets.exists(json))
+				json = Assets.getText(json);
+			
+			data = Json.parse(json);
+		}
+		
+		else {
+			data = Description;
+		}
 		
 		// JSON-Array
 		if (Std.is(data.frames, Array))

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -25,6 +25,7 @@ class GraphicVirtualInput extends BitmapData {}
 class VirtualInputData extends #if (lime_legacy || nme) ByteArray #else ByteArrayData #end {}
 
 typedef FlxAngelCodeSource = OneOfTwo<Xml, String>;
+typedef FlxTexturePackerSource = OneOfTwo<String, TexturePackerObject>;
 typedef FlxSoundAsset = OneOfThree<String, Sound, Class<Sound>>;
 typedef FlxGraphicAsset = OneOfThree<FlxGraphic, BitmapData, String>;
 typedef FlxGraphicSource = OneOfThree<BitmapData, Class<Dynamic>, String>;

--- a/tests/unit/src/flixel/graphics/frames/FlxAtlasFramesTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/FlxAtlasFramesTest.hx
@@ -1,18 +1,28 @@
 package flixel.graphics.frames;
 
 import flash.display.BitmapData;
+import haxe.Json;
 import massive.munit.Assert;
 
 class FlxAtlasFramesTest extends FlxTest
 {
+	var bmd:BitmapData;
+	var hashJson:String;
+	var atlasHash:FlxAtlasFrames;
+	
+	@Before
+	function before()
+	{
+		bmd = new BitmapData(1, 1);
+		hashJson = '{"frames":{"alien.png":{"frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},"medium.png":{"frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},"ship.png":{"frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},"small.png":{"frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}}}';
+		atlasHash = FlxAtlasFrames.fromTexturePackerJson(bmd, hashJson);
+	}
+	
 	@Test
 	function testTexturePackerJson()
 	{
-		var bmd = new BitmapData(1, 1);
 		var arrJson = '{"frames":[{"filename":"alien.png","frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},{"filename":"medium.png","frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},{"filename":"ship.png","frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},{"filename":"small.png","frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}]}';
-		var hashJson = '{"frames":{"alien.png":{"frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},"medium.png":{"frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},"ship.png":{"frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},"small.png":{"frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}}}';
 		var atlasArray = FlxAtlasFrames.fromTexturePackerJson(bmd, arrJson);
-		var atlasHash = FlxAtlasFrames.fromTexturePackerJson(bmd, hashJson);
 		
 		Assert.areEqual(atlasArray.numFrames, atlasHash.numFrames);
 		
@@ -21,6 +31,21 @@ class FlxAtlasFramesTest extends FlxTest
 			var hashArr = atlasHash.framesHash.get(frameArr.name);
 			Assert.areEqual(frameArr.name, hashArr.name);
 			Assert.isTrue(frameArr.sourceSize.equals(hashArr.sourceSize));
+		}
+	}
+	
+	@Test
+	function testTexturePackerJsonObject()
+	{
+		var parsed = Json.parse(hashJson);
+		var atlasHash2 = FlxAtlasFrames.fromTexturePackerJson(bmd, parsed);
+		
+		Assert.areEqual(atlasHash.numFrames, atlasHash2.numFrames);
+		
+		for (frame in atlasHash.frames)
+		{
+			var frame2 = atlasHash2.framesHash.get(frame.name);
+			Assert.isTrue(frame.sourceSize.equals(frame2.sourceSize));
 		}
 	}
 }


### PR DESCRIPTION
Closes #2019

In case the JSON is already parsed to an object, this avoids hundreds of thousands of allocations for big spritesheets.