### PR TITLE
FlxAssetPaths: fix filterExtensions for files with multiple dots

### DIFF
--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -49,9 +49,8 @@ class FlxAssetPaths
 				{
 					var explodedName:Array<String> = name.split(".");
 					var extension:String = explodedName[explodedName.length-1]; // get the last string with a dot before it
-					if (filterExtensions.indexOf(extension) == -1){
+					if (filterExtensions.indexOf(extension) == -1)
 						continue;
-					}
 				}
 				
 				fileReferences.push(new FileReference(directory + name));

--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -47,8 +47,7 @@ class FlxAssetPaths
 				
 				if (filterExtensions != null)
 				{
-					var explodedName:Array<String> = name.split(".");
-					var extension:String = explodedName[explodedName.length-1]; // get the last string with a dot before it
+					var extension:String = name.split(".").last(); // get the last string with a dot before it
 					if (filterExtensions.indexOf(extension) == -1)
 						continue;
 				}

--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -47,9 +47,11 @@ class FlxAssetPaths
 				
 				if (filterExtensions != null)
 				{
-					var extension:String = name.split(".")[1]; // get the string after the dot
-					if (filterExtensions.indexOf(extension) == -1)
+					var explodedName:Array<String> = name.split(".");
+					var extension:String = explodedName[explodedName.length-1]; // get the last string with a dot before it
+					if (filterExtensions.indexOf(extension) == -1){
 						continue;
+					}
 				}
 				
 				fileReferences.push(new FileReference(directory + name));


### PR DESCRIPTION
Currently, getFileReferences filtered extensions using the first string after a dot. This means that myfile.png.old is included even when a filter is set to only import png files. This causes various compiler errors when tortoisesvn is used, due to duplicate file.ext.svn-base files being added. 

New implementation takes the *last* string after a dot, meaning that myfile.png.old is treated as a .old file and will not be included if "old" is not on the filter list.