### PR TITLE
FlxAnimationController: copy flipX and flipY in copyFrom()

### DIFF
--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -98,7 +98,7 @@ class FlxAnimationController implements IFlxDestroyable
 		
 		for (anim in controller._animations)
 		{
-			add(anim.name, anim.frames, anim.frameRate, anim.looped);
+			add(anim.name, anim.frames, anim.frameRate, anim.looped, anim.flipX, anim.flipY);
 		}
 		
 		if (controller._prerotated != null)

--- a/tests/unit/src/flixel/animation/FlxAnimationControllerTest.hx
+++ b/tests/unit/src/flixel/animation/FlxAnimationControllerTest.hx
@@ -96,7 +96,23 @@ class FlxAnimationControllerTest extends FlxTest
 		
 		Assert.isNull(sprite.animation.getByName("Test"));
 	}
-	
+
+	@Test // #2027
+	function testCopyFrom()
+	{
+		loadSpriteSheet();
+		sprite.animation.add("anim", [0, 1, 0], 15, true, true, false);
+		
+		var copy = sprite.clone();
+		var anim = copy.animation.getByName("anim");
+
+		FlxAssert.arraysEqual([0, 1, 0], anim.frames);
+		Assert.areEqual(15, anim.frameRate);
+		Assert.isTrue(anim.looped);
+		Assert.isTrue(anim.flipX);
+		Assert.isFalse(anim.flipY);
+	}
+
 	function loadSpriteSheet():Void
 	{
 		var bitmapData = new BitmapData(2, 1);


### PR DESCRIPTION
When using **FlxAnimationController.copyFrom**, which is used by both **FlxSprite.loadGraphicFromSprite** and **FlxSprite.clone**, **animation.flipX** and **animation.flipY** are not passed in to the new call to **add**, resulting in them both always reverting to their default of **false**.

This patch passes in both of these optional parameters, preserving flip settings on copied animations.