### PR TITLE
FlxButton: fix justPressed being true for two frames

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -281,8 +281,6 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		super.update(elapsed);
 		
-		input.update();
-		
 		if (visible) 
 		{
 			// Update the button, but only if at least either mouse or touches are enabled
@@ -297,6 +295,8 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 				lastStatus = status;
 			}
 		}
+		
+		input.update();
 	}
 	
 	private function updateStatusAnimation():Void


### PR DESCRIPTION
FlxButton's JUST_PRESSED lasts for two frames. The expectation is that JUST_PRESSED only lasts for one frame, but two frames of it are currently required to trigger a PRESSED. Moving the input's update fixes this.

Proxy PR, I haven't tested this at all.