### PR TITLE
FlxSoundGroup: add pause() and resume()

### DIFF
--- a/flixel/system/FlxSoundGroup.hx
+++ b/flixel/system/FlxSoundGroup.hx
@@ -55,6 +55,26 @@ class FlxSoundGroup
 		return false;
 	}
 	
+	/**
+	 * Call this function to pause all sounds in this group.
+	 * @since 4.3.0
+	 */
+	public function pause():Void
+	{
+		for (sound in sounds)
+			sound.pause();
+	}
+	
+	/**
+	 * Unpauses all sounds in this group. Only works on sounds that have been paused.
+	 * @since 4.3.0
+	 */
+	public function resume():Void
+	{
+		for (sound in sounds)
+			sound.resume();
+	}
+	
 	private function set_volume(volume:Float):Float
 	{
 		this.volume = volume;
@@ -63,21 +83,5 @@ class FlxSoundGroup
 			sound.updateTransform();
 		}
 		return volume;
-	}
-	
-	public function pause():Void
-	{
-		for (sound in sounds)
-		{
-			sound.pause();
-		}
-	}
-	
-	public function resume():Void
-	{
-		for (sound in sounds)
-		{
-			sound.resume();
-		}
 	}
 }

--- a/flixel/system/FlxSoundGroup.hx
+++ b/flixel/system/FlxSoundGroup.hx
@@ -64,4 +64,20 @@ class FlxSoundGroup
 		}
 		return volume;
 	}
+	
+	public function pause():Void
+	{
+		for (sound in sounds)
+		{
+			sound.pause();
+		}
+	}
+	
+	public function resume():Void
+	{
+		for (sound in sounds)
+		{
+			sound.resume();
+		}
+	}
 }


### PR DESCRIPTION
This update allows developers to pause and resume all sounds in a sound group. This is useful when, for example, opening a pause menu. In such case, the developer could pause all gameplay sounds (in one or more groups) and resume them after the menu closes.

The code suggested is pretty straightforward so examples shouldn't be necessary. In any case, I could add some under request.