### PR TITLE
FlxGamepad: add getAnalogAxes()

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -614,6 +614,11 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return getAnalogYAxisValue(Stick);
 	}
+
+	public function getAnalogAxes(AxesButtonID:FlxGamepadInputID):FlxVector
+	{
+		return FlxVector.get(getXAxis(AxesButtonID), getYAxis(AxesButtonID));
+	}
 	
 	/**
 	 * Whether any buttons have the specified input state.

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -615,6 +615,11 @@ class FlxGamepad implements IFlxDestroyable
 		return getAnalogYAxisValue(Stick);
 	}
 
+	/**
+	 * Given a ButtonID for an analog stick, gets a `FlxVector`
+	 * from the values of its x and y axes.
+	 * @param	AxesButtonID an analog stick FlxGamepadButtonID.LEFT_STICK
+	 */
 	public function getAnalogAxes(AxesButtonID:FlxGamepadInputID):FlxVector
 	{
 		return FlxVector.get(getXAxis(AxesButtonID), getYAxis(AxesButtonID));

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -599,7 +599,7 @@ class FlxGamepad implements IFlxDestroyable
 	
 	/**
 	 * Given a ButtonID for an analog stick, gets the value of its y axis
-	 * @param	AxesButtonID an analog stick FlxGamepadButtonID.LEFT_STICK
+	 * @param	AxesButtonID an analog stick like FlxGamepadButtonID.LEFT_STICK
 	 */
 	public inline function getYAxis(AxesButtonID:FlxGamepadInputID):Float
 	{
@@ -616,9 +616,10 @@ class FlxGamepad implements IFlxDestroyable
 	}
 
 	/**
-	 * Given a ButtonID for an analog stick, gets a `FlxVector`
-	 * from the values of its x and y axes.
-	 * @param	AxesButtonID an analog stick FlxGamepadButtonID.LEFT_STICK
+	 * Convenience method that wraps `getXAxis()` and `getYAxis()` into a `FlxVector`.
+	 *
+	 * @param	AxesButtonID an analog stick like `FlxGamepadButtonID.LEFT_STICK`
+	 * @since	4.3.0
 	 */
 	public function getAnalogAxes(AxesButtonID:FlxGamepadInputID):FlxVector
 	{


### PR DESCRIPTION
add `getAnalogAxes` to `FlxGamepad`, which will return a `FlxVector` containing the X and Y axis of that input ID.