### PR TITLE
FlxMouseEventManager: add move, click and wheel events, closes #2085

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -59,6 +59,11 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var useSystemCursor(default, set):Bool = false;
 	/**
+	 * Check to see if the mouse has just been moved.
+	 * @since 4.3.0
+	 */
+	public var justMoved(get, never):Bool;
+	/**
 	 * Check to see if the left mouse button is currently pressed.
 	 */
 	public var pressed(get, never):Bool;
@@ -113,7 +118,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var justPressedTimeInTicksMiddle(get, never):Int;
 	#end
-
+	
 	/**
 	 * The left mouse button.
 	 */
@@ -148,6 +153,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	private var _lastY:Int = 0;
 	private var _lastWheel:Int = 0;
 	private var _lastLeftButtonState:FlxInputState;
+	
+	/**
+	 * Helper variables to see if the mouse has moved since the last update.
+	 */
+	private var _prevX:Int = 0;
+	private var _prevY:Int = 0;
 	
 	//Helper variable for cleaning up memory
 	private var _stage:Stage;
@@ -421,6 +432,9 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	private function update():Void
 	{
+		_prevX = x;
+		_prevY = y;
+		
 		#if !FLX_UNIT_TEST // Travis segfaults when game.mouseX / Y is accessed
 		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY); 
 		
@@ -509,6 +523,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	}
 	#end
 	
+	private inline function get_justMoved():Bool					 return _prevX != x || _prevY != y;
 	private inline function get_pressed():Bool                       return _leftButton.pressed;
 	private inline function get_justPressed():Bool                   return _leftButton.justPressed;
 	private inline function get_justReleased():Bool                  return _leftButton.justReleased;

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -60,7 +60,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	public var useSystemCursor(default, set):Bool = false;
 	/**
 	 * Check to see if the mouse has just been moved.
-	 * @since 4.3.0
+	 * @since 4.4.0
 	 */
 	public var justMoved(get, never):Bool;
 	/**

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -195,10 +195,28 @@ class FlxMouseEventManager extends FlxBasic
 	}
 	
 	/**
+	 * Sets the mouseMove callback associated with an object.
+	 *
+	 * @param   OnMouseMove   Callback when the mouse is moved while over this object.
+	 *                        Must have Object as argument - e.g. onMouseMove(object:FlxObject).
+	 * @since 4.3.0
+	 */
+	public static function setMouseMoveCallback<T:FlxObject>(Object:T, OnMouseMove:T->Void):Void
+	{
+		var reg = getRegister(Object);
+		
+		if (reg != null)
+		{
+			reg.onMouseMove = OnMouseMove;
+		}
+	}
+	
+	/**
 	 * Sets the mouseWheel callback associated with an object.
 	 *
-	 * @param   OnMouseWheel  Callback when mouse wheel is moved while over this object.
+	 * @param   OnMouseWheel  Callback when the mouse wheel is moved while over this object.
 	 *                        Must have Object as argument - e.g. onMouseWheel(object:FlxObject).
+	 * @since 4.3.0
 	 */
 	public static function setMouseWheelCallback<T:FlxObject>(Object:T, OnMouseWheel:T->Void):Void
 	{
@@ -399,6 +417,18 @@ class FlxMouseEventManager extends FlxBasic
 			}
 		}
 		
+		// MouseMove - Look for objects with mouse over that have mouseMove callbacks
+		if (FlxG.mouse.justMoved)
+		{
+			for (current in currentOverObjects)
+			{
+				if (current.onMouseMove != null && current.object.exists && current.object.visible)
+				{
+					current.onMouseMove(current.object);
+				}
+			}
+		}
+		
 		#if FLX_MOUSE
 		// MouseDown - Look for objects with mouse over when user presses mouse button.
 		for (current in currentOverObjects)
@@ -519,6 +549,7 @@ private class ObjectMouseData<T:FlxObject> implements IFlxDestroyable
 	public var onMouseUp:T->Void;
 	public var onMouseOver:T->Void;
 	public var onMouseOut:T->Void;
+	public var onMouseMove:T->Void;
 	public var onMouseWheel:T->Void;
 	public var mouseChildren:Bool;
 	public var mouseEnabled:Bool;
@@ -549,6 +580,7 @@ private class ObjectMouseData<T:FlxObject> implements IFlxDestroyable
 		onMouseUp = null;
 		onMouseOver = null;
 		onMouseOut = null;
+		onMouseMove = null;
 		onMouseWheel = null;
 		mouseButtons = null;
 	}

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -47,7 +47,7 @@ class FlxMouseEventManager extends FlxBasic
 	 * The maximum amount of time between two clicks that is considered a double click, in milliseconds.
 	 * @since 4.4.0
 	 */
