### PR TITLE
Fix FlxStringUtil.formatMoney() for large values

### DIFF
--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -120,15 +120,15 @@ class FlxStringUtil
 
 		var string:String = "";
 		var comma:String = "";
-		var amount:Int = Math.floor(Amount);
+		var amount:Float = Math.ffloor(Amount);
 		while (amount > 0)
 		{
 			if (string.length > 0 && comma.length <= 0)
 				comma = (EnglishStyle ? "," : ".");
 
 			var zeroes = "";
-			var helper = amount - Math.floor(amount / 1000) * 1000;
-			amount = Math.floor(amount / 1000);
+			var helper = amount - Math.ffloor(amount / 1000) * 1000;
+			amount = Math.ffloor(amount / 1000);
 			if (amount > 0)
 			{
 				if (helper < 100)
@@ -144,7 +144,7 @@ class FlxStringUtil
 		
 		if (ShowDecimal)
 		{
-			amount = Math.floor(Amount * 100) - (Math.floor(Amount) * 100);
+			amount = Math.ffloor(Amount * 100) - (Math.ffloor(Amount) * 100);
 			string += (EnglishStyle ? "." : ",");
 			if (amount < 10)
 				string += "0";

--- a/tests/unit/src/flixel/util/FlxStringUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxStringUtilTest.hx
@@ -82,6 +82,7 @@ class FlxStringUtilTest
 		Assert.areEqual("110.20", FlxStringUtil.formatMoney(110.2));
 		Assert.areEqual("110", FlxStringUtil.formatMoney(110.2, false));
 		Assert.areEqual("100,000,000.00", FlxStringUtil.formatMoney(100000000));
+		Assert.areEqual("10,000,000,000.00", FlxStringUtil.formatMoney(10000000000)); // #2120
 		Assert.areEqual("100.000.000,00", FlxStringUtil.formatMoney(100000000, true, false));
 		Assert.areEqual("0.60", FlxStringUtil.formatMoney(0.6)); // #1754
 		Assert.areEqual("0", FlxStringUtil.formatMoney(0.6, false));


### PR DESCRIPTION
Using ffloor instead of flood, which resulted in loss of information on numbers larger than the max value of an int

If you want to try it, just call the function with a float > 2^31-1, it sometimes returns "0", sometimes -2^31

You can in in action in the images below :
![without](https://user-images.githubusercontent.com/6261257/33661307-9f87f9d4-da87-11e7-96a6-fd6742678612.jpg)
Without the fix

![with](https://user-images.githubusercontent.com/6261257/33661306-9f6e9520-da87-11e7-9927-7bdabb7882f7.jpg)
With the fix

If you want to checkout the (ugly) code, it's [right here](https://github.com/TAGL-Entertainment/LD40/blob/master/source/ui/InfoScreen.hx#L118) 
