### PR TITLE
FlxRandom: make shuffle() slightly more efficient

### DIFF
--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -335,7 +335,7 @@ class FlxRandom
 	public function shuffle<T>(array:Array<T>):Void
 	{
 		var maxValidIndex = array.length - 1;
-		for (i in 0...array.length)
+		for (i in 0...maxValidIndex)
 		{
 			var j = int(i, maxValidIndex);
 			var tmp = array[i];


### PR DESCRIPTION
The shuffle function should have i iterating in the range [0,n-2] (where n=array.length). Then we choose a 'j' index to swap in the range [i,n-1]. However, currently i iterates in the range [0,n-1], which means on the final iteration the function does an unnecessary swap of element [n-1] with itself. I've made a small code change to correct this.