### PR TITLE
FlxAnalog fixes and improvements

### DIFF
--- a/flixel/ui/FlxAnalog.hx
+++ b/flixel/ui/FlxAnalog.hx
@@ -90,13 +90,14 @@ class FlxAnalog extends FlxSpriteGroup
 	/**
 	 * Create a virtual thumbstick - useful for input on mobile devices.
 	 *
-	 * @param   X        The X-coordinate of the point in space.
-	 * @param   Y        The Y-coordinate of the point in space.
-	 * @param   radius   The radius where the thumb can move.
-	 *                   If `0`, half the background's width will be used as radius.
-	 * @param   ease     The duration of the easing. The value must be between `0` and `1`.
+	 * @param   X            The X-coordinate of the point in space.
+	 * @param   Y            The Y-coordinate of the point in space.
+	 * @param   radius       The radius where the thumb can move. If `0`, half the base's width will be used.
+	 * @param   ease         The duration of the easing. The value must be between `0` and `1`.
+	 * @param   BaseGraphic  The graphic you want to display as base of the joystick.
+	 * @param   ThumbGraphic The graphic you want to display as thumb of the joystick.
 	 */
-	public function new(X:Float = 0, Y:Float = 0, Radius:Float = 0, Ease:Float = 0.25)
+	public function new(X:Float = 0, Y:Float = 0, Radius:Float = 0, ?Ease:Float = 0.25, ?BaseGraphic:FlxGraphicAsset, ?ThumbGraphic:FlxGraphicAsset)
 	{
 		super();
 		
@@ -107,8 +108,8 @@ class FlxAnalog extends FlxSpriteGroup
 		
 		_point = FlxPoint.get();
 		
-		createBase();
-		createThumb();
+		createBase(BaseGraphic);
+		createThumb(ThumbGraphic);
 		
 		x = X;
 		y = Y;
@@ -119,14 +120,16 @@ class FlxAnalog extends FlxSpriteGroup
 	
 	/**
 	 * Creates the background of the analog stick.
-	 * Override this to customize the background.
 	 */
-	private function createBase():Void
+	private function createBase(?Graphic:FlxGraphicAsset):Void
 	{
-		base = new FlxSprite(x, y);
-		base.frames = FlxAssets.getVirtualInputFrames();
-		base.animation.frameName = "base";
-		base.resetSizeFromFrame();
+		base = new FlxSprite(x, y, Graphic);
+		if (Graphic == null)
+		{
+			base.frames = FlxAssets.getVirtualInputFrames();
+			base.animation.frameName = "base";
+			base.resetSizeFromFrame();
+		}
 		base.x += -base.width * 0.5;
 		base.y += -base.height * 0.5;
 		base.scrollFactor.set();
@@ -141,14 +144,16 @@ class FlxAnalog extends FlxSpriteGroup
 	
 	/**
 	 * Creates the thumb of the analog stick.
-	 * Override this to customize the thumb.
 	 */
-	private function createThumb():Void 
+	private function createThumb(?Graphic:FlxGraphicAsset):Void 
 	{
-		thumb = new FlxSprite(x, y);
-		thumb.frames = FlxAssets.getVirtualInputFrames();
-		thumb.animation.frameName = "thumb";
-		thumb.resetSizeFromFrame();
+		thumb = new FlxSprite(x, y, Graphic);
+		if (Graphic == null)
+		{
+			thumb.frames = FlxAssets.getVirtualInputFrames();
+			thumb.animation.frameName = "thumb";
+			thumb.resetSizeFromFrame();
+		}
 		thumb.scrollFactor.set();
 		thumb.solid = false;
 		
@@ -162,12 +167,11 @@ class FlxAnalog extends FlxSpriteGroup
 	/**
 	 * Creates the touch zone. It's based on the size of the background.
 	 * The thumb will react when the mouse is in the zone.
-	 * Override this to customize the zone.
 	 */
 	private function createZone():Void
 	{
-		if (base != null)
-			_radius = base.width / 2;
+		if (base != null && _radius == 0)
+			_radius = base.width * 0.5;
 		
 		_zone.set(x - _radius, y - _radius, 2 * _radius, 2 * _radius);
 	}
@@ -210,7 +214,7 @@ class FlxAnalog extends FlxSpriteGroup
 			offAll = false;
 		}
 		#end
-
+		
 		// There is no reason to get into the loop if their is already a pointer on the analog
 		#if FLX_TOUCH
 		if (_currentTouch != null)
@@ -255,6 +259,7 @@ class FlxAnalog extends FlxSpriteGroup
 			if (Math.abs(_amount) < 0.1) 
 			{
 				_amount = 0;
+				_direction = 0;
 			}
 		}
 		
@@ -368,7 +373,7 @@ class FlxAnalog extends FlxSpriteGroup
 	 */
 	public function getAngle():Float
 	{
-		return Math.atan2(acceleration.y, acceleration.x) * FlxAngle.TO_DEG;
+		return _direction * FlxAngle.TO_DEG;
 	}
 	
 	/**

--- a/flixel/ui/FlxAnalog.hx
+++ b/flixel/ui/FlxAnalog.hx
@@ -5,6 +5,7 @@ import flixel.FlxSprite;
 import flixel.group.FlxSpriteGroup;
 import flixel.input.touch.FlxTouch;
 import flixel.math.FlxAngle;
+import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
@@ -92,8 +93,8 @@ class FlxAnalog extends FlxSpriteGroup
 	 *
 	 * @param   X            The X-coordinate of the point in space.
 	 * @param   Y            The Y-coordinate of the point in space.
-	 * @param   radius       The radius where the thumb can move. If `0`, half the base's width will be used.
-	 * @param   ease         The duration of the easing. The value must be between `0` and `1`.
+	 * @param   Radius       The radius where the thumb can move. If 0, half the base's width will be used.
+	 * @param   Ease         Used to smoothly back thumb to center. Must be between 0 and (FlxG.updateFrameRate / 60).
 	 * @param   BaseGraphic  The graphic you want to display as base of the joystick.
 	 * @param   ThumbGraphic The graphic you want to display as thumb of the joystick.
 	 */
@@ -102,7 +103,7 @@ class FlxAnalog extends FlxSpriteGroup
 		super();
 		
 		_radius = Radius;
-		_ease = Ease;
+		_ease = FlxMath.bound(Ease, 0, 60 / FlxG.updateFramerate);
 		
 		_analogs.push(this);
 		
@@ -123,7 +124,7 @@ class FlxAnalog extends FlxSpriteGroup
 	 */
 	private function createBase(?Graphic:FlxGraphicAsset):Void
 	{
-		base = new FlxSprite(x, y, Graphic);
+		base = new FlxSprite(0, 0, Graphic);
 		if (Graphic == null)
 		{
 			base.frames = FlxAssets.getVirtualInputFrames();
@@ -147,7 +148,7 @@ class FlxAnalog extends FlxSpriteGroup
 	 */
 	private function createThumb(?Graphic:FlxGraphicAsset):Void 
 	{
-		thumb = new FlxSprite(x, y, Graphic);
+		thumb = new FlxSprite(0, 0, Graphic);
 		if (Graphic == null)
 		{
 			thumb.frames = FlxAssets.getVirtualInputFrames();
@@ -254,7 +255,7 @@ class FlxAnalog extends FlxSpriteGroup
 		
 		if ((status == HIGHLIGHT || status == NORMAL) && _amount != 0)
 		{
-			_amount *= _ease;
+			_amount -= _amount * _ease * FlxG.updateFramerate / 60;
 			
 			if (Math.abs(_amount) < 0.1) 
 			{
@@ -334,8 +335,8 @@ class FlxAnalog extends FlxSpriteGroup
 					_direction = Math.atan2(dy, dx);
 					_amount = Math.min(_radius, dist) / _radius;
 					
-					acceleration.x = Math.cos(_direction);
-					acceleration.y = Math.sin(_direction);
+					acceleration.x = Math.cos(_direction) * _amount;
+					acceleration.y = Math.sin(_direction) * _amount;
 				}
 			}
 			else if (JustReleased && status == PRESSED)

--- a/flixel/ui/FlxAnalog.hx
+++ b/flixel/ui/FlxAnalog.hx
@@ -329,8 +329,8 @@ class FlxAnalog extends FlxSpriteGroup
 					_direction = Math.atan2(dy, dx);
 					_amount = Math.min(_radius, dist) / _radius;
 					
-					acceleration.x = Math.cos(_direction) * _amount * _radius;
-					acceleration.y = Math.sin(_direction) * _amount * _radius;
+					acceleration.x = Math.cos(_direction);
+					acceleration.y = Math.sin(_direction);
 				}
 			}
 			else if (JustReleased && status == PRESSED)

--- a/flixel/ui/FlxAnalog.hx
+++ b/flixel/ui/FlxAnalog.hx
@@ -98,7 +98,7 @@ class FlxAnalog extends FlxSpriteGroup
 	 * @param   BaseGraphic  The graphic you want to display as base of the joystick.
 	 * @param   ThumbGraphic The graphic you want to display as thumb of the joystick.
 	 */
-	public function new(X:Float = 0, Y:Float = 0, Radius:Float = 0, ?Ease:Float = 0.25, ?BaseGraphic:FlxGraphicAsset, ?ThumbGraphic:FlxGraphicAsset)
+	public function new(X:Float = 0, Y:Float = 0, Radius:Float = 0, Ease:Float = 0.25, ?BaseGraphic:FlxGraphicAsset, ?ThumbGraphic:FlxGraphicAsset)
 	{
 		super();
 		


### PR DESCRIPTION
1. **[feature]** Added `?BaseGraphic` and `?ThumbGraphic` to constructor, this way we can create a `FlxAnalog` with custom graphics without need to create an extending class to override methods.
_(Not a breaking change)_

2. **[fix]** Changed how `ease` works to keep consistency across frame rates, it now works like `FlxCamera#followLerp`.
_(It works similar, not a breaking change I believe)_

3. **[fix]** Fixed constructor's `Radius` that was never being used, now it checks if `_radius == 0` before override it.
_(Not a breaking change)_

4. **[performance]** Now I use the already calculated angle stored in `_direction` to return `getAngle()`, avoid calling `Math.atan2()` twice.
_(I set `_direction = 0` only when the thumb backs to center, that means the `getAngle()` won't return `0` until then, differently the way it worked before that at `JustReleased` was setting acceleration to `0` and instantly `getAngle()` was returning `0`, would this be a breaking change?)_

5. **[fix]** Removed `_radius` from output's `acceleration` calc, it nows returns a normalized value. This is useful in case we want to multiply this value by a custom amount like `charSpeed`, etc.
_(it was based on the `radius` that is a screen in pixels value resulting in an strange acceleration range, this is kind of a breaking change)_