### PR TITLE
Fix FlxTilemap.getTileIndexByCoords() not checking for tilemap bounds.

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -724,6 +724,10 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		// Figure out what tile we are starting and ending on.
 		var startIndex:Int = getTileIndexByCoords(Start);
 		var endIndex:Int = getTileIndexByCoords(End);
+		
+		// Check if any point given is outside the tilemap
+		if ((startIndex < 0) || (endIndex < 0))
+			return null;
 
 		// Check that the start and end are clear.
 		if ((_tileObjects[_data[startIndex]].allowCollisions > 0) || (_tileObjects[_data[endIndex]].allowCollisions > 0))
@@ -1234,14 +1238,15 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 */
 	override public function overlapsPoint(WorldPoint:FlxPoint, InScreenSpace:Bool = false, ?Camera:FlxCamera):Bool
 	{
-		if (!InScreenSpace)
-			return tileAtPointAllowsCollisions(WorldPoint);
+		if (InScreenSpace)
+		{
+			if (Camera == null)
+				Camera = FlxG.camera;
+			
+			WorldPoint.subtractPoint(Camera.scroll);
+			WorldPoint.putWeak();
+		}
 		
-		if (Camera == null)
-			Camera = FlxG.camera;
-		
-		WorldPoint.subtractPoint(Camera.scroll);
-		WorldPoint.putWeak();
 		return tileAtPointAllowsCollisions(WorldPoint);
 	}
 	

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -646,9 +646,14 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 
 	override public function getTileIndexByCoords(Coord:FlxPoint):Int
 	{
-		var result = Std.int((Coord.y - y) / _scaledTileHeight) * widthInTiles + Std.int((Coord.x - x) / _scaledTileWidth);
+		var localX = Coord.x - x;
+		var localY = Coord.y - y;
 		Coord.putWeak();
-		return result;
+		
+		if ((localX < 0) || (localY < 0) || (localX >= width) || (localY >= height))
+			return -1;
+		
+		return Std.int(localY / _scaledTileHeight) * widthInTiles + Std.int(localX / _scaledTileWidth);
 	}
 	
 	override public function getTileCoordsByIndex(Index:Int, Midpoint:Bool = true):FlxPoint


### PR DESCRIPTION
This is to eliminate false callbacks by FlxMouseEventManager with tilemaps.
Also added the new check where getTileIndexByCoords() is also used and did the small refactoring in FlxBaseTilemap.overlapsPoint().