### PR TITLE
FlxText: fix text changes removing clipRect, closes #2031

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -771,7 +771,13 @@ class FlxText extends FlxSprite
 			height = newHeight;
 			var key:String = FlxG.bitmap.getUniqueKey("text");
 			
+			// retain the clipRect through text changes
+			var tempRect = clipRect;
+			
 			makeGraphic(Std.int(newWidth), Std.int(newHeight), FlxColor.TRANSPARENT, false, key);
+			
+			clipRect = tempRect;
+			
 			if (_hasBorderAlpha)
 				_borderPixels = graphic.bitmap.clone();
 			frameHeight = Std.int(height);


### PR DESCRIPTION
Fixes #2031 

Rendering new text wipes out the existing clipRect, which I can't see being useful. This retains the clip.

Core issue is that FlxSprite wipes the clip after `makeGraphic()` is called, but text seems like it should be an exception.