-	public static var MAX_DOUBLE_CLICK_DELAY:Int = 500;
+	public static var maxDoubleClickDelay:Int = 500;
 	
 	/**
 	 * As alternative you can call FlxMouseEventManager.init().
@@ -522,7 +522,7 @@ class FlxMouseEventManager extends FlxBasic
 		
 		// MouseClick - Look for objects that had mouse down and now have mouse over when the user releases the mouse button.
 		// DoubleClick - Look for objects that were recently clicked and have just been clicked again.
-		if (_mouseClickedObjects.length > 0 && FlxG.game.ticks - _mouseClickedTime > MAX_DOUBLE_CLICK_DELAY)
+		if (_mouseClickedObjects.length > 0 && FlxG.game.ticks - _mouseClickedTime > maxDoubleClickDelay)
 		{
 			_mouseClickedObjects = [];
 		}

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -561,11 +561,12 @@ class FlxMouseEventManager extends FlxBasic
 					}
 				}
 			}
-			
-			if (_mouseDownObjects.length > 0)
-			{
-				_mouseDownObjects = [];
-			}
+		}
+		
+		if (_mouseDownObjects.length > 0 && !FlxG.mouse.pressed)
+		{
+			// if the user just released the mouse OR if the user released the mouse while the window was tabbed out
+			_mouseDownObjects = [];
 		}
 		
 		// MouseWheel - Look for objects with mouse over when user spins the mouse wheel.

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -181,7 +181,7 @@ class FlxMouseEventManager extends FlxBasic
 	/**
 	 * Sets the mouseOut callback associated with an object.
 	 *
-	 * @param   OnMouseOver   Callback when mouse is moves out of this object.
+	 * @param   OnMouseOver   Callback when mouse is moved out of this object.
 	 *                        Must have Object as argument - e.g. onMouseDown(object:FlxObject).
 	 */
 	public static function setMouseOutCallback<T:FlxObject>(Object:T, OnMouseOut:T->Void):Void
@@ -191,6 +191,22 @@ class FlxMouseEventManager extends FlxBasic
 		if (reg != null)
 		{
 			reg.onMouseOut = OnMouseOut;
+		}
+	}
+	
+	/**
+	 * Sets the mouseWheel callback associated with an object.
+	 *
+	 * @param   OnMouseWheel  Callback when mouse wheel is moved while over this object.
+	 *                        Must have Object as argument - e.g. onMouseWheel(object:FlxObject).
+	 */
+	public static function setMouseWheelCallback<T:FlxObject>(Object:T, OnMouseWheel:T->Void):Void
+	{
+		var reg = getRegister(Object);
+		
+		if (reg != null)
+		{
+			reg.onMouseWheel = OnMouseWheel;
 		}
 	}
 	
@@ -413,6 +429,18 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
+		
+		// MouseWheel - Look for objects with mouse over when user spins the mouse wheel.
+		for (current in currentOverObjects)
+		{
+			if (current.onMouseWheel != null && current.object.exists && current.object.visible)
+			{
+				if (FlxG.mouse.wheel != 0)
+				{
+					current.onMouseWheel(current.object);
+				}
+			}
+		}
 		#end
 		
 		_mouseOverObjects = currentOverObjects;
@@ -491,6 +519,7 @@ private class ObjectMouseData<T:FlxObject> implements IFlxDestroyable
 	public var onMouseUp:T->Void;
 	public var onMouseOver:T->Void;
 	public var onMouseOut:T->Void;
+	public var onMouseWheel:T->Void;
 	public var mouseChildren:Bool;
 	public var mouseEnabled:Bool;
 	public var pixelPerfect:Bool;
@@ -520,6 +549,7 @@ private class ObjectMouseData<T:FlxObject> implements IFlxDestroyable
 		onMouseUp = null;
 		onMouseOver = null;
 		onMouseOut = null;
+		onMouseWheel = null;
 		mouseButtons = null;
 	}
 }

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -437,6 +437,7 @@ class FlxMouseEventManager extends FlxBasic
 			}
 		}
 		
+		#if FLX_MOUSE
 		// MouseMove - Look for objects with mouse over that have mouseMove callbacks
 		if (FlxG.mouse.justMoved)
 		{
@@ -449,7 +450,6 @@ class FlxMouseEventManager extends FlxBasic
 			}
 		}
 		
-		#if FLX_MOUSE
 		// MouseDown - Look for objects with mouse over when user presses mouse button.
 		for (current in currentOverObjects)
 		{

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -510,11 +510,11 @@ class FlxMouseEventManager extends FlxBasic
 		}
 		
 		// MouseWheel - Look for objects with mouse over when user spins the mouse wheel.
-		for (current in currentOverObjects)
+		if (FlxG.mouse.wheel != 0)
 		{
-			if (current.onMouseWheel != null && current.object.exists && current.object.visible)
+			for (current in currentOverObjects)
 			{
-				if (FlxG.mouse.wheel != 0)
+				if (current.onMouseWheel != null && current.object.exists && current.object.visible)
 				{
 					current.onMouseWheel(current.object);
 				}


### PR DESCRIPTION
Closes #2085 

Added `MOVE`, `CLICK`, and `WHEEL` mouse callbacks. It works, but I haven't extensively tested it yet, which I'll be doing with HaxeUI and my game. MMB/RMB click callbacks don't seem as necessary, and I decided not to `DOUBLE_CLICK` unless someone really wants it.

Also added `justMoved` to `FlxMouse`. It seemed more appropriate there than in `FlxPointer` since pointer doesn't have a once-per-frame `update()`.

AS3's mouse events  aren't tied to the framerate in my testing, and flixel can't do anything to match that, but that's ok.