### PR TITLE
add hypot() and vectorTo()

### DIFF
--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -293,6 +293,20 @@ class FlxPoint implements IFlxPooled
 		point.putWeak();
 		return FlxMath.vectorLength(dx, dy);
 	}
+
+	/**
+	 * Get the vector between this point and another point.
+	 * 
+	 * @param 	AnotherPoint	A FlxPoint object to calculate a vector to.
+	 * @return	The vector between the two points as a FlxVector.
+	 */
+	public function vectorTo(point:FlxPoint):FlxVector
+	{
+		var dx:Float = x - point.x;
+		var dy:Float = y - point.y;
+		point.putWeak();
+		return FlxVector.get(dx, dy);
+	}
 	
 	/**
 	 * Rounds x and y using Math.floor()
@@ -395,6 +409,16 @@ class FlxPoint implements IFlxPooled
 	public inline function toVector():FlxVector
 	{
 		return FlxVector.get(x, y);
+	}
+
+	/**
+	 * Function to get the hypotenuse of the right triangle 
+	 * formed by the components of this `FlxPoint`
+	 * @since 4.3.0
+	 */
+	public inline function hypot():Float
+	{
+		return Math.sqrt(x * x + y * y);
 	}
 	
 	/**


### PR DESCRIPTION
`vectorTo()`, a possibly useful complement to `distanceTo()` in case they want the actual vector between two points.

`hypot()` calculates the hypotenuse of the right triangle formed by the components of the point.