### PR TITLE
FlxAnalog: fix mouse input without FLX_NO_TOUCH

### DIFF
--- a/flixel/ui/FlxAnalog.hx
+++ b/flixel/ui/FlxAnalog.hx
@@ -237,7 +237,8 @@ class FlxAnalog extends FlxSpriteGroup
 				break;
 			}
 		}
-		#elseif !FLX_NO_MOUSE
+		#end
+		#if !FLX_NO_MOUSE
 		_point.set(FlxG.mouse.screenX, FlxG.mouse.screenY);
 		
 		if (!updateAnalog(_point, FlxG.mouse.pressed, FlxG.mouse.justPressed, FlxG.mouse.justReleased))
@@ -391,7 +392,8 @@ class FlxAnalog extends FlxSpriteGroup
 		{
 			return _currentTouch.justPressed && status == PRESSED;
 		}
-		#elseif !FLX_NO_MOUSE
+		#end
+		#if !FLX_NO_MOUSE
 		return FlxG.mouse.justPressed && status == PRESSED;
 		#end
 		
@@ -410,7 +412,8 @@ class FlxAnalog extends FlxSpriteGroup
 		{
 			return _currentTouch.justReleased && status == HIGHLIGHT;
 		}
-		#elseif !FLX_NO_MOUSE
+		#end
+		#if !FLX_NO_MOUSE
 		return FlxG.mouse.justReleased && status == HIGHLIGHT;
 		#end
 		


### PR DESCRIPTION
Currently the default `project.xml` disables `touch` only for `desktop` platforms. Platforms like `flash` and `html5` still have both `touch` and `mouse` enabled.
https://github.com/HaxeFlixel/flixel-templates/blob/dev/default/Project.xml.tpl#L61

We could make the `project.xml` defaults to `<haxedef name="FLX_NO_TOUCH" unless="mobile" />`. But we'd still may want to test our project with mouse and touch enabled, so I changed this file to accept mouse event when touch is enabled.