### PR TITLE
Fix to CLICK events for FlxMouseEventManager remove

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -540,7 +540,7 @@ class FlxMouseEventManager extends FlxBasic
 			
 			for (down in _mouseDownObjects)
 			{
-				if (down.object.exists && down.object.visible && getRegister(down.object, currentOverObjects) != null)
+				if (down.object != null && down.object.exists && down.object.visible && getRegister(down.object, currentOverObjects) != null)
 				{
 					if (down.onMouseClick != null)
 					{


### PR DESCRIPTION
If a register in FlxMouseEventManager is removed from within a callback, it could crash as the register still may exist in the persistent arrays, like `_mouseDownObjects` despite being destroyed.

Repro:
```haxe
FlxMouseEventManager.add(mySprite, null, null, onMDown);
...
function onMDown(mySprite) {
     FlxMouseEventManager.remove(mySprite); // triggered during DOWN, errors when checking CLICK
}
```

Only affects the click and double click block as those don't first check if either callback is null. All the rest do.