### PR TITLE
Initial support for OpenFL 6.0 (using Tilemap)

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1481,7 +1481,7 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			#if openfl_legacy // can't skip this on next, see #1793
+			#if (openfl_legacy || (openfl >= "4.0.0")) // can't skip this on next, see #1793
 			if (FxAlpha == 0)
 				return;
 			#end

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -6,12 +6,30 @@ import flash.geom.Rectangle;
 import flixel.FlxG;
 import openfl.Assets;
 import openfl.display.OpenGLView;
+
+#if openfl_legacy
 import openfl.gl.GL;
 import openfl.gl.GLFramebuffer;
 import openfl.gl.GLRenderbuffer;
 import openfl.gl.GLTexture;
 import openfl.gl.GLBuffer;
 import openfl.utils.Float32Array;
+#else
+import lime.graphics.opengl.GL;
+import lime.graphics.opengl.GLFramebuffer;
+import lime.graphics.opengl.GLRenderbuffer;
+import lime.graphics.opengl.GLTexture;
+import lime.graphics.opengl.GLBuffer;
+import lime.utils.Float32Array;
+#end
+
+#if (lime >= "4.0.0")
+import lime.graphics.opengl.WebGLContext;
+#end
+
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
 
 private class Uniform
 {
@@ -66,7 +84,11 @@ class PostProcess extends OpenGLView
 
 		buffer = GL.createBuffer();
 		GL.bindBuffer(GL.ARRAY_BUFFER, buffer);
+		#if (lime >= "4.0.0")
+		(GL:WebGLContext).bufferData(GL.ARRAY_BUFFER, new Float32Array(vertices), GL.STATIC_DRAW);
+		#else
 		GL.bufferData(GL.ARRAY_BUFFER, new Float32Array(#if !openfl_next cast #end vertices), GL.STATIC_DRAW);
+		#end
 		GL.bindBuffer(GL.ARRAY_BUFFER, null);
 
 		postProcessShader = new Shader([

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -180,7 +180,7 @@ class PostProcess extends OpenGLView
 		texture = GL.createTexture();
 		
 		GL.bindTexture(GL.TEXTURE_2D, texture);
-		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGB,  width, height,  0,  GL.RGB, GL.UNSIGNED_BYTE, null);
+		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGB,  width, height,  0,  GL.RGB, GL.UNSIGNED_BYTE, #if (lime >= "4.0.0") 0 #else null #end);
 
 		GL.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
 		GL.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);

--- a/flixel/effects/postprocess/Shader.hx
+++ b/flixel/effects/postprocess/Shader.hx
@@ -1,9 +1,15 @@
 package flixel.effects.postprocess;
 
 #if FLX_POST_PROCESS
+#if openfl_legacy
 import openfl.gl.GL;
 import openfl.gl.GLProgram;
 import openfl.gl.GLShader;
+#else
+import lime.graphics.opengl.GL;
+import lime.graphics.opengl.GLProgram;
+import lime.graphics.opengl.GLShader;
+#end
 
 /**
  * GLSL Shader object

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -6,12 +6,12 @@ import flixel.graphics.frames.FlxAtlasFrames;
 import flixel.graphics.frames.FlxFrame;
 import flixel.graphics.frames.FlxFramesCollection;
 import flixel.graphics.frames.FlxImageFrame;
+import flixel.graphics.tile.FlxTilesheet;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
-import openfl.display.Tilesheet;
 
 /**
  * `BitmapData` wrapper which is used for rendering.
@@ -316,7 +316,7 @@ class FlxGraphic implements IFlxDestroyable
 	/**
 	 * Tilesheet for this graphic object. It is used only for `FlxG.renderTile` mode.
 	 */
-	public var tilesheet(get, null):Tilesheet;
+	public var tilesheet(get, null):FlxTilesheet;
 	
 	/**
 	 * Usage counter for this `FlxGraphic` object.
@@ -364,7 +364,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * Internal var holding Tilesheet for bitmap of this graphic.
 	 * It is used only in `FlxG.renderTile` mode
 	 */
-	private var _tilesheet:Tilesheet;
+	private var _tilesheet:FlxTilesheet;
 	
 	private var _useCount:Int = 0;
 	
@@ -522,7 +522,7 @@ class FlxGraphic implements IFlxDestroyable
 	/**
 	 * Tilesheet getter. Generates new one (and regenerates) if there is no tilesheet for this graphic yet.
 	 */
-	private function get_tilesheet():Tilesheet
+	private function get_tilesheet():FlxTilesheet
 	{
 		if (_tilesheet == null)
 		{
@@ -531,7 +531,7 @@ class FlxGraphic implements IFlxDestroyable
 			if (dumped)
 				undump();
 			
-			_tilesheet = new Tilesheet(bitmap);
+			_tilesheet = new FlxTilesheet(bitmap);
 			
 			if (dumped)
 				dump();
@@ -613,7 +613,7 @@ class FlxGraphic implements IFlxDestroyable
 			height = bitmap.height;
 			#if !flash
 			if (FlxG.renderTile && _tilesheet != null)
-				_tilesheet = new Tilesheet(bitmap);
+				_tilesheet = new FlxTilesheet(bitmap);
 			#end
 		}
 		

--- a/flixel/graphics/tile/FlxDrawBaseItem.hx
+++ b/flixel/graphics/tile/FlxDrawBaseItem.hx
@@ -4,7 +4,6 @@ import flixel.FlxCamera;
 import flixel.graphics.frames.FlxFrame;
 import flixel.math.FlxMatrix;
 import openfl.display.BlendMode;
-import openfl.display.Tilesheet;
 import openfl.geom.ColorTransform;
 
 /**
@@ -16,36 +15,36 @@ class FlxDrawBaseItem<T>
 	public static function blendToInt(blend:BlendMode):Int
 	{
 		if (blend == null)
-			return Tilesheet.TILE_BLEND_NORMAL;
+			return FlxTilesheet.TILE_BLEND_NORMAL;
 		
 		return switch (blend)
 		{
 			case BlendMode.ADD:
-				Tilesheet.TILE_BLEND_ADD;
+				FlxTilesheet.TILE_BLEND_ADD;
 			#if !flash
 			case BlendMode.MULTIPLY:
-				Tilesheet.TILE_BLEND_MULTIPLY;
+				FlxTilesheet.TILE_BLEND_MULTIPLY;
 			case BlendMode.SCREEN:
-				Tilesheet.TILE_BLEND_SCREEN;
+				FlxTilesheet.TILE_BLEND_SCREEN;
 			case BlendMode.SUBTRACT:
-				Tilesheet.TILE_BLEND_SUBTRACT;
+				FlxTilesheet.TILE_BLEND_SUBTRACT;
 			#if !lime_legacy
 			case BlendMode.DARKEN:
-				Tilesheet.TILE_BLEND_DARKEN;
+				FlxTilesheet.TILE_BLEND_DARKEN;
 			case BlendMode.LIGHTEN:
-				Tilesheet.TILE_BLEND_LIGHTEN;
+				FlxTilesheet.TILE_BLEND_LIGHTEN;
 			case BlendMode.OVERLAY:
-				Tilesheet.TILE_BLEND_OVERLAY;
+				FlxTilesheet.TILE_BLEND_OVERLAY;
 			case BlendMode.HARDLIGHT:
-				Tilesheet.TILE_BLEND_HARDLIGHT;
+				FlxTilesheet.TILE_BLEND_HARDLIGHT;
 			case BlendMode.DIFFERENCE:
-				Tilesheet.TILE_BLEND_DIFFERENCE;
+				FlxTilesheet.TILE_BLEND_DIFFERENCE;
 			case BlendMode.INVERT:
-				Tilesheet.TILE_BLEND_INVERT;
+				FlxTilesheet.TILE_BLEND_INVERT;
 			#end
 			#end
 			default:
-				Tilesheet.TILE_BLEND_NORMAL;
+				FlxTilesheet.TILE_BLEND_NORMAL;
 		}
 	}
 	

--- a/flixel/graphics/tile/FlxDrawTilesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTilesItem.hx
@@ -6,7 +6,6 @@ import flixel.graphics.tile.FlxDrawBaseItem.FlxDrawItemType;
 import flixel.math.FlxMatrix;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxShader;
-import openfl.display.Tilesheet;
 import openfl.geom.ColorTransform;
 
 class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
@@ -83,20 +82,20 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 		if (!FlxG.renderTile || position <= 0)
 			return;
 		
-		var flags:Int = Tilesheet.TILE_TRANS_2x2 | Tilesheet.TILE_RECT | Tilesheet.TILE_ALPHA;
+		var flags:Int = FlxTilesheet.TILE_TRANS_2x2 | FlxTilesheet.TILE_RECT | FlxTilesheet.TILE_ALPHA;
 		
 		if (colored)
-			flags |= Tilesheet.TILE_RGB;
+			flags |= FlxTilesheet.TILE_RGB;
 		
 		#if (!openfl_legacy && openfl >= "3.6.0")
 		if (hasColorOffsets)
-			flags |= Tilesheet.TILE_TRANS_COLOR;
+			flags |= FlxTilesheet.TILE_TRANS_COLOR;
 		#end
 
 		flags |= blending;
 
 		#if !(nme && flash)
-		camera.canvas.graphics.drawTiles(graphics.tilesheet, drawData,
+		graphics.tilesheet.draw(camera.canvas, drawData,
 			(camera.antialiasing || antialiasing), flags,
 			#if !openfl_legacy shader, #end
 			position);

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -11,11 +11,11 @@ import openfl.display.Graphics;
 import openfl.display.TriangleCulling;
 import openfl.geom.ColorTransform;
 
-#if flash
+#if (flash || openfl >= "4.0.0")
 import openfl.Vector;
 #end
 
-typedef DrawData<T> = #if flash Vector<T> #else Array<T> #end;
+typedef DrawData<T> = #if (flash || openfl >= "4.0.0") Vector<T> #else Array<T> #end;
 
 /**
  * ...

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -1,5 +1,6 @@
-package flixel.graphics.tile;
+package flixel.graphics.tile; #if (openfl < "4.0.0")
 
+import openfl.display.Sprite;
 import openfl.display.Tilesheet;
 
 class FlxTilesheet extends Tilesheet
@@ -8,4 +9,94 @@ class FlxTilesheet extends Tilesheet
 	 * Tracks total number of `drawTiles()` calls made each frame.
 	 */
 	public static var _DRAWCALLS:Int = 0;
+	
+	public static inline var TILE_SCALE = Tilesheet.TILE_SCALE;
+	public static inline var TILE_ROTATION = Tilesheet.TILE_ROTATION;
+	public static inline var TILE_RGB = Tilesheet.TILE_RGB;
+	public static inline var TILE_ALPHA = Tilesheet.TILE_ALPHA;
+	public static inline var TILE_TRANS_2x2 = Tilesheet.TILE_TRANS_2x2;
+	public static inline var TILE_RECT = Tilesheet.TILE_RECT;
+	public static inline var TILE_ORIGIN = Tilesheet.TILE_ORIGIN;
+	public static inline var TILE_BLEND_NORMAL = Tilesheet.TILE_BLEND_NORMAL;
+	public static inline var TILE_BLEND_ADD = Tilesheet.TILE_BLEND_ADD;
+	public static inline var TILE_BLEND_MULTIPLY = Tilesheet.TILE_BLEND_MULTIPLY;
+	public static inline var TILE_BLEND_SCREEN = Tilesheet.TILE_BLEND_SCREEN;
+	public static inline var TILE_BLEND_SUBTRACT = Tilesheet.TILE_BLEND_SUBTRACT;
+	
+	#if !openfl_legacy
+	public static inline var TILE_TRANS_COLOR = Tilesheet.TILE_TRANS_COLOR;
+	public static inline var TILE_BLEND_DARKEN = Tilesheet.TILE_BLEND_DARKEN;
+	public static inline var TILE_BLEND_LIGHTEN = Tilesheet.TILE_BLEND_LIGHTEN;
+	public static inline var TILE_BLEND_OVERLAY = Tilesheet.TILE_BLEND_OVERLAY;
+	public static inline var TILE_BLEND_HARDLIGHT = Tilesheet.TILE_BLEND_HARDLIGHT;
+	public static inline var TILE_BLEND_DIFFERENCE = Tilesheet.TILE_BLEND_DIFFERENCE;
+	public static inline var TILE_BLEND_INVERT = Tilesheet.TILE_BLEND_INVERT;
+	#end
+	
+	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, #if !openfl_legacy shader:Dynamic, #end, count:Int = -1):Void
+	{
+		drawTiles (canvas.graphics, tileData, smooth, flags, #if !openfl_legacy shader:Dynamic, #end count);
+	}
 }
+
+#else
+
+import openfl.display.BitmapData;
+import openfl.display.Graphics;
+import openfl.display.Sprite;
+import openfl.display.Tileset;
+import openfl.geom.Rectangle;
+import openfl.geom.Point;
+
+class FlxTilesheet extends Tileset
+{
+	/**
+	 * Tracks total number of `drawTiles()` calls made each frame.
+	 */
+	public static var _DRAWCALLS:Int = 0;
+	
+	public static inline var TILE_SCALE = 0x0001;
+	public static inline var TILE_ROTATION = 0x0002;
+	public static inline var TILE_RGB = 0x0004;
+	public static inline var TILE_ALPHA = 0x0008;
+	public static inline var TILE_TRANS_2x2 = 0x0010;
+	public static inline var TILE_RECT = 0x0020;
+	public static inline var TILE_ORIGIN = 0x0040;
+	public static inline var TILE_TRANS_COLOR = 0x0080;
+	public static inline var TILE_BLEND_NORMAL = 0x00000000;
+	public static inline var TILE_BLEND_ADD = 0x00010000;
+	public static inline var TILE_BLEND_MULTIPLY = 0x00020000;
+	public static inline var TILE_BLEND_SCREEN = 0x00040000;
+	public static inline var TILE_BLEND_SUBTRACT = 0x00080000;
+	public static inline var TILE_BLEND_DARKEN = 0x00100000;
+	public static inline var TILE_BLEND_LIGHTEN = 0x00200000;
+	public static inline var TILE_BLEND_OVERLAY = 0x00400000;
+	public static inline var TILE_BLEND_HARDLIGHT = 0x00800000;
+	public static inline var TILE_BLEND_DIFFERENCE = 0x01000000;
+	public static inline var TILE_BLEND_INVERT = 0x02000000;
+	
+	private var _centerPoints = new Array<Point>();
+	
+	public function new(image:BitmapData)
+	{	
+		super(image);
+	}
+	
+	public function addTileRect(rectangle:Rectangle, centerPoint:Point = null):Int
+	{
+		var id = addRect (rectangle);
+		_centerPoints.push (centerPoint);
+		return id;
+	}
+	
+	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, #if !openfl_legacy shader:Dynamic, #end count:Int = -1):Void
+	{
+		//drawTiles (canvas.graphics, tileData, smooth, flags, count);
+	}
+	
+	//public function getTileCenter (index:Int):Point;
+	//public function getTileRect (index:Int):Rectangle;
+	//public function getTileUVs (index:Int):Rectangle;
+}
+
+#end

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -111,8 +111,8 @@ class FlxTilesheet extends Tileset
 		{
 			tilemap = new Tilemap(0, 0, this);
 			_tilemap[canvas] = tilemap;
-			canvas.addChild(tilemap);
 		}
+		canvas.addChild(tilemap);
 		tilemap.shader = shader;
 		tilemap.visible = true;
 		tilemap.width = Lib.current.stage.stageWidth;

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -36,7 +36,7 @@ class FlxTilesheet extends Tilesheet
 	
 	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, #if !openfl_legacy shader:Shader, #end count:Int = -1):Void
 	{
-		drawTiles (canvas.graphics, tileData, smooth, flags, #if !openfl_legacy shader:Dynamic, #end count);
+		canvas.graphics.drawTiles (this, tileData, smooth, flags, #if !openfl_legacy shader, #end count);
 	}
 }
 

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -34,7 +34,7 @@ class FlxTilesheet extends Tilesheet
 	public static inline var TILE_BLEND_INVERT = Tilesheet.TILE_BLEND_INVERT;
 	#end
 	
-	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, #if !openfl_legacy shader:Shader, #end, count:Int = -1):Void
+	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, #if !openfl_legacy shader:Shader, #end count:Int = -1):Void
 	{
 		drawTiles (canvas.graphics, tileData, smooth, flags, #if !openfl_legacy shader:Dynamic, #end count);
 	}

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -10,6 +10,7 @@ import flash.display.StageAlign;
 import flash.display.StageScaleMode;
 import flash.events.Event;
 import flash.events.MouseEvent;
+import flash.events.ProgressEvent;
 import flash.geom.Matrix;
 import flash.geom.Rectangle;
 import flash.Lib;
@@ -20,7 +21,7 @@ import flash.text.TextFormatAlign;
 import flixel.util.FlxColor;
 import flixel.util.FlxStringUtil;
 
-class FlxBasePreloader extends NMEPreloader
+class FlxBasePreloader extends DefaultPreloader
 {
 	/**
 	 * Add this string to allowedURLs array if you want to be able to test game with enabled site-locking on local machine
@@ -401,3 +402,208 @@ class FlxBasePreloader extends NMEPreloader
 	}
 	#end
 }
+
+#if (openfl >= "4.0.0")
+@:dox(hide) class DefaultPreloader extends Sprite {
+	
+	
+	private var endAnimation:Int;
+	private var outline:Sprite;
+	private var progress:Sprite;
+	private var startAnimation:Int;
+	
+	
+	public function new () {
+		
+		super ();
+		
+		var backgroundColor = getBackgroundColor ();
+		var r = backgroundColor >> 16 & 0xFF;
+		var g = backgroundColor >> 8  & 0xFF;
+		var b = backgroundColor & 0xFF;
+		var perceivedLuminosity = (0.299 * r + 0.587 * g + 0.114 * b);
+		var color = 0x000000;
+		
+		if (perceivedLuminosity < 70) {
+			
+			color = 0xFFFFFF;
+			
+		}
+		
+		var x = 30;
+		var height = 7;
+		var y = getHeight () / 2 - height / 2;
+		var width = getWidth () - x * 2;
+		
+		var padding = 2;
+		
+		outline = new Sprite ();
+		outline.graphics.beginFill (color, 0.07);
+		outline.graphics.drawRect (0, 0, width, height);
+		outline.x = x;
+		outline.y = y;
+		outline.alpha = 0;
+		addChild (outline);
+		
+		progress = new Sprite ();
+		progress.graphics.beginFill (color, 0.35);
+		progress.graphics.drawRect (0, 0, width - padding * 2, height - padding * 2);
+		progress.x = x + padding;
+		progress.y = y + padding;
+		progress.scaleX = 0;
+		progress.alpha = 0;
+		addChild (progress);
+		
+		startAnimation = Lib.getTimer () + 100;
+		endAnimation = startAnimation + 1000;
+		
+		addEventListener (Event.ADDED_TO_STAGE, this_onAddedToStage);
+		
+	}
+	
+	
+	public function getBackgroundColor ():Int {
+		
+		return Lib.current.stage.window.config.background;
+		
+	}
+	
+	
+	public function getHeight ():Float {
+		
+		var height = Lib.current.stage.window.config.height;
+		
+		if (height > 0) {
+			
+			return height;
+			
+		} else {
+			
+			return Lib.current.stage.stageHeight;
+			
+		}
+		
+	}
+	
+	
+	public function getWidth ():Float {
+		
+		var width = Lib.current.stage.window.config.width;
+		
+		if (width > 0) {
+			
+			return width;
+			
+		} else {
+			
+			return Lib.current.stage.stageWidth;
+			
+		}
+		
+	}
+	
+	
+	@:keep public function onInit ():Void {
+		
+		addEventListener (Event.ENTER_FRAME, this_onEnterFrame);
+		
+	}
+	
+	
+	@:keep public function onLoaded ():Void {
+		
+		removeEventListener (Event.ENTER_FRAME, this_onEnterFrame);
+		
+		dispatchEvent (new Event (Event.UNLOAD));
+		
+	}
+	
+	
+	@:keep public function onUpdate (bytesLoaded:Int, bytesTotal:Int):Void {
+		
+		var percentLoaded = 0.0;
+		
+		if (bytesTotal > 0) {
+			
+			percentLoaded = bytesLoaded / bytesTotal;
+			
+			if (percentLoaded > 1) {
+				
+				percentLoaded = 1;
+				
+			}
+			
+		}
+		
+		progress.scaleX = percentLoaded;
+		
+	}
+	
+	
+	
+	
+	// Event Handlers
+	
+	
+	
+	
+	private function this_onAddedToStage (event:Event):Void {
+		
+		removeEventListener (Event.ADDED_TO_STAGE, this_onAddedToStage);
+		
+		onInit ();
+		onUpdate (loaderInfo.bytesLoaded, loaderInfo.bytesTotal);
+		
+		addEventListener (ProgressEvent.PROGRESS, this_onProgress);
+		addEventListener (Event.COMPLETE, this_onComplete);
+		
+	}
+	
+	
+	private function this_onComplete (event:Event):Void {
+		
+		event.preventDefault ();
+		
+		removeEventListener (ProgressEvent.PROGRESS, this_onProgress);
+		removeEventListener (Event.COMPLETE, this_onComplete);
+		
+		#if (openfl < "5.0.0")
+		addEventListener (Event.COMPLETE, function (event) {
+			
+			dispatchEvent (new Event (Event.UNLOAD));
+			
+		});
+		#end
+		
+		onLoaded ();
+		
+	}
+	
+	
+	private function this_onEnterFrame (event:Event):Void {
+		
+		var elapsed = Lib.getTimer () - startAnimation;
+		var total = endAnimation - startAnimation;
+		
+		var percent = elapsed / total;
+		
+		if (percent < 0) percent = 0;
+		if (percent > 1) percent = 1;
+		
+		outline.alpha = percent;
+		progress.alpha = percent;
+		
+	}
+	
+	
+	private function this_onProgress (event:ProgressEvent):Void {
+		
+		onUpdate (Std.int (event.bytesLoaded), Std.int (event.bytesTotal));
+		
+	}
+	
+	
+}
+#else
+typedef DefaultPreloader = NMEPreloader;
+#end

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -14,6 +14,10 @@ import flixel.tweens.FlxTween;
 import flixel.util.FlxStringUtil;
 import openfl.Assets;
 
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
+
 #if flash11
 import flash.utils.ByteArray;
 #end

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -128,7 +128,7 @@ class Interaction extends Window
 	{
 		// Did the user click a debugger UI element instead of performing
 		// a click related to a tool?
-		if (event.type == MouseEvent.MOUSE_DOWN && belongsToDebugger(event.target))
+		if (event.type == MouseEvent.MOUSE_DOWN && belongsToDebugger(cast event.target))
 			return;
 		
 		pointerJustPressed = event.type == MouseEvent.MOUSE_DOWN;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -10,7 +10,11 @@ import flixel.util.FlxColor;
 import openfl.Assets;
 
 #if !flash
+#if openfl_legacy
 import openfl.gl.GL;
+#else
+import lime.graphics.opengl.GL;
+#end
 #end
 
 /**

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -191,6 +191,13 @@ class CameraFrontEnd
 			if (FlxG.renderTile)
 			{
 				camera.clearDrawStack();
+				#if (openfl >= "4.0.0")
+				// TODO: Better solution, hide unused tilemaps
+				for (i in 0...camera.canvas.numChildren)
+				{
+					camera.canvas.getChildAt(i).visible = false;
+				}
+				#end
 				camera.canvas.graphics.clear();
 				// Clearing camera's debug sprite
 				#if FLX_DEBUG

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -11,6 +11,10 @@ import flixel.math.FlxMath;
 import flixel.input.keyboard.FlxKey;
 import openfl.Assets;
 
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
+
 @:allow(flixel.FlxG)
 class SoundFrontEnd
 {

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -92,12 +92,14 @@ class FlxDefines
 		abortMinVersion("Lime", "2.8.1", (macro null).pos);
 		#end
 
+		#if openfl_legacy
 		#if (openfl >= "4.0.0")
 		abortMaxVersion("OpenFL", "4.0.0", "3.6.1", (macro null).pos);
 		#end
 		
 		#if ((lime >= "3.0.0") || (tools >= "3.0.0"))
 		abortMaxVersion("Lime", "3.0.0", "2.9.1", (macro null).pos);
+		#end
 		#end
 	}
 

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -23,6 +23,10 @@ import openfl.Assets;
 import haxe.Utf8;
 using flixel.util.FlxStringUtil;
 
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
+
 #if flash
 import openfl.geom.Rectangle;
 #end


### PR DESCRIPTION
Hello!

I know there is a cool branch in-the-works that uses an OpenGL renderer for Flixel. For sake of compatibility for OpenFL and Lime in the short-term, but also as an alternative approach to the future, I would like to offer this change which has 1.) general changes to support current versions of OpenFL, as well as 2.) a change to `FlxTilesheet` which maps `drawTiles` to `Tilemap`

Testing on the Mode platformer demo, everything seems to work properly, but sometimes enemy jets disappear. I am not fully sure why.

Although it largely works, there are some issues with the life-cycle of adding, removing or ordering `Tilemap` objects, which you guys can probably sort out fairly easily. I wanted to get the brunt of this working.

This consumes a new beta `TileArray` API, available in the current OpenFL "develop" branch. Happy to discuss this more on how we can improve.