### PR TITLE
Removes private keyword from fields

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -14,11 +14,11 @@ class FlxBasic implements IFlxDestroyable
 	 * Static counters for performance tracking.
 	 */
 	@:allow(flixel.FlxGame)
-	private static var activeCount:Int = 0;
+	static var activeCount:Int = 0;
 	@:allow(flixel.FlxGame)
-	private static var visibleCount:Int = 0;
+	static var visibleCount:Int = 0;
 	#end
-	
+
 	/**
 	 * IDs seem like they could be pretty useful, huh?
 	 * They're not actually used for anything yet though.
@@ -41,7 +41,7 @@ class FlxBasic implements IFlxDestroyable
 	 * Controls whether `update()` and `draw()` are automatically called by `FlxState`/`FlxGroup`.
 	 */
 	public var exists(default, set):Bool = true;
-	
+
 	/**
 	 * Gets ot sets the first camera of this object.
 	 */
@@ -51,25 +51,25 @@ class FlxBasic implements IFlxDestroyable
 	 * set, it uses `FlxCamera.defaultCameras`, which is a reference to `FlxG.cameras.list` (all cameras) by default.
 	 */
 	public var cameras(get, set):Array<FlxCamera>;
-	
+
 	/**
 	 * Enum that informs the collision system which type of object this is (to avoid expensive type casting).
 	 */
 	@:noCompletion
-	private var flixelType(default, null):FlxType = NONE;
-	
+	var flixelType(default, null):FlxType = NONE;
+
 	@:noCompletion
-	private var _cameras:Array<FlxCamera>;
-	
+	var _cameras:Array<FlxCamera>;
+
 	public function new() {}
-	
+
 	/**
 	 * **WARNING:** A destroyed `FlxBasic` can't be used anymore.
 	 * It may even cause crashes if it is still part of a group or state.
 	 * You may want to use `kill()` instead if you want to disable the object temporarily only and `revive()` it later.
-	 * 
+	 *
 	 * This function is usually not called manually (Flixel calls it automatically during state switches for all `add()`ed objects).
-	 * 
+	 *
 	 * Override this function to `null` out variables manually or call `destroy()` on class members if necessary.
 	 * Don't forget to call `super.destroy()`!
 	 */
@@ -78,7 +78,7 @@ class FlxBasic implements IFlxDestroyable
 		exists = false;
 		_cameras = null;
 	}
-	
+
 	/**
 	 * Handy function for "killing" game objects. Use `reset()` to revive them.
 	 * Default behavior is to flag them as nonexistent AND dead.
@@ -90,7 +90,7 @@ class FlxBasic implements IFlxDestroyable
 		alive = false;
 		exists = false;
 	}
-	
+
 	/**
 	 * Handy function for bringing game objects "back to life". Just sets `alive` and `exists` back to `true`.
 	 * In practice, this function is most often called by `FlxObject#reset()`.
@@ -100,18 +100,18 @@ class FlxBasic implements IFlxDestroyable
 		alive = true;
 		exists = true;
 	}
-	
+
 	/**
 	 * Override this function to update your class's position and appearance.
 	 * This is where most of your game rules and behavioral code will go.
 	 */
-	public function update(elapsed:Float):Void 
-	{ 
+	public function update(elapsed:Float):Void
+	{
 		#if FLX_DEBUG
 		activeCount++;
 		#end
 	}
-	
+
 	/**
 	 * Override this function to control how the object is drawn.
 	 * Doing so is rarely necessary, but can be very useful.
@@ -122,7 +122,7 @@ class FlxBasic implements IFlxDestroyable
 		visibleCount++;
 		#end
 	}
-	
+
 	public function toString():String
 	{
 		return FlxStringUtil.getDebugString([
@@ -131,39 +131,39 @@ class FlxBasic implements IFlxDestroyable
 			LabelValuePair.weak("alive", alive),
 			LabelValuePair.weak("exists", exists)]);
 	}
-	
+
 	@:noCompletion
-	private function set_visible(Value:Bool):Bool
+	function set_visible(Value:Bool):Bool
 	{
 		return visible = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_active(Value:Bool):Bool
+	function set_active(Value:Bool):Bool
 	{
 		return active = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_exists(Value:Bool):Bool
+	function set_exists(Value:Bool):Bool
 	{
 		return exists = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_alive(Value:Bool):Bool
+	function set_alive(Value:Bool):Bool
 	{
 		return alive = Value;
 	}
-	
+
 	@:noCompletion
-	private function get_camera():FlxCamera
+	function get_camera():FlxCamera
 	{
 		return (_cameras == null || _cameras.length == 0) ? FlxCamera.defaultCameras[0] : _cameras[0];
 	}
-	
+
 	@:noCompletion
-	private function set_camera(Value:FlxCamera):FlxCamera
+	function set_camera(Value:FlxCamera):FlxCamera
 	{
 		if (_cameras == null)
 			_cameras = [Value];
@@ -171,15 +171,15 @@ class FlxBasic implements IFlxDestroyable
 			_cameras[0] = Value;
 		return Value;
 	}
-	
+
 	@:noCompletion
-	private function get_cameras():Array<FlxCamera>
+	function get_cameras():Array<FlxCamera>
 	{
 		return (_cameras == null) ? FlxCamera.defaultCameras : _cameras;
 	}
-	
+
 	@:noCompletion
-	private function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
+	function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
 	{
 		return _cameras = Value;
 	}
@@ -209,9 +209,9 @@ interface IFlxBasic
 	public function draw():Void;
 	public function update(elapsed:Float):Void;
 	public function destroy():Void;
-	
+
 	public function kill():Void;
 	public function revive():Void;
-	
+
 	public function toString():String;
 }

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -31,7 +31,7 @@ using flixel.util.FlxColorTransformUtil;
  * The camera class is used to display the game's visuals.
  * By default one camera is created automatically, that is the same size as window.
  * You can add more cameras or even replace the main camera using utilities in `FlxG.cameras`.
- * 
+ *
  * Every camera has following display list:
  * `flashSprite:Sprite` (which is a container for everything else in the camera, it's added to FlxG.game sprite)
  *     |-> `_scrollRect:Sprite` (which is used for cropping camera's graphic, mostly in tile render mode)
@@ -52,7 +52,7 @@ class FlxCamera extends FlxBasic
 	 * By default, this is just a reference to `FlxG.cameras.list` / all cameras, but it can be very useful to change.
 	 */
 	public static var defaultCameras:Array<FlxCamera>;
-	
+
 	/**
 	 * The X position of this camera's display. `zoom` does NOT affect this number.
 	 * Measured in pixels from the left side of the window.
@@ -65,7 +65,7 @@ class FlxCamera extends FlxBasic
 	 * You might be interested in using camera's `scroll.y` instead.
 	 */
 	public var y(default, set):Float = 0;
-	
+
 	/**
 	 * The scaling on horizontal axis for this camera.
 	 * Setting `scaleX` changes `scaleX` and x coordinate of camera's internal display objects.
@@ -84,7 +84,7 @@ class FlxCamera extends FlxBasic
 	 * Product of camera's scaleY and game's scale mode scale.y multiplication.
 	 */
 	public var totalScaleY(default, null):Float;
-	
+
 	/**
 	 * Tells the camera to use this following style.
 	 */
@@ -134,48 +134,48 @@ class FlxCamera extends FlxBasic
 	 * make the camera look at specified point in world coordinates.
 	 */
 	public var scroll:FlxPoint = FlxPoint.get();
-	
+
 	/**
 	 * The actual `BitmapData` of the camera display itself.
 	 * Used in blit render mode, where you can manipulate its pixels for achieving some visual effects.
 	 */
 	public var buffer:BitmapData;
-	
+
 	/**
 	 * The natural background color of the camera, in `AARRGGBB` format. Defaults to `FlxG.cameras.bgColor`.
 	 * On Flash, transparent backgrounds can be used in conjunction with `useBgAlphaBlending`.
 	 */
 	public var bgColor:FlxColor;
-	
+
 	/**
 	 * Sometimes it's easier to just work with a `FlxSprite` than it is to work directly with the `BitmapData` buffer.
 	 * This sprite reference will allow you to do exactly that.
 	 * Basically this sprite's `pixels` property is camera's `BitmapData` buffer.
 	 * NOTE: This variable is used only in blit render mode.
-	 * 
+	 *
 	 * The FlxBloom demo shows how you can use this variable in blit render mode.
 	 * @see http://haxeflixel.com/demos/FlxBloom/
 	 */
 	public var screen:FlxSprite;
-	
+
 	/**
 	 * Whether to use alpha blending for camera's background fill or not.
 	 * If `true` then previously drawn graphics won't be erased,
 	 * and if camera's `bgColor` is transparent/semitransparent then you
 	 * will be able to see graphics of the previous frame.
 	 * Useful for blit render mode (and works only in this mode). Default value is `false`.
-	 * 
+	 *
 	 * Usage example can be seen in FlxBloom demo.
 	 * @see http://haxeflixel.com/demos/FlxBloom/
 	 */
 	public var useBgAlphaBlending:Bool = false;
-	
+
 	/**
 	 * Used to render buffer to screen space.
 	 * NOTE: We don't recommend modifying this directly unless you are fairly experienced.
 	 * Uses include 3D projection, advanced display list modification, and more.
 	 * This is container for everything else that is used by camera and rendered to the camera.
-	 * 
+	 *
 	 * Its position is modified by `updateFlashSpritePosition()` which is called every frame.
 	 */
 	public var flashSprite:Sprite = new Sprite();
@@ -187,7 +187,7 @@ class FlxCamera extends FlxBasic
 	 * WARNING: setting this to `false` on blitting targets is very expensive.
 	 */
 	public var pixelPerfectRender:Bool;
-	
+
 	/**
 	 * How wide the camera display is, in game pixels.
 	 */
@@ -201,38 +201,38 @@ class FlxCamera extends FlxBasic
 	 * Indicates how far the camera is zoomed in.
 	 */
 	public var zoom(default, set):Float;
-	
+
 	/**
 	 * Difference between native size of camera and zoomed size, divided in half
 	 * Needed to do occlusion of objects when zoom != initialZoom
 	 */
-	private var viewOffsetX(default, null):Float = 0;
-	private var viewOffsetY(default, null):Float = 0;
-	
+	var viewOffsetX(default, null):Float = 0;
+	var viewOffsetY(default, null):Float = 0;
+
 	/**
 	 * The size of the camera plus view offset.
 	 * These variables are used for object visibility checks.
 	 */
-	private var viewOffsetWidth(default, null):Float = 0;
-	private var viewOffsetHeight(default, null):Float = 0;
-	
+	var viewOffsetWidth(default, null):Float = 0;
+	var viewOffsetHeight(default, null):Float = 0;
+
 	/**
 	 * Dimensions of area visible at current camera zoom.
 	 */
-	private var viewWidth(default, null):Float = 0;
-	private var viewHeight(default, null):Float = 0;
-	
+	var viewWidth(default, null):Float = 0;
+	var viewHeight(default, null):Float = 0;
+
 	/**
 	 * Helper matrix object. Used in blit render mode when camera's zoom is less than initialZoom
 	 * (it is applied to all objects rendered on the camera at such circumstances).
 	 */
-	private var _blitMatrix:FlxMatrix = new FlxMatrix();
-	
+	var _blitMatrix:FlxMatrix = new FlxMatrix();
+
 	/**
 	 * Logical flag for tracking whether to apply _blitMatrix transformation to objects or not.
 	 */
-	private var _useBlitMatrix:Bool = false;
-	
+	var _useBlitMatrix:Bool = false;
+
 	/**
 	 * The alpha value of this camera display (a number between `0.0` and `1.0`).
 	 */
@@ -258,20 +258,20 @@ class FlxCamera extends FlxBasic
 	 * Enables or disables the filters set via `setFilters()`.
 	 */
 	public var filtersEnabled:Bool = true;
-	
+
 	/**
 	 * Internal, used in blit render mode in camera's `fill()` method for less garbage creation.
 	 * It represents the size of buffer `BitmapData`
 	 * (the area of camera's buffer which should be filled with `bgColor`).
 	 * Do not modify it unless you know what are you doing.
 	 */
-	private var _flashRect:Rectangle;
+	var _flashRect:Rectangle;
 	/**
 	 * Internal, used in blit render mode in camera's `fill()` method for less garbage creation:
 	 * Its coordinates are always `(0,0)`, where camera's buffer filling should start.
 	 * Do not modify it unless you know what are you doing.
 	 */
-	private var _flashPoint:Point = new Point();
+	var _flashPoint:Point = new Point();
 	/**
 	 * Internal, used for positioning camera's `flashSprite` on screen.
 	 * Basically it represents position of camera's center point in game sprite.
@@ -279,112 +279,112 @@ class FlxCamera extends FlxBasic
 	 * Its value depends on camera's size (`width` and `height`), game's `scale` and camera's initial zoom factor.
 	 * Do not modify it unless you know what are you doing.
 	 */
-	private var _flashOffset:FlxPoint = FlxPoint.get();
+	var _flashOffset:FlxPoint = FlxPoint.get();
 	/**
 	 * Internal, represents the color of `flash()` special effect.
 	 */
-	private var _fxFlashColor:FlxColor = FlxColor.TRANSPARENT;
+	var _fxFlashColor:FlxColor = FlxColor.TRANSPARENT;
 	/**
 	 * Internal, stores `flash()` special effect duration.
 	 */
-	private var _fxFlashDuration:Float = 0;
+	var _fxFlashDuration:Float = 0;
 	/**
 	 * Internal, camera's `flash()` complete callback.
 	 */
-	private var _fxFlashComplete:Void->Void = null;
+	var _fxFlashComplete:Void->Void = null;
 	/**
 	 * Internal, used to control the `flash()` special effect.
 	 */
-	private var _fxFlashAlpha:Float = 0;
+	var _fxFlashAlpha:Float = 0;
 	/**
 	 * Internal, color of fading special effect.
 	 */
-	private var _fxFadeColor:FlxColor = FlxColor.TRANSPARENT;
+	var _fxFadeColor:FlxColor = FlxColor.TRANSPARENT;
 	/**
 	 * Used to calculate the following target current velocity.
 	 */
-	private var _lastTargetPosition:FlxPoint;
+	var _lastTargetPosition:FlxPoint;
 	/**
 	 * Helper to calculate follow target current scroll.
 	 */
-	private var _scrollTarget:FlxPoint = FlxPoint.get();
+	var _scrollTarget:FlxPoint = FlxPoint.get();
 	/**
 	 * Internal, `fade()` special effect duration.
 	 */
-	private var _fxFadeDuration:Float = 0;
+	var _fxFadeDuration:Float = 0;
 	/**
 	 * Internal, "direction" of the `fade()` effect.
 	 * `true` means that camera fades from a color, `false` - camera fades to it.
 	 */
-	private var _fxFadeIn:Bool = false;
+	var _fxFadeIn:Bool = false;
 	/**
 	 * Internal, used to control the `fade()` special effect complete callback.
 	 */
-	private var _fxFadeComplete:Void->Void = null;
+	var _fxFadeComplete:Void->Void = null;
 	/**
 	 * Internal, tracks whether fade effect is running or not.
 	 */
-	private var _fxFadeCompleted:Bool = true;
+	var _fxFadeCompleted:Bool = true;
 	/**
 	 * Internal, alpha component of fade color.
 	 * Changes from 0 to 1 or from 1 to 0 as the effect continues.
 	 */
-	private var _fxFadeAlpha:Float = 0;
+	var _fxFadeAlpha:Float = 0;
 	/**
 	 * Internal, percentage of screen size representing the maximum distance that the screen can move while shaking.
 	 */
-	private var _fxShakeIntensity:Float = 0;
+	var _fxShakeIntensity:Float = 0;
 	/**
 	 * Internal, duration of the `shake()` effect.
 	 */
-	private var _fxShakeDuration:Float = 0;
+	var _fxShakeDuration:Float = 0;
 	/**
 	 * Internal, `shake()` effect complete callback.
 	 */
-	private var _fxShakeComplete:Void->Void;
+	var _fxShakeComplete:Void->Void;
 	/**
 	 * Internal, defines on what axes to `shake()`. Default value is `XY` / both.
 	 */
-	private var _fxShakeAxes:FlxAxes = XY;
+	var _fxShakeAxes:FlxAxes = XY;
 	/**
 	 * Internal, used for repetitive calculations and added to help avoid costly allocations.
 	 */
-	private var _point:FlxPoint = FlxPoint.get();
+	var _point:FlxPoint = FlxPoint.get();
 	/**
 	 * Internal, the filters array to be applied to the camera.
 	 */
-	private var _filters:Array<BitmapFilter>;
-	
+	var _filters:Array<BitmapFilter>;
+
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.
 	 */
 	public var initialZoom(default, null):Float = 1;
-	
+
 	/**
 	 * Internal helper variable for doing better wipes/fills between renders.
 	 * Used it blit render mode only (in `fill()` method).
 	 */
-	private var _fill:BitmapData;
+	var _fill:BitmapData;
 	/**
 	 * Internal, used to render buffer to screen space. Used it blit render mode only.
 	 * This Bitmap used for rendering camera's buffer (`_flashBitmap.bitmapData = buffer;`)
 	 * Its position is modified by `updateInternalSpritePositions()`, which is called on camera's resize and scale events.
 	 * It is a child of the `_scrollRect` `Sprite`.
 	 */
-	private var _flashBitmap:Bitmap;
-	
+	var _flashBitmap:Bitmap;
+
 	/**
 	 * Internal sprite, used for correct trimming of camera viewport.
 	 * It is a child of `flashSprite`.
 	 * Its position is modified by `updateScrollRect()` method, which is called on camera's resize and scale events.
 	 */
-	private var _scrollRect:Sprite = new Sprite();
-	
+	var _scrollRect:Sprite = new Sprite();
+
 	/**
 	 * Helper rect for `drawTriangles()` visibility checks
 	 */
-	private var _bounds:FlxRect = FlxRect.get();
-	
+	var _bounds:FlxRect = FlxRect.get();
+
 	/**
 	 * Sprite used for actual rendering in tile render mode (instead of `_flashBitmap` for blitting).
 	 * Its graphics is used as a drawing surface for `drawTriangles()` and `drawTiles()` methods.
@@ -392,63 +392,63 @@ class FlxCamera extends FlxBasic
 	 * Its position is modified by `updateInternalSpritePositions()`, which is called on camera's resize and scale events.
 	 */
 	public var canvas:Sprite;
-	
+
 	#if FLX_DEBUG
 	/**
-	 * Sprite for visual effects (flash and fade) and drawDebug information 
+	 * Sprite for visual effects (flash and fade) and drawDebug information
 	 * (bounding boxes are drawn on it) for tile render mode.
 	 * It is a child of `_scrollRect` `Sprite` (which trims graphics that should be invisible).
 	 * Its position is modified by `updateInternalSpritePositions()`, which is called on camera's resize and scale events.
 	 */
 	public var debugLayer:Sprite;
 	#end
-	
-	private var _helperMatrix:FlxMatrix = new FlxMatrix();
-	
-	private var _helperPoint:Point = new Point();
-	
+
+	var _helperMatrix:FlxMatrix = new FlxMatrix();
+
+	var _helperPoint:Point = new Point();
+
 	/**
 	 * Currently used draw stack item
 	 */
-	private var _currentDrawItem:FlxDrawBaseItem<Dynamic>;
+	var _currentDrawItem:FlxDrawBaseItem<Dynamic>;
 	/**
 	 * Pointer to head of stack with draw items
 	 */
-	private var _headOfDrawStack:FlxDrawBaseItem<Dynamic>;
+	var _headOfDrawStack:FlxDrawBaseItem<Dynamic>;
 	/**
 	 * Last draw tiles item
 	 */
-	private var _headTiles:FlxDrawTilesItem;
+	var _headTiles:FlxDrawTilesItem;
 	/**
 	 * Last draw triangles item
 	 */
-	private var _headTriangles:FlxDrawTrianglesItem;
-	
+	var _headTriangles:FlxDrawTrianglesItem;
+
 	/**
 	 * Draw tiles stack items that can be reused
 	 */
-	private static var _storageTilesHead:FlxDrawTilesItem;
-	
+	static var _storageTilesHead:FlxDrawTilesItem;
+
 	/**
 	 * Draw triangles stack items that can be reused
 	 */
-	private static var _storageTrianglesHead:FlxDrawTrianglesItem;
-	
+	static var _storageTrianglesHead:FlxDrawTrianglesItem;
+
 	/**
 	 * Internal variable, used for visibility checks to minimize `drawTriangles()` calls.
 	 */
-	private static var drawVertices:Vector<Float> = new Vector<Float>();
+	static var drawVertices:Vector<Float> = new Vector<Float>();
 	/**
 	 * Internal variable, used in blit render mode to render triangles (`drawTriangles()`) on camera's buffer.
 	 */
-	private static var trianglesSprite:Sprite = new Sprite();
+	static var trianglesSprite:Sprite = new Sprite();
 	/**
 	 * Internal variables, used in blit render mode to draw trianglesSprite on camera's buffer.
 	 * Added for less garbage creation.
 	 */
-	private static var renderPoint:FlxPoint = FlxPoint.get();
-	private static var renderRect:FlxRect = FlxRect.get();
-	
+	static var renderPoint:FlxPoint = FlxPoint.get();
+	static var renderRect:FlxRect = FlxRect.get();
+
 	@:noCompletion
 	public function startQuadBatch(graphic:FlxGraphic, colored:Bool, hasColorOffsets:Bool = false,
 		?blend:BlendMode, smooth:Bool = false, ?shader:FlxShader)
@@ -458,18 +458,18 @@ class FlxCamera extends FlxBasic
 		#else
 		var itemToReturn:FlxDrawTilesItem = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
-		
-		if (_currentDrawItem != null && _currentDrawItem.type == FlxDrawItemType.TILES 
-			&& _headTiles.graphics == graphic 
+
+		if (_currentDrawItem != null && _currentDrawItem.type == FlxDrawItemType.TILES
+			&& _headTiles.graphics == graphic
 			&& _headTiles.colored == colored
 			&& _headTiles.hasColorOffsets == hasColorOffsets
 			&& _headTiles.blending == blendInt
 			&& _headTiles.antialiasing == smooth
 			&& _headTiles.shader == shader)
-		{	
+		{
 			return _headTiles;
 		}
-		
+
 		if (_storageTilesHead != null)
 		{
 			itemToReturn = _storageTilesHead;
@@ -481,58 +481,58 @@ class FlxCamera extends FlxBasic
 		{
 			itemToReturn = new FlxDrawTilesItem();
 		}
-		
+
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smooth;
 		itemToReturn.colored = colored;
 		itemToReturn.hasColorOffsets = hasColorOffsets;
 		itemToReturn.blending = blendInt;
 		itemToReturn.shader = shader;
-		
+
 		itemToReturn.nextTyped = _headTiles;
 		_headTiles = itemToReturn;
-		
+
 		if (_headOfDrawStack == null)
 		{
 			_headOfDrawStack = itemToReturn;
 		}
-		
+
 		if (_currentDrawItem != null)
 		{
 			_currentDrawItem.next = itemToReturn;
 		}
-		
+
 		_currentDrawItem = itemToReturn;
-		
+
 		return itemToReturn;
 		#end
 	}
-	
+
 	@:noCompletion
 	public function startTrianglesBatch(graphic:FlxGraphic, smoothing:Bool = false,
 		isColored:Bool = false, ?blend:BlendMode):FlxDrawTrianglesItem
 	{
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
-		
-		if (_currentDrawItem != null && _currentDrawItem.type == FlxDrawItemType.TRIANGLES 
-			&& _headTriangles.graphics == graphic 
+
+		if (_currentDrawItem != null && _currentDrawItem.type == FlxDrawItemType.TRIANGLES
+			&& _headTriangles.graphics == graphic
 			&& _headTriangles.antialiasing == smoothing
 			&& _headTriangles.colored == isColored
 			&& _headTriangles.blending == blendInt)
-		{	
+		{
 			return _headTriangles;
 		}
-		
+
 		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend);
 	}
-	
+
 	@:noCompletion
 	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false,
 		isColored:Bool = false, ?blend:BlendMode):FlxDrawTrianglesItem
 	{
 		var itemToReturn:FlxDrawTrianglesItem = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
-		
+
 		if (_storageTrianglesHead != null)
 		{
 			itemToReturn = _storageTrianglesHead;
@@ -544,36 +544,36 @@ class FlxCamera extends FlxBasic
 		{
 			itemToReturn = new FlxDrawTrianglesItem();
 		}
-		
+
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smoothing;
 		itemToReturn.colored = isColored;
 		itemToReturn.blending = blendInt;
-		
+
 		itemToReturn.nextTyped = _headTriangles;
 		_headTriangles = itemToReturn;
-		
+
 		if (_headOfDrawStack == null)
 		{
 			_headOfDrawStack = itemToReturn;
 		}
-		
+
 		if (_currentDrawItem != null)
 		{
 			_currentDrawItem.next = itemToReturn;
 		}
-		
+
 		_currentDrawItem = itemToReturn;
-		
+
 		return itemToReturn;
 	}
-	
+
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
-	private function clearDrawStack():Void
-	{	
+	function clearDrawStack():Void
+	{
 		var currTiles:FlxDrawTilesItem = _headTiles;
 		var newTilesHead:FlxDrawTilesItem;
-		
+
 		while (currTiles != null)
 		{
 			newTilesHead = currTiles.nextTyped;
@@ -582,10 +582,10 @@ class FlxCamera extends FlxBasic
 			_storageTilesHead = currTiles;
 			currTiles = newTilesHead;
 		}
-		
+
 		var currTriangles:FlxDrawTrianglesItem = _headTriangles;
 		var newTrianglesHead:FlxDrawTrianglesItem;
-		
+
 		while (currTriangles != null)
 		{
 			newTrianglesHead = currTriangles.nextTyped;
@@ -594,15 +594,15 @@ class FlxCamera extends FlxBasic
 			_storageTrianglesHead = currTriangles;
 			currTriangles = newTrianglesHead;
 		}
-		
+
 		_currentDrawItem = null;
 		_headOfDrawStack = null;
 		_headTiles = null;
 		_headTriangles = null;
 	}
-	
+
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
-	private function render():Void
+	function render():Void
 	{
 		var currItem:FlxDrawBaseItem<Dynamic> = _headOfDrawStack;
 		while (currItem != null)
@@ -611,17 +611,17 @@ class FlxCamera extends FlxBasic
 			currItem = currItem.next;
 		}
 	}
-	
+
 	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix,
 		?transform:ColorTransform, ?blend:BlendMode, ?smoothing:Bool = false, ?shader:FlxShader):Void
 	{
 		if (FlxG.renderBlit)
 		{
 			_helperMatrix.copyFrom(matrix);
-			
+
 			if (_useBlitMatrix)
 			{
-				_helperMatrix.concat(_blitMatrix);	
+				_helperMatrix.concat(_blitMatrix);
 				buffer.draw(pixels, _helperMatrix, null, null, null, (smoothing || antialiasing));
 			}
 			else
@@ -634,7 +634,7 @@ class FlxCamera extends FlxBasic
 		{
 			var isColored = (transform != null && transform.hasRGBMultipliers());
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
-			
+
 			#if FLX_RENDER_TRIANGLE
 			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend);
 			#else
@@ -643,7 +643,7 @@ class FlxCamera extends FlxBasic
 			drawItem.addQuad(frame, matrix, transform);
 		}
 	}
-	
+
 	public function copyPixels(?frame:FlxFrame, ?pixels:BitmapData, ?sourceRect:Rectangle,
 		destPoint:Point, ?transform:ColorTransform, ?blend:BlendMode, ?smoothing:Bool = false, ?shader:FlxShader):Void
 	{
@@ -675,10 +675,10 @@ class FlxCamera extends FlxBasic
 		{
 			_helperMatrix.identity();
 			_helperMatrix.translate(destPoint.x + frame.offset.x, destPoint.y + frame.offset.y);
-			
+
 			var isColored = (transform != null && transform.hasRGBMultipliers());
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
-			
+
 			#if !FLX_RENDER_TRIANGLE
 			var drawItem:FlxDrawTilesItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#else
@@ -687,34 +687,34 @@ class FlxCamera extends FlxBasic
 			drawItem.addQuad(frame, _helperMatrix, transform);
 		}
 	}
-	
+
 	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>,
 		uvtData:DrawData<Float>, ?colors:DrawData<Int>, ?position:FlxPoint, ?blend:BlendMode,
 		repeat:Bool = false, smoothing:Bool = false):Void
 	{
 		if (FlxG.renderBlit)
-		{	
+		{
 			if (position == null)
 				position = renderPoint.set();
-			
+
 			_bounds.set(0, 0, width, height);
-			
+
 			var verticesLength:Int = vertices.length;
 			var currentVertexPosition:Int = 0;
-			
+
 			var tempX:Float, tempY:Float;
 			var i:Int = 0;
 			var bounds = renderRect.set();
 			drawVertices.splice(0, drawVertices.length);
-			
+
 			while (i < verticesLength)
 			{
-				tempX = position.x + vertices[i]; 
+				tempX = position.x + vertices[i];
 				tempY = position.y + vertices[i + 1];
-				
+
 				drawVertices[currentVertexPosition++] = tempX;
 				drawVertices[currentVertexPosition++] = tempY;
-				
+
 				if (i == 0)
 				{
 					bounds.set(tempX, tempY, 0, 0);
@@ -723,12 +723,12 @@ class FlxCamera extends FlxBasic
 				{
 					FlxDrawTrianglesItem.inflateBounds(bounds, tempX, tempY);
 				}
-				
+
 				i += 2;
 			}
-			
+
 			position.putWeak();
-			
+
 			if (!_bounds.overlaps(bounds))
 			{
 				drawVertices.splice(drawVertices.length - verticesLength, verticesLength);
@@ -739,7 +739,7 @@ class FlxCamera extends FlxBasic
 				trianglesSprite.graphics.beginBitmapFill(graphic.bitmap, null, repeat, smoothing);
 				trianglesSprite.graphics.drawTriangles(drawVertices, indices, uvtData);
 				trianglesSprite.graphics.endFill();
-				
+
 				// TODO: check this block of code for cases, when zoom < 1 (or initial zoom?)...
 				if (_useBlitMatrix)
 					_helperMatrix.copyFrom(_blitMatrix);
@@ -748,7 +748,7 @@ class FlxCamera extends FlxBasic
 					_helperMatrix.identity();
 					_helperMatrix.translate(-viewOffsetX, -viewOffsetY);
 				}
-				
+
 				buffer.draw(trianglesSprite, _helperMatrix);
 				#if FLX_DEBUG
 				if (FlxG.debugger.drawDebug)
@@ -762,7 +762,7 @@ class FlxCamera extends FlxBasic
 				#end
 				// End of TODO...
 			}
-			
+
 			bounds.put();
 		}
 		else
@@ -773,18 +773,18 @@ class FlxCamera extends FlxBasic
 			drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds);
 		}
 	}
-	
+
 	/**
 	 * Helper method preparing debug rectangle for rendering in blit render mode
 	 * @param	rect	rectangle to prepare for rendering
 	 * @return	transformed rectangle with respect to camera's zoom factor
 	 */
-	private function transformRect(rect:FlxRect):FlxRect
+	function transformRect(rect:FlxRect):FlxRect
 	{
 		if (FlxG.renderBlit)
 		{
 			rect.offset(-viewOffsetX, -viewOffsetY);
-			
+
 			if (_useBlitMatrix)
 			{
 				rect.x *= zoom;
@@ -793,65 +793,65 @@ class FlxCamera extends FlxBasic
 				rect.height *= zoom;
 			}
 		}
-		
+
 		return rect;
 	}
-	
+
 	/**
 	 * Helper method preparing debug point for rendering in blit render mode (for debug path rendering, for example)
 	 * @param	point		point to prepare for rendering
 	 * @return	transformed point with respect to camera's zoom factor
 	 */
-	private function transformPoint(point:FlxPoint):FlxPoint
+	function transformPoint(point:FlxPoint):FlxPoint
 	{
 		if (FlxG.renderBlit)
 		{
 			point.subtract(viewOffsetX, viewOffsetY);
-			
+
 			if (_useBlitMatrix)
 				point.scale(zoom);
 		}
-		
+
 		return point;
 	}
-	
+
 	/**
 	 * Helper method preparing debug vectors (relative positions) for rendering in blit render mode
 	 * @param	vector	relative position to prepare for rendering
 	 * @return	transformed vector with respect to camera's zoom factor
 	 */
-	private inline function transformVector(vector:FlxPoint):FlxPoint
+	inline function transformVector(vector:FlxPoint):FlxPoint
 	{
 		if (FlxG.renderBlit && _useBlitMatrix)
 			vector.scale(zoom);
-		
+
 		return vector;
 	}
-	
+
 	/**
-	 * Helper method for applying transformations (scaling and offsets) 
+	 * Helper method for applying transformations (scaling and offsets)
 	 * to specified display objects which has been added to the camera display list.
 	 * For example, debug sprite for nape debug rendering.
 	 * @param	object	display object to apply transformations to.
 	 * @return	transformed object.
 	 */
-	private function transformObject(object:DisplayObject):DisplayObject
+	function transformObject(object:DisplayObject):DisplayObject
 	{
 		object.scaleX *= totalScaleX;
 		object.scaleY *= totalScaleY;
-		
+
 		object.x -= scroll.x * totalScaleX;
 		object.y -= scroll.y * totalScaleY;
-		
+
 		object.x -= 0.5 * width * (scaleX - initialZoom) * FlxG.scaleMode.scale.x;
 		object.y -= 0.5 * height * (scaleY - initialZoom) * FlxG.scaleMode.scale.y;
-		
+
 		return object;
 	}
-	
+
 	/**
 	 * Instantiates a new camera at the specified location, with the specified size and zoom level.
-	 * 
+	 *
 	 * @param   X        X location of the camera's display in pixels. Uses native, 1:1 resolution, ignores zoom.
 	 * @param   Y        Y location of the camera's display in pixels. Uses native, 1:1 resolution, ignores zoom.
 	 * @param   Width    The width of the camera display in pixels.
@@ -862,20 +862,20 @@ class FlxCamera extends FlxBasic
 	public function new(X:Int = 0, Y:Int = 0, Width:Int = 0, Height:Int = 0, Zoom:Float = 0)
 	{
 		super();
-		
+
 		x = X;
 		y = Y;
-		
+
 		// Use the game dimensions if width / height are <= 0
 		width = (Width <= 0) ? FlxG.width : Width;
 		height = (Height <= 0) ? FlxG.height : Height;
 		_flashRect = new Rectangle(0, 0, width, height);
-		
+
 		flashSprite.addChild(_scrollRect);
 		_scrollRect.scrollRect = new Rectangle();
-		
+
 		pixelPerfectRender = FlxG.renderBlit;
-		
+
 		if (FlxG.renderBlit)
 		{
 			screen = new FlxSprite();
@@ -890,33 +890,33 @@ class FlxCamera extends FlxBasic
 		{
 			canvas = new Sprite();
 			_scrollRect.addChild(canvas);
-			
+
 			#if FLX_DEBUG
 			debugLayer = new Sprite();
 			_scrollRect.addChild(debugLayer);
 			#end
 		}
-		
+
 		set_color(FlxColor.WHITE);
-		
+
 		initialZoom = (Zoom == 0) ? defaultZoom : Zoom;
 		zoom = Zoom; //sets the scale of flash sprite, which in turn loads flashOffset values
-		
+
 		updateScrollRect();
 		updateFlashOffset();
 		updateFlashSpritePosition();
 		updateInternalSpritePositions();
-		
+
 		bgColor = FlxG.cameras.bgColor;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
 	override public function destroy():Void
 	{
 		FlxDestroyUtil.removeChild(flashSprite, _scrollRect);
-		
+
 		if (FlxG.renderBlit)
 		{
 			FlxDestroyUtil.removeChild(_scrollRect, _flashBitmap);
@@ -931,7 +931,7 @@ class FlxCamera extends FlxBasic
 			FlxDestroyUtil.removeChild(_scrollRect, debugLayer);
 			debugLayer = null;
 			#end
-			
+
 			FlxDestroyUtil.removeChild(_scrollRect, canvas);
 			if (canvas != null)
 			{
@@ -941,22 +941,22 @@ class FlxCamera extends FlxBasic
 				}
 				canvas = null;
 			}
-			
+
 			if (_headOfDrawStack != null)
 			{
 				clearDrawStack();
 			}
-			
+
 			_blitMatrix = null;
 			_helperMatrix = null;
 			_helperPoint = null;
 		}
-		
+
 		_bounds = null;
 		scroll = FlxDestroyUtil.put(scroll);
 		targetOffset = FlxDestroyUtil.put(targetOffset);
 		deadzone = FlxDestroyUtil.put(deadzone);
-		
+
 		target = null;
 		flashSprite = null;
 		_scrollRect = null;
@@ -968,7 +968,7 @@ class FlxCamera extends FlxBasic
 
 		super.destroy();
 	}
-	
+
 	/**
 	 * Updates the camera scroll as well as special effects like screen-shake or fades.
 	 */
@@ -979,17 +979,17 @@ class FlxCamera extends FlxBasic
 		{
 			updateFollow();
 		}
-		
-		updateScroll();	
+
+		updateScroll();
 		updateFlash(elapsed);
 		updateFade(elapsed);
-		
+
 		flashSprite.filters = filtersEnabled ? _filters : null;
-		
+
 		updateFlashSpritePosition();
 		updateShake(elapsed);
 	}
-	
+
 	/**
 	 * Updates (bounds) the camera scroll.
 	 * Called every frame by camera's `update()` method.
@@ -998,24 +998,24 @@ class FlxCamera extends FlxBasic
 	{
 		// Adjust bounds to account for zoom
 		var zoom = this.zoom / FlxG.initialZoom;
-		
+
 		var minX:Null<Float> = minScrollX == null ? null : minScrollX - (zoom - 1) * width / (2 * zoom);
 		var maxX:Null<Float> = maxScrollX == null ? null : maxScrollX + (zoom - 1) * width / (2 * zoom);
 		var minY:Null<Float> = minScrollY == null ? null : minScrollY - (zoom - 1) * height / (2 * zoom);
 		var maxY:Null<Float> = maxScrollY == null ? null : maxScrollY + (zoom - 1) * height / (2 * zoom);
-		
+
 		// Make sure we didn't go outside the camera's bounds
 		scroll.x = FlxMath.bound(scroll.x, minX, (maxX != null) ? maxX - width : null);
 		scroll.y = FlxMath.bound(scroll.y, minY, (maxY != null) ? maxY - height : null);
 	}
-	
+
 	/**
 	 * Updates camera's scroll.
 	 * Called every frame by camera's `update()` method (if camera's `target` isn't `null`).
 	 */
 	public function updateFollow():Void
 	{
-		//Either follow the object closely, 
+		//Either follow the object closely,
 		//or double check our deadzone and update accordingly.
 		if (deadzone == null)
 		{
@@ -1028,8 +1028,8 @@ class FlxCamera extends FlxBasic
 			var edge:Float;
 			var targetX:Float = target.x + targetOffset.x;
 			var targetY:Float = target.y + targetOffset.y;
-			
-			if (style == SCREEN_BY_SCREEN) 
+
+			if (style == SCREEN_BY_SCREEN)
 			{
 				if (targetX >= (scroll.x + width))
 				{
@@ -1055,13 +1055,13 @@ class FlxCamera extends FlxBasic
 				if (_scrollTarget.x > edge)
 				{
 					_scrollTarget.x = edge;
-				} 
+				}
 				edge = targetX + target.width - deadzone.x - deadzone.width;
 				if (_scrollTarget.x < edge)
 				{
 					_scrollTarget.x = edge;
 				}
-				
+
 				edge = targetY - deadzone.y;
 				if (_scrollTarget.y > edge)
 				{
@@ -1073,20 +1073,20 @@ class FlxCamera extends FlxBasic
 					_scrollTarget.y = edge;
 				}
 			}
-			
+
 			if (Std.is(target, FlxSprite))
 			{
-				if (_lastTargetPosition == null)  
+				if (_lastTargetPosition == null)
 				{
 					_lastTargetPosition = FlxPoint.get(target.x, target.y); // Creates this point.
-				} 
+				}
 				_scrollTarget.x += (target.x - _lastTargetPosition.x) * followLead.x;
 				_scrollTarget.y += (target.y - _lastTargetPosition.y) * followLead.y;
-				
+
 				_lastTargetPosition.x = target.x;
 				_lastTargetPosition.y = target.y;
 			}
-			
+
 			if (followLerp >= 60 / FlxG.updateFramerate)
 			{
 				scroll.copyFrom(_scrollTarget); // no easing
@@ -1098,8 +1098,8 @@ class FlxCamera extends FlxBasic
 			}
 		}
 	}
-	
-	private function updateFlash(elapsed:Float):Void
+
+	function updateFlash(elapsed:Float):Void
 	{
 		//Update the "flash" special effect
 		if (_fxFlashAlpha > 0.0)
@@ -1111,12 +1111,12 @@ class FlxCamera extends FlxBasic
 			}
 		}
 	}
-	
-	private function updateFade(elapsed:Float):Void
+
+	function updateFade(elapsed:Float):Void
 	{
 		if (_fxFadeCompleted)
 			return;
-		
+
 		if (_fxFadeIn)
 		{
 			_fxFadeAlpha -= elapsed / _fxFadeDuration;
@@ -1136,15 +1136,15 @@ class FlxCamera extends FlxBasic
 			}
 		}
 	}
-	
-	private function completeFade()
+
+	function completeFade()
 	{
 		_fxFadeCompleted = true;
 		if (_fxFadeComplete != null)
 			_fxFadeComplete();
 	}
-	
-	private function updateShake(elapsed:Float):Void
+
+	function updateShake(elapsed:Float):Void
 	{
 		if (_fxShakeDuration > 0)
 		{
@@ -1169,12 +1169,12 @@ class FlxCamera extends FlxBasic
 			}
 		}
 	}
-	
+
 	/**
 	 * Recalculates `flashSprite` position.
 	 * Called every frame by camera's `update()` method and every time you change camera's position.
 	 */
-	private function updateFlashSpritePosition():Void
+	function updateFlashSpritePosition():Void
 	{
 		if (flashSprite != null)
 		{
@@ -1182,50 +1182,50 @@ class FlxCamera extends FlxBasic
 			flashSprite.y = y * FlxG.scaleMode.scale.y + _flashOffset.y;
 		}
 	}
-	
+
 	/**
 	 * Recalculates `_flashOffset` point, which is used for positioning flashSprite in the game.
 	 * It's called every time you resize the camera or the game.
 	 */
-	private function updateFlashOffset():Void
+	function updateFlashOffset():Void
 	{
 		_flashOffset.x = width * 0.5 * FlxG.scaleMode.scale.x * initialZoom;
 		_flashOffset.y = height * 0.5 * FlxG.scaleMode.scale.y * initialZoom;
 	}
-	
+
 	/**
 	 * Updates `_scrollRect` sprite to crop graphics of the camera:
 	 * 1) `scrollRect` property of this sprite
 	 * 2) position of this sprite inside `flashSprite`
-	 * 
+	 *
 	 * It takes camera's size and game's scale into account.
 	 * It's called every time you resize the camera or the game.
 	 */
-	private function updateScrollRect():Void
+	function updateScrollRect():Void
 	{
 		var rect:Rectangle = (_scrollRect != null) ? _scrollRect.scrollRect : null;
-		
+
 		if (rect != null)
 		{
 			rect.x = rect.y = 0;
-			
+
 			rect.width = width * initialZoom * FlxG.scaleMode.scale.x;
 			rect.height = height * initialZoom * FlxG.scaleMode.scale.y;
-			
+
 			_scrollRect.scrollRect = rect;
-			
+
 			_scrollRect.x = -0.5 * rect.width;
 			_scrollRect.y = -0.5 * rect.height;
 		}
 	}
-	
+
 	/**
 	 * Modifies position of `_flashBitmap` in blit render mode and `canvas` and `debugSprite`
 	 * in tile render mode (these objects are children of `_scrollRect` sprite).
 	 * It takes camera's size and game's scale into account.
 	 * It's called every time you resize the camera or the game.
 	 */
-	private function updateInternalSpritePositions():Void
+	function updateInternalSpritePositions():Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -1241,16 +1241,16 @@ class FlxCamera extends FlxBasic
 			{
 				canvas.x = -0.5 * width * (scaleX - initialZoom) * FlxG.scaleMode.scale.x;
 				canvas.y = -0.5 * height * (scaleY - initialZoom) * FlxG.scaleMode.scale.y;
-				
+
 				canvas.scaleX = totalScaleX;
 				canvas.scaleY = totalScaleY;
-				
+
 				#if FLX_DEBUG
 				if (debugLayer != null)
 				{
 					debugLayer.x = canvas.x;
 					debugLayer.y = canvas.y;
-					
+
 					debugLayer.scaleX = totalScaleX;
 					debugLayer.scaleY = totalScaleY;
 				}
@@ -1258,10 +1258,10 @@ class FlxCamera extends FlxBasic
 			}
 		}
 	}
-	
+
 	/**
 	 * Tells this camera object what `FlxObject` to track.
-	 * 
+	 *
 	 * @param   Target   The object you want the camera to track. Set to `null` to not follow anything.
 	 * @param   Style    Leverage one of the existing "deadzone" presets. Default is `LOCKON`.
 	 *                   If you use a custom deadzone, ignore this parameter and
@@ -1275,7 +1275,7 @@ class FlxCamera extends FlxBasic
 
 		if (Lerp == null)
 			Lerp = 60 / FlxG.updateFramerate;
-		
+
 		style = Style;
 		target = Target;
 		followLerp = Lerp;
@@ -1283,38 +1283,38 @@ class FlxCamera extends FlxBasic
 		var w:Float = 0;
 		var h:Float = 0;
 		_lastTargetPosition = null;
-		
+
 		switch (Style)
 		{
 			case LOCKON:
-				if (target != null) 
-				{	
+				if (target != null)
+				{
 					w = target.width;
 					h = target.height;
 				}
 				deadzone = FlxRect.get((width - w) / 2, (height - h) / 2 - h * 0.25, w, h);
-			
+
 			case PLATFORMER:
 				var w:Float = (width / 8);
 				var h:Float = (height / 3);
 				deadzone = FlxRect.get((width - w) / 2, (height - h) / 2 - h * 0.25, w, h);
-				
+
 			case TOPDOWN:
 				helper = Math.max(width, height) / 4;
 				deadzone = FlxRect.get((width - helper) / 2, (height - helper) / 2, helper, helper);
-				
+
 			case TOPDOWN_TIGHT:
 				helper = Math.max(width, height) / 8;
 				deadzone = FlxRect.get((width - helper) / 2, (height - helper) / 2, helper, helper);
-				
+
 			case SCREEN_BY_SCREEN:
 				deadzone = FlxRect.get(0, 0, width, height);
-				
+
 			case NO_DEAD_ZONE:
 				deadzone = null;
 		}
 	}
-	
+
 	/**
 	 * Snaps the camera to the current `target`. Useful to move the camera without
 	 * any easing when the `target` position changes and there is a `followLerp`.
@@ -1324,10 +1324,10 @@ class FlxCamera extends FlxBasic
 		updateFollow();
 		scroll.copyFrom(_scrollTarget);
 	}
-	
+
 	/**
 	 * Move the camera focus to this location instantly.
-	 * 
+	 *
 	 * @param   Point   Where you want the camera to focus.
 	 */
 	public inline function focusOn(point:FlxPoint):Void
@@ -1335,10 +1335,10 @@ class FlxCamera extends FlxBasic
 		scroll.set(point.x - width * 0.5, point.y - height * 0.5);
 		point.putWeak();
 	}
-	
+
 	/**
 	 * The screen is filled with this color and gradually returns to normal.
-	 * 
+	 *
 	 * @param   Color        The color you want to use.
 	 * @param   Duration     How long it takes for the flash to fade.
 	 * @param   OnComplete   A function you want to run when the flash finishes.
@@ -1357,10 +1357,10 @@ class FlxCamera extends FlxBasic
 		_fxFlashComplete = OnComplete;
 		_fxFlashAlpha = 1.0;
 	}
-	
+
 	/**
 	 * The screen is gradually filled with this color.
-	 * 
+	 *
 	 * @param   Color        The color you want to use.
 	 * @param   Duration     How long it takes for the fade to finish.
 	 * @param   FadeIn       `true` fades from a color, `false` fades to it.
@@ -1372,22 +1372,22 @@ class FlxCamera extends FlxBasic
 	{
 		if (!_fxFadeCompleted && !Force)
 			return;
-		
+
 		_fxFadeColor = Color;
 		if (Duration <= 0)
 			Duration = 0.000001;
-		
+
 		_fxFadeIn = FadeIn;
 		_fxFadeDuration = Duration;
 		_fxFadeComplete = OnComplete;
-		
+
 		_fxFadeAlpha = _fxFadeIn ? 0.999999 : 0.000001;
 		_fxFadeCompleted = false;
 	}
-	
+
 	/**
 	 * A simple screen-shake effect.
-	 * 
+	 *
 	 * @param   Intensity    Percentage of screen size representing the maximum distance
 	 *                       that the screen can move while shaking.
 	 * @param   Duration     The length in seconds that the shaking effect should last.
@@ -1400,16 +1400,16 @@ class FlxCamera extends FlxBasic
 	{
 		if (Axes == null)
 			Axes = XY;
-		
+
 		if (!Force && _fxShakeDuration > 0)
 			return;
-	
+
 		_fxShakeIntensity = Intensity;
 		_fxShakeDuration = Duration;
 		_fxShakeComplete = OnComplete;
 		_fxShakeAxes = Axes;
 	}
-	
+
 	/**
 	 * Just turns off all the camera effects instantly.
 	 */
@@ -1420,7 +1420,7 @@ class FlxCamera extends FlxBasic
 		_fxShakeDuration = 0;
 		updateFlashSpritePosition();
 	}
-	
+
 	/**
 	 * Sets the filter array to be applied to the camera.
 	 */
@@ -1428,19 +1428,19 @@ class FlxCamera extends FlxBasic
 	{
 		_filters = filters;
 	}
-	
+
 	/**
 	 * Copy the bounds, focus object, and `deadzone` info from an existing camera.
-	 * 
+	 *
 	 * @param   Camera  The camera you want to copy from.
 	 * @return  A reference to this `FlxCamera` object.
 	 */
 	public function copyFrom(Camera:FlxCamera):FlxCamera
 	{
 		setScrollBounds(Camera.minScrollX, Camera.maxScrollX, Camera.minScrollY, Camera.maxScrollY);
-		
+
 		target = Camera.target;
-		
+
 		if (target != null)
 		{
 			if (Camera.deadzone == null)
@@ -1458,10 +1458,10 @@ class FlxCamera extends FlxBasic
 		}
 		return this;
 	}
-	
+
 	/**
 	 * Fill the camera with the specified color.
-	 * 
+	 *
 	 * @param   Color        The color to fill with in `0xAARRGGBB` hex format.
 	 * @param   BlendAlpha   Whether to blend the alpha value or just wipe the previous contents. Default is `true`.
 	 */
@@ -1487,7 +1487,7 @@ class FlxCamera extends FlxBasic
 			#end
 
 			var targetGraphics:Graphics = (graphics == null) ? canvas.graphics : graphics;
-			
+
 			targetGraphics.beginFill(Color, FxAlpha);
 			// i'm drawing rect with these parameters to avoid light lines at the top and left of the camera,
 			// which could appear while cameras fading
@@ -1495,20 +1495,20 @@ class FlxCamera extends FlxBasic
 			targetGraphics.endFill();
 		}
 	}
-	
+
 	/**
 	 * Internal helper function, handles the actual drawing of all the special effects.
 	 */
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
-	private function drawFX():Void
+	function drawFX():Void
 	{
 		var alphaComponent:Float;
-		
+
 		//Draw the "flash" special effect onto the buffer
 		if (_fxFlashAlpha > 0.0)
 		{
 			alphaComponent = _fxFlashColor.alpha;
-			
+
 			if (FlxG.renderBlit)
 			{
 				fill((Std.int(((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFlashAlpha) << 24) + (_fxFlashColor & 0x00ffffff));
@@ -1518,12 +1518,12 @@ class FlxCamera extends FlxBasic
 				fill((_fxFlashColor & 0x00ffffff), true, ((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFlashAlpha / 255, canvas.graphics);
 			}
 		}
-		
+
 		//Draw the "fade" special effect onto the buffer
 		if (_fxFadeAlpha > 0.0)
 		{
 			alphaComponent = _fxFadeColor.alpha;
-			
+
 			if (FlxG.renderBlit)
 			{
 				fill((Std.int(((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFadeAlpha) << 24) + (_fxFadeColor & 0x00ffffff));
@@ -1534,9 +1534,9 @@ class FlxCamera extends FlxBasic
 			}
 		}
 	}
-	
+
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
-	private function checkResize():Void
+	function checkResize():Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -1553,23 +1553,23 @@ class FlxCamera extends FlxBasic
 				_fill = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
 				FlxG.bitmap.removeIfNoUse(oldBuffer);
 			}
-			
+
 			updateBlitMatrix();
 		}
 	}
-	
-	private inline function updateBlitMatrix():Void
+
+	inline function updateBlitMatrix():Void
 	{
 		_blitMatrix.identity();
 		_blitMatrix.translate(-viewOffsetX, -viewOffsetY);
 		_blitMatrix.scale(scaleX, scaleY);
-		
+
 		_useBlitMatrix = (scaleX < initialZoom) || (scaleY < initialZoom);
 	}
-	
+
 	/**
 	 * Shortcut for setting both `width` and `height`.
-	 * 
+	 *
 	 * @param   Width    The new camera width.
 	 * @param   Height   The new camera height.
 	 */
@@ -1578,11 +1578,11 @@ class FlxCamera extends FlxBasic
 		width = Width;
 		height = Height;
 	}
-	
+
 	/**
 	 * Helper function to set the coordinates of this camera.
 	 * Handy since it only requires one line of code.
-	 * 
+	 *
 	 * @param   X   The new x position.
 	 * @param   Y   The new y position.
 	 */
@@ -1591,10 +1591,10 @@ class FlxCamera extends FlxBasic
 		x = X;
 		y = Y;
 	}
-	
+
 	/**
 	 * Specify the bounding rectangle of where the camera is allowed to move.
-	 * 
+	 *
 	 * @param   X             The smallest X value of your level (usually `0`).
 	 * @param   Y             The smallest Y value of your level (usually `0`).
 	 * @param   Width         The largest X value of your level (usually the level width).
@@ -1608,14 +1608,14 @@ class FlxCamera extends FlxBasic
 		{
 			FlxG.worldBounds.set(X, Y, Width, Height);
 		}
-		
+
 		setScrollBounds(X, X + Width, Y, Y + Height);
 	}
-	
+
 	/**
 	 * Specify the bounds of where the camera is allowed to move.
 	 * Set the boundary of a side to `null` to leave that side unbounded.
-	 * 
+	 *
 	 * @param   MinX   The minimum X value the camera can scroll to
 	 * @param   MaxX   The maximum X value the camera can scroll to
 	 * @param   MinY   The minimum Y value the camera can scroll to
@@ -1629,11 +1629,11 @@ class FlxCamera extends FlxBasic
 		maxScrollY = MaxY;
 		updateScroll();
 	}
-	
+
 	/**
 	 * Helper function to set the scale of this camera.
 	 * Handy since it only requires one line of code.
-	 * 
+	 *
 	 * @param   X   The new scale on x axis
 	 * @param   Y   The new scale of y axis
 	 */
@@ -1641,14 +1641,14 @@ class FlxCamera extends FlxBasic
 	{
 		scaleX = X;
 		scaleY = Y;
-		
+
 		totalScaleX = scaleX * FlxG.scaleMode.scale.x;
 		totalScaleY = scaleY * FlxG.scaleMode.scale.y;
-		
+
 		if (FlxG.renderBlit)
 		{
 			updateBlitMatrix();
-			
+
 			if (_useBlitMatrix)
 			{
 				_flashBitmap.scaleX = initialZoom * FlxG.scaleMode.scale.x;
@@ -1660,16 +1660,16 @@ class FlxCamera extends FlxBasic
 				_flashBitmap.scaleY = totalScaleY;
 			}
 		}
-		
+
 		calcOffsetX();
 		calcOffsetY();
-		
+
 		updateScrollRect();
 		updateInternalSpritePositions();
-		
+
 		FlxG.cameras.cameraResized.dispatch(this);
 	}
-	
+
 	/**
 	 * Called by camera front end every time you resize the game.
 	 * It triggers reposition of camera's internal display objects.
@@ -1689,13 +1689,13 @@ class FlxCamera extends FlxBasic
 	{
 		return (point.x + width > viewOffsetX) && (point.x < viewOffsetWidth) && (point.y + height > viewOffsetY) && (point.y < viewOffsetHeight);
 	}
-	
-	private function set_followLerp(Value:Float):Float
+
+	function set_followLerp(Value:Float):Float
 	{
 		return followLerp = FlxMath.bound(Value, 0, 60 / FlxG.updateFramerate);
 	}
-	
-	private function set_width(Value:Int):Int
+
+	function set_width(Value:Int):Int
 	{
 		if (width != Value && Value > 0)
 		{
@@ -1704,13 +1704,13 @@ class FlxCamera extends FlxBasic
 			updateFlashOffset();
 			updateScrollRect();
 			updateInternalSpritePositions();
-			
+
 			FlxG.cameras.cameraResized.dispatch(this);
 		}
 		return Value;
 	}
-	
-	private function set_height(Value:Int):Int
+
+	function set_height(Value:Int):Int
 	{
 		if (height != Value && Value > 0)
 		{
@@ -1719,20 +1719,20 @@ class FlxCamera extends FlxBasic
 			updateFlashOffset();
 			updateScrollRect();
 			updateInternalSpritePositions();
-			
+
 			FlxG.cameras.cameraResized.dispatch(this);
 		}
 		return Value;
 	}
-	
-	private function set_zoom(Zoom:Float):Float
+
+	function set_zoom(Zoom:Float):Float
 	{
 		zoom = (Zoom == 0) ? defaultZoom : Zoom;
 		setScale(zoom, zoom);
 		return zoom;
 	}
-	
-	private function set_alpha(Alpha:Float):Float
+
+	function set_alpha(Alpha:Float):Float
 	{
 		alpha = FlxMath.bound(Alpha, 0, 1);
 		if (FlxG.renderBlit)
@@ -1745,19 +1745,19 @@ class FlxCamera extends FlxBasic
 		}
 		return Alpha;
 	}
-	
-	private function set_angle(Angle:Float):Float
+
+	function set_angle(Angle:Float):Float
 	{
 		angle = Angle;
 		flashSprite.rotation = Angle;
 		return Angle;
 	}
-	
-	private function set_color(Color:FlxColor):FlxColor
+
+	function set_color(Color:FlxColor):FlxColor
 	{
 		color = Color;
 		var colorTransform:ColorTransform;
-		
+
 		if (FlxG.renderBlit)
 		{
 			if (_flashBitmap == null)
@@ -1770,11 +1770,11 @@ class FlxCamera extends FlxBasic
 		{
 			colorTransform = canvas.transform.colorTransform;
 		}
-		
+
 		colorTransform.redMultiplier = color.redFloat;
 		colorTransform.greenMultiplier = color.greenFloat;
 		colorTransform.blueMultiplier = color.blueFloat;
-		
+
 		if (FlxG.renderBlit)
 		{
 			_flashBitmap.transform.colorTransform = colorTransform;
@@ -1783,11 +1783,11 @@ class FlxCamera extends FlxBasic
 		{
 			canvas.transform.colorTransform = colorTransform;
 		}
-		
+
 		return Color;
 	}
-	
-	private function set_antialiasing(Antialiasing:Bool):Bool
+
+	function set_antialiasing(Antialiasing:Bool):Bool
 	{
 		antialiasing = Antialiasing;
 		if (FlxG.renderBlit)
@@ -1796,22 +1796,22 @@ class FlxCamera extends FlxBasic
 		}
 		return Antialiasing;
 	}
-	
-	private function set_x(x:Float):Float
+
+	function set_x(x:Float):Float
 	{
 		this.x = x;
 		updateFlashSpritePosition();
 		return x;
 	}
-	
-	private function set_y(y:Float):Float
+
+	function set_y(y:Float):Float
 	{
 		this.y = y;
 		updateFlashSpritePosition();
 		return y;
 	}
-	
-	override private function set_visible(visible:Bool):Bool
+
+	override function set_visible(visible:Bool):Bool
 	{
 		if (flashSprite != null)
 		{
@@ -1819,15 +1819,15 @@ class FlxCamera extends FlxBasic
 		}
 		return this.visible = visible;
 	}
-	
-	private inline function calcOffsetX():Void
+
+	inline function calcOffsetX():Void
 	{
 		viewOffsetX = 0.5 * width * (scaleX - initialZoom) / scaleX;
 		viewOffsetWidth = width - viewOffsetX;
 		viewWidth = width - 2 * viewOffsetX;
 	}
-	
-	private inline function calcOffsetY():Void
+
+	inline function calcOffsetY():Void
 	{
 		viewOffsetY = 0.5 * height * (scaleY - initialZoom) / scaleY;
 		viewOffsetHeight = height - viewOffsetY;

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -89,13 +89,13 @@ class FlxG
 	 * array but you can do what you like with it.
 	 */
 	public static var camera:FlxCamera;
-	
+
 	/**
 	 * The HaxeFlixel version, in semantic versioning syntax. Use `Std.string()`
 	 * on it to get a `String` formatted like this: `"HaxeFlixel MAJOR.MINOR.PATCH-COMMIT_SHA"`.
 	 */
 	public static var VERSION(default, null):FlxVersion = new FlxVersion(4, 4, 0);
-	
+
 	/**
 	 * Internal tracker for game object.
 	 */
@@ -122,7 +122,7 @@ class FlxG
 	 * NOTE: This is NOT the same thing as the update framerate!
 	 */
 	public static var drawFramerate(default, set):Int;
-	
+
 	/**
 	 * Whether the game is running on a mobile device.
 	 * If on HTML5, it returns `FlxG.html5.onMobile`.
@@ -130,12 +130,12 @@ class FlxG
 	 * @since 4.2.0
 	 */
 	public static var onMobile(get, never):Bool;
-	
+
 	public static var renderMethod(default, null):FlxRenderMethod;
-	
+
 	public static var renderBlit(default, null):Bool;
 	public static var renderTile(default, null):Bool;
-	
+
 	/**
 	 * Represents the amount of time in seconds that passed since last frame.
 	 */
@@ -148,11 +148,11 @@ class FlxG
 	 * slowdown instead of frameskip; default is 1/10th of a second.
 	 */
 	public static var maxElapsed:Float = 0.1;
-	
+
 	/**
 	 * The width of the screen in game pixels. Read-only, use `resizeGame()` to change.
 	 */
-	@:allow(flixel.system.scaleModes) 
+	@:allow(flixel.system.scaleModes)
 	public static var width(default, null):Int;
 	/**
 	 * The height of the screen in game pixels. Read-only, use `resizeGame()` to change.
@@ -173,19 +173,19 @@ class FlxG
 	 * Use `.set()` instead of creating a new object!
 	 */
 	public static var worldBounds(default, null):FlxRect = FlxRect.get();
-	
+
 	/**
 	 * A `FlxSave` used internally by flixel to save sound preferences and
 	 * the history of the console window, but no reason you can't use it for your own stuff too!
 	 */
 	public static var save(default, null):FlxSave = new FlxSave();
-	
+
 	/**
 	 * A `FlxRandom` object which can be used to generate random numbers.
 	 * Also used by Flixel internally.
 	 */
 	public static var random(default, null):FlxRandom = new FlxRandom();
-	
+
 	#if FLX_MOUSE
 	/**
 	 * Used for mouse input. e.g.: check if the left mouse button
@@ -193,14 +193,14 @@ class FlxG
 	 */
 	public static var mouse(default, set):FlxMouse;
 	#end
-	
+
 	#if FLX_TOUCH
 	/**
 	 * Useful for devices with multitouch support.
 	 */
 	public static var touches(default, null):FlxTouchManager;
 	#end
-	
+
 	#if FLX_POINTER_INPUT
 	/**
 	 * Contains all "swipes" from both mouse and touch input that have just ended.
@@ -215,35 +215,35 @@ class FlxG
 	 */
 	public static var keys(default, null):FlxKeyboard;
 	#end
-	
+
 	#if FLX_GAMEPAD
 	/**
 	 * Allows accessing the available gamepads.
 	 */
 	public static var gamepads(default, null):FlxGamepadManager;
 	#end
-	
+
 	#if android
 	/**
 	 * Useful for tracking Back, Home buttons etc on Android devices.
 	 */
 	public static var android(default, null):FlxAndroidKeys;
 	#end
-	
+
 	#if mobile
 	/**
 	 * Provides access to the accelerometer data of mobile devices as `x`/`y`/`z` values.
 	 */
 	public static var accelerometer(default, null):FlxAccelerometer;
 	#end
-	
+
 	#if js
 	/**
 	 * Has some HTML5-specific things like browser detection, browser dimensions etc...
 	 */
 	public static var html5(default, null):HTML5FrontEnd = new HTML5FrontEnd();
 	#end
-	
+
 	/**
 	 * Mostly used internally, but you can use it too to reset inputs and create input classes of your own.
 	 */
@@ -274,7 +274,7 @@ class FlxG
 	 * Contains all the functions needed for recording and replaying.
 	 */
 	public static var vcr(default, null):VCRFrontEnd;
-	
+
 	/**
 	 * Contains things related to bitmaps, for example regarding the `BitmapData` cache and the cache itself.
 	 */
@@ -287,23 +287,23 @@ class FlxG
 	 * Contains a list of all plugins and the functions required to `add()`, `remove()` them etc.
 	 */
 	public static var plugins(default, null):PluginFrontEnd;
-	
+
 	public static var initialWidth(default, null):Int = 0;
 	public static var initialHeight(default, null):Int = 0;
 	public static var initialZoom(default, null):Float = 0;
-	
+
 	#if FLX_SOUND_SYSTEM
 	/**
 	 * Contains a list of all sounds and other things to manage or `play()` sounds.
 	 */
 	public static var sound(default, null):SoundFrontEnd;
 	#end
-	
+
 	/**
 	 * Contains system-wide signals like `gameResized` or `stateSwitched`.
-	 */ 
+	 */
 	public static var signals(default, null):SignalFrontEnd = new SignalFrontEnd();
-	
+
 	/**
 	 * Resizes the game within the window by reapplying the current scale mode.
 	 */
@@ -311,7 +311,7 @@ class FlxG
 	{
 		scaleMode.onMeasure(Width, Height);
 	}
-	
+
 	/**
 	 * Resizes the window. Only works on desktop targets (Neko, Windows, Linux, Mac).
 	 */
@@ -325,7 +325,7 @@ class FlxG
 		#end
 		#end
 	}
-	
+
 	/**
 	 * Like hitting the reset button a game console, this will re-launch the game as if it just started.
 	 */
@@ -333,7 +333,7 @@ class FlxG
 	{
 		game._resetGame = true;
 	}
-	
+
 	/**
 	 * Attempts to switch from the current game state to `nextState`.
 	 * The state switch is successful if `switchTo()` of the current `state` returns `true`.
@@ -343,7 +343,7 @@ class FlxG
 		if (state.switchTo(nextState))
 			game._requestedState = nextState;
 	}
-	
+
 	/**
 	 * Request a reset of the current game state.
 	 * Calls `switchState()` with a new instance of the current `state`.
@@ -363,7 +363,7 @@ class FlxG
 	 *
 	 * NOTE: this takes the entire area of `FlxTilemap`s into account (including "empty" tiles).
 	 *       Use `FlxTilemap#overlaps()` if you don't want that.
-	 * 
+	 *
 	 * @param   ObjectOrGroup1    The first object or group you want to check.
 	 * @param   ObjectOrGroup2    The second object or group you want to check. If it is the same as the first,
 	 *                            Flixel knows to just do a comparison within that group.
@@ -392,13 +392,13 @@ class FlxG
 		quadTree.destroy();
 		return result;
 	}
-	
+
 	/**
 	 * A pixel perfect collision check between two `FlxSprite` objects.
 	 * It will do a bounds check first, and if that passes it will run a
 	 * pixel perfect match on the intersecting area. Works with rotated and animated sprites.
 	 * May be slow, so use it sparingly.
-	 * 
+	 *
 	 * @param   Sprite1          The first `FlxSprite` to test against.
 	 * @param   Sprite2          The second `FlxSprite` to test again, sprite order is irrelevant.
 	 * @param   AlphaTolerance   The tolerance value above which alpha pixels are included.
@@ -412,7 +412,7 @@ class FlxG
 	{
 		return FlxCollision.pixelPerfectCheck(Sprite1, Sprite2, AlphaTolerance, Camera);
 	}
-	
+
 	/**
 	 * Call this function to see if one `FlxObject` collides with another within `FlxG.worldBounds`.
 	 * Can be called with one object and one group, or two groups, or two objects,
@@ -422,7 +422,7 @@ class FlxG
 	 * This function just calls `FlxG.overlap` and presets the `ProcessCallback` parameter to `FlxObject.separate`.
 	 * To create your own collision logic, write your own `ProcessCallback` and use `FlxG.overlap` to set it up.
 	 * NOTE: does NOT take objects' `scrollFactor` into account, all overlaps are checked in world space.
-	 * 
+	 *
 	 * @param   ObjectOrGroup1   The first object or group you want to check.
 	 * @param   ObjectOrGroup2   The second object or group you want to check. If it is the same as the first,
 	 *                           Flixel knows to just do a comparison within that group.
@@ -436,11 +436,11 @@ class FlxG
 	{
 		return overlap(ObjectOrGroup1, ObjectOrGroup2, NotifyCallback, FlxObject.separate);
 	}
-	
+
 	/**
 	 * Regular `DisplayObject`s are normally displayed over the Flixel cursor and the Flixel debugger if simply
 	 * added to `stage`. This function simplifies things by adding a `DisplayObject` directly below mouse level.
-	 * 
+	 *
 	 * @param   Child           The `DisplayObject` to add
 	 * @param   IndexModifier   Amount to add to the index - makes sure the index stays within bounds.
 	 * @return  The added `DisplayObject`
@@ -450,15 +450,15 @@ class FlxG
 	{
 		var index = game.getChildIndex(game._inputContainer);
 		var max = game.numChildren;
-		
+
 		index = FlxMath.maxAdd(index, IndexModifier, max);
 		game.addChildAt(Child, index);
 		return Child;
 	}
-	
+
 	/**
 	 * Removes a child from the Flixel display list, if it is part of it.
-	 * 
+	 *
 	 * @param   Child   The `DisplayObject` to add
 	 * @return  The removed `DisplayObject`
 	 */
@@ -469,21 +469,21 @@ class FlxG
 			game.removeChild(Child);
 		return Child;
 	}
-	
+
 	public static function addPostProcess(postProcess:PostProcess):PostProcess
 	{
 		#if FLX_POST_PROCESS
 		if (OpenGLView.isSupported)
 		{
 			var postProcesses = game.postProcesses;
-			
+
 			// chaining
 			var length = postProcesses.length;
 			if (length > 0)
 			{
 				postProcesses[length - 1].to = postProcess;
 			}
-			
+
 			game.postProcessLayer.addChild(postProcess);
 			postProcesses.push(postProcess);
 		}
@@ -492,10 +492,10 @@ class FlxG
 			FlxG.log.error("Shaders are not supported on this platform.");
 		}
 		#end
-		
+
 		return postProcess;
 	}
-	
+
 	public static function removePostProcess(postProcess:PostProcess):Void
 	{
 		#if FLX_POST_PROCESS
@@ -504,17 +504,17 @@ class FlxG
 		{
 			chainPostProcesses();
 			postProcess.to = null;
-			
+
 			FlxDestroyUtil.removeChild(game.postProcessLayer, postProcess);
 		}
 		#end
 	}
-	
+
 	#if FLX_POST_PROCESS
-	private static function chainPostProcesses():Void
+	static function chainPostProcesses():Void
 	{
 		var postProcesses = game.postProcesses;
-		
+
 		if (postProcesses.length > 0)
 		{
 			for (i in 0...postProcesses.length - 1)
@@ -525,11 +525,11 @@ class FlxG
 		}
 	}
 	#end
-	
+
 	/**
-	 * Opens a web page, by default a new tab or window. If the URL does not 
+	 * Opens a web page, by default a new tab or window. If the URL does not
 	 * already start with `"http://"` or `"https://"`, it gets added automatically.
-	 * 
+	 *
 	 * @param   URL      The address of the web page.
 	 * @param   Target   `"_blank"`, `"_self"`, `"_parent"` or `"_top"`
 	 */
@@ -541,63 +541,63 @@ class FlxG
 			prefix = "http://";
 		Lib.getURL(new URLRequest(prefix + URL), Target);
 	}
-	
+
 	/**
 	 * Called by `FlxGame` to set up `FlxG` during `FlxGame`'s constructor.
 	 */
 	@:allow(flixel.FlxGame.new)
-	private static function init(Game:FlxGame, Width:Int, Height:Int, Zoom:Float):Void
+	static function init(Game:FlxGame, Width:Int, Height:Int, Zoom:Float):Void
 	{
 		game = Game;
 		width = Std.int(Math.abs(Width));
 		height = Std.int(Math.abs(Height));
-		
+
 		initRenderMethod();
-		
+
 		FlxG.initialWidth = width;
 		FlxG.initialHeight = height;
 		FlxG.initialZoom = FlxCamera.defaultZoom = Zoom;
-		
+
 		resizeGame(Lib.current.stage.stageWidth, Lib.current.stage.stageHeight);
-		
+
 		// Instantiate inputs
 		#if FLX_KEYBOARD
 		keys = inputs.add(new FlxKeyboard());
 		#end
-		
+
 		#if FLX_MOUSE
 		mouse = inputs.add(new FlxMouse(game._inputContainer));
 		#end
-		
+
 		#if FLX_TOUCH
 		touches = inputs.add(new FlxTouchManager());
 		#end
-		
+
 		#if FLX_GAMEPAD
 		gamepads = inputs.add(new FlxGamepadManager());
 		#end
-		
+
 		#if android
 		android = inputs.add(new FlxAndroidKeys());
 		#end
-		
+
 		#if mobile
 		accelerometer = new FlxAccelerometer();
 		#end
 		save.bind("flixel");
-		
+
 		plugins = new PluginFrontEnd();
 		vcr = new VCRFrontEnd();
-		
+
 		#if FLX_SOUND_SYSTEM
 		sound = new SoundFrontEnd();
 		#end
 	}
-	
-	private static function initRenderMethod():Void
+
+	static function initRenderMethod():Void
 	{
 		renderMethod = BLITTING;
-		
+
 		#if (!lime_legacy && !flash)
 		if (!Lib.application.config.windows[0].hardware)
 		{
@@ -619,21 +619,21 @@ class FlxG
 		renderMethod = DRAW_TILES;
 		#end
 		#end
-		
+
 		renderBlit = renderMethod == BLITTING;
 		renderTile = renderMethod == DRAW_TILES;
-		
+
 		FlxObject.defaultPixelPerfectPosition = renderBlit;
 	}
-	
+
 	/**
 	 * Called whenever the game is reset, doesn't have to do quite as much work as the basic initialization stuff.
 	 */
 	@:allow(flixel.FlxGame)
-	private static function reset():Void
+	static function reset():Void
 	{
 		random.resetInitialSeed();
-		
+
 		bitmap.reset();
 		inputs.reset();
 		#if FLX_SOUND_SYSTEM
@@ -647,16 +647,16 @@ class FlxG
 		worldBounds.set( -10, -10, width + 20, height + 20);
 		worldDivisions = 6;
 	}
-	
-	private static function set_scaleMode(ScaleMode:BaseScaleMode):BaseScaleMode
+
+	static function set_scaleMode(ScaleMode:BaseScaleMode):BaseScaleMode
 	{
 		scaleMode = ScaleMode;
 		game.onResize(null);
 		return ScaleMode;
 	}
-	
+
 	#if FLX_MOUSE
-	private static function set_mouse(NewMouse:FlxMouse):FlxMouse
+	static function set_mouse(NewMouse:FlxMouse):FlxMouse
 	{
 		if (mouse == null) // if no mouse, just add it
 		{
@@ -674,66 +674,66 @@ class FlxG
 		return oldMouse;
 	}
 	#end
-	
-	private static function set_updateFramerate(Framerate:Int):Int
+
+	static function set_updateFramerate(Framerate:Int):Int
 	{
 		if (Framerate < drawFramerate)
 			log.warn("FlxG.framerate: the game's framerate shouldn't be smaller than the flash framerate," +
 				" since it can stop your game from updating.");
-		
+
 		updateFramerate = Framerate;
-		
+
 		game._stepMS = Math.abs(1000 / Framerate);
 		game._stepSeconds = game._stepMS / 1000;
-		
+
 		if (game._maxAccumulation < game._stepMS)
 			game._maxAccumulation = game._stepMS;
-		
+
 		return Framerate;
 	}
-	
-	private static function set_drawFramerate(Framerate:Int):Int
+
+	static function set_drawFramerate(Framerate:Int):Int
 	{
 		if (Framerate > updateFramerate)
 			log.warn("FlxG.drawFramerate: the update framerate shouldn't be smaller than the draw framerate," +
 				" since it can stop your game from updating.");
-		
+
 		drawFramerate = Std.int(Math.abs(Framerate));
-		
+
 		if (game.stage != null)
 			game.stage.frameRate = drawFramerate;
-		
+
 		game._maxAccumulation = 2000 / drawFramerate - 1;
-		
+
 		if (game._maxAccumulation < game._stepMS)
 			game._maxAccumulation = game._stepMS;
-		
+
 		return Framerate;
 	}
-	
-	private static function get_fullscreen():Bool
+
+	static function get_fullscreen():Bool
 	{
 		return stage.displayState == StageDisplayState.FULL_SCREEN
 			|| stage.displayState == StageDisplayState.FULL_SCREEN_INTERACTIVE;
 	}
-	
-	private static function set_fullscreen(Value:Bool):Bool
+
+	static function set_fullscreen(Value:Bool):Bool
 	{
 		stage.displayState = Value ? StageDisplayState.FULL_SCREEN : StageDisplayState.NORMAL;
 		return Value;
 	}
-	
-	private static inline function get_stage():Stage
+
+	static inline function get_stage():Stage
 	{
 		return Lib.current.stage;
 	}
-	
-	private static inline function get_state():FlxState
+
+	static inline function get_state():FlxState
 	{
 		return game._state;
 	}
-	
-	private static inline function get_onMobile():Bool
+
+	static inline function get_onMobile():Bool
 	{
 		return
 			#if js

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -50,7 +50,7 @@ class FlxGame extends Sprite
 	 * Framerate to use on focus lost. Default is `10`.
 	 */
 	public var focusLostFramerate:Int = 10;
-	
+
 	#if FLX_RECORD
 	/**
 	 * Flag for whether a replay is currently playing.
@@ -63,21 +63,21 @@ class FlxGame extends Sprite
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
 	public var recording(default, null):Bool = false;
 	#end
-	
+
 	#if FLX_SOUND_TRAY
 	/**
 	 * The sound tray display container.
 	 */
 	public var soundTray(default, null):FlxSoundTray;
 	#end
-	
+
 	#if FLX_DEBUG
 	/**
 	 * The debugger overlay object.
 	 */
 	public var debugger(default, null):FlxDebugger;
 	#end
-	
+
 	/**
 	 * Time in milliseconds that has passed (amount of "ticks" passed) since the game has started.
 	 */
@@ -86,155 +86,155 @@ class FlxGame extends Sprite
 	 * Enables or disables the filters set via `setFilters()`.
 	 */
 	public var filtersEnabled:Bool = true;
-	
+
 	/**
 	 * A flag for triggering the `gameStarted` "event".
 	 */
 	@:allow(flixel.system.FlxSplash)
-	private var _gameJustStarted:Bool = false;
-	
+	var _gameJustStarted:Bool = false;
+
 	/**
 	 * Class type of the initial/first game state for the game, usually `MenuState` or something like that.
 	 */
-	private var _initialState:Class<FlxState>;
+	var _initialState:Class<FlxState>;
 	/**
 	 * Current game state.
 	 */
-	private var _state:FlxState;
+	var _state:FlxState;
 	/**
 	 * Total number of milliseconds elapsed since game start.
 	 */
-	private var _total:Int = 0;
+	var _total:Int = 0;
 	/**
 	 * Time stamp of game startup. Needed on JS where `Lib.getTimer()`
 	 * returns time stamp of current date, not the time passed since app start.
 	 */
-	private var _startTime:Int = 0;
+	var _startTime:Int = 0;
 	/**
 	 * Total number of milliseconds elapsed since last update loop.
 	 * Counts down as we step through the game loop.
 	 */
-	private var _accumulator:Float;
+	var _accumulator:Float;
 	/**
 	 * Milliseconds of time since last step.
 	 */
-	private var _elapsedMS:Float;
+	var _elapsedMS:Float;
 	/**
 	 * Milliseconds of time per step of the game loop. e.g. 60 fps = 16ms.
 	 */
-	private var _stepMS:Float;
+	var _stepMS:Float;
 	/**
 	 * Optimization so we don't have to divide step by 1000 to get its value in seconds every frame.
 	 */
-	private var _stepSeconds:Float;
+	var _stepSeconds:Float;
 	/**
 	 * Max allowable accumulation (see `_accumulator`).
 	 * Should always (and automatically) be set to roughly 2x the stage framerate.
 	 */
-	private var _maxAccumulation:Float;
-	
+	var _maxAccumulation:Float;
+
 	/**
 	 * Whether the game lost focus.
 	 */
-	private var _lostFocus:Bool = false;
-	
+	var _lostFocus:Bool = false;
+
 	/**
 	 * The filters array to be applied to the game.
 	 */
-	private var _filters:Array<BitmapFilter>;
-	
+	var _filters:Array<BitmapFilter>;
+
 	#if (desktop && lime_legacy)
 	/**
-	 * Ugly workaround to ensure consistent behaviour between flash and cpp 
+	 * Ugly workaround to ensure consistent behaviour between flash and cpp
 	 * (the focus event should not fire when the game starts up!)
 	 */
-	private var _onFocusFiredOnce:Bool = false;
+	var _onFocusFiredOnce:Bool = false;
 	#end
-	
-	#if FLX_FOCUS_LOST_SCREEN 
+
+	#if FLX_FOCUS_LOST_SCREEN
 	/**
 	 * The "focus lost" screen.
 	 */
-	private var _focusLostScreen:FlxFocusLostScreen;
+	var _focusLostScreen:FlxFocusLostScreen;
 	#end
-	
+
 	/**
 	 * Mouse cursor.
 	 */
 	@:allow(flixel.FlxG)
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
-	private var _inputContainer:Sprite;
-	
+	var _inputContainer:Sprite;
+
 	#if FLX_SOUND_TRAY
 	/**
 	 * Change this after calling `super()` in the `FlxGame` constructor
 	 * to use a customized sound tray based on `FlxSoundTray`.
 	 */
-	private var _customSoundTray:Class<FlxSoundTray> = FlxSoundTray;
+	var _customSoundTray:Class<FlxSoundTray> = FlxSoundTray;
 	#end
-	
+
 	#if FLX_FOCUS_LOST_SCREEN
 	/**
 	 * Change this after calling `super()` in the `FlxGame` constructor
 	 * to use a customized screen which will be show when the application lost focus.
 	 */
-	private var _customFocusLostScreen:Class<FlxFocusLostScreen> = FlxFocusLostScreen;
+	var _customFocusLostScreen:Class<FlxFocusLostScreen> = FlxFocusLostScreen;
 	#end
-	
+
 	/**
 	 * Whether the splash screen should be skipped.
 	 */
-	private var _skipSplash:Bool = false;
-	
+	var _skipSplash:Bool = false;
+
 	#if desktop
 	/**
 	 * Should we start fullscreen or not? This is useful if you want to load fullscreen settings from a
 	 * `FlxSave` and set it when the game starts, instead of having it hard-set in your `Project.xml`.
 	 */
-	private var _startFullscreen:Bool = false;
+	var _startFullscreen:Bool = false;
 	#end
-	
+
 	/**
 	 * If a state change was requested, the new state object is stored here until we switch to it.
 	 */
-	private var _requestedState:FlxState;
+	var _requestedState:FlxState;
 	/**
 	 * A flag for keeping track of whether a game reset was requested or not.
 	 */
-	private var _resetGame:Bool = false;
-	
+	var _resetGame:Bool = false;
+
 	#if FLX_RECORD
 	/**
 	 * Container for a game replay object.
 	 */
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
-	private var _replay:FlxReplay;
+	var _replay:FlxReplay;
 	/**
 	 * Flag for whether a playback of a recording was requested.
 	 */
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
-	private var _replayRequested:Bool = false;
+	var _replayRequested:Bool = false;
 	/**
 	 * Flag for whether a new recording was requested.
 	 */
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
-	private var _recordingRequested:Bool = false;
+	var _recordingRequested:Bool = false;
 	#end
-	
+
 	#if FLX_POST_PROCESS
 	/**
 	 * `Sprite` for postprocessing effects
 	 */
-	private var postProcessLayer:Sprite = new Sprite();
+	var postProcessLayer:Sprite = new Sprite();
 	/**
 	 * Post process effects active on the `postProcessLayer`.
 	 */
-	private var postProcesses:Array<PostProcess> = [];
+	var postProcesses:Array<PostProcess> = [];
 	#end
-	
+
 	/**
 	 * Instantiate a new game object.
-	 * 
+	 *
 	 * @param GameWidth       The width of your game in game pixels, not necessarily final display pixels (see `Zoom`).
 	 *                        If equal to `0`, the window width specified in the `Project.xml` is used.
 	 * @param GameHeight      The height of your game in game pixels, not necessarily final display pixels (see `Zoom`).
@@ -250,14 +250,14 @@ class FlxGame extends Sprite
 		UpdateFramerate:Int = 60, DrawFramerate:Int = 60, SkipSplash:Bool = false, StartFullscreen:Bool = false)
 	{
 		super();
-		
+
 		#if desktop
 		_startFullscreen = StartFullscreen;
 		#end
-		
+
 		// Super high priority init stuff
 		_inputContainer = new Sprite();
-		
+
 		if (GameWidth == 0)
 			GameWidth = FlxG.stage.stageWidth;
 		if (GameHeight == 0)
@@ -265,22 +265,22 @@ class FlxGame extends Sprite
 
 		// Basic display and update setup stuff
 		FlxG.init(this, GameWidth, GameHeight, Zoom);
-		
+
 		FlxG.updateFramerate = UpdateFramerate;
 		FlxG.drawFramerate = DrawFramerate;
 		_accumulator = _stepMS;
 		_skipSplash = SkipSplash;
-		
+
 		#if FLX_RECORD
 		_replay = new FlxReplay();
 		#end
-		
+
 		// Then get ready to create the game object for real
 		_initialState = (InitialState == null) ? FlxState : InitialState;
-		
+
 		addEventListener(Event.ADDED_TO_STAGE, create);
 	}
-	
+
 	/**
 	 * Sets the filter array to be applied to the game.
 	 */
@@ -288,42 +288,42 @@ class FlxGame extends Sprite
 	{
 		_filters = filters;
 	}
-	
+
 	/**
 	 * Used to instantiate the guts of the flixel game object once we have a valid reference to the root.
 	 */
-	private function create(_):Void
+	function create(_):Void
 	{
 		if (stage == null)
 			return;
 
 		removeEventListener(Event.ADDED_TO_STAGE, create);
-		
+
 		_startTime = getTimer();
 		_total = getTicks();
-		
+
 		#if desktop
 		FlxG.fullscreen = _startFullscreen;
 		#end
-		
+
 		// Set up the view window and double buffering
 		stage.scaleMode = StageScaleMode.NO_SCALE;
 		stage.align = StageAlign.TOP_LEFT;
 		stage.frameRate = FlxG.drawFramerate;
-		
+
 		addChild(_inputContainer);
-		
+
 		#if FLX_POST_PROCESS
 		if (OpenGLView.isSupported)
 			addChild(postProcessLayer);
 		#end
-		
+
 		// Creating the debugger overlay
 		#if FLX_DEBUG
 		debugger = new FlxDebugger(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
 		addChild(debugger);
 		#end
-		
+
 		// No need for overlays on mobile.
 		#if !mobile
 		// Volume display tab
@@ -331,13 +331,13 @@ class FlxGame extends Sprite
 		soundTray = Type.createInstance(_customSoundTray, []);
 		addChild(soundTray);
 		#end
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		_focusLostScreen = Type.createInstance(_customFocusLostScreen, []);
 		addChild(_focusLostScreen);
 		#end
 		#end
-		
+
 		// Focus gained/lost monitoring
 		#if desktop
 		stage.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
@@ -346,164 +346,164 @@ class FlxGame extends Sprite
 		stage.addEventListener(Event.DEACTIVATE, onFocusLost);
 		stage.addEventListener(Event.ACTIVATE, onFocus);
 		#end
-		
+
 		// Instantiate the initial state
 		resetGame();
 		switchState();
-		
+
 		if (FlxG.updateFramerate < FlxG.drawFramerate)
 			FlxG.log.warn("FlxG.updateFramerate: The update framerate shouldn't be smaller" +
 				" than the draw framerate, since it can slow down your game.");
-		
+
 		// Finally, set up an event for the actual game loop stuff.
 		stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);
-		
+
 		// We need to listen for resize event which means new context
 		// it means that we need to recreate BitmapDatas of dumped tilesheets
 		stage.addEventListener(Event.RESIZE, onResize);
-		
+
 		// make sure the cursor etc are properly scaled from the start
 		resizeGame(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
-		
+
 		Assets.addEventListener(Event.CHANGE, FlxG.bitmap.onAssetsReload);
 	}
-	
-	private function onFocus(_):Void
+
+	function onFocus(_):Void
 	{
 		#if flash
-		if (!_lostFocus) 
+		if (!_lostFocus)
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
-		
+
 		#if (desktop && lime_legacy)
-		// make sure the on focus event doesn't fire on startup 
+		// make sure the on focus event doesn't fire on startup
 		if (!_onFocusFiredOnce)
 		{
 			_onFocusFiredOnce = true;
 			return;
 		}
 		#end
-		
+
 		#if mobile
 		// just check if device orientation has been changed
 		onResize(_);
 		#end
-		
+
 		_lostFocus = false;
 		FlxG.signals.focusGained.dispatch();
 		_state.onFocus();
-		
+
 		if (!FlxG.autoPause)
 			return;
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = false;
-		#end 
-		
+		#end
+
 		#if FLX_DEBUG
 		debugger.stats.onFocus();
 		#end
-		
+
 		stage.frameRate = FlxG.drawFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocus();
 		#end
 		FlxG.inputs.onFocus();
 	}
-	
-	private function onFocusLost(event:Event):Void
+
+	function onFocusLost(event:Event):Void
 	{
 		#if next
 		if (event != null && event.target != FlxG.stage)
 			return;
 		#end
-		
+
 		#if flash
 		if (_lostFocus)
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
-		
+
 		_lostFocus = true;
 		FlxG.signals.focusLost.dispatch();
 		_state.onFocusLost();
-		
+
 		if (!FlxG.autoPause)
 			return;
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = true;
-		#end 
-		
+		#end
+
 		#if FLX_DEBUG
 		debugger.stats.onFocusLost();
 		#end
-		
+
 		stage.frameRate = focusLostFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocusLost();
 		#end
 		FlxG.inputs.onFocusLost();
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function onResize(_):Void 
+	function onResize(_):Void
 	{
 		var width:Int = FlxG.stage.stageWidth;
 		var height:Int = FlxG.stage.stageHeight;
-		
+
 		#if !flash
 		if (FlxG.renderTile)
 			FlxG.bitmap.onContext();
 		#end
-		
+
 		resizeGame(width, height);
 	}
-	
-	private function resizeGame(width:Int, height:Int):Void
+
+	function resizeGame(width:Int, height:Int):Void
 	{
 		FlxG.resizeGame(width, height);
-		
+
 		_state.onResize(width, height);
-		
+
 		FlxG.cameras.resize();
 		FlxG.signals.gameResized.dispatch(width, height);
-		
+
 		#if FLX_DEBUG
 		debugger.onResize(width, height);
 		#end
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.draw();
 		#end
-		
+
 		#if FLX_SOUND_TRAY
 		if (soundTray != null)
 			soundTray.screenCenter();
 		#end
-		
+
 		#if FLX_POST_PROCESS
 		for (postProcess in postProcesses)
 			postProcess.rebuild();
 		#end
 	}
-	
+
 	/**
 	 * Handles the `onEnterFrame` call and figures out how many updates and draw calls to do.
 	 */
-	private function onEnterFrame(_):Void
+	function onEnterFrame(_):Void
 	{
 		ticks = getTicks();
 		_elapsedMS = ticks - _total;
 		_total = ticks;
-		
+
 		#if FLX_SOUND_TRAY
 		if (soundTray != null && soundTray.active)
 			soundTray.update(_elapsedMS);
 		#end
-		
+
 		if (!_lostFocus || !FlxG.autoPause)
 		{
 			if (FlxG.vcr.paused)
@@ -527,48 +527,48 @@ class FlxGame extends Sprite
 					return;
 				}
 			}
-			
+
 			if (FlxG.fixedTimestep)
 			{
 				_accumulator += _elapsedMS;
 				_accumulator = (_accumulator > _maxAccumulation) ? _maxAccumulation : _accumulator;
-				
+
 				while (_accumulator >= _stepMS)
 				{
 					step();
-					_accumulator -= _stepMS; 
+					_accumulator -= _stepMS;
 				}
 			}
 			else
 			{
 				step();
 			}
-			
+
 			#if FLX_DEBUG
 			FlxBasic.visibleCount = 0;
 			#end
-			
+
 			draw();
-			
+
 			#if FLX_DEBUG
 			debugger.stats.visibleObjects(FlxBasic.visibleCount);
 			debugger.update();
 			#end
 		}
 	}
-	
+
 	/**
 	 * Internal method to create a new instance of `_initialState` and reset the game.
 	 * This gets called when the game is created, as well as when a new state is requested.
 	 */
-	private inline function resetGame():Void
+	inline function resetGame():Void
 	{
 		FlxG.signals.preGameReset.dispatch();
-		
+
 		#if FLX_DEBUG
 		_skipSplash = true;
 		#end
-		
+
 		if (_skipSplash || FlxSplash.nextState != null) // already played
 		{
 			_requestedState = cast Type.createInstance(_initialState, []);
@@ -581,14 +581,14 @@ class FlxGame extends Sprite
 			_requestedState = new FlxSplash();
 			_skipSplash = true; // only play it once
 		}
-		
+
 		#if FLX_DEBUG
 		if (Std.is(_requestedState, FlxSubState))
 			throw "You can't set FlxSubState class instance as the state for you game";
 		#end
-		
+
 		FlxG.reset();
-		
+
 		FlxG.signals.postGameReset.dispatch();
 	}
 
@@ -597,7 +597,7 @@ class FlxGame extends Sprite
 	 * this function handles actual destroying the old state and related processes,
 	 * and calls creates on the new state and plugs it into the game object.
 	 */
-	private function switchState():Void
+	function switchState():Void
 	{
 		// Basic reset stuff
 		FlxG.cameras.reset();
@@ -605,48 +605,48 @@ class FlxGame extends Sprite
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.destroy();
 		#end
-		
+
 		FlxG.signals.stateSwitched.dispatch();
-		
+
 		#if FLX_RECORD
 		FlxRandom.updateStateSeed();
 		#end
-		
+
 		// Destroy the old state (if there is an old state)
 		if (_state != null)
 			_state.destroy();
-		
+
 		// we need to clear bitmap cache only after previous state is destroyed, which will reset useCount for FlxGraphic objects
 		FlxG.bitmap.clearCache();
-		
+
 		// Finally assign and create the new state
 		_state = _requestedState;
-		
+
 		FlxG.signals.preStateCreate.dispatch(_state);
-		
+
 		_state.create();
-		
+
 		if (_gameJustStarted)
 			gameStart();
-		
+
 		#if FLX_DEBUG
 		debugger.console.registerObject("state", _state);
 		#end
 	}
-	
-	private function gameStart():Void
+
+	function gameStart():Void
 	{
 		FlxG.signals.gameStarted.dispatch();
 		_gameJustStarted = false;
 	}
-	
+
 	/**
 	 * This is the main game update logic section.
 	 * The `onEnterFrame()` handler is in charge of calling this
 	 * the appropriate number of times each frame.
 	 * This block handles state changes, replays, all that good stuff.
 	 */
-	private function step():Void
+	function step():Void
 	{
 		// Handle game reset request
 		if (_resetGame)
@@ -654,22 +654,22 @@ class FlxGame extends Sprite
 			resetGame();
 			_resetGame = false;
 		}
-		
+
 		handleReplayRequests();
-		
+
 		#if FLX_DEBUG
 		// Finally actually step through the game physics
 		FlxBasic.activeCount = 0;
 		#end
-		
+
 		update();
-		
+
 		#if FLX_DEBUG
 		debugger.stats.activeObjects(FlxBasic.activeCount);
 		#end
 	}
-	
-	private function handleReplayRequests():Void
+
+	function handleReplayRequests():Void
 	{
 		#if FLX_RECORD
 		// Handle replay-related requests
@@ -678,7 +678,7 @@ class FlxGame extends Sprite
 			_recordingRequested = false;
 			_replay.create(FlxRandom.getRecordingSeed());
 			recording = true;
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.recording();
 			FlxG.log.notice("Starting new flixel gameplay record.");
@@ -689,66 +689,66 @@ class FlxGame extends Sprite
 			_replayRequested = false;
 			_replay.rewind();
 			FlxG.random.initialSeed = _replay.seed;
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.playingReplay();
 			#end
-			
+
 			replaying = true;
 		}
 		#end
 	}
-	
+
 	/**
 	 * This function is called by `step()` and updates the actual game state.
 	 * May be called multiple times per "frame" or draw call.
 	 */
-	private function update():Void
+	function update():Void
 	{
 		if (!_state.active || !_state.exists)
 			return;
-		
+
 		if (_state != _requestedState)
 			switchState();
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.visible)
 			ticks = getTicks();
 		#end
-		
+
 		updateElapsed();
-		
+
 		FlxG.signals.preUpdate.dispatch();
-		
+
 		updateInput();
-		
+
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)
 			postProcesses[0].update(FlxG.elapsed);
 		#end
-		
+
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.update(FlxG.elapsed);
 		#end
 		FlxG.plugins.update(FlxG.elapsed);
-		
+
 		_state.tryUpdate(FlxG.elapsed);
-		
+
 		FlxG.cameras.update(FlxG.elapsed);
 		FlxG.signals.postUpdate.dispatch();
-		
+
 		#if FLX_DEBUG
 		debugger.stats.flixelUpdate(getTicks() - ticks);
 		#end
-		
+
 		#if FLX_POINTER_INPUT
 		FlxArrayUtil.clearArray(FlxG.swipes);
 		#end
-		
+
 		filters = filtersEnabled ? _filters : null;
 	}
-	
-	private function updateElapsed():Void
+
+	function updateElapsed():Void
 	{
 		if (FlxG.fixedTimestep)
 		{
@@ -757,24 +757,24 @@ class FlxGame extends Sprite
 		else
 		{
 			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
-			
+
 			var max = FlxG.maxElapsed * FlxG.timeScale;
 			if (FlxG.elapsed > max)
 				FlxG.elapsed = max;
 		}
 	}
-	
-	private function updateInput():Void
+
+	function updateInput():Void
 	{
 		#if FLX_RECORD
 		if (replaying)
 		{
 			_replay.playNextFrame();
-			
+
 			if (FlxG.vcr.timeout > 0)
 			{
 				FlxG.vcr.timeout -= _stepMS;
-				
+
 				if (FlxG.vcr.timeout <= 0)
 				{
 					if (FlxG.vcr.replayCallback != null)
@@ -788,18 +788,18 @@ class FlxGame extends Sprite
 					}
 				}
 			}
-			
+
 			if (replaying && _replay.finished)
 			{
 				FlxG.vcr.stopReplay();
-				
+
 				if (FlxG.vcr.replayCallback != null)
 				{
 					FlxG.vcr.replayCallback();
 					FlxG.vcr.replayCallback = null;
 				}
 			}
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.updateRuntime(_stepMS);
 			#end
@@ -811,72 +811,72 @@ class FlxGame extends Sprite
 		#else
 		FlxG.inputs.update();
 		#end
-		
+
 		#if FLX_RECORD
 		if (recording)
 		{
 			_replay.recordFrame();
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.updateRuntime(_stepMS);
 			#end
 		}
 		#end
 	}
-	
+
 	/**
 	 * Goes through the game state and draws all the game objects and special effects.
 	 */
-	private function draw():Void
+	function draw():Void
 	{
 		if (!_state.visible || !_state.exists)
 			return;
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.visible)
 			ticks = getTicks();
 		#end
-		
+
 		FlxG.signals.preDraw.dispatch();
-		
+
 		if (FlxG.renderTile)
 			FlxTilesheet._DRAWCALLS = 0;
-		
+
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)
 			postProcesses[0].capture();
 		#end
-		
+
 		FlxG.cameras.lock();
-		
+
 		FlxG.plugins.draw();
-		
+
 		_state.draw();
-		
+
 		if (FlxG.renderTile)
 		{
 			FlxG.cameras.render();
-			
+
 			#if FLX_DEBUG
 			debugger.stats.drawCalls(FlxTilesheet._DRAWCALLS);
 			#end
 		}
-	
+
 		FlxG.cameras.unlock();
-		
+
 		FlxG.signals.postDraw.dispatch();
-		
+
 		#if FLX_DEBUG
 		debugger.stats.flixelDraw(getTicks() - ticks);
 		#end
 	}
-	
-	private inline function getTicks()
+
+	inline function getTicks()
 	{
 		return getTimer() - _startTime;
 	}
-	
-	private dynamic function getTimer():Int
+
+	dynamic function getTimer():Int
 	{
 		// expensive, only call if necessary
 		return Lib.getTimer();

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -24,7 +24,7 @@ class FlxObject extends FlxBasic
 	 * Default value for `FlxObject`'s `pixelPerfectPosition` var.
 	 */
 	public static var defaultPixelPerfectPosition:Bool = false;
-	
+
 	/**
 	 * This value dictates the maximum number of pixels two objects have to intersect
 	 * before collision stops trying to separate them.
@@ -67,15 +67,15 @@ class FlxObject extends FlxBasic
 	 * Special-case constant meaning any direction, used mainly by `allowCollisions` and `touching`.
 	 */
 	public static inline var ANY:Int = LEFT | RIGHT | UP | DOWN;
-	
+
 	@:noCompletion
-	private static var _firstSeparateFlxRect:FlxRect = FlxRect.get();
+	static var _firstSeparateFlxRect:FlxRect = FlxRect.get();
 	@:noCompletion
-	private static var _secondSeparateFlxRect:FlxRect = FlxRect.get();
-	
+	static var _secondSeparateFlxRect:FlxRect = FlxRect.get();
+
 	/**
 	 * The main collision resolution function in Flixel.
-	 * 
+	 *
 	 * @param   Object1   Any `FlxObject`.
 	 * @param   Object2   Any other `FlxObject`.
 	 * @return  Whether the objects in fact touched and were separated.
@@ -86,11 +86,11 @@ class FlxObject extends FlxBasic
 		var separatedY:Bool = separateY(Object1, Object2);
 		return separatedX || separatedY;
 	}
-	
+
 	/**
 	 * Similar to `separate()`, but only checks whether any overlap is found and updates
 	 * the `touching` flags of the input objects, but no separation is performed.
-	 * 
+	 *
 	 * @param   Object1   Any `FlxObject`.
 	 * @param   Object2   Any other `FlxObject`.
 	 * @return  Whether the objects in fact touched.
@@ -101,33 +101,33 @@ class FlxObject extends FlxBasic
 		var touchingY:Bool = updateTouchingFlagsY(Object1, Object2);
 		return touchingX || touchingY;
 	}
-	
+
 	/**
 	 * Internal function that computes overlap among two objects on the X axis. It also updates the `touching` variable.
 	 * `checkMaxOverlap` is used to determine whether we want to exclude (therefore check) overlaps which are
 	 * greater than a certain maximum (linked to `SEPARATE_BIAS`). Default is `true`, handy for `separateX` code.
 	 */
 	@:noCompletion
-	private static function computeOverlapX(Object1:FlxObject, Object2:FlxObject, checkMaxOverlap:Bool = true):Float
+	static function computeOverlapX(Object1:FlxObject, Object2:FlxObject, checkMaxOverlap:Bool = true):Float
 	{
 		var overlap:Float = 0;
 		//First, get the two object deltas
 		var obj1delta:Float = Object1.x - Object1.last.x;
 		var obj2delta:Float = Object2.x - Object2.last.x;
-		
+
 		if (obj1delta != obj2delta)
 		{
 			//Check if the X hulls actually overlap
 			var obj1deltaAbs:Float = (obj1delta > 0) ? obj1delta : -obj1delta;
 			var obj2deltaAbs:Float = (obj2delta > 0) ? obj2delta : -obj2delta;
-			
+
 			var obj1rect:FlxRect = _firstSeparateFlxRect.set(Object1.x - ((obj1delta > 0) ? obj1delta : 0), Object1.last.y, Object1.width + obj1deltaAbs, Object1.height);
 			var obj2rect:FlxRect = _secondSeparateFlxRect.set(Object2.x - ((obj2delta > 0) ? obj2delta : 0), Object2.last.y, Object2.width + obj2deltaAbs, Object2.height);
-			
+
 			if ((obj1rect.x + obj1rect.width > obj2rect.x) && (obj1rect.x < obj2rect.x + obj2rect.width) && (obj1rect.y + obj1rect.height > obj2rect.y) && (obj1rect.y < obj2rect.y + obj2rect.height))
 			{
 				var maxOverlap:Float = checkMaxOverlap ? (obj1deltaAbs + obj2deltaAbs + SEPARATE_BIAS) : 0;
-				
+
 				//If they did overlap (and can), figure out by how much and flip the corresponding flags
 				if (obj1delta > obj2delta)
 				{
@@ -159,10 +159,10 @@ class FlxObject extends FlxBasic
 		}
 		return overlap;
 	}
-	
+
 	/**
 	 * The X-axis component of the object separation process.
-	 * 
+	 *
 	 * @param   Object1   Any `FlxObject`.
 	 * @param   Object2   Any other `FlxObject`.
 	 * @return  Whether the objects in fact touched and were separated along the X axis.
@@ -176,7 +176,7 @@ class FlxObject extends FlxBasic
 		{
 			return false;
 		}
-		
+
 		//If one of the objects is a tilemap, just pass it off.
 		if (Object1.flixelType == TILEMAP)
 		{
@@ -188,20 +188,20 @@ class FlxObject extends FlxBasic
 			var tilemap:FlxBaseTilemap<Dynamic> = cast Object2;
 			return tilemap.overlapsWithCallback(Object1, separateX, true);
 		}
-		
+
 		var overlap:Float = computeOverlapX(Object1, Object2);
 		//Then adjust their positions and velocities accordingly (if there was any overlap)
 		if (overlap != 0)
 		{
 			var obj1v:Float = Object1.velocity.x;
 			var obj2v:Float = Object2.velocity.x;
-			
+
 			if (!obj1immovable && !obj2immovable)
 			{
 				overlap *= 0.5;
 				Object1.x = Object1.x - overlap;
 				Object2.x += overlap;
-				
+
 				var obj1velocity:Float = Math.sqrt((obj2v * obj2v * Object2.mass) / Object1.mass) * ((obj2v > 0) ? 1 : -1);
 				var obj2velocity:Float = Math.sqrt((obj1v * obj1v * Object1.mass) / Object2.mass) * ((obj1v > 0) ? 1 : -1);
 				var average:Float = (obj1velocity + obj2velocity) * 0.5;
@@ -225,10 +225,10 @@ class FlxObject extends FlxBasic
 
 		return false;
 	}
-	
+
 	/**
 	 * Checking overlap and updating `touching` variables, X-axis part used by `updateTouchingFlags`.
-	 * 
+	 *
 	 * @param   Object1   Any `FlxObject`.
 	 * @param   Object2   Any other `FlxObject`.
 	 * @return  Whether the objects in fact touched along the X axis.
@@ -249,33 +249,33 @@ class FlxObject extends FlxBasic
 		// Since we are not separating, always return any amount of overlap => false as last parameter
 		return computeOverlapX(Object1, Object2, false) != 0;
 	}
-	
+
 	/**
 	 * Internal function that computes overlap among two objects on the Y axis. It also updates the `touching` variable.
 	 * `checkMaxOverlap` is used to determine whether we want to exclude (therefore check) overlaps which are
 	 * greater than a certain maximum (linked to `SEPARATE_BIAS`). Default is `true`, handy for `separateY` code.
 	 */
 	@:noCompletion
-	private static function computeOverlapY(Object1:FlxObject, Object2:FlxObject, checkMaxOverlap:Bool = true):Float
+	static function computeOverlapY(Object1:FlxObject, Object2:FlxObject, checkMaxOverlap:Bool = true):Float
 	{
 		var overlap:Float = 0;
 		//First, get the two object deltas
 		var obj1delta:Float = Object1.y - Object1.last.y;
 		var obj2delta:Float = Object2.y - Object2.last.y;
-		
+
 		if (obj1delta != obj2delta)
 		{
 			//Check if the Y hulls actually overlap
 			var obj1deltaAbs:Float = (obj1delta > 0) ? obj1delta : -obj1delta;
 			var obj2deltaAbs:Float = (obj2delta > 0) ? obj2delta : -obj2delta;
-			
+
 			var obj1rect:FlxRect = _firstSeparateFlxRect.set(Object1.x, Object1.y - ((obj1delta > 0) ? obj1delta : 0), Object1.width, Object1.height + obj1deltaAbs);
 			var obj2rect:FlxRect = _secondSeparateFlxRect.set(Object2.x, Object2.y - ((obj2delta > 0) ? obj2delta : 0), Object2.width, Object2.height + obj2deltaAbs);
-			
+
 			if ((obj1rect.x + obj1rect.width > obj2rect.x) && (obj1rect.x < obj2rect.x + obj2rect.width) && (obj1rect.y + obj1rect.height > obj2rect.y) && (obj1rect.y < obj2rect.y + obj2rect.height))
 			{
 				var maxOverlap:Float = checkMaxOverlap ? (obj1deltaAbs + obj2deltaAbs + SEPARATE_BIAS) : 0;
-				
+
 				//If they did overlap (and can), figure out by how much and flip the corresponding flags
 				if (obj1delta > obj2delta)
 				{
@@ -307,10 +307,10 @@ class FlxObject extends FlxBasic
 		}
 		return overlap;
 	}
-	
+
 	/**
 	 * The Y-axis component of the object separation process.
-	 * 
+	 *
 	 * @param   Object1   Any `FlxObject`.
 	 * @param   Object2   Any other `FlxObject`.
 	 * @return  Whether the objects in fact touched and were separated along the Y axis.
@@ -324,7 +324,7 @@ class FlxObject extends FlxBasic
 		{
 			return false;
 		}
-		
+
 		//If one of the objects is a tilemap, just pass it off.
 		if (Object1.flixelType == TILEMAP)
 		{
@@ -345,13 +345,13 @@ class FlxObject extends FlxBasic
 			var obj2delta:Float = Object2.y - Object2.last.y;
 			var obj1v:Float = Object1.velocity.y;
 			var obj2v:Float = Object2.velocity.y;
-			
+
 			if (!obj1immovable && !obj2immovable)
 			{
 				overlap *= 0.5;
 				Object1.y = Object1.y - overlap;
 				Object2.y += overlap;
-				
+
 				var obj1velocity:Float = Math.sqrt((obj2v * obj2v * Object2.mass) / Object1.mass) * ((obj2v > 0) ? 1 : -1);
 				var obj2velocity:Float = Math.sqrt((obj1v * obj1v * Object1.mass) / Object2.mass) * ((obj1v > 0) ? 1 : -1);
 				var average:Float = (obj1velocity + obj2velocity) * 0.5;
@@ -382,13 +382,13 @@ class FlxObject extends FlxBasic
 			}
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Checking overlap and updating touching variables, Y-axis part used by `updateTouchingFlags`.
-	 * 
+	 *
 	 * @param   Object1   Any `FlxObject`.
 	 * @param   Object2   Any other `FlxObject`.
 	 * @return  Whether the objects in fact touched along the Y axis.
@@ -409,7 +409,7 @@ class FlxObject extends FlxBasic
 		// Since we are not separating, always return any amount of overlap => false as last parameter
 		return computeOverlapY(Object1, Object2, false) != 0;
 	}
-	
+
 	/**
 	 * X position of the upper left corner of this object in world space.
 	 */
@@ -489,7 +489,7 @@ class FlxObject extends FlxBasic
 	 */
 	public var last(default, null):FlxPoint;
 	/**
-	 * The virtual mass of the object. Default value is 1. Currently only used with elasticity 
+	 * The virtual mass of the object. Default value is 1. Currently only used with elasticity
 	 * during collision resolution. Change at your own risk; effects seem crazy unpredictable so far!
 	 */
 	public var mass:Float = 1;
@@ -518,12 +518,12 @@ class FlxObject extends FlxBasic
 	 */
 	public var health:Float = 1;
 	/**
-	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts. Use bitwise operators to check the values 
+	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts. Use bitwise operators to check the values
 	 * stored here, or use isTouching(), justTouched(), etc. You can even use them broadly as boolean values if you're feeling saucy!
 	 */
 	public var touching:Int = NONE;
 	/**
-	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts from the previous game loop step. Use bitwise operators to check the values 
+	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts from the previous game loop step. Use bitwise operators to check the values
 	 * stored here, or use isTouching(), justTouched(), etc. You can even use them broadly as boolean values if you're feeling saucy!
 	 */
 	public var wasTouching:Int = NONE;
@@ -533,18 +533,18 @@ class FlxObject extends FlxBasic
 	 */
 	public var allowCollisions(default, set):Int = ANY;
 	/**
-	 * Whether this sprite is dragged along with the horizontal movement of objects it collides with 
+	 * Whether this sprite is dragged along with the horizontal movement of objects it collides with
 	 * (makes sense for horizontally-moving platforms in platformers for example).
 	 */
 	public var collisonXDrag:Bool = true;
-	
+
 	#if FLX_DEBUG
 	/**
 	 * Overriding this will force a specific color to be used for debug rect
 	 * (ignoring any of the other debug bounding box colors specified).
 	 */
 	public var debugBoundingBoxColor:Null<FlxColor> = null;
-	
+
 	/**
 	 * Color used for the debug rect if `allowCollisions == FlxObject.ANY`.
 	 * @since 4.2.0
@@ -571,7 +571,7 @@ class FlxObject extends FlxBasic
 	 */
 	public var ignoreDrawDebug:Bool = false;
 	#end
-	
+
 	/**
 	 * The path this object follows. Not initialized by default.
 	 * Assign a `new FlxPath()` object and `start()` it if you want to this object to follow a path.
@@ -579,12 +579,12 @@ class FlxObject extends FlxBasic
 	 * See `flixel.util.FlxPath` for more info and usage examples.
 	 */
 	public var path(default, set):FlxPath = null;
-	
+
 	@:noCompletion
-	private var _point:FlxPoint = FlxPoint.get();
+	var _point:FlxPoint = FlxPoint.get();
 	@:noCompletion
-	private var _rect:FlxRect = FlxRect.get();
-	
+	var _rect:FlxRect = FlxRect.get();
+
 	/**
 	 * @param   X        The X-coordinate of the point in space.
 	 * @param   Y        The Y-coordinate of the point in space.
@@ -594,55 +594,55 @@ class FlxObject extends FlxBasic
 	public function new(X:Float = 0, Y:Float = 0, Width:Float = 0, Height:Float = 0)
 	{
 		super();
-		
+
 		x = X;
 		y = Y;
 		width = Width;
 		height = Height;
-		
+
 		initVars();
 	}
-	
+
 	/**
 	 * Internal function for initialization of some object's variables.
 	 */
 	@:noCompletion
-	private function initVars():Void
+	function initVars():Void
 	{
 		flixelType = OBJECT;
 		last = FlxPoint.get(x, y);
 		scrollFactor = FlxPoint.get(1, 1);
 		pixelPerfectPosition = FlxObject.defaultPixelPerfectPosition;
-		
+
 		initMotionVars();
 	}
-	
+
 	/**
 	 * Internal function for initialization of some variables that are used in `updateMotion()`.
 	 */
 	@:noCompletion
-	private inline function initMotionVars():Void
+	inline function initMotionVars():Void
 	{
 		velocity = FlxPoint.get();
 		acceleration = FlxPoint.get();
 		drag = FlxPoint.get();
 		maxVelocity = FlxPoint.get(10000, 10000);
 	}
-	
+
 	/**
 	 * **WARNING:** A destroyed `FlxBasic` can't be used anymore.
 	 * It may even cause crashes if it is still part of a group or state.
 	 * You may want to use `kill()` instead if you want to disable the object temporarily only and `revive()` it later.
-	 * 
+	 *
 	 * This function is usually not called manually (Flixel calls it automatically during state switches for all `add()`ed objects).
-	 * 
+	 *
 	 * Override this function to `null` out variables manually or call `destroy()` on class members if necessary.
 	 * Don't forget to call `super.destroy()`!
 	 */
 	override public function destroy():Void
 	{
 		super.destroy();
-		
+
 		velocity = FlxDestroyUtil.put(velocity);
 		acceleration = FlxDestroyUtil.put(acceleration);
 		drag = FlxDestroyUtil.put(drag);
@@ -652,56 +652,56 @@ class FlxObject extends FlxBasic
 		_point = FlxDestroyUtil.put(_point);
 		_rect = FlxDestroyUtil.put(_rect);
 	}
-	
+
 	/**
 	 * Override this function to update your class's position and appearance.
 	 * This is where most of your game rules and behavioral code will go.
 	 */
-	override public function update(elapsed:Float):Void 
+	override public function update(elapsed:Float):Void
 	{
 		#if FLX_DEBUG
 		// this just increments FlxBasic.activeCount, no need to waste a function call on release
 		super.update(elapsed);
 		#end
-		
+
 		last.set(x, y);
-		
+
 		if (path != null && path.active)
 			path.update(elapsed);
-		
+
 		if (moves)
 			updateMotion(elapsed);
-		
+
 		wasTouching = touching;
 		touching = NONE;
 	}
-	
+
 	/**
 	 * Internal function for updating the position and speed of this object.
 	 * Useful for cases when you need to update this but are buried down in too many supers.
 	 * Does a slightly fancier-than-normal integration to help with higher fidelity framerate-independent motion.
 	 */
 	@:noCompletion
-	private function updateMotion(elapsed:Float):Void
+	function updateMotion(elapsed:Float):Void
 	{
 		var velocityDelta = 0.5 * (FlxVelocity.computeVelocity(angularVelocity, angularAcceleration, angularDrag, maxAngular, elapsed) - angularVelocity);
-		angularVelocity += velocityDelta; 
+		angularVelocity += velocityDelta;
 		angle += angularVelocity * elapsed;
 		angularVelocity += velocityDelta;
-		
+
 		velocityDelta = 0.5 * (FlxVelocity.computeVelocity(velocity.x, acceleration.x, drag.x, maxVelocity.x, elapsed) - velocity.x);
 		velocity.x += velocityDelta;
 		var delta = velocity.x * elapsed;
 		velocity.x += velocityDelta;
 		x += delta;
-		
+
 		velocityDelta = 0.5 * (FlxVelocity.computeVelocity(velocity.y, acceleration.y, drag.y, maxVelocity.y, elapsed) - velocity.y);
 		velocity.y += velocityDelta;
 		delta = velocity.y * elapsed;
 		velocity.y += velocityDelta;
 		y += delta;
 	}
-	
+
 	/**
 	 * Rarely called, and in this case just increments the visible objects count and calls `drawDebug()` if necessary.
 	 */
@@ -713,12 +713,12 @@ class FlxObject extends FlxBasic
 			drawDebug();
 		#end
 	}
-	
+
 	/**
 	 * Checks to see if some `FlxObject` overlaps this `FlxObject` or `FlxGroup`.
 	 * If the group has a LOT of things in it, it might be faster to use `FlxG.overlap()`.
 	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
-	 * 
+	 *
 	 * @param   ObjectOrGroup   The object or group being tested.
 	 * @param   InScreenSpace   Whether to take scroll factors into account when checking for overlap.
 	 *                          Default is `false`, or "only compare in world space."
@@ -734,15 +734,15 @@ class FlxObject extends FlxBasic
 		{
 			return FlxTypedGroup.overlaps(overlapsCallback, group, 0, 0, InScreenSpace, Camera);
 		}
-		
+
 		if (ObjectOrGroup.flixelType == TILEMAP)
 		{
 			//Since tilemap's have to be the caller, not the target, to do proper tile-based collisions,
 			// we redirect the call to the tilemap overlap here.
-			var tilemap:FlxBaseTilemap<Dynamic> = cast ObjectOrGroup; 
+			var tilemap:FlxBaseTilemap<Dynamic> = cast ObjectOrGroup;
 			return tilemap.overlaps(this, InScreenSpace, Camera);
 		}
-		
+
 		var object:FlxObject = cast ObjectOrGroup;
 		if (!InScreenSpace)
 		{
@@ -759,21 +759,21 @@ class FlxObject extends FlxBasic
 		return	(objectScreenPos.x + object.width > _point.x) && (objectScreenPos.x < _point.x + width) &&
 				(objectScreenPos.y + object.height > _point.y) && (objectScreenPos.y < _point.y + height);
 	}
-	
+
 	@:noCompletion
-	private inline function overlapsCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool,
+	inline function overlapsCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool,
 		Camera:FlxCamera):Bool
 	{
 		return overlaps(ObjectOrGroup, InScreenSpace, Camera);
 	}
-	
+
 	/**
 	 * Checks to see if this `FlxObject` were located at the given position,
 	 * would it overlap the `FlxObject` or `FlxGroup`?
 	 * This is distinct from `overlapsPoint()`, which just checks that point,
 	 * rather than taking the object's size into account.
 	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
-	 * 
+	 *
 	 * @param   X               The X position you want to check.
 	 *                          Pretends this object (the caller, not the parameter) is located here.
 	 * @param   Y               The Y position you want to check.
@@ -794,7 +794,7 @@ class FlxObject extends FlxBasic
 		{
 			return FlxTypedGroup.overlaps(overlapsAtCallback, group, X, Y, InScreenSpace, Camera);
 		}
-		
+
 		if (ObjectOrGroup.flixelType == TILEMAP)
 		{
 			//Since tilemap's have to be the caller, not the target, to do proper tile-based collisions,
@@ -804,14 +804,14 @@ class FlxObject extends FlxBasic
 			var tilemap:FlxBaseTilemap<Dynamic> = cast ObjectOrGroup;
 			return tilemap.overlapsAt(tilemap.x - (X - x), tilemap.y - (Y - y), this, InScreenSpace, Camera);
 		}
-		
+
 		var object:FlxObject = cast ObjectOrGroup;
 		if (!InScreenSpace)
 		{
 			return	(object.x + object.width > X) && (object.x < X + width) &&
 					(object.y + object.height > Y) && (object.y < Y + height);
 		}
-		
+
 		if (Camera == null)
 		{
 			Camera = FlxG.camera;
@@ -821,17 +821,17 @@ class FlxObject extends FlxBasic
 		return	(objectScreenPos.x + object.width > _point.x) && (objectScreenPos.x < _point.x + width) &&
 			(objectScreenPos.y + object.height > _point.y) && (objectScreenPos.y < _point.y + height);
 	}
-	
+
 	@:noCompletion
-	private inline function overlapsAtCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool,
+	inline function overlapsAtCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool,
 		Camera:FlxCamera):Bool
 	{
 		return overlapsAt(X, Y, ObjectOrGroup, InScreenSpace, Camera);
 	}
-	
+
 	/**
 	 * Checks to see if a point in 2D world space overlaps this `FlxObject`.
-	 * 
+	 *
 	 * @param   Point           The point in world space you want to check.
 	 * @param   InScreenSpace   Whether to take scroll factors into account when checking for overlap.
 	 * @param   Camera          Specify which game camera you want.
@@ -844,7 +844,7 @@ class FlxObject extends FlxBasic
 		{
 			return (point.x >= x) && (point.x < x + width) && (point.y >= y) && (point.y < y + height);
 		}
-		
+
 		if (Camera == null)
 		{
 			Camera = FlxG.camera;
@@ -855,11 +855,11 @@ class FlxObject extends FlxBasic
 		point.putWeak();
 		return (xPos >= _point.x) && (xPos < _point.x + width) && (yPos >= _point.y) && (yPos < _point.y + height);
 	}
-	
+
 	/**
 	 * Check and see if this object is currently within the world bounds -
 	 * useful for killing objects that get too far away.
-	 * 
+	 *
 	 * @return   Whether the object is within the world bounds or not.
 	 */
 	public inline function inWorldBounds():Bool
@@ -867,10 +867,10 @@ class FlxObject extends FlxBasic
 		return (x + width > FlxG.worldBounds.x) && (x < FlxG.worldBounds.right) &&
 			(y + height > FlxG.worldBounds.y) && (y < FlxG.worldBounds.bottom);
 	}
-	
+
 	/**
 	 * Call this function to figure out the on-screen position of the object.
-	 * 
+	 *
 	 * @param   Point    Takes a `FlxPoint` object and assigns the post-scrolled X and Y values of this object to it.
 	 * @param   Camera   Specify which game camera you want.
 	 *                   If `null`, it will just grab the first global camera.
@@ -884,24 +884,24 @@ class FlxObject extends FlxBasic
 
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		point.set(x, y);
 		if (pixelPerfectPosition)
 			point.floor();
-		
+
 		return point.subtract(Camera.scroll.x * scrollFactor.x, Camera.scroll.y * scrollFactor.y);
 	}
-	
+
 	public function getPosition(?point:FlxPoint):FlxPoint
 	{
 		if (point == null)
 			point = FlxPoint.get();
 		return point.set(x, y);
 	}
-	
+
 	/**
 	 * Retrieve the midpoint of this object in world coordinates.
-	 * 
+	 *
 	 * @param   point   Allows you to pass in an existing `FlxPoint` object if you're so inclined.
 	 *                  Otherwise a new one is created.
 	 * @return  A `FlxPoint` object containing the midpoint of this object in world coordinates.
@@ -912,18 +912,18 @@ class FlxObject extends FlxBasic
 			point = FlxPoint.get();
 		return point.set(x + width * 0.5, y + height * 0.5);
 	}
-	
+
 	public function getHitbox(?rect:FlxRect):FlxRect
 	{
 		if (rect == null)
 			rect = FlxRect.get();
 		return rect.set(x, y, width, height);
 	}
-	
+
 	/**
 	 * Handy function for reviving game objects.
 	 * Resets their existence flags and position.
-	 * 
+	 *
 	 * @param   X   The new X position of this object.
 	 * @param   Y   The new Y position of this object.
 	 */
@@ -936,10 +936,10 @@ class FlxObject extends FlxBasic
 		velocity.set();
 		revive();
 	}
-	
+
 	/**
 	 * Check and see if this object is currently on screen.
-	 * 
+	 *
 	 * @param   Camera   Specify which game camera you want.
 	 *                   If `null`, it will just grab the first global camera.
 	 * @return  Whether the object is on screen or not.
@@ -948,11 +948,11 @@ class FlxObject extends FlxBasic
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		getScreenPosition(_point, Camera);
 		return Camera.containsPoint(_point, width, height);
 	}
-	
+
 	/**
 	 * Check if object is rendered pixel perfect on a specific camera.
 	 */
@@ -962,11 +962,11 @@ class FlxObject extends FlxBasic
 			Camera = FlxG.camera;
 		return pixelPerfectRender == null ? Camera.pixelPerfectRender : pixelPerfectRender;
 	}
-	
+
 	/**
 	 * Handy function for checking if this object is touching a particular surface.
 	 * Be sure to check it before calling `super.update()`, as that will reset the flags.
-	 * 
+	 *
 	 * @param   Direction   Any of the collision flags (e.g. `LEFT`, `FLOOR`, etc).
 	 * @return  Whether the object is touching an object in (any of) the specified direction(s) this frame.
 	 */
@@ -974,11 +974,11 @@ class FlxObject extends FlxBasic
 	{
 		return (touching & Direction) > NONE;
 	}
-	
+
 	/**
 	 * Handy function for checking if this object is just landed on a particular surface.
 	 * Be sure to check it before calling `super.update()`, as that will reset the flags.
-	 * 
+	 *
 	 * @param   Direction   Any of the collision flags (e.g. `LEFT`, `FLOOR`, etc).
 	 * @return  Whether the object just landed on (any of) the specified surface(s) this frame.
 	 */
@@ -986,11 +986,11 @@ class FlxObject extends FlxBasic
 	{
 		return ((touching & Direction) > NONE) && ((wasTouching & Direction) <= NONE);
 	}
-	
+
 	/**
 	 * Reduces the `health` variable of this object by the amount specified in `Damage`.
 	 * Calls `kill()` if health drops to or below zero.
-	 * 
+	 *
 	 * @param   Damage   How much health to take away (use a negative number to give a health bonus).
 	 */
 	public function hurt(Damage:Float):Void
@@ -999,10 +999,10 @@ class FlxObject extends FlxBasic
 		if (health <= 0)
 			kill();
 	}
-	
+
 	/**
 	 * Centers this `FlxObject` on the screen, either by the x axis, y axis, or both.
-	 * 
+	 *
 	 * @param   axes   On what axes to center the object - default is `FlxAxes.XY` / both.
 	 * @return  This FlxObject for chaining
 	 */
@@ -1010,19 +1010,19 @@ class FlxObject extends FlxBasic
 	{
 		if (axes == null)
 			axes = FlxAxes.XY;
-		
+
 		if (axes != FlxAxes.Y)
 			x = (FlxG.width / 2) - (width / 2);
 		if (axes != FlxAxes.X)
 			y = (FlxG.height / 2) - (height / 2);
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Helper function to set the coordinates of this object.
 	 * Handy since it only requires one line of code.
-	 * 
+	 *
 	 * @param   X   The new x position
 	 * @param   Y   The new y position
 	 */
@@ -1031,10 +1031,10 @@ class FlxObject extends FlxBasic
 		x = X;
 		y = Y;
 	}
-	
+
 	/**
 	 * Shortcut for setting both width and Height.
-	 * 
+	 *
 	 * @param   Width    The new hitbox width.
 	 * @param   Height   The new hitbox height.
 	 */
@@ -1043,39 +1043,39 @@ class FlxObject extends FlxBasic
 		width = Width;
 		height = Height;
 	}
-	
+
 	#if FLX_DEBUG
 	public function drawDebug():Void
 	{
 		if (ignoreDrawDebug)
 			return;
-		
+
 		for (camera in cameras)
 		{
 			drawDebugOnCamera(camera);
-			
+
 			if (path != null && !path.ignoreDrawDebug)
 				path.drawDebug();
 		}
 	}
-	
+
 	/**
 	 * Override this function to draw custom "debug mode" graphics to the
 	 * specified camera while the debugger's `drawDebug` mode is toggled on.
-	 * 
+	 *
 	 * @param   Camera   Which camera to draw the debug visuals to.
 	 */
 	public function drawDebugOnCamera(camera:FlxCamera):Void
 	{
 		if (!camera.visible || !camera.exists || !isOnScreen(camera))
 			return;
-		
+
 		var rect = getBoundingBox(camera);
 		var gfx:Graphics = beginDrawDebug(camera);
 		drawDebugBoundingBox(gfx, rect, allowCollisions, immovable);
 		endDrawDebug(camera);
 	}
-	
+
 	function drawDebugBoundingBox(gfx:Graphics, rect:FlxRect, allowCollisions:Int, partial:Bool)
 	{
 		// Find the color to use
@@ -1091,13 +1091,13 @@ class FlxObject extends FlxBasic
 				color = debugBoundingBoxColorNotSolid;
 			}
 		}
-		
+
 		// fill static graphics object with square shape
 		gfx.lineStyle(1, color, 0.5);
 		gfx.drawRect(rect.x, rect.y, rect.width, rect.height);
 	}
 
-	private inline function beginDrawDebug(camera:FlxCamera):Graphics
+	inline function beginDrawDebug(camera:FlxCamera):Graphics
 	{
 		if (FlxG.renderBlit)
 		{
@@ -1109,8 +1109,8 @@ class FlxObject extends FlxBasic
 			return camera.debugLayer.graphics;
 		}
 	}
-	
-	private inline function endDrawDebug(camera:FlxCamera)
+
+	inline function endDrawDebug(camera:FlxCamera)
 	{
 		if (FlxG.renderBlit)
 			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
@@ -1118,49 +1118,49 @@ class FlxObject extends FlxBasic
 	#end
 
 	@:access(flixel.FlxCamera)
-	private function getBoundingBox(camera:FlxCamera):FlxRect
+	function getBoundingBox(camera:FlxCamera):FlxRect
 	{
 		getScreenPosition(_point, camera);
-		
+
 		_rect.set(_point.x, _point.y, width, height);
 		_rect = camera.transformRect(_rect);
-		
+
 		if (isPixelPerfectRender(camera))
 		{
 			_rect.floor();
 		}
-		
+
 		return _rect;
 	}
-	
+
 	/**
 	 * Convert object to readable string name. Useful for debugging, save games, etc.
 	 */
 	override public function toString():String
 	{
 		return FlxStringUtil.getDebugString([
-			LabelValuePair.weak("x", x), 
-			LabelValuePair.weak("y", y), 
-			LabelValuePair.weak("w", width), 
-			LabelValuePair.weak("h", height), 
-			LabelValuePair.weak("visible", visible), 
+			LabelValuePair.weak("x", x),
+			LabelValuePair.weak("y", y),
+			LabelValuePair.weak("w", width),
+			LabelValuePair.weak("h", height),
+			LabelValuePair.weak("visible", visible),
 			LabelValuePair.weak("velocity", velocity)]);
 	}
-	
+
 	@:noCompletion
-	private function set_x(NewX:Float):Float
+	function set_x(NewX:Float):Float
 	{
 		return x = NewX;
 	}
-	
+
 	@:noCompletion
-	private function set_y(NewY:Float):Float
+	function set_y(NewY:Float):Float
 	{
 		return y = NewY;
 	}
-	
+
 	@:noCompletion
-	private function set_width(Width:Float):Float
+	function set_width(Width:Float):Float
 	{
 		#if FLX_DEBUG
 		if (Width < 0)
@@ -1169,12 +1169,12 @@ class FlxObject extends FlxBasic
 			return Width;
 		}
 		#end
-		
+
 		return width = Width;
 	}
-	
+
 	@:noCompletion
-	private function set_height(Height:Float):Float
+	function set_height(Height:Float):Float
 	{
 		#if FLX_DEBUG
 		if (Height < 0)
@@ -1183,91 +1183,91 @@ class FlxObject extends FlxBasic
 			return Height;
 		}
 		#end
-		
+
 		return height = Height;
 	}
-	
+
 	@:noCompletion
-	private function get_width():Float
+	function get_width():Float
 	{
 		return width;
 	}
-	
+
 	@:noCompletion
-	private function get_height():Float
+	function get_height():Float
 	{
 		return height;
 	}
-	
+
 	@:noCompletion
-	private inline function get_solid():Bool
+	inline function get_solid():Bool
 	{
 		return (allowCollisions & ANY) > NONE;
 	}
-	
+
 	@:noCompletion
-	private function set_solid(Solid:Bool):Bool
+	function set_solid(Solid:Bool):Bool
 	{
 		allowCollisions = Solid ? ANY : NONE;
 		return Solid;
 	}
-	
+
 	@:noCompletion
-	private function set_angle(Value:Float):Float
+	function set_angle(Value:Float):Float
 	{
 		return angle = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_moves(Value:Bool):Bool
+	function set_moves(Value:Bool):Bool
 	{
 		return moves = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_immovable(Value:Bool):Bool
+	function set_immovable(Value:Bool):Bool
 	{
 		return immovable = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_pixelPerfectRender(Value:Bool):Bool 
+	function set_pixelPerfectRender(Value:Bool):Bool
 	{
 		return pixelPerfectRender = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_allowCollisions(Value:Int):Int 
+	function set_allowCollisions(Value:Int):Int
 	{
 		return allowCollisions = Value;
 	}
 
 	#if FLX_DEBUG
-	private function set_debugBoundingBoxColorSolid(color:FlxColor)
+	function set_debugBoundingBoxColorSolid(color:FlxColor)
 	{
 		return debugBoundingBoxColorSolid = color;
 	}
 
-	private function set_debugBoundingBoxColorNotSolid(color:FlxColor)
+	function set_debugBoundingBoxColorNotSolid(color:FlxColor)
 	{
 		return debugBoundingBoxColorNotSolid = color;
 	}
-	
-	private function set_debugBoundingBoxColorPartial(color:FlxColor)
+
+	function set_debugBoundingBoxColorPartial(color:FlxColor)
 	{
 		return debugBoundingBoxColorPartial = color;
 	}
 	#end
-	
+
 	@:noCompletion
-	private function set_path(path:FlxPath):FlxPath
+	function set_path(path:FlxPath):FlxPath
 	{
 		if (this.path == path)
 			return path;
-		
+
 		if (this.path != null)
 			this.path.object = null;
-		
+
 		if (path != null)
 			path.object = this;
 		return this.path = path;

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -42,20 +42,20 @@ class FlxSprite extends FlxObject
 	 * Class that handles adding and playing animations on this sprite.
 	 */
 	public var animation:FlxAnimationController;
-	
+
 	// TODO: maybe convert this var to property...
 	/**
 	 * The current display state of the sprite including current animation frame,
 	 * tint, flip etc... may be `null` unless `useFramePixels` is `true`.
 	 */
 	public var framePixels:BitmapData;
-	
+
 	/**
 	 * Always `true` on `FlxG.renderBlit`. On `FlxG.renderTile` it determines whether
 	 * `framePixels` is used and defaults to `false` for performance reasons.
 	 */
 	public var useFramePixels(default, set):Bool = true;
-	
+
 	/**
 	 * Controls whether the object is smoothed when rotated, affects performance.
 	 */
@@ -65,7 +65,7 @@ class FlxSprite extends FlxObject
 	 * NOTE: Rarely if ever necessary, most sprite operations will flip this flag automatically.
 	 */
 	public var dirty:Bool = true;
-	
+
 	/**
 	 * This sprite's graphic / `BitmapData` object.
 	 * Automatically adjusts graphic size and render helpers if changed.
@@ -115,7 +115,7 @@ class FlxSprite extends FlxObject
 	 * Whether this sprite is flipped on the Y axis.
 	 */
 	public var flipY(default, set):Bool = false;
-	
+
 	/**
 	 * WARNING: The `origin` of the sprite will default to its center. If you change this,
 	 * the visuals and the collisions will likely be pretty out-of-sync if you do any rotation.
@@ -142,14 +142,14 @@ class FlxSprite extends FlxObject
 	 * `0xAARRGGBB` colors, but the alpha value will simply be ignored. To change the opacity use `alpha`.
 	 */
 	public var color(default, set):FlxColor = 0xffffff;
-	
+
 	public var colorTransform(default, null):ColorTransform;
-	
+
 	/**
 	 * Whether or not to use a `ColorTransform` set via `setColorTransform()`.
 	 */
 	public var useColorTransform(default, null):Bool = false;
-	
+
 	/**
 	 * Clipping rectangle for this sprite.
 	 * Changing the rect's properties directly doesn't have any effect,
@@ -157,7 +157,7 @@ class FlxSprite extends FlxObject
 	 * Set to `null` to discard graphic frame clipping.
 	 */
 	public var clipRect(default, set):FlxRect;
-	
+
 	/**
 	 * GLSL shader for this sprite. Only works with OpenFL Next or WebGL.
 	 * Avoid changing it frequently as this is a costly operation.
@@ -165,76 +165,76 @@ class FlxSprite extends FlxObject
 	 */
 	#if openfl_legacy @:noCompletion #end
 	public var shader:FlxShader;
-	
+
 	/**
 	 * The actual frame used for sprite rendering
 	 */
 	@:noCompletion
-	private var _frame:FlxFrame;
-	
+	var _frame:FlxFrame;
+
 	/**
 	 * Graphic of `_frame`. Used in tile render mode, when `useFramePixels` is `true`.
 	 */
 	@:noCompletion
-	private var _frameGraphic:FlxGraphic;
-	
+	var _frameGraphic:FlxGraphic;
+
 	@:noCompletion
-	private var _facingHorizontalMult:Int = 1;
+	var _facingHorizontalMult:Int = 1;
 	@:noCompletion
-	private var _facingVerticalMult:Int = 1;
-	
+	var _facingVerticalMult:Int = 1;
+
 	/**
 	 * Internal, reused frequently during drawing and animating.
 	 */
 	@:noCompletion
-	private var _flashPoint:Point;
+	var _flashPoint:Point;
 	/**
 	 * Internal, reused frequently during drawing and animating.
 	 */
 	@:noCompletion
-	private var _flashRect:Rectangle;
+	var _flashRect:Rectangle;
 	/**
 	 * Internal, reused frequently during drawing and animating.
 	 */
 	@:noCompletion
-	private var _flashRect2:Rectangle;
+	var _flashRect2:Rectangle;
 	/**
 	 * Internal, reused frequently during drawing and animating. Always contains `(0,0)`.
 	 */
 	@:noCompletion
-	private var _flashPointZero:Point;
+	var _flashPointZero:Point;
 	/**
 	 * Internal, helps with animation, caching and drawing.
 	 */
 	@:noCompletion
-	private var _matrix:FlxMatrix;
-	
+	var _matrix:FlxMatrix;
+
 	/**
 	 * Rendering helper variable
 	 */
 	@:noCompletion
-	private var _halfSize:FlxPoint;
-	
+	var _halfSize:FlxPoint;
+
 	/**
 	 * These vars are being used for rendering in some of `FlxSprite` subclasses (`FlxTileblock`, `FlxBar`,
 	 * and `FlxBitmapText`) and for checks if the sprite is in camera's view.
 	 */
 	@:noCompletion
-	private var _sinAngle:Float = 0;
+	var _sinAngle:Float = 0;
 	@:noCompletion
-	private var _cosAngle:Float = 1;
+	var _cosAngle:Float = 1;
 	@:noCompletion
-	private var _angleChanged:Bool = true;
+	var _angleChanged:Bool = true;
 	/**
 	 * Maps `FlxObject` direction constants to axis flips
 	 */
 	@:noCompletion
-	private var _facingFlip:Map<Int, {x:Bool, y:Bool}> = new Map<Int, {x:Bool, y:Bool}>();
-	
+	var _facingFlip:Map<Int, {x:Bool, y:Bool}> = new Map<Int, {x:Bool, y:Bool}>();
+
 	/**
 	 * Creates a `FlxSprite` at a specified position with a specified one-frame graphic.
 	 * If none is provided, a 16x16 image of the HaxeFlixel logo is used.
-	 * 
+	 *
 	 * @param   X               The initial X position of the sprite.
 	 * @param   Y               The initial Y position of the sprite.
 	 * @param   SimpleGraphic   The graphic you want to display
@@ -243,19 +243,19 @@ class FlxSprite extends FlxObject
 	public function new(?X:Float = 0, ?Y:Float = 0, ?SimpleGraphic:FlxGraphicAsset)
 	{
 		super(X, Y);
-		
+
 		useFramePixels = FlxG.renderBlit;
 		if (SimpleGraphic != null)
 			loadGraphic(SimpleGraphic);
 	}
-	
+
 	@:noCompletion
-	override private function initVars():Void 
+	override function initVars():Void
 	{
 		super.initVars();
-		
+
 		animation = new FlxAnimationController(this);
-		
+
 		_flashPoint = new Point();
 		_flashRect = new Rectangle();
 		_flashRect2 = new Rectangle();
@@ -267,30 +267,30 @@ class FlxSprite extends FlxObject
 		_matrix = new FlxMatrix();
 		colorTransform = new ColorTransform();
 	}
-	
+
 	/**
 	 * **WARNING:** A destroyed `FlxBasic` can't be used anymore.
 	 * It may even cause crashes if it is still part of a group or state.
 	 * You may want to use `kill()` instead if you want to disable the object temporarily only and `revive()` it later.
-	 * 
+	 *
 	 * This function is usually not called manually (Flixel calls it automatically during state switches for all `add()`ed objects).
-	 * 
+	 *
 	 * Override this function to `null` out variables manually or call `destroy()` on class members if necessary.
 	 * Don't forget to call `super.destroy()`!
 	 */
 	override public function destroy():Void
 	{
 		super.destroy();
-		
+
 		animation = FlxDestroyUtil.destroy(animation);
-		
+
 		offset = FlxDestroyUtil.put(offset);
 		origin = FlxDestroyUtil.put(origin);
 		scale = FlxDestroyUtil.put(scale);
 		_halfSize = FlxDestroyUtil.put(_halfSize);
-		
+
 		framePixels = FlxDestroyUtil.dispose(framePixels);
-		
+
 		_flashPoint = null;
 		_flashRect = null;
 		_flashRect2 = null;
@@ -298,24 +298,24 @@ class FlxSprite extends FlxObject
 		_matrix = null;
 		colorTransform = null;
 		blend = null;
-		
+
 		frames = null;
 		graphic = null;
 		_frame = FlxDestroyUtil.destroy(_frame);
 		_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
-		
+
 		shader = null;
 	}
-	
+
 	public function clone():FlxSprite
 	{
 		return (new FlxSprite()).loadGraphicFromSprite(this);
 	}
-	
+
 	/**
 	 * Load graphic from another `FlxSprite` and copy its tile sheet data.
 	 * This method can useful for non-flash targets.
-	 * 
+	 *
 	 * @param   Sprite   The `FlxSprite` from which you want to load graphic data.
 	 * @return  This `FlxSprite` instance (nice for chaining stuff together, if you're into that).
 	 */
@@ -335,7 +335,7 @@ class FlxSprite extends FlxObject
 		clipRect = Sprite.clipRect;
 		return this;
 	}
-	
+
 	/**
 	 * Load an image from an embedded graphic file.
 	 *
@@ -343,7 +343,7 @@ class FlxSprite extends FlxObject
 	 * When you load an identical copy of a previously used image, by default
 	 * HaxeFlixel copies the previous reference onto the `pixels` field instead
 	 * of creating another copy of the image data, to save memory.
-	 * 
+	 *
 	 * @param   Graphic    The image you want to use.
 	 * @param   Animated   Whether the `Graphic` parameter is a single sprite or a row / grid of sprites.
 	 * @param   Width      Specify the width of your sprite
@@ -362,31 +362,31 @@ class FlxSprite extends FlxObject
 		var graph:FlxGraphic = FlxG.bitmap.add(Graphic, Unique, Key);
 		if (graph == null)
 			return this;
-		
+
 		if (Width == 0)
 		{
 			Width = Animated ? graph.height : graph.width;
 			Width = (Width > graph.width) ? graph.width : Width;
 		}
-		
+
 		if (Height == 0)
 		{
 			Height = Animated ? Width : graph.height;
 			Height = (Height > graph.height) ? graph.height : Height;
 		}
-		
+
 		if (Animated)
 			frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(Width, Height));
 		else
 			frames = graph.imageFrame;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Create a pre-rotated sprite sheet from a simple sprite.
 	 * This can make a huge difference in graphical performance!
-	 * 
+	 *
 	 * @param   Graphic        The image you want to rotate and stamp.
 	 * @param   Rotations      The number of rotation frames the final sprite should have.
 	 *                         For small sprites this can be quite a large number (`360` even) without any problems.
@@ -405,10 +405,10 @@ class FlxSprite extends FlxObject
 		var brushGraphic:FlxGraphic = FlxG.bitmap.add(Graphic, false, Key);
 		if (brushGraphic == null)
 			return this;
-		
+
 		var brush:BitmapData = brushGraphic.bitmap;
 		var key:String = brushGraphic.key;
-		
+
 		if (Frame >= 0)
 		{
 			// we assume that source graphic has one row frame animation with equal width and height
@@ -416,15 +416,15 @@ class FlxSprite extends FlxObject
 			var framesNum:Int = Std.int(brush.width / brushSize);
 			Frame = (framesNum > Frame) ? Frame : (Frame % framesNum);
 			key += ":" + Frame;
-			
+
 			var full:BitmapData = brush;
 			brush = new BitmapData(brushSize, brushSize, true, FlxColor.TRANSPARENT);
 			_flashRect.setTo(Frame * brushSize, 0, brushSize, brushSize);
 			brush.copyPixels(full, _flashRect, _flashPointZero);
 		}
-		
+
 		key += ":" + Rotations + ":" + AutoBuffer;
-		
+
 		//Generate a new sheet if necessary, then fix up the width and height
 		var tempGraph:FlxGraphic = FlxG.bitmap.get(key);
 		if (tempGraph == null)
@@ -432,27 +432,27 @@ class FlxSprite extends FlxObject
 			var bitmap:BitmapData = FlxBitmapDataUtil.generateRotations(brush, Rotations, AntiAliasing, AutoBuffer);
 			tempGraph = FlxGraphic.fromBitmapData(bitmap, false, key);
 		}
-		
+
 		var max:Int = (brush.height > brush.width) ? brush.height : brush.width;
 		max = AutoBuffer ? Std.int(max * 1.5) : max;
-		
+
 		frames = FlxTileFrames.fromGraphic(tempGraph, FlxPoint.get(max, max));
-		
+
 		if (AutoBuffer)
 		{
 			width = brush.width;
 			height = brush.height;
 			centerOffsets();
 		}
-		
+
 		bakedRotationAngle = 360 / Rotations;
 		animation.createPrerotated();
 		return this;
 	}
-	
+
 	/**
 	 * Helper method which allows using `FlxFrame` as graphic source for sprite's `loadRotatedGraphic()` method.
-	 * 
+	 *
 	 * @param   frame          Frame to load into this sprite.
 	 * @param   rotations      The number of rotation frames the final sprite should have.
 	 *                         For small sprites this can be quite a large number (`360` even) without any problems.
@@ -469,14 +469,14 @@ class FlxSprite extends FlxObject
 			key += ":" + Frame.name;
 		else
 			key += ":" + Frame.frame.toString();
-		
+
 		var graphic:FlxGraphic = FlxG.bitmap.get(key);
 		if (graphic == null)
 			graphic = FlxGraphic.fromBitmapData(Frame.paint(), false, key);
-		
+
 		return loadRotatedGraphic(graphic, Rotations, -1, AntiAliasing, AutoBuffer);
 	}
-	
+
 	/**
 	 * This function creates a flat colored rectangular image dynamically.
 	 *
@@ -484,7 +484,7 @@ class FlxSprite extends FlxObject
 	 * When you make an identical copy of a previously used image, by default
 	 * HaxeFlixel copies the previous reference onto the pixels field instead
 	 * of creating another copy of the image data, to save memory.
-	 * 
+	 *
 	 * @param   Width    The width of the sprite you want to generate.
 	 * @param   Height   The height of the sprite you want to generate.
 	 * @param   Color    Specifies the color of the generated block (ARGB format).
@@ -504,12 +504,12 @@ class FlxSprite extends FlxObject
 		frames = graph.imageFrame;
 		return this;
 	}
-	
+
 	/**
 	 * Called whenever a new graphic is loaded for this sprite (after `loadGraphic()`, `makeGraphic()` etc).
 	 */
 	public function graphicLoaded():Void {}
-	
+
 	/**
 	 * Resets some internal variables used for frame `BitmapData` calculation.
 	 */
@@ -520,7 +520,7 @@ class FlxSprite extends FlxObject
 		_flashRect.width = frameWidth;
 		_flashRect.height = frameHeight;
 	}
-	
+
 	/**
 	 * Resets frame size to frame dimensions.
 	 */
@@ -534,7 +534,7 @@ class FlxSprite extends FlxObject
 		_halfSize.set(0.5 * frameWidth, 0.5 * frameHeight);
 		resetSize();
 	}
-	
+
 	/**
 	 * Resets sprite's size back to frame size.
 	 */
@@ -543,7 +543,7 @@ class FlxSprite extends FlxObject
 		width = frameWidth;
 		height = frameHeight;
 	}
-	
+
 	/**
 	 * Helper method just for convenience, so you don't need to type
 	 * `sprite.frame = sprite.frame;`
@@ -554,11 +554,11 @@ class FlxSprite extends FlxObject
 	{
 		frame = this.frame;
 	}
-	
+
 	/**
 	 * Helper function to set the graphic's dimensions by using `scale`, allowing you to keep the current aspect ratio
 	 * should one of the Integers be `<= 0`. It might make sense to call `updateHitbox()` afterwards!
-	 * 
+	 *
 	 * @param   Width    How wide the graphic should be. If `<= 0`, and `Height` is set, the aspect ratio will be kept.
 	 * @param   Height   How high the graphic should be. If `<= 0`, and `Width` is set, the aspect ratio will be kept.
 	 */
@@ -566,17 +566,17 @@ class FlxSprite extends FlxObject
 	{
 		if (Width <= 0 && Height <= 0)
 			return;
-		
+
 		var newScaleX:Float = Width / frameWidth;
 		var newScaleY:Float = Height / frameHeight;
 		scale.set(newScaleX, newScaleY);
-		
+
 		if (Width <= 0)
 			scale.x = newScaleY;
 		else if (Height <= 0)
 			scale.y = newScaleX;
 	}
-	
+
 	/**
 	 * Updates the sprite's hitbox (`width`, `height`, `offset`) according to the current `scale`.
 	 * Also calls `centerOrigin()`.
@@ -588,49 +588,49 @@ class FlxSprite extends FlxObject
 		offset.set(-0.5 * (width - frameWidth), -0.5 * (height - frameHeight));
 		centerOrigin();
 	}
-	
+
 	/**
 	 * Resets some important variables for sprite optimization and rendering.
 	 */
 	@:noCompletion
-	private function resetHelpers():Void
+	function resetHelpers():Void
 	{
 		resetFrameSize();
 		resetSizeFromFrame();
 		_flashRect2.x = 0;
 		_flashRect2.y = 0;
-		
+
 		if (graphic != null)
 		{
 			_flashRect2.width = graphic.width;
 			_flashRect2.height = graphic.height;
 		}
-		
+
 		centerOrigin();
-		
+
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 			updateFramePixels();
 		}
 	}
-	
-	override public function update(elapsed:Float):Void 
+
+	override public function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		updateAnimation(elapsed);
 	}
-	
+
 	/**
 	 * This is separated out so it can be easily overridden.
 	 */
-	private function updateAnimation(elapsed:Float):Void
+	function updateAnimation(elapsed:Float):Void
 	{
 		animation.update(elapsed);
 	}
-	
+
 	@:noCompletion
-	private function checkEmptyFrame()
+	function checkEmptyFrame()
 	{
 		if (_frame == null)
 			loadGraphic("flixel/images/logo/default.png");
@@ -642,78 +642,78 @@ class FlxSprite extends FlxObject
 	override public function draw():Void
 	{
 		checkEmptyFrame();
-		
+
 		if (alpha == 0 || _frame.type == FlxFrameType.EMPTY)
 			return;
-		
-		if (dirty) //rarely 
+
+		if (dirty) //rarely
 			calcFrame(useFramePixels);
-		
+
 		for (camera in cameras)
 		{
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;
-			
+
 			getScreenPosition(_point, camera).subtractPoint(offset);
-			
+
 			if (isSimpleRender(camera))
 				drawSimple(camera);
 			else
 				drawComplex(camera);
-			
+
 			#if FLX_DEBUG
 			FlxBasic.visibleCount++;
 			#end
 		}
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.drawDebug)
 			drawDebug();
 		#end
 	}
-	
+
 	@:noCompletion
-	private function drawSimple(camera:FlxCamera):Void
+	function drawSimple(camera:FlxCamera):Void
 	{
 		if (isPixelPerfectRender(camera))
 			_point.floor();
-		
+
 		_point.copyToFlash(_flashPoint);
 		camera.copyPixels(_frame, framePixels, _flashRect,
 			_flashPoint, colorTransform, blend, antialiasing);
 	}
-	
+
 	@:noCompletion
-	private function drawComplex(camera:FlxCamera):Void
+	function drawComplex(camera:FlxCamera):Void
 	{
 		_frame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY());
 		_matrix.translate(-origin.x, -origin.y);
 		_matrix.scale(scale.x, scale.y);
-		
+
 		if (bakedRotationAngle <= 0)
 		{
 			updateTrig();
-			
+
 			if (angle != 0)
 				_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 		}
-		
-		_point.add(origin.x, origin.y);		
+
+		_point.add(origin.x, origin.y);
 		_matrix.translate(_point.x, _point.y);
-		
+
 		if (isPixelPerfectRender(camera))
 		{
 			_matrix.tx = Math.floor(_matrix.tx);
 			_matrix.ty = Math.floor(_matrix.ty);
 		}
-		
+
 		camera.drawPixels(_frame, framePixels, _matrix, colorTransform, blend, antialiasing, shader);
 	}
-	
+
 	/**
 	 * Stamps / draws another `FlxSprite` onto this `FlxSprite`.
 	 * This function is NOT intended to replace `draw()`!
-	 * 
+	 *
 	 * @param   Brush   The sprite you want to use as a brush or stamp or pen or whatever.
 	 * @param   X       The X coordinate of the brush's top left corner on this sprite.
 	 * @param   Y       They Y coordinate of the brush's top left corner on this sprite.
@@ -721,12 +721,12 @@ class FlxSprite extends FlxObject
 	public function stamp(Brush:FlxSprite, X:Int = 0, Y:Int = 0):Void
 	{
 		Brush.drawFrame();
-		
+
 		if (graphic == null || Brush.graphic == null)
 			throw "Cannot stamp to or from a FlxSprite with no graphics.";
-		
+
 		var bitmapData:BitmapData = Brush.framePixels;
-		
+
 		if (isSimpleRenderBlit()) // simple render
 		{
 			_flashPoint.x = X + frame.frame.x;
@@ -750,18 +750,18 @@ class FlxSprite extends FlxObject
 			var brushBlend:BlendMode = Brush.blend;
 			graphic.bitmap.draw(bitmapData, _matrix, null, brushBlend, null, Brush.antialiasing);
 		}
-		
+
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 			calcFrame();
 		}
 	}
-	
+
 	/**
 	 * Request (or force) that the sprite update the frame before rendering.
 	 * Useful if you are doing procedural generation or other weirdness!
-	 * 
+	 *
 	 * @param   Force   Force the frame to redraw, even if its not flagged as necessary.
 	 */
 	public function drawFrame(Force:Bool = false):Void
@@ -780,10 +780,10 @@ class FlxSprite extends FlxObject
 			calcFrame(true);
 		}
 	}
-	
+
 	/**
 	 * Helper function that adjusts the offset automatically to center the bounding box within the graphic.
-	 * 
+	 *
 	 * @param   AdjustPosition   Adjusts the actual X and Y position just once to match the offset change.
 	 */
 	public function centerOffsets(AdjustPosition:Bool = false):Void
@@ -805,11 +805,11 @@ class FlxSprite extends FlxObject
 	{
 		origin.set(frameWidth * 0.5, frameHeight * 0.5);
 	}
-	
+
 	/**
 	 * Replaces all pixels with specified `Color` with `NewColor` pixels.
 	 * WARNING: very expensive (especially on big graphics) as it iterates over every single pixel.
-	 * 
+	 *
 	 * @param   Color            Color to replace
 	 * @param   NewColor         New color
 	 * @param   FetchPositions   Whether we need to store positions of pixels which colors were replaced.
@@ -822,11 +822,11 @@ class FlxSprite extends FlxObject
 			dirty = true;
 		return positions;
 	}
-	
+
 	/**
 	 * Sets the sprite's color transformation with control over color offsets.
 	 * With `FlxG.renderTile`, offsets are only supported on OpenFL Next version 3.6.0 or higher.
-	 * 
+	 *
 	 * @param   redMultiplier     The value for the red multiplier, in the range from `0` to `1`.
 	 * @param   greenMultiplier   The value for the green multiplier, in the range from `0` to `1`.
 	 * @param   blueMultiplier    The value for the blue multiplier, in the range from `0` to `1`.
@@ -841,32 +841,32 @@ class FlxSprite extends FlxObject
 	{
 		color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier).to24Bit();
 		alpha = alphaMultiplier;
-		
+
 		colorTransform.setMultipliers(redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier);
 		colorTransform.setOffsets(redOffset, greenOffset, blueOffset, alphaOffset);
-		
+
 		useColorTransform = alpha != 1 || color != 0xffffff || colorTransform.hasRGBOffsets();
 		dirty = true;
 	}
-	
-	private function updateColorTransform():Void
+
+	function updateColorTransform():Void
 	{
 		if (colorTransform == null)
 			colorTransform = new ColorTransform();
-		
+
 		useColorTransform = alpha != 1 || color != 0xffffff;
 		if (useColorTransform)
 			colorTransform.setMultipliers(color.redFloat, color.greenFloat, color.blueFloat, alpha);
 		else
 			colorTransform.setMultipliers(1, 1, 1, 1);
-		
+
 		dirty = true;
 	}
-	
+
 	/**
 	 * Checks to see if a point in 2D world space overlaps this `FlxSprite` object's current displayed pixels.
 	 * This check is ALWAYS made in screen space, and always takes `scrollFactor` into account.
-	 * 
+	 *
 	 * @param   Point    The point in world space you want to check.
 	 * @param   Mask     Used in the pixel hit test to determine what counts as solid.
 	 * @param   Camera   Specify which game camera you want.  If `null`, it will just grab the first global camera.
@@ -881,9 +881,9 @@ class FlxSprite extends FlxObject
 		_point.subtractPoint(offset);
 		_flashPoint.x = (point.x - Camera.scroll.x) - _point.x;
 		_flashPoint.y = (point.y - Camera.scroll.y) - _point.y;
-		
+
 		point.putWeak();
-		
+
 		// 1. Check to see if the point is outside of framePixels rectangle
 		if (_flashPoint.x < 0 || _flashPoint.x > frameWidth || _flashPoint.y < 0 || _flashPoint.y > frameHeight)
 		{
@@ -896,23 +896,23 @@ class FlxSprite extends FlxObject
 			return pixelColor.alpha * alpha >= Mask;
 		}
 	}
-	
+
 	/**
 	 * Internal function to update the current animation frame.
-	 * 
+	 *
 	 * @param   RunOnCpp   Whether the frame should also be recalculated if we're on a non-flash target
 	 */
 	@:noCompletion
-	private function calcFrame(RunOnCpp:Bool = false):Void
+	function calcFrame(RunOnCpp:Bool = false):Void
 	{
 		checkEmptyFrame();
-		
+
 		if (FlxG.renderTile && !RunOnCpp)
 			return;
-		
+
 		updateFramePixels();
 	}
-	
+
 	/**
 	 * Retrieves the `BitmapData` of the current `FlxFrame`. Updates `framePixels`.
 	 */
@@ -920,7 +920,7 @@ class FlxSprite extends FlxObject
 	{
 		if (_frame == null || !dirty)
 			return framePixels;
-		
+
 		// don't try to regenerate frame pixels if _frame already uses it as source of graphics
 		// if you'll try then it will clear framePixels and you won't see anything
 		if (FlxG.renderTile && _frameGraphic != null)
@@ -928,10 +928,10 @@ class FlxSprite extends FlxObject
 			dirty = false;
 			return framePixels;
 		}
-		
+
 		var doFlipX:Bool = checkFlipX();
 		var doFlipY:Bool = checkFlipY();
-		
+
 		if (!doFlipX && !doFlipY && _frame.type == FlxFrameType.REGULAR)
 		{
 			framePixels = _frame.paint(framePixels, _flashPointZero, false, true);
@@ -941,12 +941,12 @@ class FlxSprite extends FlxObject
 			framePixels = _frame.paintRotatedAndFlipped(framePixels, _flashPointZero,
 				FlxFrameAngle.ANGLE_0, doFlipX, doFlipY, false, true);
 		}
-		
+
 		if (useColorTransform)
 		{
 			framePixels.colorTransform(_flashRect, colorTransform);
 		}
-		
+
 		if (FlxG.renderTile && useFramePixels)
 		{
 			//recreate _frame for native target, so it will use modified framePixels
@@ -954,14 +954,14 @@ class FlxSprite extends FlxObject
 			_frameGraphic = FlxGraphic.fromBitmapData(framePixels, false, null, false);
 			_frame = _frameGraphic.imageFrame.frame.copyTo(_frame);
 		}
-		
+
 		dirty = false;
 		return framePixels;
 	}
-	
+
 	/**
 	 * Retrieve the midpoint of this sprite's graphic in world coordinates.
-	 * 
+	 *
 	 * @param   point   Allows you to pass in an existing `FlxPoint` if you're so inclined.
 	 *                  Otherwise a new one is created.
 	 * @return  A `FlxPoint` containing the midpoint of this sprite's graphic in world coordinates.
@@ -972,11 +972,11 @@ class FlxSprite extends FlxObject
 			point = FlxPoint.get();
 		return point.set(x + frameWidth * 0.5, y + frameHeight * 0.5);
 	}
-	
+
 	/**
 	 * Check and see if this object is currently on screen. Differs from `FlxObject`'s implementation
 	 * in that it takes the actual graphic into account, not just the hitbox or bounding box or whatever.
-	 * 
+	 *
 	 * @param   Camera  Specify which game camera you want. If `null`, it will just grab the first global camera.
 	 * @return  Whether the object is on screen or not.
 	 */
@@ -984,19 +984,19 @@ class FlxSprite extends FlxObject
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		var minX:Float = x - offset.x - Camera.scroll.x * scrollFactor.x;
 		var minY:Float = y - offset.y - Camera.scroll.y * scrollFactor.y;
-		
+
 		if ((angle == 0 || bakedRotationAngle > 0) && (scale.x == 1) && (scale.y == 1))
-		{	
+		{
 			_point.set(minX, minY);
 			return Camera.containsPoint(_point, frameWidth, frameHeight);
 		}
-		
+
 		var radiusX:Float = _halfSize.x;
 		var radiusY:Float = _halfSize.y;
-		
+
 		var ox:Float = origin.x;
 		if (ox != radiusX)
 		{
@@ -1004,7 +1004,7 @@ class FlxSprite extends FlxObject
 			var x2:Float = Math.abs(frameWidth - ox);
 			radiusX = Math.max(x2, x1);
 		}
-		
+
 		var oy:Float = origin.y;
 		if (oy != radiusY)
 		{
@@ -1012,39 +1012,39 @@ class FlxSprite extends FlxObject
 			var y2:Float = Math.abs(frameHeight - oy);
 			radiusY = Math.max(y2, y1);
 		}
-		
+
 		radiusX *= Math.abs(scale.x);
 		radiusY *= Math.abs(scale.y);
 		var radius:Float = Math.max(radiusX, radiusY);
 		radius *= FlxMath.SQUARE_ROOT_OF_TWO;
-		
+
 		minX += ox - radius;
 		minY += oy - radius;
-		
+
 		var doubleRadius:Float = 2 * radius;
-		
+
 		_point.set(minX, minY);
 		return Camera.containsPoint(_point, doubleRadius, doubleRadius);
 	}
-	
+
 	/**
 	 * Returns the result of `isSimpleRenderBlit()` if `FlxG.renderBlit` is
 	 * `true`, or `false` if `FlxG.renderTile` is `true`.
 	 */
 	public function isSimpleRender(?camera:FlxCamera):Bool
-	{ 
+	{
 		if (FlxG.renderTile)
 			return false;
-		
+
 		return isSimpleRenderBlit(camera);
 	}
-	
+
 	/**
 	 * Determines the function used for rendering in blitting:
 	 * `copyPixels()` for simple sprites, `draw()` for complex ones.
 	 * Sprites are considered simple when they have an `angle` of `0`, a `scale` of `1`,
 	 * don't use `blend` and `pixelPerfectRender` is `true`.
-	 * 
+	 *
 	 * @param   camera   If a camera is passed its `pixelPerfectRender` flag is taken into account
 	 */
 	public function isSimpleRenderBlit(?camera:FlxCamera):Bool
@@ -1054,10 +1054,10 @@ class FlxSprite extends FlxObject
 		result = result && (camera != null ? isPixelPerfectRender(camera) : pixelPerfectRender);
 		return result;
 	}
-	
+
 	/**
 	 * Set how a sprite flips when facing in a particular direction.
-	 * 
+	 *
 	 * @param   Direction   Use constants from `FlxObject`: `LEFT`, `RIGHT`, `UP`, and `DOWN`.
 	 *                      These may be combined with the bitwise OR operator.
 	 *                      E.g. To make a sprite flip horizontally when it is facing both `UP` and `LEFT`,
@@ -1069,10 +1069,10 @@ class FlxSprite extends FlxObject
 	{
 		_facingFlip.set(Direction, { x: FlipX, y: FlipY });
 	}
-	
+
 	/**
 	 * Sets frames and allows you to save animations in sprite's animation controller
-	 * 
+	 *
 	 * @param   Frames           Frames collection to set for this sprite.
 	 * @param   saveAnimations   Whether to save animations in animation controller or not.
 	 * @return  This sprite with loaded frames
@@ -1087,19 +1087,19 @@ class FlxSprite extends FlxObject
 			var index:Int = 0;
 			var frameIndex:Int = animation.frameIndex;
 			var currName:String = null;
-			
+
 			if (animation.curAnim != null)
 			{
 				reverse = animation.curAnim.reversed;
 				index = animation.curAnim.curFrame;
 				currName = animation.curAnim.name;
 			}
-			
+
 			animation._animations = null;
 			this.frames = Frames;
 			frame = frames.frames[frameIndex];
 			animation._animations = animations;
-			
+
 			if (currName != null)
 			{
 				animation.play(currName, false, reverse, index);
@@ -1109,21 +1109,21 @@ class FlxSprite extends FlxObject
 		{
 			this.frames = Frames;
 		}
-		
+
 		return this;
 	}
-	
+
 	@:noCompletion
-	private function get_pixels():BitmapData
+	function get_pixels():BitmapData
 	{
 		return (graphic == null) ? null : graphic.bitmap;
 	}
-	
+
 	@:noCompletion
-	private function set_pixels(Pixels:BitmapData):BitmapData
+	function set_pixels(Pixels:BitmapData):BitmapData
 	{
 		var key:String = FlxG.bitmap.findKeyForBitmap(Pixels);
-		
+
 		if (key == null)
 		{
 			key = FlxG.bitmap.getUniqueKey();
@@ -1133,13 +1133,13 @@ class FlxSprite extends FlxObject
 		{
 			graphic = FlxG.bitmap.get(key);
 		}
-		
+
 		frames = graphic.imageFrame;
 		return Pixels;
 	}
-	
+
 	@:noCompletion
-	private function set_frame(Value:FlxFrame):FlxFrame
+	function set_frame(Value:FlxFrame):FlxFrame
 	{
 		frame = Value;
 		if (frame != null)
@@ -1156,12 +1156,12 @@ class FlxSprite extends FlxObject
 		{
 			return null;
 		}
-		
+
 		if (FlxG.renderTile)
 		{
 			_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
 		}
-		
+
 		if (clipRect != null)
 		{
 			_frame = frame.clipTo(clipRect, _frame);
@@ -1170,25 +1170,25 @@ class FlxSprite extends FlxObject
 		{
 			_frame = frame.copyTo(_frame);
 		}
-		
+
 		return frame;
 	}
-	
+
 	@:noCompletion
-	private function set_facing(Direction:Int):Int
-	{		
+	function set_facing(Direction:Int):Int
+	{
 		var flip = _facingFlip.get(Direction);
 		if (flip != null)
 		{
 			flipX = flip.x;
 			flipY = flip.y;
 		}
-		
+
 		return facing = Direction;
 	}
-	
+
 	@:noCompletion
-	private function set_alpha(Alpha:Float):Float
+	function set_alpha(Alpha:Float):Float
 	{
 		if (alpha == Alpha)
 		{
@@ -1198,9 +1198,9 @@ class FlxSprite extends FlxObject
 		updateColorTransform();
 		return alpha;
 	}
-	
+
 	@:noCompletion
-	private function set_color(Color:FlxColor):Int
+	function set_color(Color:FlxColor):Int
 	{
 		if (color == Color)
 		{
@@ -1210,9 +1210,9 @@ class FlxSprite extends FlxObject
 		updateColorTransform();
 		return color;
 	}
-	
+
 	@:noCompletion
-	override private function set_angle(Value:Float):Float
+	override function set_angle(Value:Float):Float
 	{
 		var newAngle = (angle != Value);
 		var ret = super.set_angle(Value);
@@ -1223,76 +1223,76 @@ class FlxSprite extends FlxObject
 		}
 		return ret;
 	}
-	
+
 	@:noCompletion
-	private inline function updateTrig():Void
+	inline function updateTrig():Void
 	{
 		if (_angleChanged)
 		{
 			var radians:Float = angle * FlxAngle.TO_RAD;
 			_sinAngle = Math.sin(radians);
 			_cosAngle = Math.cos(radians);
-			_angleChanged = false; 
+			_angleChanged = false;
 		}
 	}
-	
+
 	@:noCompletion
-	private function set_blend(Value:BlendMode):BlendMode 
+	function set_blend(Value:BlendMode):BlendMode
 	{
 		return blend = Value;
 	}
-	
+
 	/**
 	 * Internal function for setting graphic property for this object.
 	 * It changes graphics' `useCount` also for better memory tracking.
 	 */
 	@:noCompletion
-	private function set_graphic(Value:FlxGraphic):FlxGraphic
+	function set_graphic(Value:FlxGraphic):FlxGraphic
 	{
 		var oldGraphic:FlxGraphic = graphic;
-		
+
 		if ((graphic != Value) && (Value != null))
 		{
 			Value.useCount++;
 		}
-		
+
 		if ((oldGraphic != null) && (oldGraphic != Value))
 		{
 			oldGraphic.useCount--;
 		}
-		
+
 		return graphic = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_clipRect(rect:FlxRect):FlxRect
+	function set_clipRect(rect:FlxRect):FlxRect
 	{
 		if (rect != null)
 			clipRect = rect.round();
 		else
 			clipRect = null;
-		
+
 		if (frames != null)
 			frame = frames.frames[animation.frameIndex];
-		
+
 		return rect;
 	}
-	
+
 	/**
 	 * Frames setter. Used by `loadGraphic` methods, but you can load generated frames yourself
 	 * (this should be even faster since engine doesn't need to do bunch of additional stuff).
-	 * 
+	 *
 	 * @param   Frames   frames to load into this sprite.
 	 * @return  loaded frames.
 	 */
 	@:noCompletion
-	private function set_frames(Frames:FlxFramesCollection):FlxFramesCollection
+	function set_frames(Frames:FlxFramesCollection):FlxFramesCollection
 	{
 		if (animation != null)
 		{
 			animation.destroyAnimations();
 		}
-		
+
 		if (Frames != null)
 		{
 			graphic = Frames.parent;
@@ -1310,13 +1310,13 @@ class FlxSprite extends FlxObject
 			frame = null;
 			graphic = null;
 		}
-		
+
 		clipRect = null;
 		return Frames;
 	}
-	
+
 	@:noCompletion
-	private function set_flipX(Value:Bool):Bool
+	function set_flipX(Value:Bool):Bool
 	{
 		if (FlxG.renderTile)
 		{
@@ -1325,9 +1325,9 @@ class FlxSprite extends FlxObject
 		dirty = (flipX != Value) || dirty;
 		return flipX = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_flipY(Value:Bool):Bool
+	function set_flipY(Value:Bool):Bool
 	{
 		if (FlxG.renderTile)
 		{
@@ -1336,15 +1336,15 @@ class FlxSprite extends FlxObject
 		dirty = (flipY != Value) || dirty;
 		return flipY = Value;
 	}
-	
+
 	@:noCompletion
-	private function set_antialiasing(value:Bool):Bool
+	function set_antialiasing(value:Bool):Bool
 	{
 		return antialiasing = value;
 	}
-	
+
 	@:noCompletion
-	private function set_useFramePixels(value:Bool):Bool
+	function set_useFramePixels(value:Bool):Bool
 	{
 		if (FlxG.renderTile)
 		{
@@ -1352,13 +1352,13 @@ class FlxSprite extends FlxObject
 			{
 				useFramePixels = value;
 				resetFrame();
-				
+
 				if (value)
 				{
 					updateFramePixels();
 				}
 			}
-			
+
 			return value;
 		}
 		else
@@ -1367,9 +1367,9 @@ class FlxSprite extends FlxObject
 			return true;
 		}
 	}
-	
+
 	@:noCompletion
-	private inline function checkFlipX():Bool
+	inline function checkFlipX():Bool
 	{
 		var doFlipX = (flipX != _frame.flipX);
 		if (animation.curAnim != null)
@@ -1378,9 +1378,9 @@ class FlxSprite extends FlxObject
 		}
 		return doFlipX;
 	}
-	
+
 	@:noCompletion
-	private inline function checkFlipY():Bool
+	inline function checkFlipY():Bool
 	{
 		var doFlipY = (flipY != _frame.flipY);
 		if (animation.curAnim != null)
@@ -1391,7 +1391,7 @@ class FlxSprite extends FlxObject
 	}
 }
 
-interface IFlxSprite extends IFlxBasic 
+interface IFlxSprite extends IFlxBasic
 {
 	public var x(default, set):Float;
 	public var y(default, set):Float;
@@ -1400,7 +1400,7 @@ interface IFlxSprite extends IFlxBasic
 	public var facing(default, set):Int;
 	public var moves(default, set):Bool;
 	public var immovable(default, set):Bool;
-	
+
 	public var offset(default, null):FlxPoint;
 	public var origin(default, null):FlxPoint;
 	public var scale(default, null):FlxPoint;

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -23,7 +23,7 @@ class FlxState extends FlxGroup
 	 * For example, if you have your game state first, and then you push a menu state on top of it,
 	 * if this is set to `true`, the game state would continue to be drawn behind the pause state.
 	 * By default this is `true`, so background states will continue to be drawn behind the current state.
-	 * 
+	 *
 	 * If background states are not `visible` when you have a different state on top,
 	 * you should set this to `false` for improved performance.
 	 */
@@ -34,28 +34,28 @@ class FlxState extends FlxGroup
 	 * `false` might reduce state creation time, at greater memory cost.
 	 */
 	public var destroySubStates:Bool = true;
-	
+
 	/**
 	 * The natural background color the cameras default to. In `AARRGGBB` format.
 	 */
 	public var bgColor(get, set):FlxColor;
-	
+
 	/**
 	 * Current substate. Substates also can be nested.
 	 */
 	public var subState(default, null):FlxSubState;
-	
+
 	/**
 	 * If a state change was requested, the new state object is stored here until we switch to it.
 	 */
 	@:noCompletion
-	private var _requestedSubState:FlxSubState;
+	var _requestedSubState:FlxSubState;
 
 	/**
 	 * Whether to reset the substate (when it changes, or when it's closed).
 	 */
 	@:noCompletion
-	private var _requestSubStateReset:Bool = false;
+	var _requestSubStateReset:Bool = false;
 
 	/**
 	 * This function is called after the game engine successfully switches states.
@@ -68,17 +68,17 @@ class FlxState extends FlxGroup
 	{
 		if (persistentDraw || subState == null)
 			super.draw();
-		
+
 		if (subState != null)
 			subState.draw();
 	}
-	
+
 	public function openSubState(SubState:FlxSubState):Void
 	{
 		_requestSubStateReset = true;
 		_requestedSubState = SubState;
 	}
-	
+
 	/**
 	 * Closes the substate of this state, if one exists.
 	 */
@@ -101,19 +101,19 @@ class FlxState extends FlxGroup
 			if (destroySubStates)
 				subState.destroy();
 		}
-		
+
 		// Assign the requested state (or set it to null)
 		subState = _requestedSubState;
 		_requestedSubState = null;
-		
+
 		if (subState != null)
 		{
 			// Reset the input so things like "justPressed" won't interfere
 			if (!persistentUpdate)
 				FlxG.inputs.onStateSwitch();
-			
+
 			subState._parentState = this;
-			
+
 			if (!subState._created)
 			{
 				subState._created = true;
@@ -133,18 +133,18 @@ class FlxState extends FlxGroup
 		}
 		super.destroy();
 	}
-	
+
 	/**
 	 * Called from `FlxG.switchState()`. If `false` is returned, the state
 	 * switch is cancelled - the default implementation returns `true`.
-	 * 
+	 *
 	 * Useful for customizing state switches, e.g. for transition effects.
 	 */
 	public function switchTo(nextState:FlxState):Bool
 	{
 		return true;
 	}
-	
+
 	/**
 	 * This method is called after the game loses focus.
 	 * Can be useful for third party libraries, such as tweening engines.
@@ -159,18 +159,18 @@ class FlxState extends FlxGroup
 
 	/**
 	 * This function is called whenever the window size has been changed.
-	 * 
+	 *
 	 * @param   Width    The new window width
 	 * @param   Height   The new window Height
 	 */
 	public function onResize(Width:Int, Height:Int):Void {}
-	
+
 	@:allow(flixel.FlxGame)
-	private function tryUpdate(elapsed:Float):Void
+	function tryUpdate(elapsed:Float):Void
 	{
 		if (persistentUpdate || subState == null)
 			update(elapsed);
-		
+
 		if (_requestSubStateReset)
 		{
 			_requestSubStateReset = false;
@@ -183,13 +183,13 @@ class FlxState extends FlxGroup
 	}
 
 	@:noCompletion
-	private function get_bgColor():FlxColor
+	function get_bgColor():FlxColor
 	{
 		return FlxG.cameras.bgColor;
 	}
 
 	@:noCompletion
-	private function set_bgColor(Value:FlxColor):FlxColor
+	function set_bgColor(Value:FlxColor):FlxColor
 	{
 		return FlxG.cameras.bgColor = Value;
 	}

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -20,27 +20,27 @@ class FlxSubState extends FlxState
 	 * Callback method for state close event.
 	 */
 	public var closeCallback:Void->Void;
-	
+
 	/**
 	 * Helper sprite object for non-flash targets. Draws the background.
 	 */
 	@:noCompletion
-	private var _bgSprite:FlxBGSprite;
-	
+	var _bgSprite:FlxBGSprite;
+
 	/**
 	 * Helper var for `close()` so `closeSubState()` can be called on the parent.
 	 */
 	@:noCompletion
 	@:allow(flixel.FlxState.resetSubState)
-	private var _parentState:FlxState;
-	
+	var _parentState:FlxState;
+
 	@:noCompletion
-	private var _bgColor:FlxColor;
+	var _bgColor:FlxColor;
 
 	@:noCompletion
 	@:allow(flixel.FlxState.resetSubState)
-	private var _created:Bool = false;
-	
+	var _created:Bool = false;
+
 	/**
 	 * @param   BGColor   background color for this substate
 	 */
@@ -49,12 +49,12 @@ class FlxSubState extends FlxState
 		super();
 		closeCallback = null;
 		openCallback = null;
-		
+
 		if (FlxG.renderTile)
 			_bgSprite = new FlxBGSprite();
 		bgColor = BGColor;
 	}
-	
+
 	override public function draw():Void
 	{
 		//Draw background
@@ -69,12 +69,12 @@ class FlxSubState extends FlxState
 		{
 			_bgSprite.draw();
 		}
-		
+
 		//Now draw all children
 		super.draw();
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		closeCallback = null;
@@ -82,7 +82,7 @@ class FlxSubState extends FlxState
 		_parentState = null;
 		_bgSprite = null;
 	}
-	
+
 	/**
 	 * Closes this substate.
 	 */
@@ -91,19 +91,19 @@ class FlxSubState extends FlxState
 		if (_parentState != null && _parentState.subState == this)
 			_parentState.closeSubState();
 	}
-	
+
 	@:noCompletion
-	override private inline function get_bgColor():FlxColor
+	override inline function get_bgColor():FlxColor
 	{
 		return _bgColor;
 	}
-	
+
 	@:noCompletion
-	override private function set_bgColor(Value:FlxColor):FlxColor
+	override function set_bgColor(Value:FlxColor):FlxColor
 	{
 		if (FlxG.renderTile && _bgSprite != null)
 			_bgSprite.pixels.setPixel32(0, 0, Value);
-		
+
 		return _bgColor = Value;
 	}
 }

--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -11,64 +11,64 @@ class FlxAnimation extends FlxBaseAnimation
 	 * Animation frameRate - the speed in frames per second that the animation should play at.
 	 */
 	public var frameRate(default, set):Int;
-	
+
 	/**
 	 * Keeps track of the current frame of animation.
 	 * This is NOT an index into the tile sheet, but the frame number in the animation object.
 	 */
 	public var curFrame(default, set):Int = 0;
-	
+
 	/**
 	 * Accessor for `frames.length`
 	 */
 	public var numFrames(get, null):Int;
-	
+
 	/**
 	 * Seconds between frames (basically the framerate)
 	 */
 	public var delay(default, null):Float = 0;
-	
+
 	/**
 	 * Whether the current animation has finished.
 	 */
 	public var finished(default, null):Bool = true;
-	
+
 	/**
 	 * Whether the current animation gets updated or not.
 	 */
 	public var paused:Bool = true;
-	
+
 	/**
 	 * Whether or not the animation is looped.
 	 */
 	public var looped(default, null):Bool = true;
-	
+
 	/**
 	 * Whether or not this animation is being played backwards.
 	 */
 	public var reversed(default, null):Bool = false;
-	
+
 	/**
 	 * Whether or not the frames of this animation are horizontally flipped
 	 */
 	public var flipX:Bool = false;
-	
+
 	/**
 	 * Whether or not the frames of this animation are vertically flipped
 	 */
 	public var flipY:Bool = false;
-	
+
 	/**
 	 * A list of frames stored as int indices
 	 * @since 4.2.0
 	 */
 	public var frames:Array<Int>;
-	
+
 	/**
 	 * Internal, used to time each frame of animation.
 	 */
-	private var _frameTimer:Float = 0;
-	
+	var _frameTimer:Float = 0;
+
 	/**
 	 * @param   Name        What this animation should be called (e.g. `"run"`).
 	 * @param   Frames      An array of numbers indicating what frames to play in what order (e.g. `[1, 2, 3]`).
@@ -81,14 +81,14 @@ class FlxAnimation extends FlxBaseAnimation
 		Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false)
 	{
 		super(Parent, Name);
-		
+
 		frameRate = FrameRate;
 		frames = Frames;
 		looped = Looped;
 		flipX = FlipX;
 		flipY = FlipY;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -98,10 +98,10 @@ class FlxAnimation extends FlxBaseAnimation
 		name = null;
 		super.destroy();
 	}
-	
+
 	/**
 	 * Starts this animation playback.
-	 * 
+	 *
 	 * @param   Force      Whether to force this animation to restart.
 	 * @param   Reversed   Whether to play animation backwards or not.
 	 * @param   Frame      The frame number in this animation you want to start from (`0` by default).
@@ -118,7 +118,7 @@ class FlxAnimation extends FlxBaseAnimation
 			finished = false;
 			return;
 		}
-		
+
 		reversed = Reversed;
 		paused = false;
 		_frameTimer = 0;
@@ -135,51 +135,51 @@ class FlxAnimation extends FlxBaseAnimation
 				Frame = (maxFrameIndex - Frame);
 			curFrame = Frame;
 		}
-		
+
 		if (finished)
 			parent.fireFinishCallback(name);
 	}
-	
+
 	public function restart():Void
 	{
 		play(true, reversed);
 	}
-	
+
 	public function stop():Void
 	{
 		finished = true;
 		paused = true;
 	}
-	
+
 	public function reset():Void
 	{
 		stop();
 		curFrame = reversed ? (numFrames - 1) : 0;
 	}
-	
+
 	public function finish():Void
 	{
 		stop();
 		curFrame = reversed ? 0 : (numFrames - 1);
 	}
-	
+
 	public function pause():Void
 	{
 		paused = true;
 	}
-	
+
 	public inline function resume():Void
 	{
 		paused = false;
 	}
-	
+
 	public function reverse():Void
 	{
 		reversed = !reversed;
 		if (finished)
 			play(false, reversed);
 	}
-	
+
 	override public function update(elapsed:Float):Void
 	{
 		if (delay == 0 || finished || paused)
@@ -205,13 +205,13 @@ class FlxAnimation extends FlxBaseAnimation
 			}
 		}
 	}
-	
+
 	override public function clone(Parent:FlxAnimationController):FlxAnimation
 	{
 		return new FlxAnimation(Parent, name, frames, frameRate, looped, flipX, flipY);
 	}
-	
-	private function set_frameRate(value:Int):Int
+
+	function set_frameRate(value:Int):Int
 	{
 		delay = 0;
 		frameRate = value;
@@ -219,12 +219,12 @@ class FlxAnimation extends FlxBaseAnimation
 			delay = 1.0 / value;
 		return value;
 	}
-	
-	private function set_curFrame(Frame:Int):Int
+
+	function set_curFrame(Frame:Int):Int
 	{
 		var maxFrameIndex:Int = numFrames - 1;
 		var tempFrame:Int = (reversed) ? (maxFrameIndex - Frame) : Frame;
-		
+
 		if (tempFrame >= 0)
 		{
 			if (!looped && Frame > maxFrameIndex)
@@ -239,16 +239,16 @@ class FlxAnimation extends FlxBaseAnimation
 		}
 		else
 			curFrame = FlxG.random.int(0, maxFrameIndex);
-		
+
 		curIndex = frames[curFrame];
-		
+
 		if (finished && parent != null)
 			parent.fireFinishCallback(name);
-		
+
 		return Frame;
 	}
-	
-	private inline function get_numFrames():Int
+
+	inline function get_numFrames():Int
 	{
 		return frames.length;
 	}

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -11,75 +11,75 @@ class FlxAnimationController implements IFlxDestroyable
 	 * Property access for currently playing animation (warning: can be `null`).
 	 */
 	public var curAnim(get, set):FlxAnimation;
-	
+
 	/**
 	 * The frame index of the current animation. Can be changed manually.
 	 */
 	public var frameIndex(default, set):Int = -1;
-	
+
 	/**
 	 * Tell the sprite to change to a frame with specific name.
 	 * Useful for sprites with loaded TexturePacker atlas.
 	 */
 	public var frameName(get, set):String;
-	
+
 	/**
 	 * Gets or sets the currently playing animation (warning: can be `null`).
 	 */
 	public var name(get, set):String;
-	
+
 	/**
 	 * Pause or resume the current animation.
 	 */
 	public var paused(get, set):Bool;
-	
+
 	/**
 	 * Whether the current animation has finished playing.
 	 */
 	public var finished(get, set):Bool;
-	
+
 	/**
 	 * The total number of frames in this image.
 	 * WARNING: assumes each row in the sprite sheet is full!
 	 */
 	public var frames(get, null):Int;
-	
+
 	/**
 	 * If assigned, will be called each time the current animation's frame changes.
 	 * A function that has 3 parameters: a string name, a frame number, and a frame index.
 	 */
 	public var callback:String->Int->Int->Void;
-	
+
 	/**
 	 * If assigned, will be called each time the current animation finishes.
 	 * A function that has 1 parameter: a string name - animation name.
 	 */
 	public var finishCallback:String->Void;
-	
+
 	/**
 	 * Internal, reference to owner sprite.
 	 */
-	private var _sprite:FlxSprite;
-	
+	var _sprite:FlxSprite;
+
 	/**
 	 * Internal, currently playing animation.
 	 */
 	@:allow(flixel.animation)
-	private var _curAnim:FlxAnimation;
-	
+	var _curAnim:FlxAnimation;
+
 	/**
 	 * Internal, stores all the animation that were added to this sprite.
 	 */
-	private var _animations(default, null):Map<String, FlxAnimation>;
-	
-	private var _prerotated:FlxPrerotatedAnimation;
-	
+	var _animations(default, null):Map<String, FlxAnimation>;
+
+	var _prerotated:FlxPrerotatedAnimation;
+
 	public function new(Sprite:FlxSprite)
 	{
 		_sprite = Sprite;
 		_animations = new Map<String, FlxAnimation>();
 	}
-	
+
 	public function update(elapsed:Float):Void
 	{
 		if (_curAnim != null)
@@ -91,31 +91,31 @@ class FlxAnimationController implements IFlxDestroyable
 			_prerotated.angle = _sprite.angle;
 		}
 	}
-	
+
 	public function copyFrom(controller:FlxAnimationController):FlxAnimationController
 	{
 		destroyAnimations();
-		
+
 		for (anim in controller._animations)
 		{
 			add(anim.name, anim.frames, anim.frameRate, anim.looped, anim.flipX, anim.flipY);
 		}
-		
+
 		if (controller._prerotated != null)
 		{
 			createPrerotated();
 		}
-		
+
 		if (controller.name != null)
 		{
 			name = controller.name;
 		}
-		
+
 		frameIndex = controller.frameIndex;
-		
+
 		return this;
 	}
-	
+
 	public function createPrerotated(?Controller:FlxAnimationController):Void
 	{
 		destroyAnimations();
@@ -123,13 +123,13 @@ class FlxAnimationController implements IFlxDestroyable
 		_prerotated = new FlxPrerotatedAnimation(Controller, Controller._sprite.bakedRotationAngle);
 		_prerotated.angle = _sprite.angle;
 	}
-	
+
 	public function destroyAnimations():Void
 	{
 		clearAnimations();
 		clearPrerotated();
 	}
-	
+
 	public function destroy():Void
 	{
 		destroyAnimations();
@@ -137,8 +137,8 @@ class FlxAnimationController implements IFlxDestroyable
 		callback = null;
 		_sprite = null;
 	}
-	
-	private function clearPrerotated():Void
+
+	function clearPrerotated():Void
 	{
 		if (_prerotated != null)
 		{
@@ -146,8 +146,8 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		_prerotated = null;
 	}
-	
-	private function clearAnimations():Void
+
+	function clearAnimations():Void
 	{
 		if (_animations != null)
 		{
@@ -161,14 +161,14 @@ class FlxAnimationController implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		_animations = new Map<String, FlxAnimation>();
 		_curAnim = null;
 	}
-	
+
 	/**
 	 * Adds a new animation to the sprite.
-	 * 
+	 *
 	 * @param   Name        What this animation should be called (e.g. `"run"`).
 	 * @param   Frames      An array of indices indicating what frames to play in what order (e.g. `[0, 1, 2]`).
 	 * @param   FrameRate   The speed in frames per second that the animation should play at (e.g. `40` fps).
@@ -192,22 +192,22 @@ class FlxAnimationController implements IFlxDestroyable
 				{
 					framesToAdd = Frames.copy();
 				}
-				
+
 				framesToAdd.splice(i, 1);
 			}
 			i--;
 		}
-		
+
 		if (framesToAdd.length > 0)
 		{
 			var anim = new FlxAnimation(this, Name, framesToAdd, FrameRate, Looped, FlipX, FlipY);
 			_animations.set(Name, anim);
 		}
 	}
-	
+
 	/**
 	 * Removes (and destroys) an animation.
-	 * 
+	 *
 	 * @param   Name   The name of animation to remove.
 	 */
 	public function remove(Name:String):Void
@@ -219,12 +219,12 @@ class FlxAnimationController implements IFlxDestroyable
 			anim.destroy();
 		}
 	}
-	
+
 	/**
 	 * Adds to an existing animation in the sprite by appending the specified frames to the existing frames.
 	 * Use this method when the indices of the frames in the atlas are already known.
 	 * The animation must already exist in order to append frames to it.
-	 * 
+	 *
 	 * @param   Name     What the existing animation is called (e.g. `"run"`).
 	 * @param   Frames   An array of indices indicating what frames to append (e.g. `[0, 1, 2]`).
 	 */
@@ -237,7 +237,7 @@ class FlxAnimationController implements IFlxDestroyable
 			FlxG.log.warn("No animation called \"" + Name + "\"");
 			return;
 		}
-		
+
 		// Check _animations frames
 		var numFrames:Int = Frames.length - 1;
 		var i:Int = numFrames;
@@ -251,10 +251,10 @@ class FlxAnimationController implements IFlxDestroyable
 			i--;
 		}
 	}
-	
+
 	/**
 	 * Adds a new animation to the sprite.
-	 * 
+	 *
 	 * @param   Name         What this animation should be called (e.g. `"run"`).
 	 * @param   FrameNames   An array of image names from the atlas indicating what frames to play in what order.
 	 * @param   FrameRate    The speed in frames per second that the animation should play at (e.g. `40` fps).
@@ -269,7 +269,7 @@ class FlxAnimationController implements IFlxDestroyable
 		{
 			var indices:Array<Int> = new Array<Int>();
 			byNamesHelper(indices, FrameNames); // finds frames and appends them to the blank array
-			
+
 			if (indices.length > 0)
 			{
 				var anim = new FlxAnimation(this, Name, indices, FrameRate, Looped, FlipX, FlipY);
@@ -277,12 +277,12 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
+
 	/**
 	 * Adds to an existing animation in the sprite by appending the specified frames to the existing frames.
 	 * Use this method when the exact name of each frame from the atlas is known (e.g. `"walk00.png"`, `"walk01.png"`).
 	 * The animation must already exist in order to append frames to it.
-	 * 
+	 *
 	 * @param   Name         What the existing animation is called (e.g. `"run"`).
 	 * @param   FrameNames   An array of image names from atlas indicating what frames to append.
 	 */
@@ -294,16 +294,16 @@ class FlxAnimationController implements IFlxDestroyable
 			FlxG.log.warn("No animation called \"" + Name + "\"");
 			return;
 		}
-		
+
 		if (_sprite.frames != null)
 		{
 			byNamesHelper(anim.frames, FrameNames); // finds frames and appends them to the existing array
 		}
 	}
-	
+
 	/**
 	 * Adds a new animation to the sprite. Should be slightly faster than `addByIndices()`.
-	 * 
+	 *
 	 * @param   Name        What this animation should be called (e.g. `"run"`).
 	 * @param   Prefix      Common beginning of image names in the atlas (e.g. `"tiles-"`).
 	 * @param   Indices     An array of strings indicating what frames to play in what order
@@ -322,7 +322,7 @@ class FlxAnimationController implements IFlxDestroyable
 			var frameIndices:Array<Int> = new Array<Int>();
 			// finds frames and appends them to the blank array
 			byStringIndicesHelper(frameIndices, Prefix, Indices, Postfix);
-			
+
 			if (frameIndices.length > 0)
 			{
 				var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
@@ -330,13 +330,13 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
+
 	/**
 	 * Adds to an existing animation in the sprite by appending the specified frames to the existing frames.
 	 * Should be slightly faster than `appendByIndices()`. Use this method when the names of each frame from
 	 * the atlas share a common prefix and postfix (e.g. `"walk00.png"`, `"walk01.png"`).
 	 * The animation must already exist in order to append frames to it. FrameRate and Looped are unchanged.
-	 * 
+	 *
 	 * @param   Name      What the existing animation is called (e.g. `"run"`).
 	 * @param   Prefix    Common beginning of image names in the atlas (e.g. `"tiles-"`).
 	 * @param   Indices   An array of strings indicating what frames to append (e.g. `["01", "02", "03"]`).
@@ -350,17 +350,17 @@ class FlxAnimationController implements IFlxDestroyable
 			FlxG.log.warn("No animation called \"" + Name + "\"");
 			return;
 		}
-		
+
 		if (_sprite.frames != null)
 		{
 			// finds frames and appends them to the existing array
 			byStringIndicesHelper(anim.frames, Prefix, Indices, Postfix);
 		}
 	}
-	
+
 	/**
 	 * Adds a new animation to the sprite.
-	 * 
+	 *
 	 * @param   Name        What this animation should be called (e.g. `"run"`).
 	 * @param   Prefix      Common beginning of image names in the atlas (e.g. "tiles-").
 	 * @param   Indices     An array of numbers indicating what frames to play in what order (e.g. `[0, 1, 2]`).
@@ -378,7 +378,7 @@ class FlxAnimationController implements IFlxDestroyable
 			var frameIndices:Array<Int> = new Array<Int>();
 			// finds frames and appends them to the blank array
 			byIndicesHelper(frameIndices, Prefix, Indices, Postfix);
-			
+
 			if (frameIndices.length > 0)
 			{
 				var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
@@ -386,14 +386,14 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
+
 	/**
 	 * Adds to an existing animation in the sprite by appending the specified frames to the existing frames.
 	 * Use this method when the names of each frame from the atlas share a common prefix
 	 * and postfix (e.g. `"walk00.png"`, `"walk01.png"`).
 	 * Leading zeroes are ignored for matching indices (`5` will match `"5"` and `"005"`).
 	 * The animation must already exist in order to append frames to it.
-	 * 
+	 *
 	 * @param   Name      What the existing animation is called (e.g. `"run"`).
 	 * @param   Prefix    Common beginning of image names in atlas (e.g. `"tiles-"`).
 	 * @param   Indices   An array of numbers indicating what frames to append (e.g. `[0, 1, 2]`).
@@ -407,21 +407,21 @@ class FlxAnimationController implements IFlxDestroyable
 			FlxG.log.warn("No animation called \"" + Name + "\"");
 			return;
 		}
-		
+
 		if (_sprite.frames != null)
 		{
 			// finds frames and appends them to the existing array
 			byIndicesHelper(anim.frames, Prefix, Indices, Postfix);
 		}
 	}
-	
+
 	/**
 	 * Find a sprite frame so that for `Prefix = "file"; Index = 5; Postfix = ".png"`
 	 * It will find frame with name `"file5.png"`. If it doesn't exist it will try
 	 * to find `"file05.png"`, allowing 99 frames per animation.
 	 * Returns the found frame or `-1` on failure.
 	 */
-	private function findSpriteFrame(Prefix:String, Index:Int, Postfix:String):Int
+	function findSpriteFrame(Prefix:String, Index:Int, Postfix:String):Int
 	{
 		var numFrames:Int = frames;
 		var flxFrames:Array<FlxFrame> = _sprite.frames.frames;
@@ -437,13 +437,13 @@ class FlxAnimationController implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		return -1;
 	}
-	
+
 	/**
 	 * Adds a new animation to the sprite.
-	 * 
+	 *
 	 * @param   Name        What this animation should be called (e.g. `"run"`).
 	 * @param   Prefix      Common beginning of image names in atlas (e.g. `"tiles-"`).
 	 * @param   FrameRate   The speed in frames per second that the animation should play at (e.g. `40` fps).
@@ -458,12 +458,12 @@ class FlxAnimationController implements IFlxDestroyable
 		{
 			var animFrames:Array<FlxFrame> = new Array<FlxFrame>();
 			findByPrefix(animFrames, Prefix); // adds valid frames to animFrames
-			
+
 			if (animFrames.length > 0)
 			{
 				var frameIndices:Array<Int> = new Array<Int>();
 				byPrefixHelper(frameIndices, animFrames, Prefix); // finds frames and appends them to the blank array
-				
+
 				if (frameIndices.length > 0)
 				{
 					var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
@@ -472,14 +472,14 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
+
 	/**
 	 * Adds to an existing animation in the sprite by appending the specified frames to the existing frames.
 	 * Use this method when the names of each frame from the atlas share a common prefix
 	 * (e.g. `"walk00.png"`, `"walk01.png"`).
 	 * Frames are sorted numerically while ignoring postfixes (e.g. `".png"`, `".gif"`).
 	 * The animation must already exist in order to append frames to it.
-	 * 
+	 *
 	 * @param   Name     What the existing animation is called (e.g. `"run"`).
 	 * @param   Prefix   Common beginning of image names in atlas (e.g. `"tiles-"`)
 	 */
@@ -491,12 +491,12 @@ class FlxAnimationController implements IFlxDestroyable
 			FlxG.log.warn("No animation called \"" + Name + "\"");
 			return;
 		}
-		
+
 		if (_sprite.frames != null)
 		{
 			var animFrames:Array<FlxFrame> = new Array<FlxFrame>();
 			findByPrefix(animFrames, Prefix); // adds valid frames to animFrames
-			
+
 			if (animFrames.length > 0)
 			{
 				// finds frames and appends them to the existing array
@@ -504,11 +504,11 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
+
 	/**
 	 * Plays an existing animation (e.g. `"run"`).
 	 * If you call an animation that is already playing, it will be ignored.
-	 * 
+	 *
 	 * @param   AnimName   The string name of the animation you want to play.
 	 * @param   Force      Whether to force the animation to restart.
 	 * @param   Reversed   Whether to play animation backwards or not.
@@ -525,16 +525,16 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 			_curAnim = null;
 		}
-		
+
 		if (AnimName == null || _animations.get(AnimName) == null)
 		{
 			FlxG.log.warn("No animation called \"" + AnimName + "\"");
 			return;
 		}
-		
+
 		var oldFlipX:Bool = false;
 		var oldFlipY:Bool = false;
-		
+
 		if (_curAnim != null && AnimName != _curAnim.name)
 		{
 			oldFlipX = _curAnim.flipX;
@@ -543,13 +543,13 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		_curAnim = _animations.get(AnimName);
 		_curAnim.play(Force, Reversed, Frame);
-		
+
 		if (oldFlipX != _curAnim.flipX || oldFlipY != _curAnim.flipY)
 		{
 			_sprite.dirty = true;
 		}
 	}
-	
+
 	/**
 	 * Stops current animation and resets its frame index to zero.
 	 */
@@ -560,7 +560,7 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.reset();
 		}
 	}
-	
+
 	/**
 	 * Stops current animation and sets its frame to the last one.
 	 */
@@ -571,7 +571,7 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.finish();
 		}
 	}
-	
+
 	/**
 	 * Just stops current animation.
 	 */
@@ -582,7 +582,7 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.stop();
 		}
 	}
-	
+
 	/**
 	 * Pauses the current animation.
 	 */
@@ -593,7 +593,7 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.pause();
 		}
 	}
-	
+
 	/**
 	 * Resumes the current animation if it exists.
 	 */
@@ -604,7 +604,7 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.resume();
 		}
 	}
-	
+
 	/**
 	 * Reverses current animation if it exists.
 	 */
@@ -615,15 +615,15 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.reverse();
 		}
 	}
-	
+
 	/**
 	 * Gets the FlxAnimation object with the specified name.
 	 */
 	public inline function getByName(Name:String):FlxAnimation
 	{
-		return _animations.get(Name); 
+		return _animations.get(Name);
 	}
-	
+
 	/**
 	 * Changes to a random animation frame.
 	 * Useful for instantiating particles or other weird things.
@@ -637,8 +637,8 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		frameIndex = FlxG.random.int(0, frames - 1);
 	}
-	
-	private inline function fireCallback():Void
+
+	inline function fireCallback():Void
 	{
 		if (callback != null)
 		{
@@ -647,17 +647,17 @@ class FlxAnimationController implements IFlxDestroyable
 			callback(name, number, frameIndex);
 		}
 	}
-	
+
 	@:allow(flixel.animation)
-	private inline function fireFinishCallback(?name:String):Void
+	inline function fireFinishCallback(?name:String):Void
 	{
 		if (finishCallback != null)
 		{
 			finishCallback(name);
 		}
 	}
-	
-	private function byNamesHelper(AddTo:Array<Int>, FrameNames:Array<String>):Void
+
+	function byNamesHelper(AddTo:Array<Int>, FrameNames:Array<String>):Void
 	{
 		for (frameName in FrameNames)
 		{
@@ -668,8 +668,8 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
-	private function byStringIndicesHelper(AddTo:Array<Int>, Prefix:String, Indices:Array<String>, Postfix:String):Void
+
+	function byStringIndicesHelper(AddTo:Array<Int>, Prefix:String, Indices:Array<String>, Postfix:String):Void
 	{
 		for (index in Indices)
 		{
@@ -682,32 +682,32 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 	}
 
-	private function byIndicesHelper(AddTo:Array<Int>, Prefix:String, Indices:Array<Int>, Postfix:String):Void
+	function byIndicesHelper(AddTo:Array<Int>, Prefix:String, Indices:Array<Int>, Postfix:String):Void
 	{
 		for (index in Indices)
 		{
 			var indexToAdd:Int = findSpriteFrame(Prefix, index, Postfix);
-			if (indexToAdd != -1) 
+			if (indexToAdd != -1)
 			{
 				AddTo.push(indexToAdd);
 			}
 		}
 	}
-	
-	private function byPrefixHelper(AddTo:Array<Int>, AnimFrames:Array<FlxFrame>, Prefix:String):Void
+
+	function byPrefixHelper(AddTo:Array<Int>, AnimFrames:Array<FlxFrame>, Prefix:String):Void
 	{
 		var name:String = AnimFrames[0].name;
 		var postIndex:Int = name.indexOf(".", Prefix.length);
 		var postFix:String = name.substring(postIndex == -1 ? name.length : postIndex, name.length);
 		FlxFrame.sort(AnimFrames, Prefix.length, postFix.length);
-		
+
 		for (animFrame in AnimFrames)
 		{
 			AddTo.push(getFrameIndex(animFrame));
 		}
 	}
-	
-	private function findByPrefix(AnimFrames:Array<FlxFrame>, Prefix:String):Void
+
+	function findByPrefix(AnimFrames:Array<FlxFrame>, Prefix:String):Void
 	{
 		for (frame in _sprite.frames.frames)
 		{
@@ -717,8 +717,8 @@ class FlxAnimationController implements IFlxDestroyable
 			}
 		}
 	}
-	
-	private function set_frameIndex(Frame:Int):Int
+
+	function set_frameIndex(Frame:Int):Int
 	{
 		if (_sprite.frames != null && frames > 0)
 		{
@@ -727,16 +727,16 @@ class FlxAnimationController implements IFlxDestroyable
 			frameIndex = Frame;
 			fireCallback();
 		}
-		
+
 		return frameIndex;
 	}
-	
-	private inline function get_frameName():String
+
+	inline function get_frameName():String
 	{
 		return _sprite.frame.name;
 	}
-	
-	private function set_frameName(Value:String):String
+
+	function set_frameName(Value:String):String
 	{
 		if (_sprite.frames != null && _sprite.frames.framesHash.exists(Value))
 		{
@@ -745,18 +745,18 @@ class FlxAnimationController implements IFlxDestroyable
 				_curAnim.stop();
 				_curAnim = null;
 			}
-			
+
 			var frame = _sprite.frames.framesHash.get(Value);
 			if (frame != null)
 			{
 				frameIndex = getFrameIndex(frame);
 			}
 		}
-		
+
 		return Value;
 	}
-	
-	private function get_name():String
+
+	function get_name():String
 	{
 		var animName:String = null;
 		if (_curAnim != null)
@@ -765,27 +765,27 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		return animName;
 	}
-	
-	private function set_name(AnimName:String):String
+
+	function set_name(AnimName:String):String
 	{
 		play(AnimName);
 		return AnimName;
 	}
-	
-	private inline function get_curAnim():FlxAnimation
+
+	inline function get_curAnim():FlxAnimation
 	{
 		return _curAnim;
 	}
-	
-	private inline function set_curAnim(Anim:FlxAnimation):FlxAnimation
+
+	inline function set_curAnim(Anim:FlxAnimation):FlxAnimation
 	{
 		if (Anim != _curAnim)
 		{
-			if (_curAnim != null) 
+			if (_curAnim != null)
 			{
 				_curAnim.stop();
 			}
-			
+
 			if (Anim != null)
 			{
 				Anim.play();
@@ -793,8 +793,8 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		return _curAnim = Anim;
 	}
-	
-	private inline function get_paused():Bool
+
+	inline function get_paused():Bool
 	{
 		var paused:Bool = false;
 		if (_curAnim != null)
@@ -803,15 +803,15 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		return paused;
 	}
-	
-	private inline function set_paused(Value:Bool):Bool
+
+	inline function set_paused(Value:Bool):Bool
 	{
 		if (_curAnim != null)
 		{
-			if (Value) 
-			{ 
+			if (Value)
+			{
 				_curAnim.pause();
-			} 
+			}
 			else
 			{
 				_curAnim.resume();
@@ -819,8 +819,8 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		return Value;
 	}
-	
-	private function get_finished():Bool
+
+	function get_finished():Bool
 	{
 		var finished:Bool = true;
 		if (_curAnim != null)
@@ -829,8 +829,8 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		return finished;
 	}
-	
-	private inline function set_finished(Value:Bool):Bool
+
+	inline function set_finished(Value:Bool):Bool
 	{
 		if (Value && _curAnim != null)
 		{
@@ -838,15 +838,15 @@ class FlxAnimationController implements IFlxDestroyable
 		}
 		return Value;
 	}
-	
-	private inline function get_frames():Int
+
+	inline function get_frames():Int
 	{
 		return _sprite.numFrames;
 	}
-	
+
 	/**
 	 * Helper function used for finding index of `FlxFrame` in `_framesData`'s frames array
-	 * 
+	 *
 	 * @param   Frame   `FlxFrame` to find
 	 * @return  position of specified `FlxFrame` object.
 	 */

--- a/flixel/animation/FlxBaseAnimation.hx
+++ b/flixel/animation/FlxBaseAnimation.hx
@@ -12,43 +12,43 @@ class FlxBaseAnimation implements IFlxDestroyable
 	 * Animation controller this animation belongs to
 	 */
 	public var parent:FlxAnimationController;
-	
+
 	/**
 	 * String name of the animation (e.g. `"walk"`)
 	 */
 	public var name:String;
-	
+
 	/**
 	 * Keeps track of the current index into the tile sheet based on animation or rotation.
 	 */
 	public var curIndex(default, set):Int = 0;
-	
-	private function set_curIndex(Value:Int):Int
+
+	function set_curIndex(Value:Int):Int
 	{
 		curIndex = Value;
-		
+
 		if (parent != null && parent._curAnim == this)
 		{
 			parent.frameIndex = Value;
 		}
-		
+
 		return Value;
 	}
-	
+
 	public function new(Parent:FlxAnimationController, Name:String)
 	{
 		parent = Parent;
 		name = Name;
 	}
-	
+
 	public function destroy():Void
 	{
 		parent = null;
 		name = null;
 	}
-	
+
 	public function update(elapsed:Float):Void {}
-	
+
 	public function clone(Parent:FlxAnimationController):FlxBaseAnimation
 	{
 		return null;

--- a/flixel/animation/FlxPrerotatedAnimation.hx
+++ b/flixel/animation/FlxPrerotatedAnimation.hx
@@ -7,53 +7,53 @@ package flixel.animation;
 class FlxPrerotatedAnimation extends FlxBaseAnimation
 {
 	public static inline var PREROTATED:String = "prerotated_animation";
-	
-	private var rotations:Int;
-	
-	private var baked:Float;
-	
+
+	var rotations:Int;
+
+	var baked:Float;
+
 	public function new(Parent:FlxAnimationController, Baked:Float)
 	{
 		super(Parent, PREROTATED);
 		baked = Baked;
 		rotations = Math.round(360 / Baked);
 	}
-	
+
 	public var angle(default, set):Float = 0;
-	
-	private function set_angle(Value:Float):Float
+
+	function set_angle(Value:Float):Float
 	{
 		var oldIndex:Int = curIndex;
 		var angleHelper:Int = Math.floor(Value % 360);
-		
+
 		while (angleHelper < 0)
 		{
 			angleHelper += 360;
 		}
-		
+
 		var newIndex:Int = Math.floor(angleHelper / baked + 0.5);
 		newIndex = Std.int(newIndex % rotations);
 		if (oldIndex != newIndex)
 		{
 			curIndex = newIndex;
 		}
-		
+
 		return angle = Value;
 	}
-	
-	override private function set_curIndex(Value:Int):Int
+
+	override function set_curIndex(Value:Int):Int
 	{
 		curIndex = Value;
-		
+
 		if (parent != null)
 		{
 			parent.frameIndex = Value;
 		}
-		
+
 		return Value;
 	}
-	
-	override public function clone(Parent:FlxAnimationController):FlxPrerotatedAnimation 
+
+	override public function clone(Parent:FlxAnimationController):FlxPrerotatedAnimation
 	{
 		return new FlxPrerotatedAnimation(Parent, baked);
 	}

--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -12,16 +12,16 @@ import flixel.util.FlxTimer;
  */
 class FlxFlicker implements IFlxDestroyable
 {
-	private static var _pool:FlxPool<FlxFlicker> = new FlxPool<FlxFlicker>(FlxFlicker);
-	
+	static var _pool:FlxPool<FlxFlicker> = new FlxPool<FlxFlicker>(FlxFlicker);
+
 	/**
 	 * Internal map for looking up which objects are currently flickering and getting their flicker data.
 	 */
-	private static var _boundObjects:Map<FlxObject, FlxFlicker> = new Map<FlxObject, FlxFlicker>();
-	
+	static var _boundObjects:Map<FlxObject, FlxFlicker> = new Map<FlxObject, FlxFlicker>();
+
 	/**
 	 * A simple flicker effect for sprites using a ping-pong tween by toggling visibility.
-	 * 
+	 *
 	 * @param   Object               The object.
 	 * @param   Duration             How long to flicker for (in seconds). `0` means "forever".
 	 * @param   Interval             In what interval to toggle visibility. Set to `FlxG.elapsed` if `<= 0`!
@@ -49,30 +49,30 @@ class FlxFlicker implements IFlxDestroyable
 				return _boundObjects[Object];
 			}
 		}
-		
-		if (Interval <= 0) 
+
+		if (Interval <= 0)
 		{
 			Interval = FlxG.elapsed;
 		}
-		
+
 		var flicker:FlxFlicker = _pool.get();
 		flicker.start(Object, Duration, Interval, EndVisibility, CompletionCallback, ProgressCallback);
 		return _boundObjects[Object] = flicker;
 	}
-	
+
 	/**
 	 * Returns whether the object is flickering or not.
-	 * 
+	 *
 	 * @param   Object The object to test.
 	 */
 	public static function isFlickering(Object:FlxObject):Bool
 	{
 		return _boundObjects.exists(Object);
 	}
-	
+
 	/**
 	 * Stops flickering of the object. Also it will make the object visible.
-	 * 
+	 *
 	 * @param   Object The object to stop flickering.
 	 */
 	public static function stopFlickering(Object:FlxObject):Void
@@ -83,42 +83,42 @@ class FlxFlicker implements IFlxDestroyable
 			boundFlicker.stop();
 		}
 	}
-	
+
 	/**
 	 * The flickering object.
 	 */
 	public var object(default, null):FlxObject;
-	
+
 	/**
 	 * The final visibility of the object after flicker is complete.
 	 */
 	public var endVisibility(default, null):Bool;
-	
+
 	/**
 	 * The flicker timer. You can check how many seconds has passed since flickering started etc.
 	 */
 	public var timer(default, null):FlxTimer;
-	
+
 	/**
 	 * The callback that will be triggered after flicker has completed.
 	 */
 	public var completionCallback(default, null):FlxFlicker->Void;
-	
+
 	/**
 	 * The callback that will be triggered every time object visiblity is changed.
 	 */
 	public var progressCallback(default, null):FlxFlicker->Void;
-	
+
 	/**
 	 * The duration of the flicker (in seconds). `0` means "forever".
 	 */
 	public var duration(default, null):Float;
-	
+
 	/**
 	 * The interval of the flicker.
 	 */
 	public var interval(default, null):Float;
-	
+
 	/**
 	 * Nullifies the references to prepare object for reuse and avoid memory leaks.
 	 */
@@ -129,11 +129,11 @@ class FlxFlicker implements IFlxDestroyable
 		completionCallback = null;
 		progressCallback = null;
 	}
-	
+
 	/**
 	 * Starts flickering behavior.
 	 */
-	private function start(Object:FlxObject, Duration:Float, Interval:Float, EndVisibility:Bool,
+	function start(Object:FlxObject, Duration:Float, Interval:Float, EndVisibility:Bool,
 		?CompletionCallback:FlxFlicker->Void, ?ProgressCallback:FlxFlicker->Void):Void
 	{
 		object = Object;
@@ -144,7 +144,7 @@ class FlxFlicker implements IFlxDestroyable
 		endVisibility = EndVisibility;
 		timer = new FlxTimer().start(interval, flickerProgress, Std.int(duration / interval));
 	}
-	
+
 	/**
 	 * Prematurely ends flickering.
 	 */
@@ -154,28 +154,28 @@ class FlxFlicker implements IFlxDestroyable
 		object.visible = true;
 		release();
 	}
-	
+
 	/**
 	 * Unbinds the object from flicker and releases it into pool for reuse.
 	 */
-	private function release():Void
+	function release():Void
 	{
 		_boundObjects.remove(object);
 		_pool.put(this);
 	}
-	
+
 	/**
 	 * Just a helper function for flicker() to update object's visibility.
 	 */
-	private function flickerProgress(Timer:FlxTimer):Void
+	function flickerProgress(Timer:FlxTimer):Void
 	{
 		object.visible = !object.visible;
-		
+
 		if (progressCallback != null)
 		{
 			progressCallback(this);
 		}
-		
+
 		if (Timer.loops > 0 && Timer.loopsLeft == 0)
 		{
 			object.visible = endVisibility;
@@ -186,10 +186,10 @@ class FlxFlicker implements IFlxDestroyable
 			release();
 		}
 	}
-	
+
 	/**
 	 * Internal constructor. Use static methods.
 	 */
 	@:keep
-	private function new() {}
+	function new() {}
 }

--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -153,32 +153,32 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 	/**
 	 * Internal helper for deciding how many particles to launch.
 	 */
-	private var _quantity:Int = 0;
+	var _quantity:Int = 0;
 	/**
 	 * Internal helper for the style of particle emission (all at once, or one at a time).
 	 */
-	private var _explode:Bool = true;
+	var _explode:Bool = true;
 	/**
 	 * Internal helper for deciding when to launch particles or kill them.
 	 */
-	private var _timer:Float = 0;
+	var _timer:Float = 0;
 	/**
 	 * Internal counter for figuring out how many particles to launch.
 	 */
-	private var _counter:Int = 0;
+	var _counter:Int = 0;
 	/**
 	 * Internal point object, handy for reusing for memory management purposes.
 	 */
-	private var _point:FlxPoint = FlxPoint.get();
+	var _point:FlxPoint = FlxPoint.get();
 	/**
 	 * Internal helper for automatically calling the `kill()` method
 	 */
-	private var _waitForKill:Bool = false;
-	
+	var _waitForKill:Bool = false;
+
 	/**
 	 * Creates a new `FlxTypedEmitter` object at a specific position.
 	 * Does NOT automatically generate or attach particles!
-	 * 
+	 *
 	 * @param   X      The X position of the emitter.
 	 * @param   Y      The Y position of the emitter.
 	 * @param   Size   Optional, specifies a maximum capacity for this emitter.
@@ -186,11 +186,11 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 	public function new(X:Float = 0, Y:Float = 0, Size:Int = 0)
 	{
 		super(Size);
-		
+
 		setPosition(X, Y);
 		exists = false;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -201,7 +201,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		drag = FlxDestroyUtil.destroy(drag);
 		acceleration = FlxDestroyUtil.destroy(acceleration);
 		_point = FlxDestroyUtil.put(_point);
-		
+
 		blend = null;
 		angularAcceleration = null;
 		angularDrag = null;
@@ -213,13 +213,13 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		alpha = null;
 		color = null;
 		elasticity = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * This function generates a new array of particle sprites to attach to the emitter.
-	 * 
+	 *
 	 * @param   Graphics         If you opted to not pre-configure an array of `FlxParticle` objects,
 	 *                           you can simply pass in a particle image or sprite sheet.
 	 * @param   Quantity         The number of particles to generate when using the "create from image" option.
@@ -237,41 +237,41 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 	{
 		maxSize = Quantity;
 		var totalFrames:Int = 1;
-		
+
 		if (Multiple)
-		{ 
+		{
 			var sprite = new FlxSprite();
 			sprite.loadGraphic(Graphics, true);
 			totalFrames = sprite.numFrames;
 			sprite.destroy();
 		}
-			
+
 		for (i in 0...Quantity)
 			add(loadParticle(Graphics, Quantity, bakedRotationAngles, Multiple, AutoBuffer, totalFrames));
-		
+
 		return this;
 	}
-	
-	private function loadParticle(Graphics:FlxGraphicAsset, Quantity:Int, bakedRotationAngles:Int,
+
+	function loadParticle(Graphics:FlxGraphicAsset, Quantity:Int, bakedRotationAngles:Int,
 		Multiple:Bool = false, AutoBuffer:Bool = false, totalFrames:Int):T
 	{
 		var particle:T = Type.createInstance(particleClass, []);
 		var frame = Multiple ? FlxG.random.int(0, totalFrames - 1) : -1;
-		
+
 		if (FlxG.renderBlit && bakedRotationAngles > 0)
 			particle.loadRotatedGraphic(Graphics, bakedRotationAngles, frame, false, AutoBuffer);
 		else
 			particle.loadGraphic(Graphics, Multiple);
-		
+
 		if (Multiple)
 			particle.animation.frameIndex = frame;
-		
+
 		return particle;
 	}
-	
+
 	/**
 	 * Similar to `FlxSprite#makeGraphic()`, this function allows you to quickly make single-color particles.
-	 * 
+	 *
 	 * @param   Width      The width of the generated particles. Default is `2` pixels.
 	 * @param   Height     The height of the generated particles. Default is `2` pixels.
 	 * @param   Color      The color of the generated particles. Default is white.
@@ -287,10 +287,10 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 			particle.makeGraphic(Width, Height, Color);
 			add(particle);
 		}
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Called automatically by the game loop, decides when to launch particles and when to "die".
 	 */
@@ -306,30 +306,30 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		else if (_waitForKill)
 		{
 			_timer += elapsed;
-			
+
 			if ((lifespan.max > 0) && (_timer > lifespan.max))
 			{
 				kill();
 				return;
 			}
 		}
-		
+
 		super.update(elapsed);
 	}
-	
-	private function explode():Void
+
+	function explode():Void
 	{
 		var amount:Int = _quantity;
 		if (amount <= 0 || amount > length)
 			amount = length;
-		
+
 		for (i in 0...amount)
 			emitParticle();
-		
+
 		onFinished();
 	}
-	
-	private function emitContinuously(elapsed:Float):Void
+
+	function emitContinuously(elapsed:Float):Void
 	{
 		// Spawn one particle per frame
 		if (frequency <= 0)
@@ -339,7 +339,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		else
 		{
 			_timer += elapsed;
-			
+
 			while (_timer > frequency)
 			{
 				_timer -= frequency;
@@ -347,23 +347,23 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 			}
 		}
 	}
-	
-	private function emitParticleContinuously():Void
+
+	function emitParticleContinuously():Void
 	{
 		emitParticle();
 		_counter++;
-		
+
 		if (_quantity > 0 && _counter >= _quantity)
 			onFinished();
 	}
-	
-	private function onFinished():Void
+
+	function onFinished():Void
 	{
 		emitting = false;
 		_waitForKill = true;
 		_quantity = 0;
 	}
-	
+
 	/**
 	 * Call this function to turn off all the particles and the emitter.
 	 */
@@ -371,13 +371,13 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 	{
 		emitting = false;
 		_waitForKill = false;
-		
+
 		super.kill();
 	}
-	
+
 	/**
 	 * Call this function to start emitting particles.
-	 * 
+	 *
 	 * @param   Explode     Whether the particles should all burst out at once.
 	 * @param   Frequency   Ignored if `Explode` is set to `true`. `Frequency` is how often to emit a particle.
 	 *                      `0` = never emit, `0.1` = 1 particle every 0.1 seconds, `5` = 1 particle every 5 seconds.
@@ -389,45 +389,45 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		exists = true;
 		visible = true;
 		emitting = true;
-		
+
 		_explode = Explode;
 		frequency = Frequency;
 		_quantity += Quantity;
-		
+
 		_counter = 0;
 		_timer = 0;
-		
+
 		_waitForKill = false;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * This function can be used both internally and externally to emit the next particle.
 	 */
 	public function emitParticle():T
 	{
 		var particle:T = cast recycle(cast particleClass);
-		
+
 		particle.reset(0, 0); // Position is set later, after size has been calculated
-		
+
 		particle.blend = blend;
 		particle.immovable = immovable;
 		particle.solid = solid;
 		particle.allowCollisions = allowCollisions;
 		particle.autoUpdateHitbox = autoUpdateHitbox;
-		
+
 		// Particle lifespan settings
 		if (lifespan.active)
 		{
 			particle.lifespan = FlxG.random.float(lifespan.min, lifespan.max);
 		}
-		
+
 		if (velocity.active)
 		{
 			// Particle velocity/launch angle settings
 			particle.velocityRange.active = particle.lifespan > 0 && !particle.velocityRange.start.equals(particle.velocityRange.end);
-		
+
 			if (launchMode == FlxEmitterMode.CIRCLE)
 			{
 				var particleAngle:Float = 0;
@@ -456,10 +456,10 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		}
 		else
 			particle.velocityRange.active = false;
-		
+
 		// Particle angular velocity settings
 		particle.angularVelocityRange.active = particle.lifespan > 0 && angularVelocity.start != angularVelocity.end;
-		
+
 		if (!ignoreAngularVelocity)
 		{
 			if (angularAcceleration.active)
@@ -471,7 +471,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 				particle.angularVelocityRange.end = FlxG.random.float(angularVelocity.end.min, angularVelocity.end.max);
 				particle.angularVelocity = particle.angularVelocityRange.start;
 			}
-			
+
 			if (angularDrag.active)
 				particle.angularDrag = FlxG.random.float(angularDrag.start.min, angularDrag.start.max);
 		}
@@ -480,11 +480,11 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 			particle.angularVelocity = (FlxG.random.float(angle.end.min, angle.end.max) - FlxG.random.float(angle.start.min, angle.start.max)) / FlxG.random.float(lifespan.min, lifespan.max);
 			particle.angularVelocityRange.active = false;
 		}
-		
+
 		// Particle angle settings
 		if (angle.active)
 			particle.angle = FlxG.random.float(angle.start.min, angle.start.max);
-		
+
 		// Particle scale settings
 		if (scale.active)
 		{
@@ -500,7 +500,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		}
 		else
 			particle.scaleRange.active = false;
-		
+
 		// Particle alpha settings
 		if (alpha.active)
 		{
@@ -511,7 +511,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		}
 		else
 			particle.alphaRange.active = false;
-		
+
 		// Particle color settings
 		if (color.active)
 		{
@@ -522,7 +522,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		}
 		else
 			particle.colorRange.active = false;
-		
+
 		// Particle drag settings
 		if (drag.active)
 		{
@@ -550,7 +550,7 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		}
 		else
 			particle.accelerationRange.active = false;
-		
+
 		// Particle elasticity settings
 		if (elasticity.active)
 		{
@@ -561,33 +561,33 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		}
 		else
 			particle.elasticityRange.active = false;
-		
+
 		// Set position
 		particle.x = FlxG.random.float(x, x + width) - particle.width / 2;
 		particle.y = FlxG.random.float(y, y + height) - particle.height / 2;
-		
+
 		// Restart animation
 		if (particle.animation.curAnim != null)
 			particle.animation.curAnim.restart();
-		
+
 		particle.onEmit();
-		
+
 		return particle;
 	}
-	
+
 	/**
 	 * Change the emitter's midpoint to match the midpoint of a `FlxObject`.
-	 * 
+	 *
 	 * @param   Object   The `FlxObject` that you want to sync up with.
 	 */
 	public function focusOn(Object:FlxObject):Void
 	{
 		Object.getMidpoint(_point);
-		
+
 		x = _point.x - (Std.int(width) >> 1);
 		y = _point.y - (Std.int(height) >> 1);
 	}
-	
+
 	/**
 	 * Helper function to set the coordinates of this object.
 	 */
@@ -596,19 +596,19 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 		x = X;
 		y = Y;
 	}
-	
+
 	public inline function setSize(Width:Float, Height:Float):Void
 	{
 		width = Width;
 		height = Height;
 	}
-	
-	private inline function get_solid():Bool
+
+	inline function get_solid():Bool
 	{
 		return (allowCollisions & FlxObject.ANY) > FlxObject.NONE;
 	}
-	
-	private function set_solid(Solid:Bool):Bool
+
+	function set_solid(Solid:Bool):Bool
 	{
 		if (Solid)
 		{

--- a/flixel/effects/particles/FlxParticle.hx
+++ b/flixel/effects/particles/FlxParticle.hx
@@ -69,8 +69,8 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 	/**
 	 * The amount of change from the previous frame.
 	 */
-	private var _delta:Float = 0;
-	
+	var _delta:Float = 0;
+
 	/**
 	 * Instantiate a new particle. Like `FlxSprite`, all meaningful creation
 	 * happens during `loadGraphic()` or `makeGraphic()` or whatever.
@@ -79,7 +79,7 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 	public function new()
 	{
 		super();
-		
+
 		velocityRange = new FlxRange<FlxPoint>(FlxPoint.get(), FlxPoint.get());
 		angularVelocityRange = new FlxRange<Float>(0);
 		scaleRange = new FlxRange<FlxPoint>(FlxPoint.get(1, 1), FlxPoint.get(1, 1));
@@ -88,10 +88,10 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 		dragRange = new FlxRange<FlxPoint>(FlxPoint.get(), FlxPoint.get());
 		accelerationRange = new FlxRange<FlxPoint>(FlxPoint.get(), FlxPoint.get());
 		elasticityRange = new FlxRange<Float>(0);
-		
+
 		exists = false;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -121,15 +121,15 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 			accelerationRange.end = FlxDestroyUtil.put(accelerationRange.end);
 			angularVelocityRange = null;
 		}
-		
+
 		alphaRange = null;
 		colorRange = null;
 		accelerationRange = null;
 		elasticityRange = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * The particle's main update logic. Basically updates properties if alive, based on ranged properties.
 	 */
@@ -137,7 +137,7 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 	{
 		if (age < lifespan)
 			age += elapsed;
-		
+
 		if (age >= lifespan && lifespan != 0)
 		{
 			kill();
@@ -146,63 +146,63 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 		{
 			_delta = elapsed / lifespan;
 			percent = age / lifespan;
-			
+
 			if (velocityRange.active)
 			{
 				velocity.x += (velocityRange.end.x - velocityRange.start.x) * _delta;
 				velocity.y += (velocityRange.end.y - velocityRange.start.y) * _delta;
 			}
-			
+
 			if (angularVelocityRange.active)
 			{
 				angularVelocity += (angularVelocityRange.end - angularVelocityRange.start) * _delta;
 			}
-			
+
 			if (scaleRange.active)
 			{
 				scale.x += (scaleRange.end.x - scaleRange.start.x) * _delta;
 				scale.y += (scaleRange.end.y - scaleRange.start.y) * _delta;
 				if (autoUpdateHitbox) updateHitbox();
 			}
-			
+
 			if (alphaRange.active)
 			{
 				alpha += (alphaRange.end - alphaRange.start) * _delta;
 			}
-			
+
 			if (colorRange.active)
 			{
 				color = FlxColor.interpolate(colorRange.start, colorRange.end, percent);
 			}
-			
+
 			if (dragRange.active)
 			{
 				drag.x += (dragRange.end.x - dragRange.start.x) * _delta;
 				drag.y += (dragRange.end.y - dragRange.start.y) * _delta;
 			}
-			
+
 			if (accelerationRange.active)
 			{
 				acceleration.x += (accelerationRange.end.x - accelerationRange.start.x) * _delta;
 				acceleration.y += (accelerationRange.end.y - accelerationRange.start.y) * _delta;
 			}
-			
+
 			if (elasticityRange.active)
 			{
 				elasticity += (elasticityRange.end - elasticityRange.start) * _delta;
 			}
 		}
-		
+
 		super.update(elapsed);
 	}
-	
-	override public function reset(X:Float, Y:Float):Void 
+
+	override public function reset(X:Float, Y:Float):Void
 	{
 		super.reset(X, Y);
 		age = 0;
 		visible = true;
 	}
-	
+
 	/**
 	 * Triggered whenever this object is launched by a `FlxEmitter`.
 	 * You can override this to add custom behavior like a sound or AI or something.
@@ -224,6 +224,6 @@ interface IFlxParticle extends IFlxSprite
 	public var dragRange:FlxRange<FlxPoint>;
 	public var accelerationRange:FlxRange<FlxPoint>;
 	public var elasticityRange:FlxRange<Float>;
-	
+
 	public function onEmit():Void;
 }

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -13,11 +13,11 @@ import openfl.gl.GLTexture;
 import openfl.gl.GLBuffer;
 import openfl.utils.Float32Array;
 
-private class Uniform
+class Uniform
 {
 	public var id:Int;
 	public var value:Float;
-	
+
 	public function new(id, value)
 	{
 		this.id = id;
@@ -31,8 +31,8 @@ private class Uniform
  */
 class PostProcess extends OpenGLView
 {
-	private var screenWidth:Int;
-	private var screenHeight:Int;
+	var screenWidth:Int;
+	var screenHeight:Int;
 
 	/**
 	 * Create a new PostProcess object
@@ -43,7 +43,7 @@ class PostProcess extends OpenGLView
 	{
 		super();
 		uniforms = new Map<String, Uniform>();
-		
+
 		// create and bind the framebuffer
 		framebuffer = GL.createFramebuffer();
 		rebuild();
@@ -51,7 +51,7 @@ class PostProcess extends OpenGLView
 		defaultFramebuffer = new GLFramebuffer(GL.version, 1); // faked framebuffer
 		#else
 		var status = GL.checkFramebufferStatus(GL.FRAMEBUFFER);
-		
+
 		switch (status)
 		{
 			case GL.FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
@@ -116,8 +116,8 @@ class PostProcess extends OpenGLView
 	 * Set to `null` to render to the screen.
 	 */
 	public var to(never, set):PostProcess;
-	
-	private function set_to(value:PostProcess):PostProcess
+
+	function set_to(value:PostProcess):PostProcess
 	{
 		renderTo = (value == null ? defaultFramebuffer : value.framebuffer);
 		return value;
@@ -137,15 +137,15 @@ class PostProcess extends OpenGLView
 		this.screenHeight = FlxG.stage.stageHeight;
 		createTexture(screenWidth, screenHeight);
 		createRenderbuffer(screenWidth, screenHeight);
-		
+
 		GL.bindFramebuffer(GL.FRAMEBUFFER, null);
 	}
 
-	private inline function createRenderbuffer(width:Int, height:Int)
+	inline function createRenderbuffer(width:Int, height:Int)
 	{
 		// Bind the renderbuffer and create a depth buffer
 		renderbuffer = GL.createRenderbuffer();
-		
+
 		GL.bindRenderbuffer(GL.RENDERBUFFER, renderbuffer);
 		GL.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, width, height);
 
@@ -153,10 +153,10 @@ class PostProcess extends OpenGLView
 		GL.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, renderbuffer);
 	}
 
-	private inline function createTexture(width:Int, height:Int)
+	inline function createTexture(width:Int, height:Int)
 	{
 		texture = GL.createTexture();
-		
+
 		GL.bindTexture(GL.TEXTURE_2D, texture);
 		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGB,  width, height,  0,  GL.RGB, GL.UNSIGNED_BYTE, null);
 
@@ -177,7 +177,7 @@ class PostProcess extends OpenGLView
 		GL.bindFramebuffer(GL.FRAMEBUFFER, framebuffer);
 		GL.clear(GL.DEPTH_BUFFER_BIT | GL.COLOR_BUFFER_BIT);
 	}
-	
+
 	public function update(elapsed:Float)
 	{
 		time += elapsed;
@@ -191,7 +191,7 @@ class PostProcess extends OpenGLView
 	{
 		GL.bindFramebuffer(GL.FRAMEBUFFER, renderTo);
 		GL.viewport(0, 0, screenWidth, screenHeight);
-		
+
 		postProcessShader.bind();
 
 		GL.enableVertexAttribArray(vertexSlot);
@@ -224,9 +224,9 @@ class PostProcess extends OpenGLView
 		GL.disableVertexAttribArray(texCoordSlot);
 
 		GL.useProgram(null);
-		
+
 		GL.bindFramebuffer(GL.FRAMEBUFFER, null);
-		
+
 		// check gl error
 		if (GL.getError() == GL.INVALID_FRAMEBUFFER_OPERATION)
 		{
@@ -235,27 +235,27 @@ class PostProcess extends OpenGLView
 	}
 	#end
 
-	private var framebuffer:GLFramebuffer;
-	private var renderbuffer:GLRenderbuffer;
-	private var texture:GLTexture;
+	var framebuffer:GLFramebuffer;
+	var renderbuffer:GLRenderbuffer;
+	var texture:GLTexture;
 
-	private var postProcessShader:Shader;
-	private var buffer:GLBuffer;
-	private var renderTo:GLFramebuffer;
-	private var defaultFramebuffer:GLFramebuffer = null;
+	var postProcessShader:Shader;
+	var buffer:GLBuffer;
+	var renderTo:GLFramebuffer;
+	var defaultFramebuffer:GLFramebuffer = null;
 
 	/* @private Time accumulator passed to the shader */
-	private var time:Float = 0;
+	var time:Float = 0;
 
-	private var vertexSlot:Int;
-	private var texCoordSlot:Int;
-	private var imageUniform:Int;
-	private var resolutionUniform:Int;
-	private var timeUniform:Int;
-	private var uniforms:Map<String, Uniform>;
+	var vertexSlot:Int;
+	var texCoordSlot:Int;
+	var imageUniform:Int;
+	var resolutionUniform:Int;
+	var timeUniform:Int;
+	var uniforms:Map<String, Uniform>;
 
 	/* @private Simple full screen vertex shader */
-	private static inline var VERTEX_SHADER:String = "
+	static inline var VERTEX_SHADER:String = "
 #ifdef GL_ES
 	precision mediump float;
 #endif
@@ -269,8 +269,8 @@ void main() {
 	gl_Position = vec4(aVertex, 0.0, 1.0);
 }";
 
-	private static var vertices(get, never):Array<Float>;
-	private static inline function get_vertices():Array<Float>
+	static var vertices(get, never):Array<Float>;
+	static inline function get_vertices():Array<Float>
 	{
 		return [
 			-1.0, -1.0, 0, 0,
@@ -289,7 +289,7 @@ class PostProcess
 	{
 		FlxG.log.error("Post processing is only supported on cpp and neko");
 	}
-	
+
 	public function enable(?to:PostProcess) {}
 	public function capture() {}
 	public function rebuild() {}

--- a/flixel/effects/postprocess/Shader.hx
+++ b/flixel/effects/postprocess/Shader.hx
@@ -10,11 +10,11 @@ import openfl.gl.GLShader;
  */
 class Shader
 {
-	private var program:GLProgram;
-	
+	var program:GLProgram;
+
 	/**
 	 * Creates a new Shader
-	 * 
+	 *
 	 * @param  sources   A list of GLSL shader sources to compile and link into a program
 	 */
 	public function new(sources:Array<ShaderSource>)
@@ -46,7 +46,7 @@ class Shader
 	 * @param   source   The shader source code
 	 * @param   type     The type of shader to compile (fragment, vertex)
 	 */
-	private function compile(source:String, type:Int):GLShader
+	function compile(source:String, type:Int):GLShader
 	{
 		var shader = GL.createShader(type);
 		GL.shaderSource(shader, source);

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -24,10 +24,10 @@ class FlxGraphic implements IFlxDestroyable
 	 * at creation if none is specified in the constructor.
 	 */
 	public static var defaultPersist:Bool = false;
-	
+
 	/**
 	 * Creates and caches FlxGraphic object from openfl.Assets key string.
-	 * 
+	 *
 	 * @param   Source   `openfl.Assets` key string. For example: `"assets/image.png"`.
 	 * @param   Unique   Ensures that the `BitmapData` uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
@@ -38,7 +38,7 @@ class FlxGraphic implements IFlxDestroyable
 	public static function fromAssetKey(Source:String, Unique:Bool = false, ?Key:String, Cache:Bool = true):FlxGraphic
 	{
 		var bitmap:BitmapData = null;
-		
+
 		if (!Cache)
 		{
 			bitmap = FlxAssets.getBitmapData(Source);
@@ -46,24 +46,24 @@ class FlxGraphic implements IFlxDestroyable
 				return null;
 			return createGraphic(bitmap, Key, Unique, Cache);
 		}
-		
+
 		var key:String = FlxG.bitmap.generateKey(Source, Key, Unique);
 		var graphic:FlxGraphic = FlxG.bitmap.get(key);
 		if (graphic != null)
 			return graphic;
-		
+
 		bitmap = FlxAssets.getBitmapData(Source);
 		if (bitmap == null)
 			return null;
-		
+
 		graphic = createGraphic(bitmap, key, Unique);
 		graphic.assetsKey = Source;
 		return graphic;
 	}
-	
+
 	/**
 	 * Creates and caches `FlxGraphic` object from a specified `Class<BitmapData>`.
-	 * 
+	 *
 	 * @param   Source   `Class<BitmapData>` to create `BitmapData` for `FlxGraphic` from.
 	 * @param   Unique   Ensures that the `BitmapData` uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
@@ -80,22 +80,22 @@ class FlxGraphic implements IFlxDestroyable
 			bitmap = FlxAssets.getBitmapFromClass(Source);
 			return createGraphic(bitmap, Key, Unique, Cache);
 		}
-		
+
 		var key:String = FlxG.bitmap.getKeyForClass(Source);
 		key = FlxG.bitmap.generateKey(key, Key, Unique);
 		var graphic:FlxGraphic = FlxG.bitmap.get(key);
 		if (graphic != null)
 			return graphic;
-		
+
 		bitmap = FlxAssets.getBitmapFromClass(Source);
 		graphic = createGraphic(bitmap, key, Unique);
 		graphic.assetsClass = Source;
 		return graphic;
 	}
-	
+
 	/**
 	 * Creates and caches `FlxGraphic` object from specified `BitmapData` object.
-	 * 
+	 *
 	 * @param   Source   `BitmapData` for `FlxGraphic` to use.
 	 * @param   Unique   Ensures that the `BitmapData` uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
@@ -108,9 +108,9 @@ class FlxGraphic implements IFlxDestroyable
 	{
 		if (!Cache)
 			return createGraphic(Source, Key, Unique, Cache);
-		
+
 		var key:String = FlxG.bitmap.findKeyForBitmap(Source);
-		
+
 		var assetKey:String = null;
 		var assetClass:Class<BitmapData> = null;
 		var graphic:FlxGraphic = null;
@@ -120,22 +120,22 @@ class FlxGraphic implements IFlxDestroyable
 			assetKey = graphic.assetsKey;
 			assetClass = graphic.assetsClass;
 		}
-		
+
 		key = FlxG.bitmap.generateKey(key, Key, Unique);
 		graphic = FlxG.bitmap.get(key);
 		if (graphic != null)
 			return graphic;
-		
+
 		graphic = createGraphic(Source, key, Unique);
 		graphic.assetsKey = assetKey;
 		graphic.assetsClass = assetClass;
 		return graphic;
 	}
-	
+
 	/**
 	 * Creates and (optionally) caches a `FlxGraphic` object from the specified `FlxFrame`.
 	 * It uses frame's `BitmapData`, not the `frame.parent.bitmap`.
-	 * 
+	 *
 	 * @param   Source   `FlxFrame` to get the `BitmapData` from.
 	 * @param   Unique   Ensures that the bitmap data uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
@@ -153,19 +153,19 @@ class FlxGraphic implements IFlxDestroyable
 		var graphic:FlxGraphic = FlxG.bitmap.get(key);
 		if (graphic != null)
 			return graphic;
-		
+
 		var bitmap:BitmapData = Source.paint();
 		graphic = createGraphic(bitmap, key, Unique, Cache);
 		var image:FlxImageFrame = FlxImageFrame.fromGraphic(graphic);
 		image.getByIndex(0).name = Source.name;
 		return graphic;
 	}
-	
+
 	/**
 	 * Creates and caches a FlxGraphic object from the specified `FlxFramesCollection`.
 	 * It uses `frames.parent.bitmap` as a source for the `FlxGraphic`'s `BitmapData`.
 	 * It also copies all the frames collections onto the newly created `FlxGraphic`.
-	 * 
+	 *
 	 * @param   Source   `FlxFramesCollection` to get the `BitmapData` from.
 	 * @param   Unique   Ensures that the `BitmapData` uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
@@ -176,11 +176,11 @@ class FlxGraphic implements IFlxDestroyable
 	{
 		return fromGraphic(Source.parent, Unique, Key);
 	}
-	
+
 	/**
 	 * Creates and caches a `FlxGraphic` object from the specified `FlxGraphic` object.
 	 * It copies all the frame collections onto the newly created `FlxGraphic`.
-	 * 
+	 *
 	 * @param   Source   `FlxGraphic` to get the `BitmapData` from.
 	 * @param   Unique   Ensures that the `BitmapData` uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
@@ -191,7 +191,7 @@ class FlxGraphic implements IFlxDestroyable
 	{
 		if (!Unique)
 			return Source;
-		
+
 		var key:String = FlxG.bitmap.generateKey(Source.key, Key, Unique);
 		var graphic:FlxGraphic = createGraphic(Source.bitmap, key, Unique);
 		graphic.unique = Unique;
@@ -199,10 +199,10 @@ class FlxGraphic implements IFlxDestroyable
 		graphic.assetsKey = Source.assetsKey;
 		return FlxG.bitmap.addGraphic(graphic);
 	}
-	
+
 	/**
 	 * Generates and caches new `FlxGraphic` object with a colored rectangle.
-	 * 
+	 *
 	 * @param   Width    How wide the rectangle should be.
 	 * @param   Height   How high the rectangle should be.
 	 * @param   Color    What color the rectangle should have (`0xAARRGGBB`).
@@ -214,30 +214,30 @@ class FlxGraphic implements IFlxDestroyable
 	{
 		var systemKey:String = Width + "x" + Height + ":" + Color;
 		var key:String = FlxG.bitmap.generateKey(systemKey, Key, Unique);
-		
+
 		var graphic:FlxGraphic = FlxG.bitmap.get(key);
 		if (graphic != null)
 			return graphic;
-		
+
 		var bitmap = new BitmapData(Width, Height, true, Color);
 		return createGraphic(bitmap, key);
 	}
-	
+
 	/**
 	 * Helper method for cloning specified `BitmapData` if necessary.
-	 * 
+	 *
 	 * @param   Bitmap   `BitmapData` to process
 	 * @param   Unique   Whether we need to clone specified `BitmapData` object or not
 	 * @return  Processed `BitmapData`
 	 */
-	private static inline function getBitmap(Bitmap:BitmapData, Unique:Bool = false):BitmapData
+	static inline function getBitmap(Bitmap:BitmapData, Unique:Bool = false):BitmapData
 	{
 		return Unique ? Bitmap.clone() : Bitmap;
 	}
-	
+
 	/**
 	 * Creates and caches the specified `BitmapData` object.
-	 * 
+	 *
 	 * @param   Bitmap   `BitmapData` to use as a graphic source for the new `FlxGraphic`.
 	 * @param   Key      Key to use as a cache key for the created `FlxGraphic`.
 	 * @param   Unique   Whether the new `FlxGraphic` object uses a unique `BitmapData` or not.
@@ -245,12 +245,12 @@ class FlxGraphic implements IFlxDestroyable
 	 * @param   Cache    Whether to use graphic caching or not. Default value is `true`, which means automatic caching.
 	 * @return  Created `FlxGraphic` object.
 	 */
-	private static function createGraphic(Bitmap:BitmapData, Key:String, Unique:Bool = false,
+	static function createGraphic(Bitmap:BitmapData, Key:String, Unique:Bool = false,
 		Cache:Bool = true):FlxGraphic
 	{
 		Bitmap = FlxGraphic.getBitmap(Bitmap, Unique);
 		var graphic:FlxGraphic = null;
-		
+
 		if (Cache)
 		{
 			graphic = new FlxGraphic(Key, Bitmap);
@@ -261,10 +261,10 @@ class FlxGraphic implements IFlxDestroyable
 		{
 			graphic = new FlxGraphic(null, Bitmap);
 		}
-		
+
 		return graphic;
 	}
-	
+
 	/**
 	 * Key used in the `BitmapFrontEnd` cache.
 	 */
@@ -273,7 +273,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * The Cached `BitmapData` object.
 	 */
 	public var bitmap(default, set):BitmapData;
-	
+
 	/**
 	 * Width of the cached `BitmapData`.
 	 */
@@ -282,7 +282,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * Height of the cached `BitmapData`.
 	 */
 	public var height(default, null):Int = 0;
-	
+
 	/**
 	 * Asset name from `openfl.Assets`.
 	 */
@@ -291,7 +291,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * Class name for the `BitmapData`.
 	 */
 	public var assetsClass(default, null):Class<BitmapData>;
-	
+
 	/**
 	 * Whether this graphic object should stay in cache after state changes or not.
 	 */
@@ -301,7 +301,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * Default is `true`.
 	 */
 	public var destroyOnNoUse(get, set):Bool;
-	
+
 	/**
 	 * Whether the `BitmapData` of this graphic object has been dumped or not.
 	 */
@@ -312,64 +312,64 @@ class FlxGraphic implements IFlxDestroyable
 	 * If the graphic is dumped then you should call `undump()` and have total access to pixels.
 	 */
 	public var canBeDumped(get, never):Bool;
-	
+
 	/**
 	 * Tilesheet for this graphic object. It is used only for `FlxG.renderTile` mode.
 	 */
 	public var tilesheet(get, null):Tilesheet;
-	
+
 	/**
 	 * Usage counter for this `FlxGraphic` object.
 	 */
 	public var useCount(get, set):Int;
-	
+
 	/**
 	 * `FlxImageFrame` object for the whole bitmap.
 	 */
 	public var imageFrame(get, null):FlxImageFrame;
-	
+
 	/**
 	 * Atlas frames for this graphic.
 	 * You should fill it yourself with one of `FlxAtlasFrames`'s static methods
 	 * (like `fromTexturePackerJson()`, `fromTexturePackerXml()`, etc).
 	 */
 	public var atlasFrames(get, null):FlxAtlasFrames;
-	
+
 	/**
 	 * Storage for all available frame collection of all types for this graphic object.
 	 */
-	private var frameCollections:Map<FlxFrameCollectionType, Array<Dynamic>>;
-	
+	var frameCollections:Map<FlxFrameCollectionType, Array<Dynamic>>;
+
 	/**
 	 * All types of frames collection which had been added to this graphic object.
 	 * It helps to avoid map iteration, which produces a lot of garbage.
 	 */
-	private var frameCollectionTypes:Array<FlxFrameCollectionType>;
-	
+	var frameCollectionTypes:Array<FlxFrameCollectionType>;
+
 	/**
 	 * Shows whether this object unique in cache or not.
-	 * 
+	 *
 	 * Whether undumped `BitmapData` should be cloned or not.
 	 * It is `false` by default, since it significantly increases memory consumption.
 	 */
 	public var unique:Bool = false;
-	
+
 	/**
 	 * Internal var holding `FlxImageFrame` for the whole bitmap of this graphic.
 	 * Use public `imageFrame` var to access/generate it.
 	 */
-	private var _imageFrame:FlxImageFrame;
-	
+	var _imageFrame:FlxImageFrame;
+
 	/**
 	 * Internal var holding Tilesheet for bitmap of this graphic.
 	 * It is used only in `FlxG.renderTile` mode
 	 */
-	private var _tilesheet:Tilesheet;
-	
-	private var _useCount:Int = 0;
-	
-	private var _destroyOnNoUse:Bool = true;
-	
+	var _tilesheet:Tilesheet;
+
+	var _useCount:Int = 0;
+
+	var _destroyOnNoUse:Bool = true;
+
 	/**
 	 * `FlxGraphic` constructor
 	 *
@@ -378,16 +378,16 @@ class FlxGraphic implements IFlxDestroyable
 	 * @param   Persist   Whether or not this graphic stay in the cache after resetting it.
 	 *                    Default value is `false`, which means that this graphic will be destroyed at the cache reset.
 	 */
-	private function new(Key:String, Bitmap:BitmapData, ?Persist:Bool)
+	function new(Key:String, Bitmap:BitmapData, ?Persist:Bool)
 	{
 		key = Key;
 		persist = (Persist != null) ? Persist : defaultPersist;
-		
+
 		frameCollections = new Map<FlxFrameCollectionType, Array<Dynamic>>();
 		frameCollectionTypes = new Array<FlxFrameCollectionType>();
 		bitmap = Bitmap;
 	}
-	
+
 	/**
 	 * Dumps bits of `BitmapData` to decrease memory usage, but you can't read/write pixels on it anymore
 	 * (but you can call `onContext()` (or `undump()`) method which will restore it again).
@@ -402,18 +402,18 @@ class FlxGraphic implements IFlxDestroyable
 		}
 		#end
 	}
-	
+
 	/**
 	 * Undumps bits of the `BitmapData` - regenerates it and regenerate tilesheet data for this object
 	 */
 	public function undump():Void
 	{
-		var newBitmap:BitmapData = getBitmapFromSystem();	
+		var newBitmap:BitmapData = getBitmapFromSystem();
 		if (newBitmap != null)
 			bitmap = newBitmap;
 		isDumped = false;
 	}
-	
+
 	/**
 	 * Use this method to restore cached `BitmapData` (if it's possible).
 	 * It's called automatically when the RESIZE event occurs.
@@ -427,7 +427,7 @@ class FlxGraphic implements IFlxDestroyable
 			dump(); // and dump BitmapData again
 		}
 	}
-	
+
 	/**
 	 * Asset reload callback for this graphic object.
 	 * It regenerated its tilesheet and resets frame bitmaps.
@@ -436,45 +436,45 @@ class FlxGraphic implements IFlxDestroyable
 	{
 		if (!canBeDumped)
 			return;
-		
+
 		var dumped:Bool = isDumped;
 		undump();
 		if (dumped)
 			dump();
 	}
-	
+
 	/**
 	 * Trying to free the memory as much as possible
 	 */
 	public function destroy():Void
 	{
 		bitmap = FlxDestroyUtil.dispose(bitmap);
-		
+
 		if (FlxG.renderTile)
 			_tilesheet = null;
-		
+
 		key = null;
 		assetsKey = null;
 		assetsClass = null;
 		_imageFrame = null;	// no need to dispose _imageFrame since it exists in imageFrames
-		
+
 		if (frameCollections == null) // no need to destroy frame collections if it's already null
 			return;
-		
+
 		var collections:Array<FlxFramesCollection>;
 		for (collectionType in frameCollectionTypes)
 		{
 			collections = cast frameCollections.get(collectionType);
 			FlxDestroyUtil.destroyArray(collections);
 		}
-		
+
 		frameCollections = null;
 		frameCollectionTypes = null;
 	}
-	
+
 	/**
 	 * Stores specified `FlxFrame` collection in internal map (this helps reduce object creation).
-	 * 
+	 *
 	 * @param   collection   frame collection to store.
 	 */
 	public function addFrameCollection(collection:FlxFramesCollection):Void
@@ -485,10 +485,10 @@ class FlxGraphic implements IFlxDestroyable
 			collections.push(collection);
 		}
 	}
-	
+
 	/**
 	 * Searches frame collections of specified type for this `FlxGraphic` object.
-	 * 
+	 *
 	 * @param   type   The type of frames collections to search for.
 	 * @return  Array of available frames collections of specified type for this object.
 	 */
@@ -502,11 +502,11 @@ class FlxGraphic implements IFlxDestroyable
 		}
 		return collections;
 	}
-	
+
 	/**
 	 * Creates empty frame for this graphic with specified size.
 	 * This method could be useful for tile frames, in case when you'll need empty tile.
-	 * 
+	 *
 	 * @param   size   dimensions of the frame to add.
 	 * @return  Empty frame with specified size which belongs to this `FlxGraphic` object.
 	 */
@@ -518,93 +518,93 @@ class FlxGraphic implements IFlxDestroyable
 		frame.sourceSize.copyFrom(size);
 		return frame;
 	}
-	
+
 	/**
 	 * Tilesheet getter. Generates new one (and regenerates) if there is no tilesheet for this graphic yet.
 	 */
-	private function get_tilesheet():Tilesheet
+	function get_tilesheet():Tilesheet
 	{
 		if (_tilesheet == null)
 		{
 			var dumped:Bool = isDumped;
-			
+
 			if (dumped)
 				undump();
-			
+
 			_tilesheet = new Tilesheet(bitmap);
-			
+
 			if (dumped)
 				dump();
 		}
-		
+
 		return _tilesheet;
 	}
-	
+
 	/**
 	 * Gets the `BitmapData` for this graphic object from OpenFL.
 	 * This method is used for undumping graphic.
 	 */
-	private function getBitmapFromSystem():BitmapData
+	function getBitmapFromSystem():BitmapData
 	{
 		var newBitmap:BitmapData = null;
 		if (assetsClass != null)
 			newBitmap = FlxAssets.getBitmapFromClass(assetsClass);
 		else if (assetsKey != null)
 			newBitmap = FlxAssets.getBitmapData(assetsKey);
-		
+
 		if (newBitmap != null)
 			return FlxGraphic.getBitmap(newBitmap, unique);
-		
+
 		return null;
 	}
-	
-	private inline function get_canBeDumped():Bool
+
+	inline function get_canBeDumped():Bool
 	{
 		return assetsClass != null || assetsKey != null;
 	}
-	
-	private function get_useCount():Int
+
+	function get_useCount():Int
 	{
 		return _useCount;
 	}
-	
-	private function set_useCount(Value:Int):Int
+
+	function set_useCount(Value:Int):Int
 	{
 		if (Value <= 0 && _destroyOnNoUse && !persist)
 			FlxG.bitmap.remove(this);
-		
+
 		return _useCount = Value;
 	}
-	
-	private function get_destroyOnNoUse():Bool
+
+	function get_destroyOnNoUse():Bool
 	{
 		return _destroyOnNoUse;
 	}
-	
-	private function set_destroyOnNoUse(Value:Bool):Bool
+
+	function set_destroyOnNoUse(Value:Bool):Bool
 	{
 		if (Value && _useCount <= 0 && key != null && !persist)
 		{
 			FlxG.bitmap.remove(this);
 		}
-		
+
 		return _destroyOnNoUse = Value;
 	}
-	
-	private function get_imageFrame():FlxImageFrame
+
+	function get_imageFrame():FlxImageFrame
 	{
 		if (_imageFrame == null)
 			_imageFrame = FlxImageFrame.fromRectangle(this, FlxRect.get(0, 0, bitmap.width, bitmap.height));
-		
+
 		return _imageFrame;
 	}
-	
-	private function get_atlasFrames():FlxAtlasFrames
+
+	function get_atlasFrames():FlxAtlasFrames
 	{
 		return FlxAtlasFrames.findFrame(this, null);
 	}
-	
-	private function set_bitmap(value:BitmapData):BitmapData
+
+	function set_bitmap(value:BitmapData):BitmapData
 	{
 		if (value != null)
 		{
@@ -616,7 +616,7 @@ class FlxGraphic implements IFlxDestroyable
 				_tilesheet = new Tilesheet(bitmap);
 			#end
 		}
-		
+
 		return value;
 	}
 }

--- a/flixel/graphics/atlas/FlxAtlas.hx
+++ b/flixel/graphics/atlas/FlxAtlas.hx
@@ -23,65 +23,65 @@ import openfl.geom.Matrix;
  * so you can easily load regions of atlas in sprites and tilemaps as a source of graphic
  */
 class FlxAtlas implements IFlxDestroyable
-{	
-	private static var point:Point = new Point();
-	private static var matrix:Matrix = new Matrix();
-	
+{
+	static var point:Point = new Point();
+	static var matrix:Matrix = new Matrix();
+
 	/**
 	 * Default minimum size for atlases.
 	 */
 	public static var defaultMinSize:FlxPoint = new FlxPoint(128, 128);
-	
+
 	/**
 	 * Default maximum size for atlases.
 	 */
 	public static var defaultMaxSize:FlxPoint = new FlxPoint(1024, 1024);
-	
+
 	/**
 	 * Root node of the atlas.
 	 */
 	public var root(default, null):FlxNode;
-	
+
 	/**
 	 * Name of this atlas, used as a key in the bitmap cache.
 	 */
 	public var name(default, null):String;
-	
+
 	public var nodes(default, null):Map<String, FlxNode>;
-	
+
 	/**
 	 * `BitmapData` of this atlas, combines all images into a big one.
 	 */
 	public var bitmapData(default, set):BitmapData;
-	
+
 	/**
 	 * Graphic for this atlas.
 	 */
 	public var graphic(get, null):FlxGraphic;
-	
+
 	/**
 	 * Whether this atlas should stay in memory after state switch.
 	 * Default value if `false`.
 	 */
 	public var persist(default, set):Bool = false;
-	
+
 	/**
 	 * Offsets between nodes.
 	 */
 	public var border(default, null):Int = 1;
-	
+
 	/**
 	 * Total width of the atlas.
 	 */
 	@:isVar
 	public var width(get, set):Int;
-	
+
 	/**
 	 * Total height of the atlas.
 	 */
 	@:isVar
 	public var height(get, set):Int;
-	
+
 	/**
 	 * Minimum width for this atlas.
 	 */
@@ -90,7 +90,7 @@ class FlxAtlas implements IFlxDestroyable
 	 * Minimum height for this atlas
 	 */
 	public var minHeight(default, set):Int = 128;
-	
+
 	/**
 	 * Maximum width for this atlas.
 	 */
@@ -99,24 +99,24 @@ class FlxAtlas implements IFlxDestroyable
 	 * Maximum height for this atlas.
 	 */
 	public var maxHeight(default, set):Int = 1024;
-	
+
 	/**
 	 * Whether to allow image rotation for packing in atlas.
 	 */
 	public var allowRotation(default, null):Bool = false;
-	
+
 	/**
 	 * Whether the size of this atlas should be the power of 2 or not.
 	 */
 	public var powerOfTwo(default, set):Bool = false;
-	
-	private var _graphic:FlxGraphic;
-	
+
+	var _graphic:FlxGraphic;
+
 	/**
 	 * Internal storage for building atlas from queue
 	 */
-	private var _tempStorage:Array<TempAtlasObj>;
-	
+	var _tempStorage:Array<TempAtlasObj>;
+
 	/**
 	 * Atlas constructor
 	 *
@@ -134,35 +134,35 @@ class FlxAtlas implements IFlxDestroyable
 		this.name = name;
 		this.powerOfTwo = powerOfTwo;
 		this.border = border;
-		
+
 		minSize = (minSize != null) ? minSize : defaultMinSize;
 		maxSize = (maxSize != null) ? maxSize : defaultMaxSize;
-		
+
 		this.minWidth = Std.int(minSize.x);
 		this.minHeight = Std.int(minSize.y);
 		this.maxWidth = (maxSize.x > minSize.x) ? Std.int(maxSize.x) : minWidth;
 		this.maxHeight = (maxSize.y > minSize.x) ? Std.int(maxSize.y) : minHeight;
 		this.allowRotation = rotate;
-		
+
 		initRoot();
-		
+
 		FlxG.signals.preStateCreate.add(onClear);
 	}
-	
-	private function initRoot():Void
+
+	function initRoot():Void
 	{
 		var rootWidth:Int = minWidth;
 		var rootHeight:Int = minHeight;
-		
+
 		if (powerOfTwo)
 		{
 			rootWidth = getNextPowerOfTwo(rootWidth);
 			rootHeight = getNextPowerOfTwo(rootHeight);
 		}
-		
+
 		root = new FlxNode(FlxRect.get(0, 0, rootWidth, rootHeight), this);
 	}
-	
+
 	/**
 	 * Adds a new node to the atlas.
 	 *
@@ -175,7 +175,7 @@ class FlxAtlas implements IFlxDestroyable
 	public function addNode(Graphic:FlxGraphicSource, ?Key:String):FlxNode
 	{
 		var key:String = FlxAssets.resolveKey(Graphic, Key);
-		
+
 		if (key == null)
 		{
 			#if FLX_DEBUG
@@ -183,12 +183,12 @@ class FlxAtlas implements IFlxDestroyable
 			#end
 			return null;
 		}
-		
+
 		if (hasNodeWithName(key))
 			return nodes.get(key);
-		
+
 		var data:BitmapData = FlxAssets.resolveBitmapData(Graphic);
-		
+
 		if (data == null)
 		{
 			#if FLX_DEBUG
@@ -196,47 +196,47 @@ class FlxAtlas implements IFlxDestroyable
 			#end
 			return null;
 		}
-		
+
 		// check if we can add nodes right into root
 		if (root.left == null)
 			return insertFirstNodeInRoot(data, key);
-		
+
 		if (root.right == null)
 			return expand(data, key);
-		
+
 		// try to find enough empty space in atlas
 		var inserted:FlxNode = tryInsert(data, key);
 		if (inserted != null)
 			return inserted;
-		
+
 		// if there is no empty space we need to wrap existing nodes and add new one on the right...
 		wrapRoot();
 		return expand(data, key);
 	}
-	
-	private function wrapRoot():Void
+
+	function wrapRoot():Void
 	{
 		var temp:FlxNode = root;
 		root = new FlxNode(FlxRect.get(0, 0, temp.width, temp.height), this);
 		root.left = temp;
 	}
-	
-	private function tryInsert(data:BitmapData, key:String):FlxNode
+
+	function tryInsert(data:BitmapData, key:String):FlxNode
 	{
 		var insertWidth:Int = data.width + border;
 		var insertHeight:Int = data.height + border;
-		
+
 		var rotateNode:Bool = false;
 		var nodeToInsert:FlxNode = findNodeToInsert(insertWidth, insertHeight);
-		
+
 		if (allowRotation)
 		{
 			var nodeToInsertWithRotation = findNodeToInsert(insertHeight, insertWidth);
-			
+
 			if (nodeToInsertWithRotation != null)
 			{
 				var nodeWithRotationArea:Int = nodeToInsertWithRotation.width * nodeToInsertWithRotation.height;
-				
+
 				if (nodeToInsert == null || (nodeToInsert != null && nodeToInsert.width * nodeToInsert.height > nodeWithRotationArea))
 				{
 					nodeToInsert = nodeToInsertWithRotation;
@@ -247,25 +247,25 @@ class FlxAtlas implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		if (nodeToInsert != null)
 		{
 			var horizontally:Bool = needToDivideHorizontally(nodeToInsert, insertWidth, insertHeight);
 			return divideNode(nodeToInsert, insertWidth, insertHeight, horizontally, data, key, rotateNode);
 		}
-		
+
 		return null;
 	}
-	
-	private function needToDivideHorizontally(nodeToDivide:FlxNode, insertWidth:Int, insertHeight:Int):Bool
+
+	function needToDivideHorizontally(nodeToDivide:FlxNode, insertWidth:Int, insertHeight:Int):Bool
 	{
 		var dw:Int = nodeToDivide.width - insertWidth;
 		var dh:Int = nodeToDivide.height - insertHeight;
-		
+
 		return dw > dh; // divide horizontally if true, vertically if false
 	}
-	
-	private function divideNode(nodeToDivide:FlxNode, insertWidth:Int, insertHeight:Int, divideHorizontally:Bool,
+
+	function divideNode(nodeToDivide:FlxNode, insertWidth:Int, insertHeight:Int, divideHorizontally:Bool,
 		?firstGrandChildData:BitmapData, ?firstGrandChildKey:String, firstGrandChildRotated:Bool = false):FlxNode
 	{
 		if (nodeToDivide != null)
@@ -275,60 +275,60 @@ class FlxAtlas implements IFlxDestroyable
 			var firstGrandChild:FlxNode = null;
 			var secondGrandChild:FlxNode = null;
 			var firstGrandChildFilled:Bool = (firstGrandChildKey != null);
-			
+
 			if (divideHorizontally) // divide horizontally
 			{
 				firstChild = new FlxNode(FlxRect.get(nodeToDivide.x, nodeToDivide.y, insertWidth,
 					nodeToDivide.height), this);
-				
+
 				if (nodeToDivide.width - insertWidth > 0)
 				{
 					secondChild = new FlxNode(FlxRect.get(nodeToDivide.x + insertWidth, nodeToDivide.y,
 						nodeToDivide.width - insertWidth, nodeToDivide.height), this);
 				}
-				
+
 				firstGrandChild = new FlxNode(FlxRect.get(firstChild.x, firstChild.y, insertWidth, insertHeight),
 					this, firstGrandChildFilled, firstGrandChildKey, firstGrandChildRotated);
-				
+
 				if (firstChild.height - insertHeight > 0)
 				{
 					secondGrandChild = new FlxNode(FlxRect.get(firstChild.x, firstChild.y + insertHeight,
 						insertWidth, firstChild.height - insertHeight), this);
 				}
-				
+
 			}
 			else // divide vertically
 			{
 				firstChild = new FlxNode(FlxRect.get(nodeToDivide.x, nodeToDivide.y, nodeToDivide.width,
 					insertHeight), this);
-				
+
 				if (nodeToDivide.height - insertHeight > 0)
 				{
 					secondChild = new FlxNode(FlxRect.get(nodeToDivide.x, nodeToDivide.y + insertHeight,
 						nodeToDivide.width, nodeToDivide.height - insertHeight), this);
 				}
-				
+
 				firstGrandChild = new FlxNode(FlxRect.get(firstChild.x, firstChild.y, insertWidth, insertHeight),
 					this, firstGrandChildFilled, firstGrandChildKey, firstGrandChildRotated);
-				
+
 				if (firstChild.width - insertWidth > 0)
 				{
 					secondGrandChild = new FlxNode(FlxRect.get(firstChild.x + insertWidth, firstChild.y,
 						firstChild.width - insertWidth, insertHeight), this);
 				}
 			}
-			
+
 			firstChild.left = firstGrandChild;
 			firstChild.right = secondGrandChild;
-			
+
 			nodeToDivide.left = firstChild;
 			nodeToDivide.right = secondChild;
-			
+
 			// bake data in atlas
 			if (firstGrandChildKey != null && firstGrandChildData != null)
 			{
 				expandBitmapData();
-				
+
 				if (firstGrandChildRotated)
 				{
 					matrix.identity();
@@ -341,42 +341,42 @@ class FlxAtlas implements IFlxDestroyable
 					point.setTo(firstGrandChild.x, firstGrandChild.y);
 					bitmapData.copyPixels(firstGrandChildData, firstGrandChildData.rect, point);
 				}
-				
+
 				addNodeToAtlasFrames(firstGrandChild);
 				nodes.set(firstGrandChildKey, firstGrandChild);
 			}
-			
+
 			return firstGrandChild;
 		}
-		
+
 		return null;
 	}
-	
-	private function insertFirstNodeInRoot(data:BitmapData, key:String):FlxNode
+
+	function insertFirstNodeInRoot(data:BitmapData, key:String):FlxNode
 	{
 		if (root.left == null)
 		{
 			var insertWidth:Int = data.width + border;
 			var insertHeight:Int = data.height + border;
-			
+
 			var rootWidth:Int = insertWidth;
 			var rootHeight:Int = insertHeight;
-			
+
 			if (powerOfTwo)
 			{
 				rootWidth = getNextPowerOfTwo(rootWidth);
 				rootHeight = getNextPowerOfTwo(rootHeight);
 			}
-			
+
 			rootWidth = (minWidth > rootWidth) ? minWidth : rootWidth;
 			rootHeight = (minHeight > rootHeight) ? minHeight : rootHeight;
-			
+
 			if (powerOfTwo)
 			{
 				rootWidth = getNextPowerOfTwo(rootWidth);
 				rootHeight = getNextPowerOfTwo(rootHeight);
 			}
-			
+
 			if ((maxWidth > 0 && rootWidth > maxWidth) || (maxHeight > 0 && rootHeight > maxHeight))
 			{
 				#if FLX_DEBUG
@@ -386,53 +386,53 @@ class FlxAtlas implements IFlxDestroyable
 				#end
 				return null;
 			}
-			
+
 			root.width = rootWidth;
 			root.height = rootHeight;
-			
+
 			var horizontally:Bool = needToDivideHorizontally(root, insertWidth, insertHeight);
 			return divideNode(root, insertWidth, insertHeight, horizontally, data, key);
 		}
-		
+
 		return null;
 	}
-	
-	private function expand(data:BitmapData, key:String):FlxNode
+
+	function expand(data:BitmapData, key:String):FlxNode
 	{
 		if (root.right == null)
 		{
 			var insertWidth:Int = data.width + border;
 			var insertHeight:Int = data.height + border;
-			
+
 			// helpers for making decision on how to insert new node
 			var addRightWidth:Int = root.width + insertWidth;
 			var addRightHeight:Int = Std.int(Math.max(root.height, insertHeight));
-			
+
 			var addBottomWidth:Int = Std.int(Math.max(root.width, insertWidth));
 			var addBottomHeight:Int = root.height + insertHeight;
-			
+
 			var addRightWidthRotate:Int = addRightWidth;
 			var addRightHeightRotate:Int = addRightHeight;
-			
+
 			var addBottomWidthRotate:Int = addBottomWidth;
 			var addBottomHeightRotate:Int = addBottomHeight;
-			
+
 			if (allowRotation)
 			{
 				addRightWidthRotate = root.width + insertHeight;
 				addRightHeightRotate = Std.int(Math.max(root.height, insertWidth));
-				
+
 				addBottomWidthRotate = Std.int(Math.max(root.width, insertHeight));
 				addBottomHeightRotate = root.height + insertWidth;
 			}
-			
+
 			if (powerOfTwo)
 			{
 				addRightWidthRotate = addRightWidth = getNextPowerOfTwo(addRightWidth);
 				addRightHeightRotate = addRightHeight = getNextPowerOfTwo(addRightHeight);
 				addBottomWidthRotate = addBottomWidth = getNextPowerOfTwo(addBottomWidth);
 				addBottomHeightRotate = addBottomHeight = getNextPowerOfTwo(addBottomHeight);
-				
+
 				if (allowRotation)
 				{
 					addRightWidthRotate = getNextPowerOfTwo(addRightWidthRotate);
@@ -441,26 +441,26 @@ class FlxAtlas implements IFlxDestroyable
 					addBottomHeightRotate = getNextPowerOfTwo(addBottomHeightRotate);
 				}
 			}
-			
+
 			// checks for the max size
 			var canExpandRight:Bool = true;
 			var canExpandBottom:Bool = true;
-			
+
 			var canExpandRightRotate:Bool = allowRotation;
 			var canExpandBottomRotate:Bool = allowRotation;
-			
+
 			if ((maxWidth > 0 && addRightWidth > maxWidth) || (maxHeight > 0 && addRightHeight > maxHeight))
 				canExpandRight = false;
-			
+
 			if ((maxWidth > 0 && addBottomWidth > maxWidth) || (maxHeight > 0 && addBottomHeight > maxHeight))
 				canExpandBottom = false;
-			
+
 			if ((maxWidth > 0 && addRightWidthRotate > maxWidth) || (maxHeight > 0 && addRightHeightRotate > maxHeight))
 				canExpandRightRotate = false;
-			
+
 			if ((maxWidth > 0 && addBottomWidthRotate > maxWidth) || (maxHeight > 0 && addBottomHeightRotate > maxHeight))
 				canExpandBottomRotate = false;
-			
+
 			if (!canExpandRight && !canExpandBottom && !canExpandRightRotate && !canExpandBottomRotate)
 			{
 				#if FLX_DEBUG
@@ -470,19 +470,19 @@ class FlxAtlas implements IFlxDestroyable
 				#end
 				return null; // can't expand in any direction
 			}
-			
+
 			// calculate area of result atlas for various cases
 			// the case with less area will be chosen
 			var addRightArea:Int = addRightWidth * addRightHeight;
 			var addBottomArea:Int = addBottomWidth * addBottomHeight;
-			
+
 			var addRightAreaRotate:Int = addRightWidthRotate * addRightHeightRotate;
 			var addBottomAreaRotate:Int = addBottomWidthRotate * addBottomHeightRotate;
-			
+
 			var rotateRight:Bool = false;
 			var rotateBottom:Bool = false;
 			var rotateNode:Bool = false;
-			
+
 			if ((canExpandRight && canExpandRightRotate && addRightArea > addRightAreaRotate) ||
 				(!canExpandRight && canExpandRightRotate))
 			{
@@ -492,7 +492,7 @@ class FlxAtlas implements IFlxDestroyable
 				canExpandRight = true;
 				rotateRight = true;
 			}
-			
+
 			if ((canExpandBottom && canExpandBottomRotate && addBottomArea > addBottomAreaRotate) ||
 				(!canExpandBottom && canExpandBottomRotate))
 			{
@@ -502,7 +502,7 @@ class FlxAtlas implements IFlxDestroyable
 				canExpandBottom = true;
 				rotateBottom = true;
 			}
-			
+
 			if (!canExpandRight && canExpandBottom)
 			{
 				addRightArea = addBottomArea + 1; // can't expand to the right
@@ -513,12 +513,12 @@ class FlxAtlas implements IFlxDestroyable
 				addBottomArea = addRightArea + 1; // can't expand to the bottom
 				rotateNode = rotateBottom;
 			}
-			
+
 			var dataNode:FlxNode = null;
 			var temp:FlxNode = root;
 			var insertNodeWidth:Int = insertWidth;
 			var insertNodeHeight:Int = insertHeight;
-			
+
 			// decide how to insert new node
 			if (addBottomArea >= addRightArea) // add node to the right
 			{
@@ -527,7 +527,7 @@ class FlxAtlas implements IFlxDestroyable
 					insertNodeWidth = insertHeight;
 					insertNodeHeight = insertWidth;
 				}
-				
+
 				expandRoot(temp.width + insertNodeWidth, Math.max(temp.height, insertNodeHeight), true);
 				dataNode = divideNode(root.right, insertNodeWidth, insertNodeHeight, true, data, key, rotateRight);
 				expandRoot(addRightWidth, addRightHeight, false, true);
@@ -539,66 +539,66 @@ class FlxAtlas implements IFlxDestroyable
 					insertNodeWidth = insertHeight;
 					insertNodeHeight = insertWidth;
 				}
-				
+
 				expandRoot(Math.max(temp.width, insertNodeWidth), temp.height + insertNodeHeight, false);
 				dataNode = divideNode(root.right, insertNodeWidth, insertNodeHeight, true, data, key, rotateBottom);
 				expandRoot(addBottomWidth, addBottomHeight, false, true);
 			}
-			
+
 			return dataNode;
 		}
-		
+
 		return null;
 	}
-	
-	private function expandRoot(newWidth:Float, newHeight:Float, divideHorizontally:Bool,
+
+	function expandRoot(newWidth:Float, newHeight:Float, divideHorizontally:Bool,
 		decideHowToDivide:Bool = false):Void
 	{
 		if (newWidth > root.width || newHeight > root.height)
 		{
 			var temp:FlxNode = root;
 			root = new FlxNode(FlxRect.get(0, 0, newWidth, newHeight), this);
-			
+
 			divideHorizontally = decideHowToDivide ? needToDivideHorizontally(root, temp.width, temp.height) : divideHorizontally;
-			
+
 			divideNode(root, temp.width, temp.height, divideHorizontally);
 			root.left.left = temp;
 		}
 	}
-	
-	private function expandBitmapData():Void
+
+	function expandBitmapData():Void
 	{
 		if (bitmapData != null && bitmapData.width == root.width && bitmapData.height == root.height)
 		{
 			return;
 		}
-		
+
 		var newBitmapData:BitmapData = new BitmapData(root.width, root.height, true, FlxColor.TRANSPARENT);
 		if (bitmapData != null)
 		{
 			point.setTo(0, 0);
 			newBitmapData.copyPixels(bitmapData, bitmapData.rect, point);
 		}
-		
+
 		bitmapData = FlxDestroyUtil.dispose(bitmapData);
 		bitmapData = newBitmapData;
 	}
-	
-	private function getNextPowerOfTwo(number:Float):Int
+
+	function getNextPowerOfTwo(number:Float):Int
 	{
 		var n:Int = Std.int(number);
 		if (n > 0 && (n & (n - 1)) == 0) // see: http://goo.gl/D9kPj
 			return n;
-		
+
 		var result:Int = 1;
 		while (result < n) result <<= 1;
 		return result;
 	}
-	
+
 	/**
 	 * Generates a new `BitmapData` with spaces between tiles, adds this `BitmapData` to this atlas,
 	 * generates a `FlxTileFrames` object for the added node and returns it. Can be useful for tilemaps.
-	 * 
+	 *
 	 * @param   Graphic        Source image for node, where spaces will be inserted
 	 *                        (could be a `BitmapData`, `String` or `Class<Dynamic>`).
 	 * @param   Key           Optional key for image
@@ -612,8 +612,8 @@ class FlxAtlas implements IFlxDestroyable
 		tileSpacing:FlxPoint, ?tileBorder:FlxPoint, ?region:FlxRect):FlxTileFrames
 	{
 		var key:String = FlxAssets.resolveKey(Graphic, Key);
-		
-		if (key == null) 
+
+		if (key == null)
 		{
 			#if FLX_DEBUG
 			throw "addNodeWithSpacings can't find the key for specified BitmapData." +
@@ -621,15 +621,15 @@ class FlxAtlas implements IFlxDestroyable
 			#end
 			return null;
 		}
-		
+
 		key = FlxG.bitmap.getKeyWithSpacesAndBorders(key, tileSize, tileSpacing, tileBorder, region);
-		
+
 		if (hasNodeWithName(key))
 			return nodes.get(key).getTileFrames(tileSize, tileSpacing, tileBorder);
-		
+
 		var data:BitmapData = FlxAssets.resolveBitmapData(Graphic);
-		
-		if (data == null) 
+
+		if (data == null)
 		{
 			#if FLX_DEBUG
 			throw "addNodeWithSpacings can't find BitmapData with specified key: "
@@ -637,11 +637,11 @@ class FlxAtlas implements IFlxDestroyable
 			#end
 			return null;
 		}
-		
+
 		var nodeData = FlxBitmapDataUtil.addSpacesAndBorders(data, tileSize, tileSpacing, tileBorder, region);
 		var node:FlxNode = addNode(nodeData, key);
-		
-		if (node == null) 
+
+		if (node == null)
 		{
 			#if FLX_DEBUG
 			throw "addNodeWithSpacings can't insert provided image: " + Graphic +
@@ -649,13 +649,13 @@ class FlxAtlas implements IFlxDestroyable
 			#end
 			return null;
 		}
-		
+
 		if (tileBorder != null)
 			tileSize.add(2 * tileBorder.x, 2 * tileBorder.y);
-		
+
 		return node.getTileFrames(tileSize, tileSpacing, tileBorder);
 	}
-	
+
 	/**
 	 * Gets the `FlxAtlasFrames` object for this atlas.
 	 * It caches graphic of this atlas and generates `FlxAtlasFrames` if it doesn't exist yet.
@@ -665,26 +665,26 @@ class FlxAtlas implements IFlxDestroyable
 	public function getAtlasFrames():FlxAtlasFrames
 	{
 		var graph:FlxGraphic = this.graphic;
-		
+
 		var atlasFrames:FlxAtlasFrames = graph.atlasFrames;
 		if (graph.atlasFrames == null)
 		{
 			atlasFrames = new FlxAtlasFrames(graph);
 		}
-		
+
 		for (node in nodes)
 			addNodeToAtlasFrames(node);
-		
+
 		return atlasFrames;
 	}
-	
-	private function addNodeToAtlasFrames(node:FlxNode):Void
+
+	function addNodeToAtlasFrames(node:FlxNode):Void
 	{
 		if (_graphic == null || _graphic.atlasFrames == null || node == null)
 			return;
-		
+
 		var atlasFrames:FlxAtlasFrames = _graphic.atlasFrames;
-		
+
 		if (node.filled && !atlasFrames.framesHash.exists(node.key))
 		{
 			var frame:FlxRect = FlxRect.get(node.x, node.y, node.width - border, node.height - border);
@@ -696,7 +696,7 @@ class FlxAtlas implements IFlxDestroyable
 			atlasFrames.addAtlasFrame(frame, sourceSize, offset, node.key, angle);
 		}
 	}
-	
+
 	/**
 	 * Checks if the atlas already contains node with the same name.
 	 *
@@ -707,7 +707,7 @@ class FlxAtlas implements IFlxDestroyable
 	{
 		return nodes.exists(nodeName);
 	}
-	
+
 	/**
 	 * Gets a node by it's name.
 	 *
@@ -718,7 +718,7 @@ class FlxAtlas implements IFlxDestroyable
 	{
 		return nodes.get(key);
 	}
-	
+
 	/**
 	 * Optimized version of method for adding multiple nodes to atlas.
 	 * Uses less of the atlas' area (it sorts images by the size before adding them to atlas).
@@ -731,7 +731,7 @@ class FlxAtlas implements IFlxDestroyable
 	{
 		var numKeys:Int = keys.length;
 		var numBitmaps:Int = bitmaps.length;
-		
+
 		if (numBitmaps != numKeys)
 		{
 			#if FLX_DEBUG
@@ -739,32 +739,32 @@ class FlxAtlas implements IFlxDestroyable
 			#end
 			return null;
 		}
-		
+
 		_tempStorage = new Array<TempAtlasObj>();
 		for (i in 0...numBitmaps)
 		{
 			_tempStorage.push({ bmd: bitmaps[i], keyStr: keys[i] });
 		}
-		
+
 		addFromAtlasObjects(_tempStorage);
 		return this;
 	}
-	
-	private function addFromAtlasObjects(objects:Array<TempAtlasObj>):Void
+
+	function addFromAtlasObjects(objects:Array<TempAtlasObj>):Void
 	{
 		objects.sort(bitmapSorter);
 		var numBitmaps:Int = objects.length;
-		
+
 		for (i in 0...numBitmaps)
 			addNode(objects[i].bmd, objects[i].keyStr);
-		
+
 		_tempStorage = null;
 	}
-	
+
 	/**
 	 * Internal method for sorting bitmaps
 	 */
-	private function bitmapSorter(obj1:TempAtlasObj, obj2:TempAtlasObj):Int
+	function bitmapSorter(obj1:TempAtlasObj, obj2:TempAtlasObj):Int
 	{
 		if (allowRotation)
 		{
@@ -772,13 +772,13 @@ class FlxAtlas implements IFlxDestroyable
 			var area2:Int = obj2.bmd.width * obj2.bmd.height;
 			return area2 - area1;
 		}
-		
+
 		if (obj2.bmd.width == obj1.bmd.width)
 			return obj2.bmd.height - obj1.bmd.height;
-		
+
 		return obj2.bmd.width - obj1.bmd.width;
 	}
-	
+
 	/**
 	 * Creates a new "queue" for adding new nodes.
 	 * This method should be used with the `addToQueue()` and `generateFromQueue()` methods:
@@ -791,7 +791,7 @@ class FlxAtlas implements IFlxDestroyable
 		_tempStorage = new Array<TempAtlasObj>();
 		return this;
 	}
-	
+
 	/**
 	 * Adds new object to queue for later creation of new node
 	 *
@@ -802,11 +802,11 @@ class FlxAtlas implements IFlxDestroyable
 	{
 		if (_tempStorage == null)
 			_tempStorage = new Array<TempAtlasObj>();
-		
+
 		_tempStorage.push({ bmd: data, keyStr: key });
 		return this;
 	}
-	
+
 	/**
 	 * Adds all objects in "queue" to existing atlas. Doesn't remove any nodes.
 	 */
@@ -814,16 +814,16 @@ class FlxAtlas implements IFlxDestroyable
 	{
 		if (_tempStorage != null)
 			addFromAtlasObjects(_tempStorage);
-		
+
 		return this;
 	}
-	
-	private function onClear(_):Void
+
+	function onClear(_):Void
 	{
 		if (!persist || (_graphic != null && _graphic.useCount <= 0))
 			destroy();
 	}
-	
+
 	/**
 	 * Destroys the atlas. Use only if you want to clear memory and don't need this atlas anymore,
 	 * since it disposes the `BitmapData` and removes it from the cache.
@@ -837,10 +837,10 @@ class FlxAtlas implements IFlxDestroyable
 		bitmapData = null;
 		nodes = null;
 		_graphic = null;
-		
+
 		FlxG.signals.preStateCreate.remove(onClear);
 	}
-	
+
 	/**
 	 * Clears all data in atlas. Use it when you want reuse this atlas.
 	 * WARNING: it will destroy the graphic of this image, so you can get
@@ -855,7 +855,7 @@ class FlxAtlas implements IFlxDestroyable
 		nodes = new Map<String, FlxNode>();
 		_graphic = null;
 	}
-	
+
 	/**
 	 * Returns atlas data in LibGdx packer format.
 	 */
@@ -866,13 +866,13 @@ class FlxAtlas implements IFlxDestroyable
 		data += "format: RGBA8888\n";
 		data += "filter: Linear,Linear\n";
 		data += "repeat: none\n";
-		
+
 		for (node in nodes)
 		{
 			data += node.key + "\n";
 			data += "  rotate: " + node.rotated + "\n";
 			data += "  xy: " + node.x + ", " + node.y + "\n";
-			
+
 			if (allowRotation)
 			{
 				data += "size: " + node.height + ", " + node.width + "\n";
@@ -883,15 +883,15 @@ class FlxAtlas implements IFlxDestroyable
 				data += "size: " + node.width + ", " + node.height + "\n";
 				data += "orig: " + node.width + ", " + node.height + "\n";
 			}
-			
+
 			data += "  offset: 0, 0\n";
 			data += "  index: -1\n";
 		}
-		
+
 		return data;
 	}
-	
-	private function deleteSubtree(node:FlxNode):Void
+
+	function deleteSubtree(node:FlxNode):Void
 	{
 		if (node != null)
 		{
@@ -900,26 +900,26 @@ class FlxAtlas implements IFlxDestroyable
 			node.destroy();
 		}
 	}
-	
+
 	// Internal iteration method
-	private function findNodeToInsert(insertWidth:Int, insertHeight:Int):FlxNode
+	function findNodeToInsert(insertWidth:Int, insertHeight:Int):FlxNode
 	{
 		// Node stack
 		var stack:Array<FlxNode> = new Array<FlxNode>();
 		// Current node
 		var current:FlxNode = root;
-		
+
 		var emptyNodes:Array<FlxNode> = new Array<FlxNode>();
-		
+
 		var canPlaceRight:Bool = false;
 		var canPlaceLeft:Bool = false;
-		
+
 		var looping:Bool = true;
-		
+
 		var result:FlxNode = null;
 		var minArea:Int = maxWidth * maxHeight + 1;
 		var nodeArea:Int;
-		
+
 		// Main loop
 		while (looping)
 		{
@@ -927,7 +927,7 @@ class FlxAtlas implements IFlxDestroyable
 			if (current.isEmpty && current.canPlace(insertWidth, insertHeight))
 			{
 				nodeArea = current.width * current.height;
-				
+
 				if (nodeArea < minArea)
 				{
 					minArea = nodeArea;
@@ -964,39 +964,39 @@ class FlxAtlas implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		return result;
 	}
-	
-	private function set_bitmapData(value:BitmapData):BitmapData
+
+	function set_bitmapData(value:BitmapData):BitmapData
 	{
 		// update graphic bitmapData
 		if (value != null && _graphic != null)
 			_graphic.bitmap = value;
-		
+
 		return bitmapData = value;
 	}
-	
-	private function get_graphic():FlxGraphic
+
+	function get_graphic():FlxGraphic
 	{
 		if (_graphic != null)
 			return _graphic;
-			
+
 		_graphic = FlxG.bitmap.add(bitmapData, false, name);
 		_graphic.persist = persist;
-		
+
 		return _graphic;
 	}
-	
-	private function set_persist(value:Bool):Bool
+
+	function set_persist(value:Bool):Bool
 	{
 		if (_graphic != null)
 			_graphic.persist = value;
-			
+
 		return persist = value;
 	}
-	
-	private function set_minWidth(value:Int):Int
+
+	function set_minWidth(value:Int):Int
 	{
 		if (value <= maxWidth)
 		{
@@ -1004,11 +1004,11 @@ class FlxAtlas implements IFlxDestroyable
 			if (value > width)
 				width = value;
 		}
-		
+
 		return minWidth;
 	}
-	
-	private function set_minHeight(value:Int):Int
+
+	function set_minHeight(value:Int):Int
 	{
 		if (value <= maxHeight)
 		{
@@ -1016,19 +1016,19 @@ class FlxAtlas implements IFlxDestroyable
 			if (value > height)
 				height = value;
 		}
-		
+
 		return minHeight;
 	}
-	
-	private function get_width():Int
+
+	function get_width():Int
 	{
 		if (root != null)
 			return root.width;
-		
+
 		return 0;
 	}
-	
-	private function set_width(value:Int):Int
+
+	function set_width(value:Int):Int
 	{
 		if (value > get_width())
 		{
@@ -1043,24 +1043,24 @@ class FlxAtlas implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function get_height():Int
+
+	function get_height():Int
 	{
 		if (root != null)
 			return root.height;
 		return 0;
 	}
-	
-	private function set_height(value:Int):Int
+
+	function set_height(value:Int):Int
 	{
 		if (value > get_height())
 		{
 			if (powerOfTwo)
 				value = getNextPowerOfTwo(value);
-			
+
 			if (value <= maxHeight)
 			{
 				if (root != null && root.height < value)
@@ -1069,33 +1069,33 @@ class FlxAtlas implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function set_maxWidth(value:Int):Int
+
+	function set_maxWidth(value:Int):Int
 	{
 		if (value >= minWidth && (root == null || value >= width))
 			maxWidth = value;
-		
+
 		return maxWidth;
 	}
-	
-	private function set_maxHeight(value:Int):Int
+
+	function set_maxHeight(value:Int):Int
 	{
 		if (value >= minHeight && (root == null || value >= height))
 			maxHeight = value;
-		
+
 		return maxHeight;
 	}
-	
-	private function set_powerOfTwo(value:Bool):Bool
+
+	function set_powerOfTwo(value:Bool):Bool
 	{
 		if (value != powerOfTwo && value && root != null)
 		{
 			var nextWidth:Int = getNextPowerOfTwo(root.width);
 			var nextHeight:Int = getNextPowerOfTwo(root.height);
-			
+
 			if (nextWidth != root.width || nextHeight != root.height) // need to resize atlas
 			{
 				if ((maxWidth > 0 && nextWidth > maxWidth) || (maxHeight > 0 && nextHeight > maxHeight))
@@ -1106,10 +1106,10 @@ class FlxAtlas implements IFlxDestroyable
 					#end
 					return false;
 				}
-				
+
 				var temp:FlxNode = root;
 				root = new FlxNode(FlxRect.get(0, 0, nextWidth, nextHeight), this);
-				
+
 				if (temp.left != null) // this means that atlas isn't empty and we need to resize it's BitmapData
 				{
 					divideNode(root, temp.width, temp.height, needToDivideHorizontally(root, temp.width, temp.height));
@@ -1117,7 +1117,7 @@ class FlxAtlas implements IFlxDestroyable
 				}
 			}
 		}
-		
+
 		return powerOfTwo = value;
 	}
 }

--- a/flixel/graphics/atlas/FlxNode.hx
+++ b/flixel/graphics/atlas/FlxNode.hx
@@ -22,7 +22,7 @@ class FlxNode implements IFlxDestroyable
 	 * Right child of this node.
 	 */
 	public var right:FlxNode;
-	
+
 	/**
 	 * Region of the atlas which this node holds, includes spacings between nodes.
 	 */
@@ -40,7 +40,7 @@ class FlxNode implements IFlxDestroyable
 	 * Atlas object which contains this node.
 	 */
 	public var atlas:FlxAtlas;
-	
+
 	/**
 	 * The x coordinate of the top-left corner of this node.
 	 */
@@ -61,9 +61,9 @@ class FlxNode implements IFlxDestroyable
 	 * Logical flag, showing whether this node have any child nodes or image in it.
 	 */
 	public var isEmpty(get, null):Bool;
-	
+
 	public var rotated(default, null):Bool;
-	
+
 	/**
 	 * Node constructor
 	 *
@@ -82,7 +82,7 @@ class FlxNode implements IFlxDestroyable
 		this.atlas = atlas;
 		this.rotated = rotated;
 	}
-	
+
 	public inline function destroy():Void
 	{
 		key = null;
@@ -91,7 +91,7 @@ class FlxNode implements IFlxDestroyable
 		rect = null;
 		atlas = null;
 	}
-	
+
 	/**
 	 * Whether we place node with specified width and height in this node.
 	 */
@@ -99,7 +99,7 @@ class FlxNode implements IFlxDestroyable
 	{
 		return rect.width >= width && rect.height >= height;
 	}
-	
+
 	/**
 	 * Generates TileFrames object for this node
 	 *
@@ -112,7 +112,7 @@ class FlxNode implements IFlxDestroyable
 	{
 		FlxG.bitmap.add(atlas.bitmapData, false, atlas.name);
 		var frame:FlxFrame = atlas.getAtlasFrames().getByName(key);
-		
+
 		if (frame != null)
 		{
 			var tileFrames:FlxTileFrames = FlxTileFrames.fromFrame(frame, tileSize, tileSpacing);
@@ -120,10 +120,10 @@ class FlxNode implements IFlxDestroyable
 				tileFrames = tileFrames.addBorder(tileBorder);
 			return tileFrames;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Generates a `FlxImageFrame` object for this node.
 	 *
@@ -133,45 +133,45 @@ class FlxNode implements IFlxDestroyable
 	{
 		FlxG.bitmap.add(atlas.bitmapData, false, atlas.name);
 		var frame = atlas.getAtlasFrames().getByName(key);
-		
+
 		if (frame != null)
 			return FlxImageFrame.fromFrame(frame);
-		
+
 		return null;
 	}
-	
-	private inline function get_isEmpty():Bool
+
+	inline function get_isEmpty():Bool
 	{
 		return !filled && left == null && right == null;
 	}
-	
-	private inline function get_x():Int
+
+	inline function get_x():Int
 	{
 		return Std.int(rect.x);
 	}
-	
-	private inline function get_y():Int
+
+	inline function get_y():Int
 	{
 		return Std.int(rect.y);
 	}
-	
-	private inline function get_width():Int
+
+	inline function get_width():Int
 	{
 		return Std.int(rect.width);
 	}
-	
-	private function set_width(value:Int):Int
+
+	function set_width(value:Int):Int
 	{
 		rect.width = value;
 		return value;
 	}
-	
-	private inline function get_height():Int
+
+	inline function get_height():Int
 	{
 		return Std.int(rect.height);
 	}
-	
-	private function set_height(value:Int):Int
+
+	function set_height(value:Int):Int
 	{
 		rect.height = value;
 		return value;

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -19,11 +19,11 @@ import openfl.Assets;
  */
 class FlxAtlasFrames extends FlxFramesCollection
 {
-	public function new(parent:FlxGraphic, ?border:FlxPoint) 
+	public function new(parent:FlxGraphic, ?border:FlxPoint)
 	{
 		super(parent, FlxFrameCollectionType.ATLAS, border);
 	}
-	
+
 	/**
 	 * Parsing method for TexturePacker atlases in JSON format.
 	 *
@@ -39,34 +39,34 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source, false);
 		if (graphic == null)
 			return null;
-		
+
 		// No need to parse data again
 		var frames:FlxAtlasFrames = FlxAtlasFrames.findFrame(graphic);
 		if (frames != null)
 			return frames;
-		
+
 		if (graphic == null || Description == null)
 			return null;
-		
+
 		frames = new FlxAtlasFrames(graphic);
-		
+
 		var data:TexturePackerObject;
-		
+
 		if (Std.is(Description, String))
 		{
 			var json:String = Description;
-			
+
 			if (Assets.exists(json))
 				json = Assets.getText(json);
-			
+
 			data = Json.parse(json);
 		}
-		
+
 		else
 		{
 			data = Description;
 		}
-		
+
 		// JSON-Array
 		if (Std.is(data.frames, Array))
 		{
@@ -83,10 +83,10 @@ class FlxAtlasFrames extends FlxFramesCollection
 				texturePackerHelper(frameName, Reflect.field(data.frames, frameName), frames);
 			}
 		}
-		
+
 		return frames;
 	}
-	
+
 	/**
 	 * Internal method for TexturePacker parsing. Parses the actual frame data.
 	 *
@@ -94,7 +94,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 * @param   FrameData   The TexturePacker data excluding "filename".
 	 * @param   Frames      The `FlxAtlasFrames` to add this frame to.
 	 */
-	private static function texturePackerHelper(FrameName:String, FrameData:Dynamic, Frames:FlxAtlasFrames):Void
+	static function texturePackerHelper(FrameName:String, FrameData:Dynamic, Frames:FlxAtlasFrames):Void
 	{
 		var rotated:Bool = FrameData.rotated;
 		var name:String = FrameName;
@@ -102,7 +102,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var offset:FlxPoint = FlxPoint.get(FrameData.spriteSourceSize.x, FrameData.spriteSourceSize.y);
 		var angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0;
 		var frameRect:FlxRect = null;
-		
+
 		if (rotated)
 		{
 			frameRect = FlxRect.get(FrameData.frame.x, FrameData.frame.y, FrameData.frame.h, FrameData.frame.w);
@@ -112,13 +112,13 @@ class FlxAtlasFrames extends FlxFramesCollection
 		{
 			frameRect = FlxRect.get(FrameData.frame.x, FrameData.frame.y, FrameData.frame.w, FrameData.frame.h);
 		}
-		
+
 		Frames.addAtlasFrame(frameRect, sourceSize, offset, name, angle);
 	}
-	
+
 	/**
 	 * Parsing method for LibGDX atlases.
-	 * 
+	 *
 	 * @param   Source        The image source (can be `FlxGraphic`, `String` or `BitmapData`).
 	 * @param   Description   Contents of the file with atlas description.
 	 *                        You can get it with `Assets.getText(path/to/description/file)`.
@@ -130,27 +130,27 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source);
 		if (graphic == null)
 			return null;
-		
+
 		// No need to parse data again
 		var frames:FlxAtlasFrames = FlxAtlasFrames.findFrame(graphic);
 		if (frames != null)
 			return frames;
-		
+
 		if ((graphic == null) || (Description == null))
 			return null;
-		
+
 		frames = new FlxAtlasFrames(graphic);
-		
+
 		if (Assets.exists(Description))
 			Description = Assets.getText(Description);
-		
+
 		var pack:String = StringTools.trim(Description);
 		var lines:Array<String> = pack.split("\n");
-		
+
 		// find the "repeat" option and skip unused data
 		var repeatLine:Int = (lines[3].indexOf("repeat:") > -1) ? 3 : 4;
 		lines.splice(0, repeatLine + 1);
-		
+
 		var numElementsPerImage:Int = 7;
 		var numImages:Int = Std.int(lines.length / numElementsPerImage);
 		var size = [];
@@ -158,23 +158,23 @@ class FlxAtlasFrames extends FlxFramesCollection
 		for (i in 0...numImages)
 		{
 			var curIndex = i * numElementsPerImage;
-			
+
 			var name = lines[curIndex++];
 			var rotated = (lines[curIndex++].indexOf("true") >= 0);
 			var angle = FlxFrameAngle.ANGLE_0;
-			
+
 			var tempString = lines[curIndex++];
 			var size = getDimensions(tempString, size);
-			
+
 			var imageX = size[0];
 			var imageY = size[1];
-			
+
 			tempString = lines[curIndex++];
 			size = getDimensions(tempString, size);
-			
+
 			var imageWidth = size[0];
 			var imageHeight = size[1];
-			
+
 			var rect = null;
 			if (rotated)
 			{
@@ -185,15 +185,15 @@ class FlxAtlasFrames extends FlxFramesCollection
 			{
 				rect = FlxRect.get(imageX, imageY, imageWidth, imageHeight);
 			}
-			
+
 			tempString = lines[curIndex++];
 			size = getDimensions(tempString, size);
-			
+
 			var sourceSize = FlxPoint.get(size[0], size[1]);
-			
+
 			tempString = lines[curIndex++];
 			size = getDimensions(tempString, size);
-			
+
 			// this should be how it is, but libgdx's texture packer tool
 			// currently outputs the offset from the bottom left, instead:
 			//var offset = FlxPoint.get(size[0], size[1]);
@@ -201,32 +201,32 @@ class FlxAtlasFrames extends FlxFramesCollection
 			var offset = FlxPoint.get(size[0], sourceSize.y - size[1] - imageHeight);
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle);
 		}
-		
+
 		return frames;
 	}
-	
+
 	/**
 	 * Internal method for LibGDX atlas parsing. It tries to extract dimensions info from specified string.
-	 * 
+	 *
 	 * @param   line   `String` to extract info from.
 	 * @param   size   `Array` to store extracted info to.
 	 * @return  `Array` filled with dimensions info.
 	 */
-	private static function getDimensions(line:String, size:Array<Int>):Array<Int>
+	static function getDimensions(line:String, size:Array<Int>):Array<Int>
 	{
 		var colonPosition:Int = line.indexOf(":");
 		var comaPosition:Int = line.indexOf(",");
-		
+
 		size[0] = Std.parseInt(line.substring(colonPosition + 1, comaPosition));
 		size[1] = Std.parseInt(line.substring(comaPosition + 1, line.length));
-		
+
 		return size;
 	}
-	
+
 	/**
 	 * Parsing method for Sparrow texture atlases
 	 * (they can be generated with Shoebox http://renderhjs.net/shoebox/ for example).
-	 * 
+	 *
 	 * @param   Source        The image source (can be `FlxGraphic`, `String` or `BitmapData`).
 	 * @param   Description   Contents of the XML file with atlas description.
 	 *                        You can get it with `Assets.getText(path/to/description.xml)`.
@@ -238,22 +238,22 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source);
 		if (graphic == null)
 			return null;
-		
+
 		// No need to parse data again
 		var frames:FlxAtlasFrames = FlxAtlasFrames.findFrame(graphic);
 		if (frames != null)
 			return frames;
-		
+
 		if (graphic == null || Description == null)
 			return null;
-		
+
 		frames = new FlxAtlasFrames(graphic);
-		
+
 		if (Assets.exists(Description))
 			Description = Assets.getText(Description);
-		
+
 		var data:Fast = new haxe.xml.Fast(Xml.parse(Description).firstElement());
-		
+
 		for (texture in data.nodes.SubTexture)
 		{
 			var name = texture.att.name;
@@ -261,10 +261,10 @@ class FlxAtlasFrames extends FlxFramesCollection
 			var rotated = (texture.has.rotated && texture.att.rotated == "true");
 			var flipX = (texture.has.flipX && texture.att.flipX == "true");
 			var flipY = (texture.has.flipY && texture.att.flipY == "true");
-			
+
 			var rect = FlxRect.get(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y),
 				Std.parseFloat(texture.att.width), Std.parseFloat(texture.att.height));
-			
+
 			var size = if (trimmed)
 			{
 				new Rectangle(Std.parseInt(texture.att.frameX), Std.parseInt(texture.att.frameY),
@@ -274,24 +274,24 @@ class FlxAtlasFrames extends FlxFramesCollection
 			{
 				new Rectangle(0, 0, rect.width, rect.height);
 			}
-			
+
 			var angle = rotated ? FlxFrameAngle.ANGLE_NEG_90 : FlxFrameAngle.ANGLE_0;
-			
+
 			var offset = FlxPoint.get(-size.left, -size.top);
 			var sourceSize = FlxPoint.get(size.width, size.height);
-			
+
 			if (rotated && !trimmed)
 				sourceSize.set(size.height, size.width);
-			
+
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle, flipX, flipY);
 		}
-		
+
 		return frames;
 	}
-	
+
 	/**
 	 * Parsing method for TexturePacker atlases in generic XML format.
-	 * 
+	 *
 	 * @param   Source        The image source (can be `FlxGraphic`, `String` or `BitmapData`).
 	 * @param   Description   Contents of the XML file with atlas description.
 	 *                        You can get it with `Assets.getText(path/to/description.xml)`.
@@ -303,22 +303,22 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source, false);
 		if (graphic == null)
 			return null;
-		
+
 		// No need to parse data again
 		var frames = FlxAtlasFrames.findFrame(graphic);
 		if (frames != null)
 			return frames;
-		
+
 		if (graphic == null || Description == null)
 			return null;
-		
+
 		frames = new FlxAtlasFrames(graphic);
-		
+
 		if (Assets.exists(Description))
 			Description = Assets.getText(Description);
-		
+
 		var xml = Xml.parse(Description);
-		
+
 		for (sprite in xml.firstElement().elements())
 		{
 			var trimmed = (sprite.exists("oX") || sprite.exists("oY"));
@@ -329,22 +329,22 @@ class FlxAtlasFrames extends FlxFramesCollection
 			var rect = FlxRect.get(Std.parseInt(sprite.get("x")), Std.parseInt(sprite.get("y")),
 				Std.parseInt(sprite.get("w")), Std.parseInt(sprite.get("h")));
 			var sourceSize = FlxPoint.get(rect.width, rect.height);
-			
+
 			if (trimmed)
 			{
 				offset.set(Std.parseInt(sprite.get("oX")), Std.parseInt(sprite.get("oY")));
 				sourceSize.set(Std.parseInt(sprite.get("oW")), Std.parseInt(sprite.get("oH")));
 			}
-			
+
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle);
 		}
-		
+
 		return frames;
 	}
-	
+
 	/**
 	 * Parsing method for Sprite Sheet Packer atlases (http://spritesheetpacker.codeplex.com/).
-	 * 
+	 *
 	 * @param   Source        The image source (can be `FlxGraphic`, `String` or `BitmapData`).
 	 * @param   Description   Contents of the file with atlas description.
 	 *                        You can get it with `Assets.getText(path/to/description/file)`.
@@ -356,20 +356,20 @@ class FlxAtlasFrames extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source);
 		if (graphic == null)
 			return null;
-		
+
 		// No need to parse data again
 		var frames = FlxAtlasFrames.findFrame(graphic);
 		if (frames != null)
 			return frames;
-		
+
 		if (graphic == null || Description == null)
 			return null;
-		
+
 		frames = new FlxAtlasFrames(graphic);
-		
+
 		if (Assets.exists(Description))
 			Description = Assets.getText(Description);
-		
+
 		var pack = StringTools.trim(Description);
 		var lines:Array<String> = pack.split("\n");
 
@@ -378,21 +378,21 @@ class FlxAtlasFrames extends FlxFramesCollection
 			var currImageData = lines[i].split("=");
 			var name = StringTools.trim(currImageData[0]);
 			var currImageRegion = StringTools.trim(currImageData[1]).split(" ");
-			
+
 			var rect = FlxRect.get(Std.parseInt(currImageRegion[0]), Std.parseInt(currImageRegion[1]),
 				Std.parseInt(currImageRegion[2]), Std.parseInt(currImageRegion[3]));
 			var sourceSize = FlxPoint.get(rect.width, rect.height);
 			var offset = FlxPoint.get();
-			
+
 			frames.addAtlasFrame(rect, sourceSize, offset, name, FlxFrameAngle.ANGLE_0);
 		}
-		
+
 		return frames;
 	}
-	
+
 	/**
 	 * Returns the `FlxAtlasFrame` of the specified `FlxGraphic` object.
-	 * 
+	 *
 	 * @param   graphic   `FlxGraphic` object to find the `FlxAtlasFrames` collection for.
 	 * @return  `FlxAtlasFrames` collection for the specified `FlxGraphic` object
 	 *          Could be `null` if `FlxGraphic` doesn't have it yet.
@@ -401,33 +401,33 @@ class FlxAtlasFrames extends FlxFramesCollection
 	{
 		if (border == null)
 			border = FlxPoint.weak();
-		
+
 		var atlasFrames:Array<FlxAtlasFrames> = cast graphic.getFramesCollections(FlxFrameCollectionType.ATLAS);
-		
+
 		for (atlas in atlasFrames)
 			if (atlas.border.equals(border))
 				return atlas;
-		
+
 		return null;
 	}
-	
+
 	override public function addBorder(border:FlxPoint):FlxAtlasFrames
 	{
 		var resultBorder = FlxPoint.weak().addPoint(this.border).addPoint(border);
 		var atlasFrames = FlxAtlasFrames.findFrame(parent, resultBorder);
 		if (atlasFrames != null)
 			return atlasFrames;
-		
+
 		atlasFrames = new FlxAtlasFrames(parent, resultBorder);
-		
+
 		for (frame in frames)
 			atlasFrames.pushFrame(frame.setBorderTo(border));
-		
+
 		return atlasFrames;
 	}
 }
 
-typedef TexturePackerObject = 
+typedef TexturePackerObject =
 {
 	frames : Dynamic
 }

--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -22,67 +22,67 @@ import openfl.Assets;
 @:allow(flixel.text.FlxBitmapText)
 class FlxBitmapFont extends FlxFramesCollection
 {
-	private static inline var SPACE_CODE:Int = 32;
-	private static inline var TAB_CODE:Int = 9;
-	private static inline var NEW_LINE_CODE:Int = 10;
-	
-	private static inline var DEFAULT_FONT_KEY:String = "DEFAULT_FONT_KEY";
-	
-	private static inline var DEFAULT_FONT_DATA:String = " 36000000000000000000!26101010001000\"46101010100000000000000000#66010100111110010100111110010100000000$56001000111011000001101110000100%66100100000100001000010000010010000000&66011000100000011010100100011010000000'26101000000000(36010100100100010000)36100010010010100000*46000010100100101000000000+46000001001110010000000000,36000000000000010100-46000000001110000000000000.26000000001000/66000010000100001000010000100000000000056011001001010010100100110000000156011000010000100001000010000000256111000001001100100001111000000356111000001001100000101110000000456100101001010010011100001000000556111101000011100000101110000000656011001000011100100100110000000756111000001000010001100001000000856011001001001100100100110000000956011001001010010011100001000000:26001000100000;26001000101000<46001001001000010000100000=46000011100000111000000000>46100001000010010010000000?56111000001001100000000100000000@66011100100010101110101010011100000000A56011001001010010111101001000000B56111001001011100100101110000000C56011001001010000100100110000000D56111001001010010100101110000000E56111101000011000100001111000000F56111101000010000110001000000000G56011001000010110100100111000000H56100101001011110100101001000000I26101010101000J56000100001000010100100110000000K56100101001010010111001001000000L46100010001000100011100000M66100010100010110110101010100010000000N56100101001011010101101001000000O56011001001010010100100110000000P56111001001010010111001000000000Q56011001001010010100100110000010R56111001001010010111001001000000S56011101000001100000101110000000T46111001000100010001000000U56100101001010010100100110000000V56100101001010010101000100000000W66100010100010101010110110100010000000X56100101001001100100101001000000Y56100101001010010011100001001100Z56111100001001100100001111000000[36110100100100110000}46110001000010010011000000]36110010010010110000^46010010100000000000000000_46000000000000000011110000'26101000000000a56000000111010010100100111000000b56100001110010010100101110000000c46000001101000100001100000d56000100111010010100100111000000e56000000110010110110000110000000f46011010001000110010000000g5700000011001001010010011100001001100h56100001110010010100101001000000i26100010101000j37010000010010010010100k56100001001010010111001001000000l26101010101000m66000000111100101010101010101010000000n56000001110010010100101001000000o56000000110010010100100110000000p5700000111001001010010111001000010000q5700000011101001010010011100001000010r46000010101100100010000000s56000000111011000001101110000000t46100011001000100001100000u56000001001010010100100111000000v56000001001010010101000100000000w66000000101010101010101010011110000000x56000001001010010011001001000000y5700000100101001010010011100001001100z56000001111000100010001111000000{46011001001000010001100000|26101010101000}46110001000010010011000000~56010101010000000000000000000000\\46111010101010101011100000";
-	
+	static inline var SPACE_CODE:Int = 32;
+	static inline var TAB_CODE:Int = 9;
+	static inline var NEW_LINE_CODE:Int = 10;
+
+	static inline var DEFAULT_FONT_KEY:String = "DEFAULT_FONT_KEY";
+
+	static inline var DEFAULT_FONT_DATA:String = " 36000000000000000000!26101010001000\"46101010100000000000000000#66010100111110010100111110010100000000$56001000111011000001101110000100%66100100000100001000010000010010000000&66011000100000011010100100011010000000'26101000000000(36010100100100010000)36100010010010100000*46000010100100101000000000+46000001001110010000000000,36000000000000010100-46000000001110000000000000.26000000001000/66000010000100001000010000100000000000056011001001010010100100110000000156011000010000100001000010000000256111000001001100100001111000000356111000001001100000101110000000456100101001010010011100001000000556111101000011100000101110000000656011001000011100100100110000000756111000001000010001100001000000856011001001001100100100110000000956011001001010010011100001000000:26001000100000;26001000101000<46001001001000010000100000=46000011100000111000000000>46100001000010010010000000?56111000001001100000000100000000@66011100100010101110101010011100000000A56011001001010010111101001000000B56111001001011100100101110000000C56011001001010000100100110000000D56111001001010010100101110000000E56111101000011000100001111000000F56111101000010000110001000000000G56011001000010110100100111000000H56100101001011110100101001000000I26101010101000J56000100001000010100100110000000K56100101001010010111001001000000L46100010001000100011100000M66100010100010110110101010100010000000N56100101001011010101101001000000O56011001001010010100100110000000P56111001001010010111001000000000Q56011001001010010100100110000010R56111001001010010111001001000000S56011101000001100000101110000000T46111001000100010001000000U56100101001010010100100110000000V56100101001010010101000100000000W66100010100010101010110110100010000000X56100101001001100100101001000000Y56100101001010010011100001001100Z56111100001001100100001111000000[36110100100100110000}46110001000010010011000000]36110010010010110000^46010010100000000000000000_46000000000000000011110000'26101000000000a56000000111010010100100111000000b56100001110010010100101110000000c46000001101000100001100000d56000100111010010100100111000000e56000000110010110110000110000000f46011010001000110010000000g5700000011001001010010011100001001100h56100001110010010100101001000000i26100010101000j37010000010010010010100k56100001001010010111001001000000l26101010101000m66000000111100101010101010101010000000n56000001110010010100101001000000o56000000110010010100100110000000p5700000111001001010010111001000010000q5700000011101001010010011100001000010r46000010101100100010000000s56000000111011000001101110000000t46100011001000100001100000u56000001001010010100100111000000v56000001001010010101000100000000w66000000101010101010101010011110000000x56000001001010010011001001000000y5700000100101001010010011100001001100z56000001111000100010001111000000{46011001001000010001100000|26101010101000}46110001000010010011000000~56010101010000000000000000000000\\46111010101010101011100000";
+
 	/**
 	 * Default letters for XNA font.
 	 */
 	public static inline var DEFAULT_CHARS:String = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
-	
-	private static var point:Point = new Point();
-	private static var flashRect:Rectangle = new Rectangle();
-	
+
+	static var point:Point = new Point();
+	static var flashRect:Rectangle = new Rectangle();
+
 	/**
 	 * The size of the font. Can be useful for AngelCode fonts.
 	 */
 	public var size(default, null):Int = 0;
-	
+
 	public var lineHeight(default, null):Int = 0;
-	
+
 	public var bold:Bool = false;
-	
+
 	public var italic:Bool = false;
-	
+
 	public var fontName:String;
-	
+
 	public var numLetters(default, null):Int = 0;
-	
+
 	/**
 	 * Minimum x offset in this font.
 	 * This is a helper variable for rendering purposes.
 	 */
 	public var minOffsetX:Int = 0;
-	
+
 	/**
 	 * The width of space character.
 	 */
 	public var spaceWidth:Int = 0;
-	
+
 	/**
 	 * Helper map where character's frames are stored by char codes.
 	 */
-	private var charMap:Map<Int, FlxFrame>;
-	
+	var charMap:Map<Int, FlxFrame>;
+
 	/**
 	 * Helper map where character's xAdvance are stored by char codes.
 	 */
-	private var charAdvance:Map<Int, Int>;
-	
+	var charAdvance:Map<Int, Int>;
+
 	/**
 	 * Atlas frame from which this font has been parsed.
 	 */
-	private var frame:FlxFrame;
-	
+	var frame:FlxFrame;
+
 	/**
 	 * Creates a new bitmap font using specified bitmap data and letter input.
 	 */
-	private function new(frame:FlxFrame, ?border:FlxPoint)
+	function new(frame:FlxFrame, ?border:FlxPoint)
 	{
 		super(frame.parent, FlxFrameCollectionType.FONT, border);
 		this.frame = frame;
@@ -91,8 +91,8 @@ class FlxBitmapFont extends FlxFramesCollection
 		charMap = new Map<Int, FlxFrame>();
 		charAdvance = new Map<Int, Int>();
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		frame = null;
@@ -100,7 +100,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		charMap = null;
 		charAdvance = null;
 	}
-	
+
 	/**
 	 * Retrieves the default `FlxBitmapFont`.
 	 */
@@ -113,48 +113,48 @@ class FlxBitmapFont extends FlxFramesCollection
 			if (font != null)
 				return font;
 		}
-		
+
 		var letters:String = "";
 		var bd:BitmapData = new BitmapData(700, 9, true, 0xFF888888);
 		graphic = FlxG.bitmap.add(bd, false, DEFAULT_FONT_KEY);
-		
+
 		var letterPos:Int = 0;
 		var i:Int = 0;
-		
-		while (i < DEFAULT_FONT_DATA.length) 
+
+		while (i < DEFAULT_FONT_DATA.length)
 		{
 			letters += DEFAULT_FONT_DATA.substr(i, 1);
-			
+
 			var gw:Int = Std.parseInt(DEFAULT_FONT_DATA.substr(++i, 1));
 			var gh:Int = Std.parseInt(DEFAULT_FONT_DATA.substr(++i, 1));
-			
-			for (py in 0...gh) 
+
+			for (py in 0...gh)
 			{
-				for (px in 0...gw) 
+				for (px in 0...gw)
 				{
 					i++;
-					
-					if (DEFAULT_FONT_DATA.substr(i, 1) == "1") 
+
+					if (DEFAULT_FONT_DATA.substr(i, 1) == "1")
 					{
 						bd.setPixel32(1 + letterPos * 7 + px, 1 + py, FlxColor.WHITE);
 					}
-					else 
+					else
 					{
 						bd.setPixel32(1 + letterPos * 7 + px, 1 + py, FlxColor.TRANSPARENT);
 					}
 				}
 			}
-			
+
 			i++;
 			letterPos++;
 		}
-		
+
 		return FlxBitmapFont.fromXNA(graphic, letters);
 	}
-	
+
 	/**
 	 * Loads font data in AngelCode's format.
-	 * 
+	 *
 	 * @param   Source   Font image source.
 	 * @param   Data     Font data.
 	 * @return  Generated bitmap font object.
@@ -163,7 +163,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	{
 		var graphic:FlxGraphic = null;
 		var frame:FlxFrame = null;
-		
+
 		if (Std.is(Source, FlxFrame))
 		{
 			frame = cast Source;
@@ -174,13 +174,13 @@ class FlxBitmapFont extends FlxFramesCollection
 			graphic = FlxG.bitmap.add(cast Source);
 			frame = graphic.imageFrame.frame;
 		}
-		
+
 		var font:FlxBitmapFont = FlxBitmapFont.findFont(frame);
 		if (font != null)
 			return font;
-		
+
 		var fontData:Xml = null;
-		
+
 		if (Data != null)
 		{
 			if (Std.is(Data, Xml))
@@ -190,36 +190,36 @@ class FlxBitmapFont extends FlxFramesCollection
 			else // Data is String
 			{
 				var data:String = Std.string(Data);
-				
+
 				if (Assets.exists(data))
 				{
 					data = Assets.getText(data);
 				}
-				
+
 				fontData = Xml.parse(data);
 			}
 		}
-		
+
 		font = new FlxBitmapFont(frame);
-		
+
 		var fast:Fast = new Fast(fontData.firstElement());
-		
+
 		// how much to move the cursor when going to the next line.
 		font.lineHeight = Std.parseInt(fast.node.common.att.lineHeight);
 		font.size = Std.parseInt(fast.node.info.att.size);
 		font.fontName = Std.string(fast.node.info.att.face);
 		font.bold = (Std.parseInt(fast.node.info.att.bold) != 0);
 		font.italic = (Std.parseInt(fast.node.info.att.italic) != 0);
-		
+
 		var frame:FlxRect;
 		var frameHeight:Int;
 		var offset:FlxPoint;
 		var charStr:String;
 		var charCode:Int;
 		var xOffset:Int, yOffset:Int, xAdvance:Int;
-		
+
 		var chars = fast.node.chars;
-		
+
 		for (char in chars.nodes.char)
 		{
 			frame = FlxRect.get();
@@ -228,21 +228,21 @@ class FlxBitmapFont extends FlxFramesCollection
 			frame.width = Std.parseInt(char.att.width); // Width of the character in the image file.
 			frameHeight = Std.parseInt(char.att.height);
 			frame.height = frameHeight; // Height of the character in the image file.
-			
+
 			// Number of pixels to move right before drawing this character.
 			xOffset = char.has.xoffset ? Std.parseInt(char.att.xoffset) : 0;
 			//  Number of pixels to move down before drawing this character.
 			yOffset = char.has.yoffset ? Std.parseInt(char.att.yoffset) : 0;
 			//  Number of pixels to jump right after drawing this character.
 			xAdvance = char.has.xadvance ? Std.parseInt(char.att.xadvance) : 0;
-			
+
 			offset = FlxPoint.get(xOffset, yOffset);
-			
+
 			font.minOffsetX = (font.minOffsetX < -xOffset) ? -xOffset : font.minOffsetX;
-			
+
 			charCode = -1;
 			charStr = null;
-			
+
 			if (char.has.letter) // The ASCII value of the character this line is describing. Helpful for debugging
 			{
 				charStr = char.att.letter;
@@ -251,15 +251,15 @@ class FlxBitmapFont extends FlxFramesCollection
 			{
 				charCode = Std.parseInt(char.att.id);
 			}
-			
-			if (charCode == -1 && charStr == null) 
+
+			if (charCode == -1 && charStr == null)
 			{
 				throw 'Invalid font xml data!';
 			}
-			
+
 			if (charStr != null)
 			{
-				charStr = switch (charStr) 
+				charStr = switch (charStr)
 				{
 					case "space": ' ';
 					case "&quot;": '"';
@@ -268,12 +268,12 @@ class FlxBitmapFont extends FlxFramesCollection
 					case "&lt;": '<';
 					default: charStr;
 				}
-				
+
 				charCode = Utf8.charCodeAt(charStr, 0);
 			}
-			
+
 			font.addCharFrame(charCode, frame, offset, xAdvance);
-			
+
 			if (charCode == SPACE_CODE)
 			{
 				font.spaceWidth = xAdvance;
@@ -283,15 +283,15 @@ class FlxBitmapFont extends FlxFramesCollection
 				font.lineHeight = (font.lineHeight > frameHeight + yOffset) ? font.lineHeight : frameHeight + yOffset;
 			}
 		}
-		
+
 		font.updateSourceHeight();
 		return font;
 	}
-	
+
 	/**
 	 * Load bitmap font in XNA/Pixelizer format.
 	 * May work incorrectly on HTML5.
-	 * 
+	 *
 	 * @param   source        Source image for this font.
 	 * @param   letters       `String` of characters contained in the source image,
 	 *                        in order (ex. `" abcdefghijklmnopqrstuvwxyz"`). Defaults to `DEFAULT_CHARS`.
@@ -303,7 +303,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	{
 		var graphic:FlxGraphic = null;
 		var frame:FlxFrame = null;
-		
+
 		if (Std.is(source, FlxFrame))
 		{
 			frame = cast source;
@@ -314,22 +314,22 @@ class FlxBitmapFont extends FlxFramesCollection
 			graphic = FlxG.bitmap.add(cast source);
 			frame = graphic.imageFrame.frame;
 		}
-		
+
 		var font:FlxBitmapFont = FlxBitmapFont.findFont(frame);
 		if (font != null)
 			return font;
-		
+
 		letters = (letters == null) ? DEFAULT_CHARS : letters;
 		font = new FlxBitmapFont(frame);
 		font.fontName = graphic.key;
-		
+
 		var bmd:BitmapData = graphic.bitmap;
-		
+
 		var p:Point = new Point();
 		p.setTo(0, 0);
 		transformPoint(p, frame);
 		var globalBGColor:FlxColor = bmd.getPixel(Std.int(p.x), Std.int(p.y));
-		
+
 		var frameWidth:Int = Std.int(frame.frame.width);
 		var frameHeight:Int = Std.int(frame.frame.height);
 		var letterIdx:Int = 0;
@@ -338,99 +338,99 @@ class FlxBitmapFont extends FlxFramesCollection
 		var rect:FlxRect;
 		var offset:FlxPoint;
 		var xAdvance:Int;
-		
+
 		var cy:Int = 0;
 		var cx:Int;
-		
+
 		var gx:Int;
 		var gy:Int;
 		var gw:Int;
 		var gh:Int;
-		
+
 		while (cy < frameHeight && letterIdx < numLetters)
 		{
 			var rowHeight:Int = 0;
 			cx = 0;
-			
+
 			while (cx < frameWidth && letterIdx < numLetters)
 			{
 				p.setTo(cx, cy);
 				transformPoint(p, frame);
-				
-				if (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor) 
+
+				if (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
 				{
 					// found non bg pixel
 					gx = cx;
 					gy = cy;
-					
+
 					p.setTo(gx, gy);
 					transformPoint(p, frame);
-					
+
 					// find width and height of char
-					while (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor) 
+					while (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
 					{
 						gx++;
 						p.setTo(gx, cy);
 						transformPoint(p, frame);
 					}
-					
+
 					p.setTo(gx - 1, gy);
 					transformPoint(p, frame);
-					
-					while (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor) 
+
+					while (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
 					{
 						gy++;
 						p.setTo(cx, gy);
 						transformPoint(p, frame);
 					}
-					
+
 					gw = gx - cx;
 					gh = gy - cy;
-					
+
 					charCode = Utf8.charCodeAt(letters, letterIdx);
 					rect = FlxRect.get(cx, cy, gw, gh);
 					offset = FlxPoint.get(0, 0);
 					xAdvance = gw;
-					
+
 					font.addCharFrame(charCode, rect, offset, xAdvance);
-					
+
 					if (charCode == SPACE_CODE)
 					{
 						font.spaceWidth = xAdvance;
 					}
-					
+
 					// store max size
 					if (gh > rowHeight) rowHeight = gh;
 					if (gh > font.size) font.size = gh;
-					
+
 					// go to next char
 					cx += gw;
 					letterIdx++;
 				}
-				
+
 				cx++;
 			}
-			
+
 			// next row
 			cy += (rowHeight + 1);
 		}
-		
+
 		font.lineHeight = font.size;
 		font.updateSourceHeight();
-		
+
 		// remove background color
 		point.setTo(Std.int(frame.frame.x), Std.int(frame.frame.y));
-		
+
 		var frameRect = flashRect;
 		frame.frame.copyToFlash(frameRect);
-		
+
 		#if flash
 		// TODO: fix this issue...
 		// for some reason this line causes app crash on targets other than flash...
 		var bgColor32:Int = bmd.getPixel32(Std.int(frame.frame.x), Std.int(frame.frame.y));
 		bmd.threshold(bmd, frameRect, point, "==", bgColor32, FlxColor.TRANSPARENT, FlxColor.WHITE, true);
 		#end
-		
+
 		if (charBGColor != FlxColor.TRANSPARENT)
 		{
 			bmd.threshold(bmd, frameRect, point, "==", charBGColor, FlxColor.TRANSPARENT, FlxColor.WHITE, true);
@@ -438,32 +438,32 @@ class FlxBitmapFont extends FlxFramesCollection
 
 		return font;
 	}
-	
-	private static inline function transformPoint(point:Point, frame:FlxFrame):Point
+
+	static inline function transformPoint(point:Point, frame:FlxFrame):Point
 	{
 		var x:Float = point.x;
 		var y:Float = point.y;
-		
+
 		if (frame.angle == FlxFrameAngle.ANGLE_NEG_90)
 		{
 			point.x = frame.frame.width - y;
 			point.y = x;
-			
+
 		}
 		else if (frame.angle == FlxFrameAngle.ANGLE_90)
 		{
 			point.x = y;
 			point.y = frame.frame.height - x;
 		}
-		
+
 		point.x += frame.frame.x;
 		point.y += frame.frame.y;
 		return point;
 	}
-	
+
 	/**
 	 * Loads a monospaced bitmap font.
-	 * 
+	 *
 	 * @param   source    Source image for this font.
 	 * @param   letters   The characters used in the font set, in display order.
 	 *                    You can use the `TEXT_SET` constants for common font set arrangements.
@@ -478,7 +478,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	{
 		var graphic:FlxGraphic = null;
 		var frame:FlxFrame = null;
-		
+
 		if (Std.is(source, FlxFrame))
 		{
 			frame = cast source;
@@ -489,46 +489,46 @@ class FlxBitmapFont extends FlxFramesCollection
 			graphic = FlxG.bitmap.add(cast source);
 			frame = graphic.imageFrame.frame;
 		}
-		
+
 		var font:FlxBitmapFont = FlxBitmapFont.findFont(frame);
 		if (font != null)
 			return font;
-		
+
 		letters = (letters == null) ? DEFAULT_CHARS : letters;
 		region = (region == null) ? FlxRect.weak(0, 0, frame.sourceSize.x, frame.sourceSize.y) : region;
 		spacing = (spacing == null) ? FlxPoint.get(0, 0) : spacing;
-		
+
 		var bitmapWidth:Int = Std.int(region.width);
 		var bitmapHeight:Int = Std.int(region.height);
-		
+
 		var startX:Int = Std.int(region.x);
 		var startY:Int = Std.int(region.y);
-		
+
 		region.putWeak();
-		
+
 		var xSpacing:Int = Std.int(spacing.x);
 		var ySpacing:Int = Std.int(spacing.y);
-		
+
 		var charWidth:Int = Std.int(charSize.x);
 		var charHeight:Int = Std.int(charSize.y);
-		
+
 		var spacedWidth:Int = charWidth + xSpacing;
 		var spacedHeight:Int = charHeight + ySpacing;
-		
+
 		var numRows:Int = (charHeight == 0) ? 1 : Std.int((bitmapHeight + ySpacing) / spacedHeight);
 		var numCols:Int = (charWidth == 0) ? 1 : Std.int((bitmapWidth + xSpacing) / spacedWidth);
-		
+
 		font = new FlxBitmapFont(frame);
 		font.fontName = graphic.key;
 		font.lineHeight = font.size = charHeight;
-		
+
 		var charRect:FlxRect;
 		var offset:FlxPoint;
 		var xAdvance:Int = charWidth;
 		font.spaceWidth = xAdvance;
 		var letterIndex:Int = 0;
 		var numLetters:Int = Utf8.length(letters);
-		
+
 		for (j in 0...numRows)
 		{
 			for (i in 0...numCols)
@@ -537,27 +537,27 @@ class FlxBitmapFont extends FlxFramesCollection
 				offset = FlxPoint.get(0, 0);
 				font.addCharFrame(Utf8.charCodeAt(letters, letterIndex), charRect, offset, xAdvance);
 				letterIndex++;
-				
+
 				if (letterIndex >= numLetters)
 				{
 					return font;
 				}
 			}
 		}
-		
+
 		font.updateSourceHeight();
 		return font;
 	}
-	
+
 	/**
 	 * Internal method which creates and add char frames into this font.
-	 * 
+	 *
 	 * @param   charCode   Char code for char frame.
 	 * @param   frame      Character region from source image.
 	 * @param   offset     Offset before rendering this char.
 	 * @param   xAdvance   How much cursor will jump after this char.
 	 */
-	private function addCharFrame(charCode:Int, frame:FlxRect, offset:FlxPoint, xAdvance:Int):Void
+	function addCharFrame(charCode:Int, frame:FlxRect, offset:FlxPoint, xAdvance:Int):Void
 	{
 		var utf8:Utf8 = new Utf8();
 		utf8.addChar(charCode);
@@ -565,7 +565,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		if (frame.width == 0 || frame.height == 0 || getByName(charName) != null)
 			return;
 		var charFrame:FlxFrame = this.frame.subFrameTo(frame);
-		
+
 		var w:Float = charFrame.sourceSize.x;
 		var h:Float = charFrame.sourceSize.y;
 		w += (offset.x > 0) ? offset.x : 0;
@@ -578,8 +578,8 @@ class FlxBitmapFont extends FlxFramesCollection
 		charAdvance.set(charCode, xAdvance);
 		offset.put();
 	}
-	
-	private function updateSourceHeight():Void
+
+	function updateSourceHeight():Void
 	{
 		for (frame in frames)
 		{
@@ -587,32 +587,32 @@ class FlxBitmapFont extends FlxFramesCollection
 			frame.cacheFrameMatrix();
 		}
 	}
-	
+
 	public inline function charExists(charCode:Int):Bool
 	{
 		return charMap.exists(charCode);
 	}
-	
+
 	public inline function getCharFrame(charCode:Int):FlxFrame
 	{
 		return charMap.get(charCode);
 	}
-	
+
 	public inline function getCharAdvance(charCode:Int):Int
 	{
 		return charAdvance.exists(charCode) ? charAdvance.get(charCode) : 0;
 	}
-	
+
 	public inline function getCharWidth(charCode:Int):Float
 	{
 		return charMap.exists(charCode) ? charMap.get(charCode).sourceSize.x : 0;
 	}
-	
+
 	public static function findFont(frame:FlxFrame, ?border:FlxPoint):FlxBitmapFont
 	{
 		if (border == null)
 			border = FlxPoint.weak();
-		
+
 		var bitmapFonts:Array<FlxBitmapFont> = cast frame.parent.getFramesCollections(FlxFrameCollectionType.FONT);
 		for (font in bitmapFonts)
 		{
@@ -623,17 +623,17 @@ class FlxBitmapFont extends FlxFramesCollection
 		}
 		return null;
 	}
-	
-	override public function addBorder(border:FlxPoint):FlxBitmapFont 
+
+	override public function addBorder(border:FlxPoint):FlxBitmapFont
 	{
 		var resultBorder:FlxPoint = FlxPoint.weak().addPoint(this.border).addPoint(border);
-		
+
 		var font:FlxBitmapFont = FlxBitmapFont.findFont(frame, resultBorder);
 		if (font != null)
 		{
 			return font;
 		}
-		
+
 		font = new FlxBitmapFont(frame, border);
 		font.spaceWidth = spaceWidth;
 		font.fontName = fontName;
@@ -643,7 +643,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		font.lineHeight = lineHeight;
 		font.italic = italic;
 		font.bold = bold;
-		
+
 		var charWithBorder:FlxFrame;
 		var code:Int;
 		for (char in frames)
@@ -654,7 +654,7 @@ class FlxBitmapFont extends FlxFramesCollection
 			font.charMap.set(code, charWithBorder);
 			font.charAdvance.set(code, charAdvance.get(code));
 		}
-		
+
 		font.updateSourceHeight();
 		return font;
 	}

--- a/flixel/graphics/frames/FlxFilterFrames.hx
+++ b/flixel/graphics/frames/FlxFilterFrames.hx
@@ -16,12 +16,12 @@ import openfl.filters.BitmapFilter;
  */
 class FlxFilterFrames extends FlxFramesCollection
 {
-	private static var point:Point = new Point();
-	private static var rect:Rectangle = new Rectangle();
-	
+	static var point:Point = new Point();
+	static var rect:Rectangle = new Rectangle();
+
 	/**
 	 * Generates new frames collection from specified frames.
-	 * 
+	 *
 	 * @param   frames      Frames collection to generate filters for.
 	 * @param   widthInc    How much frames should expand horizontally.
 	 * @param   heightInc   How much frames should expend vertically.
@@ -33,52 +33,52 @@ class FlxFilterFrames extends FlxFramesCollection
 	{
 		return new FlxFilterFrames(frames, widthInc, heightInc, filters);
 	}
-	
+
 	/**
 	 * Original frames collection
 	 */
 	public var sourceFrames(default, null):FlxFramesCollection;
-	
+
 	/**
 	 * How much frames should expand horizontally
 	 */
 	public var widthInc(default, null):Int = 0;
-	
+
 	/**
 	 * How much frames should expand vertically
 	 */
 	public var heightInc(default, null):Int = 0;
-	
+
 	/**
 	 * Filters applied to these frames
 	 */
 	public var filters(default, set):Array<BitmapFilter>;
-	
-	private function new(sourceFrames:FlxFramesCollection, widthInc:Int = 0, heightInc:Int = 0,
+
+	function new(sourceFrames:FlxFramesCollection, widthInc:Int = 0, heightInc:Int = 0,
 		?filters:Array<BitmapFilter>)
 	{
 		super(null, FlxFrameCollectionType.FILTER);
-		
+
 		this.sourceFrames = sourceFrames;
-		
+
 		widthInc = (widthInc >= 0) ? widthInc : 0;
 		heightInc = (heightInc >= 0) ? heightInc : 0;
-		
+
 		widthInc = 2 * Math.ceil(0.5 * widthInc);
 		heightInc = 2 * Math.ceil(0.5 * heightInc);
-		
+
 		this.widthInc = widthInc;
 		this.heightInc = heightInc;
-		
+
 		this.filters = (filters == null) ? [] : filters;
-		
+
 		genFrames();
 		applyFilters();
 	}
-	
+
 	/**
 	 * Just helper method which "centers" sprite offsets
-	 * 
+	 *
 	 * @param   spr              Sprite to apply this frame collection.
 	 * @param   saveAnimations   Whether to save sprite's animations or not.
 	 * @param   updateFrames     Whether to regenerate frame `BitmapData`s or not.
@@ -87,28 +87,28 @@ class FlxFilterFrames extends FlxFramesCollection
 	{
 		if (updateFrames)
 			set_filters(filters);
-		
+
 		var w:Float = spr.width;
 		var h:Float = spr.height;
 		spr.setFrames(this, saveAnimations);
 		spr.offset.set(0.5 * widthInc, 0.5 * heightInc);
 		spr.setSize(w, h);
 	}
-	
-	private function genFrames():Void
+
+	function genFrames():Void
 	{
 		var canvas:BitmapData;
 		var graph:FlxGraphic;
 		var filterFrame:FlxFrame;
-		
+
 		for (frame in sourceFrames.frames)
 		{
 			canvas = new BitmapData(Std.int(frame.sourceSize.x + widthInc),
 				Std.int(frame.sourceSize.y + heightInc), true, FlxColor.TRANSPARENT);
 			graph = FlxGraphic.fromBitmapData(canvas, false, null, false);
-			
+
 			filterFrame = graph.imageFrame.frame;
-			
+
 			frames.push(filterFrame);
 			if (frame.name != null)
 			{
@@ -116,13 +116,13 @@ class FlxFilterFrames extends FlxFramesCollection
 				framesHash.set(frame.name, filterFrame);
 			}
 		}
-		
+
 		regenBitmaps(false);
 	}
-	
+
 	/**
 	 * Adds a filter to this frames collection.
-	 * 
+	 *
 	 * @param   filter   The filter to be added.
 	 */
 	public inline function addFilter(filter:BitmapFilter):Void
@@ -133,21 +133,21 @@ class FlxFilterFrames extends FlxFramesCollection
 			applyFilter(filter);
 		}
 	}
-	
+
 	/**
 	 * Removes a filter from this frames collection.
-	 * 
+	 *
 	 * @param   filter   The filter to be removed.
 	 */
 	public function removeFilter(filter:BitmapFilter):Void
 	{
 		if (filters.length == 0 || filter == null)
 			return;
-		
+
 		if (filters.remove(filter))
 			regenAndApplyFilters();
 	}
-	
+
 	/**
 	 * Removes all filters from the frames.
 	 */
@@ -155,42 +155,42 @@ class FlxFilterFrames extends FlxFramesCollection
 	{
 		if (filters.length == 0)
 			return;
-		
+
 		filters.splice(0, filters.length);
 		regenBitmaps();
 	}
-	
-	private function regenAndApplyFilters():Void
+
+	function regenAndApplyFilters():Void
 	{
 		regenBitmaps();
 		applyFilters();
 	}
-	
-	private function regenBitmaps(fill:Bool = true):Void
+
+	function regenBitmaps(fill:Bool = true):Void
 	{
 		var numFrames:Int = frames.length;
 		var frame:FlxFrame;
 		var sourceFrame:FlxFrame;
 		var frameOffset:Point = point;
-		
+
 		for (i in 0...numFrames)
 		{
 			sourceFrame = sourceFrames.frames[i];
 			frame = frames[i];
-			
+
 			if (fill)
 				frame.parent.bitmap.fillRect(frame.parent.bitmap.rect, FlxColor.TRANSPARENT);
-			
+
 			frameOffset.setTo(widthInc * 0.5, heightInc * 0.5);
-			
+
 			sourceFrame.paint(frame.parent.bitmap, frameOffset, true);
 		}
 	}
-	
+
 	function applyFilter(filter:BitmapFilter)
 	{
 		var bitmap:BitmapData;
-		
+
 		for (frame in frames)
 		{
 			point.setTo(0, 0);
@@ -199,31 +199,31 @@ class FlxFilterFrames extends FlxFramesCollection
 			bitmap.applyFilter(bitmap, rect, point, filter);
 		}
 	}
-	
-	private function applyFilters():Void
+
+	function applyFilters():Void
 	{
 		for (filter in filters)
 			applyFilter(filter);
 	}
-	
+
 	override public function destroy():Void
 	{
 		sourceFrames = null;
 		filters = null;
-		
+
 		for (frame in frames)
 			frame.parent.destroy();
-		
+
 		super.destroy();
 	}
-	
-	private function set_filters(value:Array<BitmapFilter>):Array<BitmapFilter>
+
+	function set_filters(value:Array<BitmapFilter>):Array<BitmapFilter>
 	{
 		filters = value;
-		
+
 		if (value != null)
 			regenAndApplyFilters();
-		
+
 		return filters;
 	}
 }

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -18,11 +18,11 @@ import haxe.ds.ArraySort;
  */
 class FlxFrame implements IFlxDestroyable
 {
-	private var point1:Point = new Point();
-	private var point2:Point = new Point();
-	private var rect:Rectangle = new Rectangle();
-	private var matrix:FlxMatrix = new FlxMatrix();
-	
+	var point1:Point = new Point();
+	var point2:Point = new Point();
+	var rect:Rectangle = new Rectangle();
+	var matrix:FlxMatrix = new FlxMatrix();
+
 	/**
 	 * Sorts an array of `FlxFrame` objects by their name, e.g.
 	 * `["tiles-001.png", "tiles-003.png", "tiles-002.png"]`
@@ -46,31 +46,31 @@ class FlxFrame implements IFlxDestroyable
 
 		return num1 - num2;
 	}
-	
+
 	public var name:String;
 	/**
 	 * Region of the image to render.
 	 */
 	public var frame(default, set):FlxRect;
-	
+
 	/**
 	 * UV coordinates for this frame.
 	 * WARNING: For optimization purposes, width and height of this rect
 	 * contain right and bottom coordinates (`x + width` and `y + height`).
 	 */
 	public var uv:FlxRect;
-	
+
 	public var parent:FlxGraphic;
-	
+
 	/**
 	 * Rotation angle of this frame.
 	 * Required for packed atlas images.
 	 */
 	public var angle:FlxFrameAngle;
-	
+
 	public var flipX:Bool;
 	public var flipY:Bool;
-	
+
 	/**
 	 * Original (uncropped) image size.
 	 */
@@ -79,39 +79,39 @@ class FlxFrame implements IFlxDestroyable
 	 * Frame offset from top left corner of original image.
 	 */
 	public var offset(default, null):FlxPoint;
-	
+
 	/**
 	 * The type of this frame.
 	 */
 	public var type:FlxFrameType;
-	
-	private var tileMatrix:Vector<Float>;
-	
-	private var blitMatrix:Vector<Float>;
-	
+
+	var tileMatrix:Vector<Float>;
+
+	var blitMatrix:Vector<Float>;
+
 	@:allow(flixel.graphics.FlxGraphic)
 	@:allow(flixel.graphics.frames.FlxFramesCollection)
-	private function new(parent:FlxGraphic, angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false,
+	function new(parent:FlxGraphic, angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false,
 		flipY:Bool = false)
 	{
 		this.parent = parent;
 		this.angle = angle;
 		this.flipX = flipX;
 		this.flipY = flipY;
-		
+
 		type = FlxFrameType.REGULAR;
-		
+
 		sourceSize = FlxPoint.get();
 		offset = FlxPoint.get();
-		
+
 		blitMatrix = new Vector<Float>(6);
 		if (FlxG.renderTile)
 			tileMatrix = new Vector<Float>(6);
 	}
-	
+
 	@:allow(flixel.graphics.frames.FlxFramesCollection)
 	@:allow(flixel.graphics.frames.FlxBitmapFont)
-	private function cacheFrameMatrix():Void
+	function cacheFrameMatrix():Void
 	{
 		prepareBlitMatrix(matrix, true);
 		blitMatrix[0] = matrix.a;
@@ -120,7 +120,7 @@ class FlxFrame implements IFlxDestroyable
 		blitMatrix[3] = matrix.d;
 		blitMatrix[4] = matrix.tx;
 		blitMatrix[5] = matrix.ty;
-		
+
 		if (FlxG.renderTile)
 		{
 			prepareBlitMatrix(matrix, false);
@@ -132,22 +132,22 @@ class FlxFrame implements IFlxDestroyable
 			tileMatrix[5] = matrix.ty;
 		}
 	}
-	
+
 	/**
 	 * Applies frame rotation to the specified matrix, which should be used for tiling or blitting.
 	 * Required for rotated frame support.
-	 * 
+	 *
 	 * @param   mat    Matrix to transform / rotate
 	 * @param   blit   Whether specified matrix will be used for blitting or for tile rendering.
 	 * @return  Transformed matrix.
 	 */
-	private inline function prepareBlitMatrix(mat:FlxMatrix, blit:Bool = true):FlxMatrix
+	inline function prepareBlitMatrix(mat:FlxMatrix, blit:Bool = true):FlxMatrix
 	{
 		mat.identity();
-		
+
 		if (blit)
 			mat.translate( -frame.x, -frame.y);
-		
+
 		if (angle == FlxFrameAngle.ANGLE_90)
 		{
 			mat.rotateByPositive90();
@@ -158,34 +158,34 @@ class FlxFrame implements IFlxDestroyable
 			mat.rotateByNegative90();
 			mat.translate(0, frame.width);
 		}
-		
+
 		mat.translate(offset.x, offset.y);
 		return mat;
 	}
-	
+
 	/**
 	 * Rotates and flips matrix. This method expects matrix which was prepared by `prepareBlitMatrix()`.
 	 * Internal use only.
-	 * 
+	 *
 	 * @param   mat        Matrix to transform
 	 * @param   rotation   Rotation to apply to specified matrix.
 	 * @param   flipX      Do we need to flip frame horizontally
 	 * @param   flipY      Do we need to flip frame vertically
 	 * @return  Transformed matrix with applied rotation and flipping
 	 */
-	private inline function rotateAndFlip(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0,
+	inline function rotateAndFlip(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0,
 		flipX:Bool = false, flipY:Bool = false):FlxMatrix
 	{
 		var w:Int = Std.int(sourceSize.x);
 		var h:Int = Std.int(sourceSize.y);
-		
+
 		// rotate frame transformation matrix if rotation isn't zero
 		if (rotation != FlxFrameAngle.ANGLE_0)
 		{
 			var t:Int = w;
 			w = h;
 			h = t;
-			
+
 			if (rotation == FlxFrameAngle.ANGLE_90)
 			{
 				mat.rotateByPositive90();
@@ -197,42 +197,42 @@ class FlxFrame implements IFlxDestroyable
 				mat.translate(0, sourceSize.x);
 			}
 		}
-		
+
 		// flip frame transformation matrix
 		if (flipX)
 		{
 			mat.scale( -1, 1);
 			mat.translate(w, 0);
 		}
-		
+
 		if (flipY)
 		{
 			mat.scale(1, -1);
 			mat.translate(0, h);
 		}
-		
+
 		return mat;
 	}
-	
+
 	/**
 	 * Prepares matrix for frame blitting (see `paint` methods).
-	 * 
+	 *
 	 * @param   mat        Matrix to transform/prepare.
 	 * @param   rotation   Rotation to apply to specified matrix.
 	 * @param   flipX      Do we need to flip frame horizontally.
 	 * @param   flipY      Do we need to flip frame vertically.
 	 * @return  Transformed matrix which can be used for frame painting.
 	 */
-	private function prepareTransformedBlitMatrix(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0,
+	function prepareTransformedBlitMatrix(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0,
 		flipX:Bool = false, flipY:Bool = false):FlxMatrix
 	{
 		mat = fillBlitMatrix(mat);
 		return rotateAndFlip(mat, rotation, flipX, flipY);
 	}
-	
+
 	/**
 	 * Prepares matrix for frame tile/triangles rendering.
-	 * 
+	 *
 	 * @param   mat        Matrix to transform/prepare
 	 * @param   rotation   Rotation to apply to specified matrix.
 	 * @param   flipX      Do we need to flip frame horizontally
@@ -247,24 +247,24 @@ class FlxFrame implements IFlxDestroyable
 			mat.identity();
 			return mat;
 		}
-		
+
 		mat.a = tileMatrix[0];
 		mat.b = tileMatrix[1];
 		mat.c = tileMatrix[2];
 		mat.d = tileMatrix[3];
 		mat.tx = tileMatrix[4];
 		mat.ty = tileMatrix[5];
-		
+
 		var doFlipX = flipX != this.flipX;
 		var doFlipY = flipY != this.flipY;
-		
+
 		if (rotation == FlxFrameAngle.ANGLE_0 && !doFlipX && !doFlipY)
 			return mat;
-		
+
 		return rotateAndFlip(mat, rotation, doFlipX, doFlipY);
 	}
-	
-	private inline function fillBlitMatrix(mat:FlxMatrix):FlxMatrix
+
+	inline function fillBlitMatrix(mat:FlxMatrix):FlxMatrix
 	{
 		mat.a = blitMatrix[0];
 		mat.b = blitMatrix[1];
@@ -274,10 +274,10 @@ class FlxFrame implements IFlxDestroyable
 		mat.ty = blitMatrix[5];
 		return mat;
 	}
-	
+
 	/**
 	 * Draws frame on specified `BitmapData` object.
-	 * 
+	 *
 	 * @param   bmd                 `BitmapData` object to draw this frame on.
 	 *                              If bmd is `null` then new a `BitmapData` is created.
 	 * @param   point               Where to draw this frame on the specified `BitmapData` object.
@@ -295,12 +295,12 @@ class FlxFrame implements IFlxDestroyable
 			point = point1;
 			point.setTo(0, 0);
 		}
-		
+
 		bmd = checkInputBitmap(bmd, point, FlxFrameAngle.ANGLE_0, mergeAlpha, disposeIfNotEqual);
-		
+
 		if (type == FlxFrameType.EMPTY)
 			return bmd;
-		
+
 		if (angle == FlxFrameAngle.ANGLE_0)
 		{
 			offset.copyToFlash(point2);
@@ -315,13 +315,13 @@ class FlxFrame implements IFlxDestroyable
 			var rect:Rectangle = getDrawFrameRect(matrix);
 			bmd.draw(parent.bitmap, matrix, null, null, rect);
 		}
-		
+
 		return bmd;
 	}
-	
+
 	/**
 	 * Draws rotated and flipped frame on specified BitmapData object.
-	 * 
+	 *
 	 * @param   bmd                 BitmapData object to draw this frame on.
 	 *                              If `bmd` is `null` then new `BitmapData` created.
 	 * @param   point               Where to draw this frame on the specified `BitmapData` object
@@ -340,31 +340,31 @@ class FlxFrame implements IFlxDestroyable
 	{
 		if (type == FlxFrameType.EMPTY && rotation == FlxFrameAngle.ANGLE_0)
 			return paint(bmd, point, mergeAlpha, disposeIfNotEqual);
-		
+
 		if (point == null)
 		{
 			point = point2;
 			point.setTo(0, 0);
 		}
-		
+
 		bmd = checkInputBitmap(bmd, point, rotation, mergeAlpha, disposeIfNotEqual);
-		
+
 		if (type == FlxFrameType.EMPTY)
 			return bmd;
-		
+
 		var doFlipX = flipX != this.flipX;
 		var doFlipY = flipY != this.flipY;
-		
+
 		prepareTransformedBlitMatrix(matrix, rotation, doFlipX, doFlipY);
 		matrix.translate(point.x, point.y);
 		var rect:Rectangle = getDrawFrameRect(matrix);
 		bmd.draw(parent.bitmap, matrix, null, null, rect);
 		return bmd;
 	}
-	
+
 	/**
 	 * Internal method which runs few checks on specified `BitmapData` object.
-	 * 
+	 *
 	 * @param   bmd                 `BitmapData` object to check against.
 	 * @param   point               Optional point for mergeAlpha checks
 	 * @param   rotation            How much we will rotate the frame when we will be
@@ -375,23 +375,23 @@ class FlxFrame implements IFlxDestroyable
 	 *                              equal to frame's original size (`sourceSize`).
 	 * @return  Prepared `BitmapData` for further frame blitting. Output `BitmapData` could be a different object.
 	 */
-	private inline function checkInputBitmap(?bmd:BitmapData, ?point:Point,
+	inline function checkInputBitmap(?bmd:BitmapData, ?point:Point,
 		rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0, mergeAlpha:Bool = false,
 		disposeIfNotEqual:Bool = false):BitmapData
 	{
 		var w:Int = Std.int(sourceSize.x);
 		var h:Int = Std.int(sourceSize.y);
-		
+
 		if (rotation != FlxFrameAngle.ANGLE_0)
 		{
 			var t:Int = w;
 			w = h;
 			h = t;
 		}
-		
+
 		if (bmd != null && disposeIfNotEqual)
 			bmd = FlxDestroyUtil.disposeIfNotEqual(bmd, w, h);
-		
+
 		if (bmd != null && !mergeAlpha)
 		{
 			rect.setTo(point.x, point.y, w, h);
@@ -401,34 +401,34 @@ class FlxFrame implements IFlxDestroyable
 		{
 			bmd = new BitmapData(w, h, true, FlxColor.TRANSPARENT);
 		}
-		
+
 		return bmd;
 	}
-	
+
 	/**
 	 * Internal method which prepares frame rect for blitting.
 	 * Required for rotated frames support.
-	 * 
+	 *
 	 * @param   mat   Frame transformation matrix (rotated / flipped / translated).
 	 * @return  Clipping rectangle which will be used for frame blitting.
 	 */
-	private inline function getDrawFrameRect(mat:FlxMatrix):Rectangle
+	inline function getDrawFrameRect(mat:FlxMatrix):Rectangle
 	{
 		var p1:FlxPoint = FlxPoint.weak(frame.x, frame.y);
 		var p2:FlxPoint = FlxPoint.weak(frame.right, frame.bottom);
-		
+
 		p1.transform(mat);
 		p2.transform(mat);
-		
+
 		var flxRect = FlxRect.get().fromTwoPoints(p1, p2);
 		flxRect.copyToFlash(rect);
 		flxRect.put();
 		return rect;
 	}
-	
+
 	/**
 	 * Generates frame with specified subregion of this frame.
-	 * 
+	 *
 	 * @param   rect          Frame region to generate frame for.
 	 * @param   frameToFill   Frame to fill with data. If `null` then a new frame will be created.
 	 * @return  Specified `frameToFill` object but filled with data.
@@ -445,9 +445,9 @@ class FlxFrame implements IFlxDestroyable
 			frameToFill.angle = angle;
 			frameToFill.frame = FlxDestroyUtil.put(frameToFill.frame);
 		}
-		
+
 		frameToFill.sourceSize.set(rect.width, rect.height);
-		
+
 		// no need to make all calculations if original frame is empty...
 		if (type == FlxFrameType.EMPTY)
 		{
@@ -455,22 +455,22 @@ class FlxFrame implements IFlxDestroyable
 			frameToFill.offset.set(0, 0);
 			return frameToFill;
 		}
-		
+
 		var clippedRect:FlxRect = FlxRect.get().setSize(frame.width, frame.height);
 		if (angle != FlxFrameAngle.ANGLE_0)
 		{
 			clippedRect.width = frame.height;
 			clippedRect.height = frame.width;
 		}
-		
+
 		var ox:Float = Math.max(offset.x, 0);
 		var oy:Float = Math.max(offset.y, 0);
-		
+
 		rect.offset(-ox, -oy);
 		var frameRect:FlxRect = clippedRect.intersection(rect);
 		clippedRect = FlxDestroyUtil.put(clippedRect);
 		rect.offset(ox, oy);
-		
+
 		if (frameRect.isEmpty)
 		{
 			frameToFill.type = FlxFrameType.EMPTY;
@@ -482,12 +482,12 @@ class FlxFrame implements IFlxDestroyable
 		{
 			frameToFill.type = FlxFrameType.REGULAR;
 			frameToFill.offset.set(frameRect.x, frameRect.y).subtract(rect.x, rect.y).addPoint(offset);
-			
+
 			var p1 = FlxPoint.weak(frameRect.x, frameRect.y);
 			var p2 = FlxPoint.weak(frameRect.right, frameRect.bottom);
-			
+
 			matrix.identity();
-			
+
 			if (angle == FlxFrameAngle.ANGLE_NEG_90)
 			{
 				matrix.rotateByPositive90();
@@ -498,26 +498,26 @@ class FlxFrame implements IFlxDestroyable
 				matrix.rotateByNegative90();
 				matrix.translate(0, frame.height);
 			}
-			
+
 			if (angle != FlxFrameAngle.ANGLE_0)
 			{
 				p1.transform(matrix);
 				p2.transform(matrix);
 			}
-			
+
 			frameRect.fromTwoPoints(p1, p2);
 			frameRect.offset(frame.x, frame.y);
 			frameToFill.frame = frameRect;
 			frameToFill.cacheFrameMatrix();
 		}
-		
+
 		return frameToFill;
 	}
-	
+
 	/**
 	 * Just a helper method for some frame adjusting.
 	 * Try to not use it, since it may cause memory leaks.
-	 * 
+	 *
 	 * @param   border   Amount to clip from frame
 	 * @return  Clipped frame
 	 */
@@ -529,7 +529,7 @@ class FlxFrame implements IFlxDestroyable
 		rect = FlxDestroyUtil.put(rect);
 		return frameToFill;
 	}
-	
+
 	/**
 	 * Frame clipping
 	 *
@@ -550,10 +550,10 @@ class FlxFrame implements IFlxDestroyable
 			clippedFrame.angle = angle;
 			clippedFrame.frame = FlxDestroyUtil.put(clippedFrame.frame);
 		}
-		
+
 		clippedFrame.sourceSize.copyFrom(sourceSize);
 		clippedFrame.name = name;
-		
+
 		// no need to make all calculations if original frame is empty...
 		if (type == FlxFrameType.EMPTY)
 		{
@@ -561,18 +561,18 @@ class FlxFrame implements IFlxDestroyable
 			clippedFrame.offset.set(0, 0);
 			return clippedFrame;
 		}
-		
+
 		var clippedRect:FlxRect = FlxRect.get(0, 0).setSize(frame.width, frame.height);
 		if (angle != FlxFrameAngle.ANGLE_0)
 		{
 			clippedRect.width = frame.height;
 			clippedRect.height = frame.width;
 		}
-		
+
 		clip.offset( -offset.x, -offset.y);
 		var frameRect:FlxRect = clippedRect.intersection(clip);
 		clippedRect = FlxDestroyUtil.put(clippedRect);
-		
+
 		if (frameRect.isEmpty)
 		{
 			clippedFrame.type = FlxFrameType.EMPTY;
@@ -584,12 +584,12 @@ class FlxFrame implements IFlxDestroyable
 		{
 			clippedFrame.type = FlxFrameType.REGULAR;
 			clippedFrame.offset.set(frameRect.x, frameRect.y).addPoint(offset);
-			
+
 			var p1 = FlxPoint.weak(frameRect.x, frameRect.y);
 			var p2 = FlxPoint.weak(frameRect.right, frameRect.bottom);
-			
+
 			matrix.identity();
-			
+
 			if (angle == FlxFrameAngle.ANGLE_NEG_90)
 			{
 				matrix.rotateByPositive90();
@@ -600,26 +600,26 @@ class FlxFrame implements IFlxDestroyable
 				matrix.rotateByNegative90();
 				matrix.translate(0, frame.height);
 			}
-			
+
 			if (angle != FlxFrameAngle.ANGLE_0)
 			{
 				p1.transform(matrix);
 				p2.transform(matrix);
 			}
-			
+
 			frameRect.fromTwoPoints(p1, p2);
 			frameRect.offset(frame.x, frame.y);
 			clippedFrame.frame = frameRect;
 			clippedFrame.cacheFrameMatrix();
 		}
-		
+
 		clip.offset(offset.x, offset.y);
 		return clippedFrame;
 	}
-	
+
 	/**
 	 * Copies data from this frame into specified frame.
-	 * 
+	 *
 	 * @param   clone   Frame to fill data with. If `null`, a new frame will be created.
 	 * @return  Frame with data of this frame.
 	 */
@@ -635,7 +635,7 @@ class FlxFrame implements IFlxDestroyable
 			clone.angle = angle;
 			clone.frame = FlxDestroyUtil.put(clone.frame);
 		}
-		
+
 		clone.offset.copyFrom(offset);
 		clone.flipX = flipX;
 		clone.flipY = flipY;
@@ -646,7 +646,7 @@ class FlxFrame implements IFlxDestroyable
 		clone.cacheFrameMatrix();
 		return clone;
 	}
-	
+
 	public function destroy():Void
 	{
 		name = null;
@@ -658,23 +658,23 @@ class FlxFrame implements IFlxDestroyable
 		blitMatrix = null;
 		tileMatrix = null;
 	}
-	
+
 	public function toString():String
 	{
 		return FlxStringUtil.getDebugString([
 			LabelValuePair.weak("name", name)]);
 	}
-	
-	private function set_frame(value:FlxRect):FlxRect
+
+	function set_frame(value:FlxRect):FlxRect
 	{
 		if (value != null)
 		{
 			if (uv == null)
 				uv = FlxRect.get();
-			
+
 			uv.set(value.x / parent.width, value.y / parent.height, value.right / parent.width, value.bottom / parent.height);
 		}
-		
+
 		return frame = value;
 	}
 }

--- a/flixel/graphics/frames/FlxFramesCollection.hx
+++ b/flixel/graphics/frames/FlxFramesCollection.hx
@@ -19,12 +19,12 @@ class FlxFramesCollection implements IFlxDestroyable
 	 * Array with all frames of this collection.
 	 */
 	public var frames:Array<FlxFrame>;
-	
+
 	/**
 	 * Number of frames in this collection.
 	 */
 	public var numFrames(get, never):Int;
-	
+
 	/**
 	 * Hash of frames for this frame collection.
 	 * Used only in `FlxAtlasFrames` and `FlxBitmapFont` (not implemented yet),
@@ -32,24 +32,24 @@ class FlxFramesCollection implements IFlxDestroyable
 	 * (give names to your frames).
 	 */
 	public var framesHash:Map<String, FlxFrame>;
-	
+
 	/**
 	 * Graphic object this frames belongs to.
 	 */
 	public var parent:FlxGraphic;
-	
+
 	/**
 	 * Type of this frame collection.
 	 * Used for faster type detection (less casting).
 	 */
 	public var type(default, null):FlxFrameCollectionType;
-	
+
 	/**
 	 * How much space was trimmed around the original frames.
 	 * Use `addBorder()` to add borders.
 	 */
 	public var border(default, null):FlxPoint;
-	
+
 	public function new(parent:FlxGraphic, ?type:FlxFrameCollectionType, ?border:FlxPoint)
 	{
 		this.parent = parent;
@@ -57,14 +57,14 @@ class FlxFramesCollection implements IFlxDestroyable
 		this.border = (border == null) ? FlxPoint.get() : border;
 		frames = [];
 		framesHash = new Map<String, FlxFrame>();
-		
+
 		if (parent != null)
 			parent.addFrameCollection(this);
 	}
-	
+
 	/**
 	 * Finds a frame in `framesHash` by its name.
-	 * 
+	 *
 	 * @param   name   The name of the frame to find.
 	 * @return  Frame with specified name (if there is one).
 	 */
@@ -72,10 +72,10 @@ class FlxFramesCollection implements IFlxDestroyable
 	{
 		return framesHash.get(name);
 	}
-	
+
 	/**
 	 * Finds frame in frames array by its index.
-	 * 
+	 *
 	 * @param   index   Index of the frame in the frames array.
 	 * @return  Frame with specified index in this frames collection (if there is one).
 	 */
@@ -83,10 +83,10 @@ class FlxFramesCollection implements IFlxDestroyable
 	{
 		return frames[index];
 	}
-	
+
 	/**
 	 * Finds frame index by its name.
-	 * 
+	 *
 	 * @param   name  Name of the frame.
 	 * @return  Index of the frame with specified name.
 	 */
@@ -97,13 +97,13 @@ class FlxFramesCollection implements IFlxDestroyable
 			if (frames[i].name == name)
 				return i;
 		}
-		
+
 		return -1;
 	}
-	
+
 	/**
 	 * Finds the index of the specified frame in the frames array.
-	 * 
+	 *
 	 * @param   frame   Frame to find.
 	 * @return  Index of the specified frame.
 	 */
@@ -111,7 +111,7 @@ class FlxFramesCollection implements IFlxDestroyable
 	{
 		return frames.indexOf(frame);
 	}
-	
+
 	public function destroy():Void
 	{
 		frames = FlxDestroyUtil.destroyArray(frames);
@@ -120,11 +120,11 @@ class FlxFramesCollection implements IFlxDestroyable
 		parent = null;
 		type = null;
 	}
-	
+
 	/**
 	 * Adds empty frame into this frame collection.
 	 * An empty frame is doing almost nothing for all the time.
-	 * 
+	 *
 	 * @param   size   Dimensions of the frame to add.
 	 * @return  Newly added empty frame.
 	 */
@@ -137,10 +137,10 @@ class FlxFramesCollection implements IFlxDestroyable
 		frames.push(frame);
 		return frame;
 	}
-	
+
 	/**
 	 * Adds new regular (not rotated) `FlxFrame` to this frame collection.
-	 * 
+	 *
 	 * @param   region   Region of image which new frame will display.
 	 * @return  Newly created `FlxFrame` object for specified region of image.
 	 */
@@ -152,7 +152,7 @@ class FlxFramesCollection implements IFlxDestroyable
 		frame.offset.set(0, 0);
 		return pushFrame(frame);
 	}
-	
+
 	/**
 	 * Adds new frame to this frame collection.
 	 * This method runs additional check, and can add rotated frames (from texture atlases).
@@ -173,19 +173,19 @@ class FlxFramesCollection implements IFlxDestroyable
 	{
 		if (name != null && framesHash.exists(name))
 			return framesHash.get(name);
-		
+
 		var texFrame:FlxFrame = new FlxFrame(parent, angle, flipX, flipY);
 		texFrame.name = name;
 		texFrame.sourceSize.set(sourceSize.x, sourceSize.y);
 		texFrame.offset.set(offset.x, offset.y);
 		texFrame.frame = checkFrame(frame, name);
-		
+
 		sourceSize = FlxDestroyUtil.put(sourceSize);
 		offset = FlxDestroyUtil.put(offset);
-		
+
 		return pushFrame(texFrame);
 	}
-	
+
 	/**
 	 * Checks if frame's area fits into atlas image, and trims if it's out of atlas image bounds.
 	 *
@@ -193,25 +193,25 @@ class FlxFramesCollection implements IFlxDestroyable
 	 * @param   name    Optional frame name for debugging info.
 	 * @return  Checked and trimmed frame rectangle.
 	 */
-	private function checkFrame(frame:FlxRect, ?name:String):FlxRect
+	function checkFrame(frame:FlxRect, ?name:String):FlxRect
 	{
 		var x:Float = FlxMath.bound(frame.x, 0, parent.width);
 		var y:Float = FlxMath.bound(frame.y, 0, parent.height);
-		
+
 		var r:Float = FlxMath.bound(frame.right, 0, parent.width);
 		var b:Float = FlxMath.bound(frame.bottom, 0, parent.height);
-		
+
 		frame.set(x, y, r - x, b - y);
-		
+
 		if (frame.width <= 0 || frame.height <= 0)
 			FlxG.log.warn("The frame " + name + " has incorrect data and results in an image with the size of (0, 0)");
-		
+
 		return frame;
 	}
-	
+
 	/**
 	 * Helper method for a adding frame to the collection.
-	 * 
+	 *
 	 * @param   frameObj   Frame to add.
 	 * @return  Added frame.
 	 */
@@ -220,19 +220,19 @@ class FlxFramesCollection implements IFlxDestroyable
 		var name:String = frameObj.name;
 		if (name != null && framesHash.exists(name))
 			return framesHash.get(name);
-		
+
 		frames.push(frameObj);
 		frameObj.cacheFrameMatrix();
-		
+
 		if (name != null)
 			framesHash.set(name, frameObj);
-		
+
 		return frameObj;
 	}
-	
+
 	/**
 	 * Generates new frames collection from this collection but trims frames by specified borders.
-	 * 
+	 *
 	 * @param   border   How much space trim around the frames.
 	 * @return  Generated frames collection.
 	 */
@@ -241,15 +241,15 @@ class FlxFramesCollection implements IFlxDestroyable
 		throw "To be overriden in subclasses";
 		return null;
 	}
-	
+
 	public function toString():String
 	{
 		return FlxStringUtil.getDebugString([
 			LabelValuePair.weak("frames", frames),
 			LabelValuePair.weak("type", type)]);
 	}
-	
-	private inline function get_numFrames():Int
+
+	inline function get_numFrames():Int
 	{
 		return frames.length;
 	}
@@ -259,7 +259,7 @@ class FlxFramesCollection implements IFlxDestroyable
  * An enumeration of all types of frame collections.
  * Added for faster type detection with less usage of casting.
  */
-enum FlxFrameCollectionType 
+enum FlxFrameCollectionType
 {
 	IMAGE;
 	TILES;

--- a/flixel/graphics/frames/FlxImageFrame.hx
+++ b/flixel/graphics/frames/FlxImageFrame.hx
@@ -21,15 +21,15 @@ class FlxImageFrame extends FlxFramesCollection
 	 * Added this var for faster access, so you don't need to type something like: `imageFrame.frames[0]`
 	 */
 	public var frame(get, null):FlxFrame;
-	
-	private function new(parent:FlxGraphic, ?border:FlxPoint)
+
+	function new(parent:FlxGraphic, ?border:FlxPoint)
 	{
 		super(parent, FlxFrameCollectionType.IMAGE, border);
 	}
-	
+
 	/**
 	 * Generates a `FlxImageFrame` object with empty frame of specified size.
-	 * 
+	 *
 	 * @param   graphic     Graphic for the `FlxImageFrame`.
 	 * @param   frameRect   The size of the empty frame to generate
 	 *                      (only `width` and `height` of the `frameRect` need to be set properly).
@@ -39,21 +39,21 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		if (graphic == null || frameRect == null)
 			return null;
-		
+
 		// find ImageFrame, if there is one already
 		var imageFrame = FlxImageFrame.findEmptyFrame(graphic, frameRect);
 		if (imageFrame != null)
 			return imageFrame;
-		
+
 		// or create it, if there is no such object
 		imageFrame = new FlxImageFrame(graphic);
 		imageFrame.addEmptyFrame(frameRect);
 		return imageFrame;
 	}
-	
+
 	/**
 	 * Generates a `FlxImageFrame` object from the specified `FlxFrame`.
-	 * 
+	 *
 	 * @param   source   `FlxFrame` to generate `FlxImageFrame` from.
 	 * @return  Created `FlxImageFrame` object.
 	 */
@@ -61,19 +61,19 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		var graphic:FlxGraphic = source.parent;
 		var rect:FlxRect = source.frame;
-		
+
 		var imageFrame:FlxImageFrame = FlxImageFrame.findFrame(graphic, rect);
 		if (imageFrame != null)
 			return imageFrame;
-		
+
 		imageFrame = new FlxImageFrame(graphic);
 		imageFrame.addSpriteSheetFrame(rect.copyTo(FlxRect.get()));
 		return imageFrame;
 	}
-	
+
 	/**
 	 * Creates a `FlxImageFrame` object for the whole image.
-	 * 
+	 *
 	 * @param   source   image graphic for the `FlxImageFrame`.
 	 * @return  Newly created `FlxImageFrame` object for specified graphic.
 	 */
@@ -81,10 +81,10 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		return fromRectangle(source, null);
 	}
-	
+
 	/**
 	 * Creates `FlxImageFrame` for the specified region of `FlxGraphic`.
-	 * 
+	 *
 	 * @param   graphic   Graphic for `FlxImageFrame`.
 	 * @param   region    Region of image to create the `FlxImageFrame` for.
 	 * @return  Newly created `FlxImageFrame` object for the specified region of `FlxGraphic` object.
@@ -93,20 +93,20 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		if (graphic == null)
 			return null;
-		
+
 		// find ImageFrame, if there is one already
 		var checkRegion:FlxRect = region;
-		
+
 		if (checkRegion == null)
 			checkRegion = FlxRect.weak(0, 0, graphic.width, graphic.height);
-		
+
 		var imageFrame:FlxImageFrame = FlxImageFrame.findFrame(graphic, checkRegion);
 		if (imageFrame != null)
 			return imageFrame;
-		
+
 		// or create it, if there is no such object
 		imageFrame = new FlxImageFrame(graphic);
-		
+
 		if (region == null)
 		{
 			region = FlxRect.get(0, 0, graphic.width, graphic.height);
@@ -115,18 +115,18 @@ class FlxImageFrame extends FlxFramesCollection
 		{
 			if (region.width == 0)
 				region.width = graphic.width - region.x;
-			
+
 			if (region.height == 0)
 				region.height = graphic.height - region.y;
 		}
-		
+
 		imageFrame.addSpriteSheetFrame(region);
 		return imageFrame;
 	}
-	
+
 	/**
 	 * Creates a `FlxImageFrame` object for specified region of the image.
-	 * 
+	 *
 	 * @param   source   Image graphic for `FlxImageFrame`.
 	 * @param   region   Region of the image to create the `FlxImageFrame` for.
 	 * @return  Newly created `FlxImageFrame` object for specified region of image.
@@ -136,11 +136,11 @@ class FlxImageFrame extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(source, false);
 		return fromGraphic(graphic, region);
 	}
-	
+
 	/**
-	 * Gets source BitmapData, generates new BitmapData (if there is no such BitmapData in the cache already) 
+	 * Gets source BitmapData, generates new BitmapData (if there is no such BitmapData in the cache already)
 	 * and creates FlxImageFrame collection.
-	 * 
+	 *
 	 * @param   source   The source of graphic for frame collection.
 	 * @param   border   Border to add around tiles (helps to avoid "tearing" problem).
 	 * @param   region   Region of image to generate image frame from. Default value is `null`, which means that
@@ -152,7 +152,7 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		var graphic:FlxGraphic = FlxG.bitmap.add(source, false);
 		if (graphic == null) return null;
-		
+
 		var key:String = FlxG.bitmap.getKeyWithSpacesAndBorders(graphic.key, null, null, border, region);
 		var result:FlxGraphic = FlxG.bitmap.get(key);
 		if (result == null)
@@ -160,15 +160,15 @@ class FlxImageFrame extends FlxFramesCollection
 			var bitmap:BitmapData = FlxBitmapDataUtil.addSpacesAndBorders(graphic.bitmap, null, null, border, region);
 			result = FlxG.bitmap.add(bitmap, false, key);
 		}
-		
+
 		var imageFrame:FlxImageFrame = FlxImageFrame.fromGraphic(graphic);
 		return imageFrame.addBorder(border);
 	}
-	
+
 	/**
 	 * Gets `FlxFrame` object, generates new `BitmapData` with border pixels around
 	 * (if there is no such BitmapData in the cache already) and creates image frame collection.
-	 * 
+	 *
 	 * @param   frame    Frame to generate tiles from.
 	 * @param   border   Border to add around frame image (helps to avoid "tearing" problem).
 	 * @return  Newly created image frame collection.
@@ -178,10 +178,10 @@ class FlxImageFrame extends FlxFramesCollection
 		var bitmap:BitmapData = frame.paint();
 		return FlxImageFrame.fromBitmapAddSpacesAndBorders(bitmap, border);
 	}
-	
+
 	/**
 	 * Searches `FlxImageFrame` object for specified `FlxGraphic` object which have the same frame rectangle.
-	 * 
+	 *
 	 * @param    graphic     `FlxGraphic` object to search the `FlxImageFrame` for.
 	 * @param    frameRect   `FlxImageFrame` object should have frame with
 	 *                        the same position and dimensions as specified with this argument.
@@ -192,28 +192,28 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		if (frameBorder == null)
 			frameBorder = FlxPoint.weak();
-		
+
 		var imageFrames:Array<FlxImageFrame> = cast graphic.getFramesCollections(FlxFrameCollectionType.IMAGE);
 		for (imageFrame in imageFrames)
 		{
 			if (imageFrame.equals(frameRect, frameBorder) && imageFrame.frame.type != FlxFrameType.EMPTY)
 				return imageFrame;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * `FlxImageFrame` comparison method. For internal use.
 	 */
-	private inline function equals(rect:FlxRect, border:FlxPoint):Bool
+	inline function equals(rect:FlxRect, border:FlxPoint):Bool
 	{
 		return rect.equals(frame.frame) && border.equals(this.border);
 	}
-	
+
 	/**
 	 * Searches `FlxImageFrame` object with the empty frame which have specified size.
-	 * 
+	 *
 	 * @param   graphic     `FlxGraphic` object to search `FlxImageFrame` for.
 	 * @param   frameRect   The size of empty frame to search for.
 	 * @return  `FlxImageFrame` with empty frame.
@@ -229,30 +229,30 @@ class FlxImageFrame extends FlxFramesCollection
 				frame.sourceSize.y == frameRect.height && frame.type == FlxFrameType.EMPTY)
 				return imageFrame;
 		}
-		
+
 		return null;
 	}
-	
-	override public function addBorder(border:FlxPoint):FlxImageFrame 
+
+	override public function addBorder(border:FlxPoint):FlxImageFrame
 	{
 		var resultBorder:FlxPoint = FlxPoint.weak().addPoint(this.border).addPoint(border);
-		
+
 		var imageFrame:FlxImageFrame = FlxImageFrame.findFrame(parent, frame.frame, resultBorder);
 		if (imageFrame != null)
 			return imageFrame;
-		
+
 		imageFrame = new FlxImageFrame(parent, resultBorder);
 		imageFrame.pushFrame(frame.setBorderTo(border));
 		return imageFrame;
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		frame = FlxDestroyUtil.destroy(frame);
 	}
-	
-	private function get_frame():FlxFrame
+
+	function get_frame():FlxFrame
 	{
 		return frames[0];
 	}

--- a/flixel/graphics/frames/FlxTileFrames.hx
+++ b/flixel/graphics/frames/FlxTileFrames.hx
@@ -20,11 +20,11 @@ class FlxTileFrames extends FlxFramesCollection
 	 * Atlas frame from which this frame collection had been generated.
 	 * Could be `null` if this collection generated from rectangle.
 	 */
-	private var atlasFrame:FlxFrame;
+	var atlasFrame:FlxFrame;
 	/**
 	 * Image region of the image from which this frame collection had been generated.
 	 */
-	private var region:FlxRect;
+	var region:FlxRect;
 	/**
 	 * The size of frame in this spritesheet.
 	 */
@@ -32,17 +32,17 @@ class FlxTileFrames extends FlxFramesCollection
 	/**
 	 * Offsets between frames in this spritesheet.
 	 */
-	private var tileSpacing:FlxPoint;
-	
+	var tileSpacing:FlxPoint;
+
 	public var numRows:Int = 0;
-	
+
 	public var numCols:Int = 0;
-	
-	private function new(parent:FlxGraphic, ?border:FlxPoint) 
+
+	function new(parent:FlxGraphic, ?border:FlxPoint)
 	{
 		super(parent, FlxFrameCollectionType.TILES, border);
 	}
-	
+
 	/**
 	 * Gets frame by its "position" in spritesheet.
 	 */
@@ -50,11 +50,11 @@ class FlxTileFrames extends FlxFramesCollection
 	{
 		return frames[row * numCols + column];
 	}
-	
+
 	/**
 	 * Gets source `BitmapData`, generates new `BitmapData` with spaces between frames
 	 * (if there is no such `BitmapData` in the cache already) and creates `FlxTileFrames` collection.
-	 * 
+	 *
 	 * @param   source        The source of graphic for frame collection.
 	 * @param   tileSize      The size of tiles in spritesheet.
 	 * @param   tileSpacing   Desired offsets between frames in spritesheet
@@ -70,7 +70,7 @@ class FlxTileFrames extends FlxFramesCollection
 		var graphic:FlxGraphic = FlxG.bitmap.add(source, false);
 		if (graphic == null)
 			return null;
-		
+
 		var key:String = FlxG.bitmap.getKeyWithSpacesAndBorders(graphic.key, tileSize, tileSpacing, tileBorder, region);
 		var result:FlxGraphic = FlxG.bitmap.get(key);
 		if (result == null)
@@ -78,29 +78,29 @@ class FlxTileFrames extends FlxFramesCollection
 			var bitmap:BitmapData = FlxBitmapDataUtil.addSpacesAndBorders(graphic.bitmap, tileSize, tileSpacing, tileBorder, region);
 			result = FlxG.bitmap.add(bitmap, false, key);
 		}
-		
+
 		var borderX:Int = 0;
 		var borderY:Int = 0;
-		
+
 		if (tileBorder != null)
 		{
 			borderX = Std.int(tileBorder.x);
-			borderY = Std.int(tileBorder.y); 
+			borderY = Std.int(tileBorder.y);
 		}
-		
+
 		var tileFrames:FlxTileFrames = FlxTileFrames.fromGraphic(result,
 			FlxPoint.get().addPoint(tileSize).add(2 * borderX, 2 * borderY), null, tileSpacing);
-		
+
 		if (tileBorder == null)
 			return tileFrames;
-		
+
 		return tileFrames.addBorder(tileBorder);
 	}
-	
+
 	/**
 	 * Gets `FlxFrame` object, generates new `BitmapData` with spaces between tiles in the frame
 	 * (if there is no such `BitmapData` in the cache already) and creates a `FlxTileFrames` collection.
-	 *  
+	 *
 	 * @param   frame         Frame to generate tiles from.
 	 * @param   tileSize      the size of tiles in spritesheet.
 	 * @param   tileSpacing   desired offsets between frames in spritesheet.
@@ -114,12 +114,12 @@ class FlxTileFrames extends FlxFramesCollection
 		var bitmap:BitmapData = frame.paint();
 		return FlxTileFrames.fromBitmapAddSpacesAndBorders(bitmap, tileSize, tileSpacing, tileBorder);
 	}
-	
+
 	/**
 	 * Generates spritesheet frame collection from provided frame. Can be useful for spritesheets packed into atlases.
 	 * It can generate spritesheets from rotated and cropped frames also,
 	 * which is important for devices with limited memory.
-	 * 
+	 *
 	 * @param   frame         Frame, containing spritesheet image
 	 * @param   tileSize      The size of tiles in spritesheet
 	 * @param   tileSpacing   Offsets between frames in spritesheet.
@@ -133,47 +133,47 @@ class FlxTileFrames extends FlxFramesCollection
 		var tileFrames:FlxTileFrames = FlxTileFrames.findFrame(graphic, tileSize, null, frame, tileSpacing);
 		if (tileFrames != null)
 			return tileFrames;
-		
+
 		// or create it, if there is no such object
 		tileSpacing = (tileSpacing != null) ? tileSpacing : FlxPoint.get(0, 0);
-		
+
 		tileFrames = new FlxTileFrames(graphic);
 		tileFrames.atlasFrame = frame;
 		tileFrames.region = frame.frame;
 		tileFrames.tileSize = tileSize;
 		tileFrames.tileSpacing = tileSpacing;
-		
+
 		tileSpacing.floor();
 		tileSize.floor();
-		
+
 		var spacedWidth:Float = tileSize.x + tileSpacing.x;
 		var spacedHeight:Float = tileSize.y + tileSpacing.y;
-		
+
 		var numRows:Int = (tileSize.y == 0) ? 1 : Std.int((frame.sourceSize.y + tileSpacing.y) / spacedHeight);
 		var numCols:Int = (tileSize.x == 0) ? 1 : Std.int((frame.sourceSize.x + tileSpacing.x) / spacedWidth);
-		
+
 		var helperRect:FlxRect = FlxRect.get(0, 0, tileSize.x, tileSize.y);
-		
+
 		for (j in 0...numRows)
 		{
-			for (i in 0...numCols)	
+			for (i in 0...numCols)
 			{
 				helperRect.x = spacedWidth * i;
 				helperRect.y = spacedHeight * j;
 				tileFrames.pushFrame(frame.subFrameTo(helperRect));
 			}
 		}
-		
+
 		helperRect = FlxDestroyUtil.put(helperRect);
-		
+
 		tileFrames.numCols = numCols;
 		tileFrames.numRows = numRows;
 		return tileFrames;
 	}
-	
+
 	/**
 	 * Just generates tile frames collection from specified array of frames.
-	 * 
+	 *
 	 * @param   Frames   `Array` of frames to generate tile frames from.
 	 *                   They all should have the same source size and parent graphic.
 	 *                   If not then `null` will be returned.
@@ -183,7 +183,7 @@ class FlxTileFrames extends FlxFramesCollection
 	{
 		var firstFrame:FlxFrame = Frames[0];
 		var graphic:FlxGraphic = firstFrame.parent;
-		
+
 		for (frame in Frames)
 		{
 			if (frame.parent != firstFrame.parent || !frame.sourceSize.equals(firstFrame.sourceSize))
@@ -192,32 +192,32 @@ class FlxTileFrames extends FlxFramesCollection
 				return null;
 			}
 		}
-		
+
 		var tileFrames:FlxTileFrames = new FlxTileFrames(graphic);
-		
+
 		tileFrames.region = null;
 		tileFrames.atlasFrame = null;
 		tileFrames.tileSize = FlxPoint.get().copyFrom(firstFrame.sourceSize);
 		tileFrames.tileSpacing = FlxPoint.get(0, 0);
 		tileFrames.numCols = Frames.length;
 		tileFrames.numRows = 1;
-		
+
 		for (frame in Frames)
 		{
 			tileFrames.frames.push(frame);
-			
+
 			if (frame.name != null)
 				tileFrames.framesHash.set(frame.name, frame);
 		}
-		
+
 		return tileFrames;
 	}
-	
+
 	/**
 	 * Creates new a `FlxTileFrames` collection from atlas frames which begin with
 	 * a common name (e.g. `"tiles-"`) and differ in indices (e.g. `"001"`, `"002"`, etc.).
 	 * This method is similar to `FlxAnimationController`'s `addByPrefix()`.
-	 * 
+	 *
 	 * @param    Frames   Collection of atlas frames to generate tiles from.
 	 * @param    Prefix   Common beginning of image names in atlas (e.g. `"tiles-"`).
 	 * @return   Generated tile frames collection.
@@ -225,29 +225,29 @@ class FlxTileFrames extends FlxFramesCollection
 	public static function fromAtlasByPrefix(Frames:FlxAtlasFrames, Prefix:String):FlxTileFrames
 	{
 		var framesToAdd = new Array<FlxFrame>();
-		
+
 		for (frame in Frames.frames)
 		{
 			if (StringTools.startsWith(frame.name, Prefix))
 				framesToAdd.push(frame);
 		}
-		
+
 		if (framesToAdd.length > 0)
 		{
 			var name:String = framesToAdd[0].name;
 			var postIndex:Int = name.indexOf(".", Prefix.length);
 			var postFix:String = name.substring(postIndex == -1 ? name.length : postIndex, name.length);
-			
+
 			FlxFrame.sort(framesToAdd, Prefix.length, postFix.length);
 			return FlxTileFrames.fromFrames(framesToAdd);
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Generates spritesheet frame collection from provided region of image.
-	 * 
+	 *
 	 * @param   graphic       Source graphic for spritesheet.
 	 * @param   tileSize      The size of tiles in spritesheet.
 	 * @param   region        Region of image to use for spritesheet generation. Default value is `null`,
@@ -263,7 +263,7 @@ class FlxTileFrames extends FlxFramesCollection
 		var tileFrames:FlxTileFrames = FlxTileFrames.findFrame(graphic, tileSize, region, null, tileSpacing);
 		if (tileFrames != null)
 			return tileFrames;
-		
+
 		// or create it, if there is no such object
 		if (region == null)
 		{
@@ -273,31 +273,31 @@ class FlxTileFrames extends FlxFramesCollection
 		{
 			if (region.width == 0)
 				region.width = graphic.width - region.x;
-			
+
 			if (region.height == 0)
 				region.height = graphic.height - region.y;
 		}
-		
+
 		tileSpacing = (tileSpacing != null) ? tileSpacing : FlxPoint.get(0, 0);
-		
+
 		tileFrames = new FlxTileFrames(graphic);
 		tileFrames.region = region;
 		tileFrames.atlasFrame = null;
 		tileFrames.tileSize = tileSize;
 		tileFrames.tileSpacing = tileSpacing;
-		
+
 		region.floor();
 		tileSpacing.floor();
 		tileSize.floor();
-		
+
 		var spacedWidth:Float = tileSize.x + tileSpacing.x;
 		var spacedHeight:Float = tileSize.y + tileSpacing.y;
-		
+
 		var numRows:Int = (tileSize.y == 0) ? 1 : Std.int((region.height + tileSpacing.y) / spacedHeight);
 		var numCols:Int = (tileSize.x == 0) ? 1 : Std.int((region.width + tileSpacing.x) / spacedWidth);
-		
+
 		var tileRect:FlxRect;
-		
+
 		for (j in 0...numRows)
 		{
 			for (i in 0...numCols)
@@ -306,15 +306,15 @@ class FlxTileFrames extends FlxFramesCollection
 				tileFrames.addSpriteSheetFrame(tileRect);
 			}
 		}
-		
+
 		tileFrames.numCols = numCols;
 		tileFrames.numRows = numRows;
 		return tileFrames;
 	}
-	
+
 	/**
 	 * Generates a spritesheet frame collection from the provided image region.
-	 * 
+	 *
 	 * @param   source        Source graphic for the spritesheet.
 	 * @param   tileSize      The size of tiles in spritesheet.
 	 * @param   region        Region of image to use for spritesheet generation. Default value is `null`,
@@ -331,23 +331,23 @@ class FlxTileFrames extends FlxFramesCollection
 			return null;
 		return fromGraphic(graphic, tileSize, region, tileSpacing);
 	}
-	
+
 	/**
 	 * This method takes array of tileset bitmaps and the size of
 	 * tiles in them and then combine them in one big tileset.
 	 * The order of bitmaps in the array is important.
-	 * 
+	 *
 	 * @param   bitmaps    tilesets
 	 * @param   tileSize   The size of tiles (tilesets should have tiles of the same size).
 	 * @return  Atlas frames collection, which you can load in tilemaps or sprites:
-	 * 
+	 *
 	 * ```haxe
 	 * var combinedFrames = FlxTileFrames.combineTileSets(bitmaps, FlxPoint.get(16, 16));
 	 * tilemap.loadMapFromCSV(mapData, combinedFrames);
 	 *```
 	 *
 	 * or
-	 * 
+	 *
 	 * ```haxe
 	 * sprite.frames = combinedFrames;
 	 * ```
@@ -356,27 +356,27 @@ class FlxTileFrames extends FlxFramesCollection
 		?border:FlxPoint):FlxTileFrames
 	{
 		var framesCollections:Array<FlxTileFrames> = [];
-		
+
 		for (bitmap in bitmaps)
 			framesCollections.push(FlxTileFrames.fromRectangle(bitmap, tileSize));
-		
+
 		return combineTileFrames(framesCollections, spacing, border);
 	}
-	
+
 	/**
 	 * This method takes array of tile frames collections and then combine them in one big tileset.
 	 * The order of bitmaps in array is important.
-	 * 
+	 *
 	 * @param   tileframes   Tile frames collection to combine tiles from.
 	 * @return  Atlas frames collection, which you can load in tilemaps or sprites:
-	 * 
+	 *
 	 * ```haxe
 	 * var combinedFrames = FlxTileFrames.combineTileFrames(tileframes);
 	 * tilemap.loadMapFromCSV(mapData, combinedFrames);
 	 * ```
 	 *
 	 * or
-	 * 
+	 *
 	 * ```haxe
 	 * sprite.frames = combinedFrames;
 	 * ```
@@ -388,47 +388,47 @@ class FlxTileFrames extends FlxFramesCollection
 		var totalArea:Int = 0;
 		var rows:Int = 0;
 		var cols:Int = 0;
-		
+
 		var tileWidth:Int = Std.int(tileframes[0].frames[0].sourceSize.x);
 		var tileHeight:Int = Std.int(tileframes[0].frames[0].sourceSize.y);
-		
+
 		var spaceX:Int = 0;
 		var spaceY:Int = 0;
-		
+
 		if (spacing != null)
 		{
 			spaceX = Std.int(spacing.x);
 			spaceY = Std.int(spacing.y);
 		}
-		
+
 		var borderX:Int = 0;
 		var borderY:Int = 0;
-		
+
 		if (border != null)
 		{
 			borderX = Std.int(border.x);
-			borderY = Std.int(border.y); 
+			borderY = Std.int(border.y);
 		}
-		
+
 		for (collection in tileframes)
 		{
 			cols = collection.numCols;
 			rows = collection.numRows;
 			totalArea += Std.int(cols * (tileWidth + 2 * borderX) * rows * (tileHeight + 2 * borderY));
 		}
-		
+
 		var side:Float = Math.sqrt(totalArea);
 		cols = Std.int(side / (tileWidth + 2 * borderX));
 		rows = Math.ceil(totalArea / (cols * (tileWidth + 2 * borderX) * (tileHeight + 2 * borderY)));
 		var width:Int = Std.int(cols * (tileWidth + 2 * borderX)) + (cols - 1) * spaceX;
 		var height:Int = Std.int(rows * (tileHeight + 2 * borderY)) + (rows - 1) * spaceY;
-		
+
 		// now we'll create result atlas and will blit every tile on it.
 		var combined:BitmapData = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
 		var graphic:FlxGraphic = FlxG.bitmap.add(combined);
 		var result:FlxTileFrames = new FlxTileFrames(graphic);
 		var destPoint:Point = new Point(borderX, borderY);
-		
+
 		result.region = FlxRect.get(0, 0, width, height);
 		result.atlasFrame = null;
 		result.tileSize = FlxPoint.get(tileWidth, tileHeight);
@@ -445,7 +445,7 @@ class FlxTileFrames extends FlxFramesCollection
 				result.addAtlasFrame(FlxRect.get(destPoint.x, destPoint.y, tileWidth, tileHeight),
 					FlxPoint.get(tileWidth, tileHeight), FlxPoint.get(0, 0));
 				destPoint.x += tileWidth + 2 * borderX + spaceX;
-				
+
 				if (destPoint.x >= combined.width)
 				{
 					destPoint.x = borderX;
@@ -458,11 +458,11 @@ class FlxTileFrames extends FlxFramesCollection
 			tileHeight, spaceX, spaceY, borderX, borderY, cols, rows);
 		return result;
 	}
-	
+
 	/**
 	 * Searches `FlxTileFrames` object for a specified `FlxGraphic` object
 	 * which has the same parameters (frame size, frame spacings, region of image, etc.).
-	 * 
+	 *
 	 * @param   graphic       `FlxGraphic` object to search `FlxTileFrames` for.
 	 * @param   tileSize      The size of tiles in TileFrames.
 	 * @param   region        The region of source image used for spritesheet generation.
@@ -481,10 +481,10 @@ class FlxTileFrames extends FlxFramesCollection
 			if (sheet.equals(tileSize, region, null, tileSpacing, border))
 				return sheet;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * TileFrames comparison method. For internal use.
 	 */
@@ -494,26 +494,26 @@ class FlxTileFrames extends FlxFramesCollection
 		{
 			return false;
 		}
-		
+
 		if (atlasFrame != null)
 		{
 			region = atlasFrame.frame;
 		}
-		
+
 		if (region == null)
 			region = FlxRect.weak(0, 0, parent.width, parent.height);
-		
+
 		if (tileSpacing == null)
 			tileSpacing = FlxPoint.weak();
-		
+
 		if (border == null)
 			border = FlxPoint.weak();
-		
+
 		return this.atlasFrame == atlasFrame && this.region.equals(region) &&
 			this.tileSize.equals(tileSize) && this.tileSpacing.equals(tileSpacing) &&
 			this.border.equals(border);
 	}
-	
+
 	override public function addBorder(border:FlxPoint):FlxTileFrames
 	{
 		var resultBorder:FlxPoint = FlxPoint.get().addPoint(this.border).addPoint(border);
@@ -524,22 +524,22 @@ class FlxTileFrames extends FlxFramesCollection
 			resultSize = FlxDestroyUtil.put(resultSize);
 			return tileFrames;
 		}
-		
+
 		tileFrames = new FlxTileFrames(parent, resultBorder);
 		tileFrames.region = FlxRect.get().copyFrom(region);
 		tileFrames.atlasFrame = atlasFrame;
 		tileFrames.tileSize = resultSize;
 		tileFrames.tileSpacing = FlxPoint.get().copyFrom(tileSpacing);
-		
+
 		for (frame in frames)
 		{
 			tileFrames.pushFrame(frame.setBorderTo(border));
 		}
-		
+
 		return tileFrames;
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		atlasFrame = null;

--- a/flixel/graphics/tile/FlxDrawBaseItem.hx
+++ b/flixel/graphics/tile/FlxDrawBaseItem.hx
@@ -17,7 +17,7 @@ class FlxDrawBaseItem<T>
 	{
 		if (blend == null)
 			return Tilesheet.TILE_BLEND_NORMAL;
-		
+
 		return switch (blend)
 		{
 			case BlendMode.ADD:
@@ -48,25 +48,25 @@ class FlxDrawBaseItem<T>
 				Tilesheet.TILE_BLEND_NORMAL;
 		}
 	}
-	
+
 	public var nextTyped:T;
-	
+
 	public var next:FlxDrawBaseItem<T>;
-	
+
 	public var graphics:FlxGraphic;
 	public var antialiasing:Bool = false;
 	public var colored:Bool = false;
 	public var hasColorOffsets:Bool = false;
 	public var blending:Int = 0;
-	
+
 	public var type:FlxDrawItemType;
-	
+
 	public var numVertices(get, never):Int;
-	
+
 	public var numTriangles(get, never):Int;
-	
+
 	public function new() {}
-	
+
 	public function reset():Void
 	{
 		graphics = null;
@@ -74,7 +74,7 @@ class FlxDrawBaseItem<T>
 		nextTyped = null;
 		next = null;
 	}
-	
+
 	public function dispose():Void
 	{
 		graphics = null;
@@ -82,23 +82,23 @@ class FlxDrawBaseItem<T>
 		type = null;
 		nextTyped = null;
 	}
-	
+
 	public function render(camera:FlxCamera):Void {}
-	
+
 	public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void {}
-	
-	private function get_numVertices():Int
+
+	function get_numVertices():Int
 	{
 		return 0;
 	}
-	
-	private function get_numTriangles():Int
+
+	function get_numTriangles():Int
 	{
 		return 0;
 	}
 }
 
-enum FlxDrawItemType 
+enum FlxDrawItemType
 {
 	TILES;
 	TRIANGLES;

--- a/flixel/graphics/tile/FlxDrawTilesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTilesItem.hx
@@ -15,27 +15,27 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 	public var position:Int = 0;
 	public var numTiles(get, never):Int;
 	public var shader:FlxShader;
-	
-	public function new() 
+
+	public function new()
 	{
 		super();
 		type = FlxDrawItemType.TILES;
 	}
-	
+
 	override public function reset():Void
 	{
 		super.reset();
 		position = 0;
 		shader = null;
 	}
-	
+
 	override public function dispose():Void
 	{
 		super.dispose();
 		drawData = null;
 		shader = null;
 	}
-	
+
 	override public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void
 	{
 		setNext(matrix.tx);
@@ -72,22 +72,22 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 		}
 		#end
 	}
-	
-	private inline function setNext(f:Float):Void
+
+	inline function setNext(f:Float):Void
 	{
 		drawData[position++] = f;
 	}
-	
+
 	override public function render(camera:FlxCamera):Void
 	{
 		if (!FlxG.renderTile || position <= 0)
 			return;
-		
+
 		var flags:Int = Tilesheet.TILE_TRANS_2x2 | Tilesheet.TILE_RECT | Tilesheet.TILE_ALPHA;
-		
+
 		if (colored)
 			flags |= Tilesheet.TILE_RGB;
-		
+
 		#if (!openfl_legacy && openfl >= "3.6.0")
 		if (hasColorOffsets)
 			flags |= Tilesheet.TILE_TRANS_COLOR;
@@ -104,8 +104,8 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 
 		FlxTilesheet._DRAWCALLS++;
 	}
-	
-	private function get_numTiles():Int
+
+	function get_numTiles():Int
 	{
 		var elementsPerTile:Int = 8; // x, y, id, trans (4 elements) and alpha
 		if (colored)
@@ -117,13 +117,13 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 
 		return Std.int(position / elementsPerTile);
 	}
-	
-	override private function get_numVertices():Int
+
+	override function get_numVertices():Int
 	{
 		return 4 * numTiles;
 	}
-	
-	override private function get_numTriangles():Int
+
+	override function get_numTriangles():Int
 	{
 		return 2 * numTiles;
 	}

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -23,34 +23,34 @@ typedef DrawData<T> = #if flash Vector<T> #else Array<T> #end;
  */
 class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 {
-	private static var point:FlxPoint = FlxPoint.get();
-	private static var rect:FlxRect = FlxRect.get();
-	
+	static var point:FlxPoint = FlxPoint.get();
+	static var rect:FlxRect = FlxRect.get();
+
 	public var vertices:DrawData<Float> = new DrawData<Float>();
 	public var indices:DrawData<Int> = new DrawData<Int>();
 	public var uvtData:DrawData<Float> = new DrawData<Float>();
 	public var colors:DrawData<Int> = new DrawData<Int>();
-	
+
 	public var verticesPosition:Int = 0;
 	public var indicesPosition:Int = 0;
 	public var colorsPosition:Int = 0;
-	
-	private var bounds:FlxRect = FlxRect.get();
-	
-	public function new() 
+
+	var bounds:FlxRect = FlxRect.get();
+
+	public function new()
 	{
 		super();
 		type = FlxDrawItemType.TRIANGLES;
 	}
-	
-	override public function render(camera:FlxCamera):Void 
+
+	override public function render(camera:FlxCamera):Void
 	{
 		if (!FlxG.renderTile)
 			return;
-		
+
 		if (numTriangles <= 0)
 			return;
-		
+
 		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
 		#if !openfl_legacy
 		camera.canvas.graphics.drawTriangles(vertices, indices, uvtData, TriangleCulling.NONE);
@@ -66,43 +66,43 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			gfx.drawTriangles(vertices, indices);
 		}
 		#end
-		
+
 		FlxTilesheet._DRAWCALLS++;
 	}
-	
-	override public function reset():Void 
+
+	override public function reset():Void
 	{
 		super.reset();
 		vertices.splice(0, vertices.length);
 		indices.splice(0, indices.length);
 		uvtData.splice(0, uvtData.length);
 		colors.splice(0, colors.length);
-		
+
 		verticesPosition = 0;
 		indicesPosition = 0;
 		colorsPosition = 0;
 	}
-	
-	override public function dispose():Void 
+
+	override public function dispose():Void
 	{
 		super.dispose();
-		
+
 		vertices = null;
 		indices = null;
 		uvtData = null;
 		colors = null;
 		bounds = null;
 	}
-	
+
 	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>,
 		?colors:DrawData<Int>, ?position:FlxPoint, ?cameraBounds:FlxRect):Void
 	{
 		if (position == null)
 			position = point.set();
-		
+
 		if (cameraBounds == null)
 			cameraBounds = rect.set(0, 0, FlxG.width, FlxG.height);
-		
+
 		var verticesLength:Int = vertices.length;
 		var prevVerticesLength:Int = this.vertices.length;
 		var numberOfVertices:Int = Std.int(verticesLength / 2);
@@ -110,19 +110,19 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		var prevUVTDataLength:Int = this.uvtData.length;
 		var prevColorsLength:Int = this.colors.length;
 		var prevNumberOfVertices:Int = this.numVertices;
-		
+
 		var tempX:Float, tempY:Float;
 		var i:Int = 0;
 		var currentVertexPosition:Int = prevVerticesLength;
-		
+
 		while (i < verticesLength)
 		{
-			tempX = position.x + vertices[i]; 
+			tempX = position.x + vertices[i];
 			tempY = position.y + vertices[i + 1];
-			
+
 			this.vertices[currentVertexPosition++] = tempX;
 			this.vertices[currentVertexPosition++] = tempY;
-			
+
 			if (i == 0)
 			{
 				bounds.set(tempX, tempY, 0, 0);
@@ -131,10 +131,10 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			{
 				inflateBounds(bounds, tempX, tempY);
 			}
-			
+
 			i += 2;
 		}
-		
+
 		if (!cameraBounds.overlaps(bounds))
 		{
 			this.vertices.splice(this.vertices.length - verticesLength, verticesLength);
@@ -146,148 +146,148 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			{
 				this.uvtData[prevUVTDataLength + i] = uvtData[i];
 			}
-			
+
 			var indicesLength:Int = indices.length;
 			for (i in 0...indicesLength)
 			{
 				this.indices[prevIndicesLength + i] = indices[i] + prevNumberOfVertices;
 			}
-			
+
 			if (colored)
 			{
 				for (i in 0...numberOfVertices)
 				{
 					this.colors[prevColorsLength + i] = colors[i];
 				}
-				
+
 				colorsPosition += numberOfVertices;
 			}
-			
+
 			verticesPosition += verticesLength;
 			indicesPosition += indicesLength;
 		}
-		
+
 		position.putWeak();
 		cameraBounds.putWeak();
 	}
-	
+
 	public static inline function inflateBounds(bounds:FlxRect, x:Float, y:Float):FlxRect
 	{
-		if (x < bounds.x) 
+		if (x < bounds.x)
 		{
 			bounds.width += bounds.x - x;
 			bounds.x = x;
 		}
-		
-		if (y < bounds.y) 
+
+		if (y < bounds.y)
 		{
 			bounds.height += bounds.y - y;
 			bounds.y = y;
 		}
-		
-		if (x > bounds.x + bounds.width) 
+
+		if (x > bounds.x + bounds.width)
 		{
 			bounds.width = x - bounds.x;
 		}
-		
-		if (y > bounds.y + bounds.height) 
+
+		if (y > bounds.y + bounds.height)
 		{
 			bounds.height = y - bounds.y;
 		}
-		
+
 		return bounds;
 	}
-	
+
 	override public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void
 	{
 		var prevVerticesPos:Int = verticesPosition;
 		var prevIndicesPos:Int = indicesPosition;
 		var prevColorsPos:Int = colorsPosition;
 		var prevNumberOfVertices:Int = numVertices;
-		
+
 		var point = FlxPoint.get();
 		point.transform(matrix);
-		
+
 		vertices[prevVerticesPos] = point.x;
 		vertices[prevVerticesPos + 1] = point.y;
-		
+
 		uvtData[prevVerticesPos] = frame.uv.x;
 		uvtData[prevVerticesPos + 1] = frame.uv.y;
-		
+
 		point.set(frame.frame.width, 0);
 		point.transform(matrix);
-		
+
 		vertices[prevVerticesPos + 2] = point.x;
 		vertices[prevVerticesPos + 3] = point.y;
-		
+
 		uvtData[prevVerticesPos + 2] = frame.uv.width;
 		uvtData[prevVerticesPos + 3] = frame.uv.y;
-		
+
 		point.set(frame.frame.width, frame.frame.height);
 		point.transform(matrix);
-		
+
 		vertices[prevVerticesPos + 4] = point.x;
 		vertices[prevVerticesPos + 5] = point.y;
-		
+
 		uvtData[prevVerticesPos + 4] = frame.uv.width;
 		uvtData[prevVerticesPos + 5] = frame.uv.height;
-		
+
 		point.set(0, frame.frame.height);
 		point.transform(matrix);
-		
+
 		vertices[prevVerticesPos + 6] = point.x;
 		vertices[prevVerticesPos + 7] = point.y;
-		
+
 		point.put();
-		
+
 		uvtData[prevVerticesPos + 6] = frame.uv.x;
 		uvtData[prevVerticesPos + 7] = frame.uv.height;
-		
+
 		indices[prevIndicesPos] = prevNumberOfVertices;
 		indices[prevIndicesPos + 1] = prevNumberOfVertices + 1;
 		indices[prevIndicesPos + 2] = prevNumberOfVertices + 2;
 		indices[prevIndicesPos + 3] = prevNumberOfVertices + 2;
 		indices[prevIndicesPos + 4] = prevNumberOfVertices + 3;
 		indices[prevIndicesPos + 5] = prevNumberOfVertices;
-		
+
 		if (colored)
 		{
 			var red = 1.0;
 			var green = 1.0;
 			var blue = 1.0;
 			var alpha = 1.0;
-			
+
 			if (transform != null)
 			{
 				red  = transform.redMultiplier;
 				green = transform.greenMultiplier;
 				blue = transform.blueMultiplier;
-				
+
 				#if !neko
 				alpha = transform.alphaMultiplier;
 				#end
 			}
-			
+
 			var color = FlxColor.fromRGBFloat(red, green, blue, alpha);
-			
+
 			colors[prevColorsPos] = color;
 			colors[prevColorsPos + 1] = color;
 			colors[prevColorsPos + 2] = color;
 			colors[prevColorsPos + 3] = color;
-			
+
 			colorsPosition += 4;
 		}
-		
+
 		verticesPosition += 8;
 		indicesPosition += 6;
 	}
-	
-	override private function get_numVertices():Int
+
+	override function get_numVertices():Int
 	{
 		return Std.int(vertices.length / 2);
 	}
-	
-	override private function get_numTriangles():Int
+
+	override function get_numTriangles():Int
 	{
 		return Std.int(indices.length / 3);
 	}

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -21,7 +21,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 * Helper for overlap functions in `FlxObject` and `FlxTilemap`.
 	 */
 	@:noCompletion
-	private static function overlaps(Callback:FlxBasic->Float->Float->Bool->FlxCamera->Bool, 
+	static function overlaps(Callback:FlxBasic->Float->Float->Bool->FlxCamera->Bool,
 		Group:FlxTypedGroup<FlxBasic>, X:Float, Y:Float, InScreenSpace:Bool, Camera:FlxCamera):Bool
 	{
 		var result:Bool = false;
@@ -30,11 +30,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			var i = 0;
 			var l = Group.length;
 			var basic:FlxBasic;
-			
+
 			while (i < l)
 			{
 				basic = cast Group.members[i++];
-				
+
 				if (basic != null && Callback(basic, X, Y, InScreenSpace, Camera))
 				{
 					result = true;
@@ -44,9 +44,9 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 		return result;
 	}
-	
+
 	@:noCompletion
-	private static function resolveGroup(ObjectOrGroup:FlxBasic):FlxTypedGroup<FlxBasic>
+	static function resolveGroup(ObjectOrGroup:FlxBasic):FlxTypedGroup<FlxBasic>
 	{
 		var group:FlxTypedGroup<FlxBasic> = null;
 		if (ObjectOrGroup != null)
@@ -63,7 +63,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 		return group;
 	}
-	
+
 	/**
 	 * `Array` of all the members in this group.
 	 */
@@ -77,7 +77,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 * variable instead of `members.length` unless you really know what you're doing!
 	 */
 	public var length(default, null):Int = 0;
-	
+
 	/**
 	 * A `FlxSignal` that dispatches when a child is added to this group.
 	 * @since 4.4.0
@@ -88,67 +88,67 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 * @since 4.4.0
 	 */
 	public var memberRemoved(get, never):FlxTypedSignal<T->Void>;
-	
+
 	/**
 	 * Internal variables for lazily creating `memberAdded` and `memberRemoved` signals when needed.
 	 */
 	@:noCompletion
-	private var _memberAdded:FlxTypedSignal<T->Void>;
+	var _memberAdded:FlxTypedSignal<T->Void>;
 	@:noCompletion
-	private var _memberRemoved:FlxTypedSignal<T->Void>;
-	
+	var _memberRemoved:FlxTypedSignal<T->Void>;
+
 	/**
 	 * Internal helper variable for recycling objects a la `FlxEmitter`.
 	 */
 	@:noCompletion
-	private var _marker:Int = 0;
-	
+	var _marker:Int = 0;
+
 	/**
 	 * @param   MaxSize   Maximum amount of members allowed.
 	 */
 	public function new(MaxSize:Int = 0)
 	{
 		super();
-		
+
 		members = [];
 		maxSize = Std.int(Math.abs(MaxSize));
 		flixelType = GROUP;
 	}
-	
+
 	/**
 	 * **WARNING:** A destroyed `FlxBasic` can't be used anymore.
 	 * It may even cause crashes if it is still part of a group or state.
 	 * You may want to use `kill()` instead if you want to disable the object temporarily only and `revive()` it later.
-	 * 
+	 *
 	 * This function is usually not called manually (Flixel calls it automatically during state switches for all `add()`ed objects).
-	 * 
+	 *
 	 * Override this function to `null` out variables manually or call `destroy()` on class members if necessary.
 	 * Don't forget to call `super.destroy()`!
 	 */
 	override public function destroy():Void
 	{
 		super.destroy();
-		
+
 		FlxDestroyUtil.destroy(_memberAdded);
 		FlxDestroyUtil.destroy(_memberRemoved);
-		
+
 		if (members != null)
 		{
 			var i:Int = 0;
 			var basic:FlxBasic = null;
-			
+
 			while (i < length)
 			{
 				basic = members[i++];
-				
+
 				if (basic != null)
 					basic.destroy();
 			}
-			
+
 			members = null;
 		}
 	}
-	
+
 	/**
 	 * Automatically goes through and calls update on everything you added.
 	 */
@@ -156,18 +156,18 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && basic.exists && basic.active)
 			{
 				basic.update(elapsed);
 			}
 		}
 	}
-	
+
 	/**
 	 * Automatically goes through and calls render on everything you added.
 	 */
@@ -175,25 +175,25 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && basic.exists && basic.visible)
 			{
 				basic.draw();
 			}
 		}
 	}
-	
+
 	/**
 	 * Adds a new `FlxBasic` subclass (`FlxBasic`, `FlxSprite`, `Enemy`, etc) to the group.
 	 * `FlxGroup` will try to replace a `null` member of the array first.
 	 * Failing that, `FlxGroup` will add it to the end of the member array.
 	 * WARNING: If the group has a `maxSize` that has already been met,
 	 * the object will NOT be added to the group!
-	 * 
+	 *
 	 * @param   Object   The object you want to add to the group.
 	 * @return  The same `FlxBasic` object that was passed in.
 	 */
@@ -204,42 +204,42 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			FlxG.log.warn("Cannot add a `null` object to a FlxGroup.");
 			return null;
 		}
-		
+
 		// Don't bother adding an object twice.
 		if (members.indexOf(Object) >= 0)
 			return Object;
-		
+
 		// First, look for a null entry where we can add the object.
 		var index:Int = getFirstNull();
 		if (index != -1)
 		{
 			members[index] = Object;
-			
+
 			if (index >= length)
 			{
 				length = index + 1;
 			}
-			
+
 			if (_memberAdded != null)
 				_memberAdded.dispatch(Object);
-			
+
 			return Object;
 		}
-		
+
 		// If the group is full, return the Object
 		if (maxSize > 0 && length >= maxSize)
 			return Object;
-		
+
 		// If we made it this far, we need to add the object to the group.
 		members.push(Object);
 		length++;
-		
+
 		if (_memberAdded != null)
 			_memberAdded.dispatch(Object);
-		
+
 		return Object;
 	}
-	
+
 	/**
 	 * Inserts a new `FlxBasic` subclass (`FlxBasic`, `FlxSprite`, `Enemy`, etc)
 	 * into the group at the specified position.
@@ -247,7 +247,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 * Failing that, `FlxGroup` will insert it at the position of the member array.
 	 * WARNING: If the group has a `maxSize` that has already been met,
 	 * the object will NOT be inserted to the group!
-	 * 
+	 *
 	 * @param   Position   The position in the group where you want to insert the object.
 	 * @param   Object     The object you want to insert into the group.
 	 * @return  The same `FlxBasic` object that was passed in.
@@ -268,10 +268,10 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		if (position < length && members[position] == null)
 		{
 			members[position] = object;
-			
+
 			if (_memberAdded != null)
 				_memberAdded.dispatch(object);
-			
+
 			return object;
 		}
 
@@ -282,28 +282,28 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		// If we made it this far, we need to insert the object into the group at the specified position.
 		members.insert(position, object);
 		length++;
-		
+
 		if (_memberAdded != null)
 			_memberAdded.dispatch(object);
-		
+
 		return object;
 	}
 
 	/**
 	 * Recycling is designed to help you reuse game objects without always re-allocating or "newing" them.
 	 * It behaves differently depending on whether `maxSize` equals `0` or is bigger than `0`.
-	 * 
+	 *
 	 * `maxSize > 0` / "rotating-recycling" (used by `FlxEmitter`):
 	 *   - at capacity:  returns the next object in line, no matter its properties like `alive`, `exists` etc.
 	 *   - otherwise:    returns a new object.
-	 * 
+	 *
 	 * `maxSize == 0` / "grow-style-recycling"
 	 *   - tries to find the first object with `exists == false`
 	 *   - otherwise: adds a new object to the `members` array
 	 *
 	 * WARNING: If this function needs to create a new object, and no object class was provided,
 	 * it will return `null` instead of a valid object!
-	 * 
+	 *
 	 * @param   ObjectClass     The class type you want to recycle (e.g. `FlxSprite`, `EvilRobot`, etc).
 	 * @param   ObjectFactory   Optional factory function to create a new object
 	 *                          if there aren't any dead members to recycle.
@@ -317,7 +317,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	public function recycle(?ObjectClass:Class<T>, ?ObjectFactory:Void->T, Force:Bool = false, Revive:Bool = true):T
 	{
 		var basic:FlxBasic = null;
-		
+
 		// rotated recycling
 		if (maxSize > 0)
 		{
@@ -330,13 +330,13 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			else
 			{
 				basic = members[_marker++];
-				
+
 				if (_marker >= maxSize)
 					_marker = 0;
-				
+
 				if (Revive)
 					basic.revive();
-				
+
 				return cast basic;
 			}
 		}
@@ -344,34 +344,34 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		else
 		{
 			basic = getFirstAvailable(ObjectClass, Force);
-			
+
 			if (basic != null)
 			{
 				if (Revive)
 					basic.revive();
 				return cast basic;
 			}
-			
+
 			return recycleCreateObject(ObjectClass, ObjectFactory);
 		}
 	}
-	
+
 	@:noCompletion
-	private inline function recycleCreateObject(?ObjectClass:Class<T>, ?ObjectFactory:Void->T):T
+	inline function recycleCreateObject(?ObjectClass:Class<T>, ?ObjectFactory:Void->T):T
 	{
 		var object:T = null;
-		
+
 		if (ObjectFactory != null)
 			add(object = ObjectFactory());
 		else if (ObjectClass != null)
 			add(object = Type.createInstance(ObjectClass, []));
-		
+
 		return object;
 	}
-	
+
 	/**
 	 * Removes an object from the group.
-	 * 
+	 *
 	 * @param   Object   The `FlxBasic` you want to remove.
 	 * @param   Splice   Whether the object should be cut from the array entirely or not.
 	 * @return  The removed object.
@@ -380,12 +380,12 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		if (members == null)
 			return null;
-		
+
 		var index:Int = members.indexOf(Object);
-		
+
 		if (index < 0)
 			return null;
-		
+
 		if (Splice)
 		{
 			members.splice(index, 1);
@@ -393,17 +393,17 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 		else
 			members[index] = null;
-		
+
 		if (_memberRemoved != null)
 			_memberRemoved.dispatch(Object);
-		
+
 		return Object;
 	}
-	
+
 	/**
 	 * Replaces an existing `FlxBasic` with a new one.
 	 * Does not do anything and returns `null` if the old object is not part of the group.
-	 * 
+	 *
 	 * @param   OldObject   The object you want to replace.
 	 * @param   NewObject   The new object you want to use instead.
 	 * @return  The new object.
@@ -411,25 +411,25 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	public function replace(OldObject:T, NewObject:T):T
 	{
 		var index:Int = members.indexOf(OldObject);
-		
+
 		if (index < 0)
 			return null;
-		
+
 		members[index] = NewObject;
-		
+
 		if (_memberRemoved != null)
 			_memberRemoved.dispatch(OldObject);
 		if (_memberAdded != null)
 			_memberAdded.dispatch(NewObject);
-		
+
 		return NewObject;
 	}
-	
+
 	/**
 	 * Call this function to sort the group according to a particular value and order.
 	 * For example, to sort game objects for Zelda-style overlaps you might call
 	 * `group.sort(FlxSort.byY, FlxSort.ASCENDING)` at the bottom of your `FlxState#update()` override.
-	 * 
+	 *
 	 * @param   Function   The sorting function to use - you can use one of the premade ones in
 	 *                     `FlxSort` or write your own using `FlxSort.byValues()` as a "backend".
 	 * @param   Order      A constant that defines the sort order.
@@ -439,11 +439,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		members.sort(Function.bind(Order));
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `exists == false` in the group.
 	 * This is handy for recycling in general, e.g. respawning enemies.
-	 * 
+	 *
 	 * @param   ObjectClass   An optional parameter that lets you narrow the
 	 *                        results to instances of this particular class.
 	 * @param   Force         Force the object to be an `ObjectClass` and not a super class of `ObjectClass`.
@@ -453,11 +453,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++]; // we use basic as FlxBasic for performance reasons
-			
+
 			if ((basic != null) && !basic.exists && ((ObjectClass == null) || Std.is(basic, ObjectClass)))
 			{
 				if (Force && Type.getClassName(Type.getClass(basic)) != Type.getClassName(ObjectClass))
@@ -467,99 +467,99 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 				return members[i - 1];
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first index set to `null`.
 	 * Returns `-1` if no index stores a `null` object.
-	 * 
+	 *
 	 * @return  An `Int` indicating the first `null` slot in the group.
 	 */
 	public function getFirstNull():Int
 	{
 		var i:Int = 0;
-		
+
 		while (i < length)
 		{
 			if (members[i] == null)
 				return i;
 			i++;
 		}
-		
+
 		return -1;
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `exists == true` in the group.
 	 * This is handy for checking if everything's wiped out, or choosing a squad leader, etc.
-	 * 
+	 *
 	 * @return  A `FlxBasic` currently flagged as existing.
 	 */
 	public function getFirstExisting():T
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && basic.exists)
 				return cast basic;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `dead == false` in the group.
 	 * This is handy for checking if everything's wiped out, or choosing a squad leader, etc.
-	 * 
+	 *
 	 * @return  A `FlxBasic` currently flagged as not dead.
 	 */
 	public function getFirstAlive():T
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++]; // we use basic as FlxBasic for performance reasons
-			
+
 			if (basic != null && basic.exists && basic.alive)
 				return cast basic;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `dead == true` in the group.
 	 * This is handy for checking if everything's wiped out, or choosing a squad leader, etc.
-	 * 
+	 *
 	 * @return  A `FlxBasic` currently flagged as dead.
 	 */
 	public function getFirstDead():T
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++]; // we use basic as FlxBasic for performance reasons
-			
+
 			if (basic != null && !basic.alive)
 				return cast basic;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Call this function to find out how many members of the group are not dead.
-	 * 
+	 *
 	 * @return  The number of `FlxBasic`s flagged as not dead. Returns `-1` if group is empty.
 	 */
 	public function countLiving():Int
@@ -567,11 +567,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		var i:Int = 0;
 		var count:Int = -1;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null)
 			{
 				if (count < 0)
@@ -580,13 +580,13 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					count++;
 			}
 		}
-		
+
 		return count;
 	}
-	
+
 	/**
 	 * Call this function to find out how many members of the group are dead.
-	 * 
+	 *
 	 * @return  The number of `FlxBasic`s flagged as dead. Returns `-1` if group is empty.
 	 */
 	public function countDead():Int
@@ -594,11 +594,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		var i:Int = 0;
 		var count:Int = -1;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null)
 			{
 				if (count < 0)
@@ -607,13 +607,13 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					count++;
 			}
 		}
-		
+
 		return count;
 	}
-	
+
 	/**
 	 * Returns a member at random from the group.
-	 * 
+	 *
 	 * @param   StartIndex  Optional offset off the front of the array.
 	 *                      Default value is `0`, or the beginning of the array.
 	 * @param   Length      Optional restriction on the number of values you want to randomly select from.
@@ -625,10 +625,10 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			StartIndex = 0;
 		if (Length <= 0)
 			Length = length;
-		
+
 		return FlxG.random.getObject(members, StartIndex, Length);
 	}
-	
+
 	/**
 	 * Remove all instances of `FlxBasic` subclasses (`FlxSprite`, `FlxTileblock`, etc) from the list.
 	 * WARNING: does not `destroy()` or `kill()` any of these objects!
@@ -636,7 +636,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	public function clear():Void
 	{
 		length = 0;
-		
+
 		if (_memberRemoved != null)
 		{
 			for (member in members)
@@ -645,10 +645,10 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					_memberRemoved.dispatch(member);
 			}
 		}
-		
+
 		FlxArrayUtil.clearArray(members);
 	}
-	
+
 	/**
 	 * Calls `kill()` on the group's `members` and then on the group itself.
 	 * You can revive this group later via `revive()` after this.
@@ -657,15 +657,15 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && basic.exists)
 				basic.kill();
 		}
-		
+
 		super.kill();
 	}
 
@@ -695,10 +695,10 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		return new FlxTypedGroupIterator<T>(members, filter);
 	}
-	
+
 	/**
 	 * Applies a function to all members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -706,11 +706,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null)
 			{
 				if (Recurse)
@@ -719,15 +719,15 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					if (group != null)
 						group.forEach(cast Function, Recurse);
 				}
-				
+
 				Function(cast basic);
 			}
 		}
 	}
-	
+
 	/**
 	 * Applies a function to all `alive` members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -735,11 +735,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && basic.exists && basic.alive)
 			{
 				if (Recurse)
@@ -748,7 +748,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					if (group != null)
 						group.forEachAlive(cast Function, Recurse);
 				}
-				
+
 				Function(cast basic);
 			}
 		}
@@ -756,7 +756,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 
 	/**
 	 * Applies a function to all dead members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -764,11 +764,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && !basic.alive)
 			{
 				if (Recurse)
@@ -777,7 +777,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					if (group != null)
 						group.forEachDead(cast Function, Recurse);
 				}
-				
+
 				Function(cast basic);
 			}
 		}
@@ -785,7 +785,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 
 	/**
 	 * Applies a function to all existing members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -793,11 +793,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null && basic.exists)
 			{
 				if (Recurse)
@@ -806,15 +806,15 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					if (group != null)
 						group.forEachExists(cast Function, Recurse);
 				}
-				
+
 				Function(cast basic);
 			}
 		}
 	}
-	
+
 	/**
 	 * Applies a function to all members of type `Class<K>`.
-	 * 
+	 *
 	 * @param   ObjectClass   A class that objects will be checked against before Function is applied, ex: `FlxSprite`.
 	 * @param   Function      A function that modifies one element at a time.
 	 * @param   Recurse       Whether or not to apply the function to members of subgroups as well.
@@ -823,11 +823,11 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
+
 		while (i < length)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null)
 			{
 				if (Recurse)
@@ -836,61 +836,61 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 					if (group != null)
 						group.forEachOfType(ObjectClass, cast Function, Recurse);
 				}
-				
+
 				if (Std.is(basic, ObjectClass))
 					Function(cast basic);
 			}
 		}
 	}
-	
+
 	@:noCompletion
-	private function set_maxSize(Size:Int):Int
+	function set_maxSize(Size:Int):Int
 	{
 		maxSize = Std.int(Math.abs(Size));
-		
+
 		if (_marker >= maxSize)
 			_marker = 0;
 
 		if (maxSize == 0 || members == null || maxSize >= length)
 			return maxSize;
-		
+
 		// If the max size has shrunk, we need to get rid of some objects
 		var i:Int = maxSize;
 		var l:Int = length;
 		var basic:FlxBasic = null;
-		
+
 		while (i < l)
 		{
 			basic = members[i++];
-			
+
 			if (basic != null)
 			{
 				if (_memberRemoved != null)
 					_memberRemoved.dispatch(cast basic);
-				
+
 				basic.destroy();
 			}
 		}
-		
+
 		FlxArrayUtil.setLength(members, maxSize);
 		length = members.length;
-		
+
 		return maxSize;
 	}
-	
-	private function get_memberAdded():FlxTypedSignal<T->Void>
+
+	function get_memberAdded():FlxTypedSignal<T->Void>
 	{
 		if (_memberAdded == null)
 			_memberAdded = new FlxTypedSignal<T->Void>();
-		
+
 		return _memberAdded;
 	}
-	
-	private function get_memberRemoved():FlxTypedSignal<T->Void>
+
+	function get_memberRemoved():FlxTypedSignal<T->Void>
 	{
 		if (_memberRemoved == null)
 			_memberRemoved = new FlxTypedSignal<T->Void>();
-		
+
 		return _memberRemoved;
 	}
 }
@@ -902,10 +902,10 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
  */
 class FlxTypedGroupIterator<T>
 {
-	private var _groupMembers:Array<T>;
-	private var _filter:T->Bool;
-	private var _cursor:Int;
-	private var _length:Int;
+	var _groupMembers:Array<T>;
+	var _filter:T->Bool;
+	var _cursor:Int;
+	var _length:Int;
 
 	public function new(GroupMembers:Array<T>, ?filter:T->Bool)
 	{

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -1,4 +1,4 @@
-package flixel.group; 
+package flixel.group;
 
 import flash.display.BitmapData;
 import flash.display.BlendMode;
@@ -29,34 +29,34 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 * The actual group which holds all sprites.
 	 */
 	public var group:FlxTypedGroup<T>;
-	
+
 	/**
 	 * The link to a group's `members` array.
 	 */
 	public var members(get, null):Array<T>;
-	
+
 	/**
 	 * The number of entries in the members array. For performance and safety you should check this
 	 * variable instead of `members.length` unless you really know what you're doing!
 	 */
 	public var length(get, null):Int;
-	
+
 	/**
 	 * The maximum capacity of this group. Default is `0`, meaning no max capacity, and the group can just grow.
 	 */
 	public var maxSize(get, set):Int;
-	
+
 	/**
 	 * Optimization to allow setting position of group without transforming children twice.
 	 */
-	private var _skipTransformChildren:Bool = false;
+	var _skipTransformChildren:Bool = false;
 
 	/**
 	 * Array of all the `FlxSprite`s that exist in this group for
 	 * optimization purposes / static typing on cpp targets.
 	 */
-	private var _sprites:Array<FlxSprite>;
-	
+	var _sprites:Array<FlxSprite>;
+
 	/**
 	 * @param   X         The initial X position of the group.
 	 * @param   Y         The initial Y position of the group.
@@ -68,27 +68,27 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		group = new FlxTypedGroup<T>(MaxSize);
 		_sprites = cast group.members;
 	}
-	
+
 	/**
 	 * This method is used for initialization of variables of complex types.
 	 * Don't forget to call `super.initVars()` if you'll override this method,
 	 * or you'll get `null` object error and app will crash.
 	 */
-	override private function initVars():Void 
+	override function initVars():Void
 	{
 		flixelType = SPRITEGROUP;
-		
+
 		offset = new FlxCallbackPoint(offsetCallback);
 		origin = new FlxCallbackPoint(originCallback);
 		scale = new FlxCallbackPoint(scaleCallback);
 		scrollFactor = new FlxCallbackPoint(scrollFactorCallback);
-		
+
 		scale.set(1, 1);
 		scrollFactor.set(1, 1);
 
 		initMotionVars();
 	}
-	
+
 	/**
 	 * Handy function for "killing" game objects. Use `reset()` to revive them.
 	 * Default behavior is to flag them as nonexistent AND dead.
@@ -102,19 +102,19 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		origin = FlxDestroyUtil.destroy(origin);
 		scale = FlxDestroyUtil.destroy(scale);
 		scrollFactor = FlxDestroyUtil.destroy(scrollFactor);
-		
+
 		group = FlxDestroyUtil.destroy(group);
 		_sprites = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Recursive cloning method: it will create a copy of this group which will hold copies of all sprites
-	 * 
+	 *
 	 * @return  copy of this sprite group
 	 */
-	override public function clone():FlxTypedSpriteGroup<T> 
+	override public function clone():FlxTypedSpriteGroup<T>
 	{
 		var newGroup = new FlxTypedSpriteGroup<T>(x, y, maxSize);
 		for (sprite in group.members)
@@ -126,33 +126,33 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		}
 		return newGroup;
 	}
-	
+
 	/**
 	 * Check and see if any sprite in this group is currently on screen.
-	 * 
+	 *
 	 * @param   Camera   Specify which game camera you want. If `null`, it will just grab the first global camera.
 	 * @return  Whether the object is on screen or not.
 	 */
-	override public function isOnScreen(?Camera:FlxCamera):Bool 
+	override public function isOnScreen(?Camera:FlxCamera):Bool
 	{
 		for (sprite in _sprites)
 		{
 			if (sprite != null && sprite.exists && sprite.visible && sprite.isOnScreen(Camera))
 				return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Checks to see if a point in 2D world space overlaps any `FlxSprite` object from this group.
-	 * 
+	 *
 	 * @param   Point           The point in world space you want to check.
 	 * @param   InScreenSpace   Whether to take scroll factors into account when checking for overlap.
 	 * @param   Camera          Specify which game camera you want. If `null`, it will just grab the first global camera.
 	 * @return  Whether or not the point overlaps this group.
 	 */
-	override public function overlapsPoint(point:FlxPoint, InScreenSpace:Bool = false, ?Camera:FlxCamera):Bool 
+	override public function overlapsPoint(point:FlxPoint, InScreenSpace:Bool = false, ?Camera:FlxCamera):Bool
 	{
 		var result:Bool = false;
 		for (sprite in _sprites)
@@ -162,20 +162,20 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 				result = result || sprite.overlapsPoint(point, InScreenSpace, Camera);
 			}
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Checks to see if a point in 2D world space overlaps any of FlxSprite object's current displayed pixels.
 	 * This check is ALWAYS made in screen space, and always takes scroll factors into account.
-	 * 
+	 *
 	 * @param   Point    The point in world space you want to check.
 	 * @param   Mask     Used in the pixel hit test to determine what counts as solid.
 	 * @param   Camera   Specify which game camera you want.  If `null`, it will just grab the first global camera.
 	 * @return  Whether or not the point overlaps this object.
 	 */
-	override public function pixelsOverlapPoint(point:FlxPoint, Mask:Int = 0xFF, ?Camera:FlxCamera):Bool 
+	override public function pixelsOverlapPoint(point:FlxPoint, Mask:Int = 0xFF, ?Camera:FlxCamera):Bool
 	{
 		var result:Bool = false;
 		for (sprite in _sprites)
@@ -185,45 +185,45 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 				result = result || sprite.pixelsOverlapPoint(point, Mask, Camera);
 			}
 		}
-		
+
 		return result;
 	}
-	
-	override public function update(elapsed:Float):Void 
+
+	override public function update(elapsed:Float):Void
 	{
 		group.update(elapsed);
-		
+
 		if (moves)
 			updateMotion(elapsed);
 	}
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		group.draw();
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.drawDebug)
 			drawDebug();
 		#end
 	}
-	
+
 	/**
 	 * Replaces all pixels with specified `Color` with `NewColor` pixels.
 	 * WARNING: very expensive (especially on big graphics) as it iterates over every single pixel.
-	 * 
+	 *
 	 * @param   Color            Color to replace
 	 * @param   NewColor         New color
 	 * @param   FetchPositions   Whether we need to store positions of pixels which colors were replaced.
 	 * @return  `Array` with replaced pixels positions
 	 */
-	override public function replaceColor(Color:Int, NewColor:Int, FetchPositions:Bool = false):Array<FlxPoint> 
+	override public function replaceColor(Color:Int, NewColor:Int, FetchPositions:Bool = false):Array<FlxPoint>
 	{
 		var positions:Array<FlxPoint> = null;
 		if (FetchPositions)
 		{
 			positions = new Array<FlxPoint>();
 		}
-		
+
 		var spritePositions:Array<FlxPoint>;
 		for (sprite in _sprites)
 		{
@@ -236,13 +236,13 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 				}
 			}
 		}
-		
+
 		return positions;
 	}
-	
+
 	/**
 	 * Adds a new `FlxSprite` subclass to the group.
-	 * 
+	 *
 	 * @param   Sprite   The sprite or sprite group you want to add to the group.
 	 * @return  The same object that was passed in.
 	 */
@@ -251,10 +251,10 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		preAdd(Sprite);
 		return group.add(Sprite);
 	}
-	
+
 	/**
 	 * Inserts a new `FlxSprite` subclass to the group at the specified position.
-	 * 
+	 *
 	 * @param   Position The position that the new sprite or sprite group should be inserted at.
 	 * @param   Sprite   The sprite or sprite group you want to insert into the group.
 	 * @return  The same object that was passed in.
@@ -266,14 +266,14 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		preAdd(Sprite);
 		return group.insert(Position, Sprite);
 	}
-	
+
 	/**
 	 * Adjusts the position and other properties of the soon-to-be child of this sprite group.
 	 * Private helper to avoid duplicate code in `add()` and `insert()`.
-	 * 
+	 *
 	 * @param	Sprite	The sprite or sprite group that is about to be added or inserted into the group.
 	 */
-	private function preAdd(Sprite:T):Void
+	function preAdd(Sprite:T):Void
 	{
 		var sprite:FlxSprite = cast Sprite;
 		sprite.x += x;
@@ -281,25 +281,25 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		sprite.alpha *= alpha;
 		sprite.scrollFactor.copyFrom(scrollFactor);
 		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
-		
+
 		if (clipRect != null) clipRectTransform(sprite, clipRect);
 	}
-	
+
 	/**
 	 * Recycling is designed to help you reuse game objects without always re-allocating or "newing" them.
 	 * It behaves differently depending on whether `maxSize` equals `0` or is bigger than `0`.
-	 * 
+	 *
 	 * `maxSize > 0` / "rotating-recycling" (used by `FlxEmitter`):
 	 *   - at capacity:  returns the next object in line, no matter its properties like `alive`, `exists` etc.
 	 *   - otherwise:    returns a new object.
-	 * 
+	 *
 	 * `maxSize == 0` / "grow-style-recycling"
 	 *   - tries to find the first object with `exists == false`
 	 *   - otherwise: adds a new object to the `members` array
 	 *
 	 * WARNING: If this function needs to create a new object, and no object class was provided,
 	 * it will return `null` instead of a valid object!
-	 * 
+	 *
 	 * @param   ObjectClass     The class type you want to recycle (e.g. `FlxSprite`, `EvilRobot`, etc).
 	 * @param   ObjectFactory   Optional factory function to create a new object
 	 *                          if there aren't any dead members to recycle.
@@ -314,10 +314,10 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		return group.recycle(ObjectClass, ObjectFactory, Force);
 	}
-	
+
 	/**
 	 * Removes the specified sprite from the group.
-	 * 
+	 *
 	 * @param   Sprite   The `FlxSprite` you want to remove.
 	 * @param   Splice   Whether the object should be cut from the array entirely or not.
 	 * @return  The removed sprite.
@@ -331,10 +331,10 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		sprite.cameras = null;
 		return group.remove(Sprite, Splice);
 	}
-	
+
 	/**
 	 * Replaces an existing `FlxSprite` with a new one.
-	 * 
+	 *
 	 * @param   OldObject   The sprite you want to replace.
 	 * @param   NewObject   The new object you want to use instead.
 	 * @return  The new sprite.
@@ -343,12 +343,12 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		return group.replace(OldObject, NewObject);
 	}
-	
+
 	/**
 	 * Call this function to sort the group according to a particular value and order.
 	 * For example, to sort game objects for Zelda-style overlaps you might call
 	 * `group.sort(FlxSort.byY, FlxSort.ASCENDING)` at the bottom of your `FlxState#update()` override.
-	 * 
+	 *
 	 * @param   Function   The sorting function to use - you can use one of the premade ones in
 	 *                     `FlxSort` or write your own using `FlxSort.byValues()` as a "backend".
 	 * @param   Order      A constant that defines the sort order.
@@ -358,11 +358,11 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		group.sort(Function, Order);
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `exists == false` in the group.
 	 * This is handy for recycling in general, e.g. respawning enemies.
-	 * 
+	 *
 	 * @param   ObjectClass   An optional parameter that lets you narrow the
 	 *                        results to instances of this particular class.
 	 * @param   Force         Force the object to be an `ObjectClass` and not a super class of `ObjectClass`.
@@ -372,74 +372,74 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		return group.getFirstAvailable(ObjectClass, Force);
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first index set to `null`.
 	 * Returns `-1` if no index stores a `null` object.
-	 * 
+	 *
 	 * @return  An `Int` indicating the first `null` slot in the group.
 	 */
 	public inline function getFirstNull():Int
 	{
 		return group.getFirstNull();
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `exists == true` in the group.
 	 * This is handy for checking if everything's wiped out, or choosing a squad leader, etc.
-	 * 
+	 *
 	 * @return  A `FlxSprite` currently flagged as existing.
 	 */
 	public inline function getFirstExisting():T
 	{
 		return group.getFirstExisting();
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `dead == false` in the group.
 	 * This is handy for checking if everything's wiped out, or choosing a squad leader, etc.
-	 * 
+	 *
 	 * @return  A `FlxSprite` currently flagged as not dead.
 	 */
 	public inline function getFirstAlive():T
 	{
 		return group.getFirstAlive();
 	}
-	
+
 	/**
 	 * Call this function to retrieve the first object with `dead == true` in the group.
 	 * This is handy for checking if everything's wiped out, or choosing a squad leader, etc.
-	 * 
+	 *
 	 * @return  A `FlxSprite` currently flagged as dead.
 	 */
 	public inline function getFirstDead():T
 	{
 		return group.getFirstDead();
 	}
-	
+
 	/**
 	 * Call this function to find out how many members of the group are not dead.
-	 * 
+	 *
 	 * @return  The number of `FlxSprite`s flagged as not dead. Returns `-1` if group is empty.
 	 */
 	public inline function countLiving():Int
 	{
 		return group.countLiving();
 	}
-	
+
 	/**
 	 * Call this function to find out how many members of the group are dead.
-	 * 
+	 *
 	 * @return  The number of `FlxSprite`s flagged as dead. Returns `-1` if group is empty.
 	 */
 	public inline function countDead():Int
 	{
 		return group.countDead();
 	}
-	
+
 	/**
 	 * Returns a member at random from the group.
-	 * 
+	 *
 	 * @param   StartIndex  Optional offset off the front of the array.
 	 *                      Default value is `0`, or the beginning of the array.
 	 * @param   Length      Optional restriction on the number of values you want to randomly select from.
@@ -449,20 +449,20 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		return group.getRandom(StartIndex, Length);
 	}
-	
+
 	/**
 	 * Iterate through every member
-	 * 
+	 *
 	 * @return An iterator
 	 */
 	public inline function iterator(?filter:T->Bool):FlxTypedGroupIterator<T>
 	{
 		return new FlxTypedGroupIterator<T>(members, filter);
 	}
-	
+
 	/**
 	 * Applies a function to all members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -473,7 +473,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	/**
 	 * Applies a function to all `alive` members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -484,7 +484,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	/**
 	 * Applies a function to all dead members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -495,7 +495,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	/**
 	 * Applies a function to all existing members.
-	 * 
+	 *
 	 * @param   Function   A function that modifies one element at a time.
 	 * @param   Recurse    Whether or not to apply the function to members of subgroups as well.
 	 */
@@ -503,10 +503,10 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		group.forEachExists(Function, Recurse);
 	}
-	
+
 	/**
 	 * Applies a function to all members of type `Class<K>`.
-	 * 
+	 *
 	 * @param   ObjectClass   A class that objects will be checked against before Function is applied, ex: `FlxSprite`.
 	 * @param   Function      A function that modifies one element at a time.
 	 * @param   Recurse       Whether or not to apply the function to members of subgroups as well.
@@ -515,7 +515,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		group.forEachOfType(ObjectClass, Function, Recurse);
 	}
-	
+
 	/**
 	 * Remove all instances of `FlxSprite` from the list.
 	 * WARNING: does not `destroy()` or `kill()` any of these objects!
@@ -524,7 +524,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		group.clear();
 	}
-	
+
 	/**
 	 * Calls `kill()` on the group's members and then on the group itself.
 	 * You can revive this group later via `revive()` after this.
@@ -534,7 +534,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		super.kill();
 		group.kill();
 	}
-	
+
 	/**
 	 * Revives the group.
 	 */
@@ -543,12 +543,12 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		super.revive();
 		group.revive();
 	}
-	
+
 	override public function reset(X:Float, Y:Float):Void
 	{
 		revive();
 		setPosition(X, Y);
-		
+
 		for (sprite in _sprites)
 		{
 			if (sprite != null)
@@ -557,11 +557,11 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 			}
 		}
 	}
-	
+
 	/**
 	 * Helper function to set the coordinates of this object.
 	 * Handy since it only requires one line of code.
-	 * 
+	 *
 	 * @param   X   The new x position
 	 * @param   Y   The new y position
 	 */
@@ -571,17 +571,17 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		var dx:Float = X - x;
 		var dy:Float = Y - y;
 		multiTransformChildren([xTransform, yTransform], [dx, dy]);
-		
+
 		// don't transform children twice
 		_skipTransformChildren = true;
 		x = X; // this calls set_x
 		y = Y; // this calls set_y
 		_skipTransformChildren = false;
 	}
-	
+
 	/**
 	 * Handy function that allows you to quickly transform one property of sprites in this group at a time.
-	 * 
+	 *
 	 * @param   Function   Function to transform the sprites. Example:
 	 *                     `function(sprite, v:Dynamic) { s.acceleration.x = v; s.makeGraphic(10,10,0xFF000000); }`
 	 * @param   Value      Value which will passed to lambda function.
@@ -598,10 +598,10 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 				Function(cast sprite, Value);
 		}
 	}
-	
+
 	/**
 	 * Handy function that allows you to quickly transform multiple properties of sprites in this group at a time.
-	 * 
+	 *
 	 * @param   FunctionArray   `Array` of functions to transform sprites in this group.
 	 * @param   ValueArray      `Array` of values which will be passed to lambda functions
 	 */
@@ -610,11 +610,11 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		if (group == null)
 			return;
-		
+
 		var numProps:Int = FunctionArray.length;
 		if (numProps > ValueArray.length)
 			return;
-		
+
 		var lambda:T->V->Void;
 		for (sprite in _sprites)
 		{
@@ -628,67 +628,67 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 			}
 		}
 	}
-	
+
 	// PROPERTIES GETTERS/SETTERS
-	
-	override private function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
+
+	override function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
 	{
 		if (cameras != Value)
 			transformChildren(camerasTransform, Value);
 		return super.set_cameras(Value);
 	}
-	
-	override private function set_exists(Value:Bool):Bool
+
+	override function set_exists(Value:Bool):Bool
 	{
 		if (exists != Value)
 			transformChildren(existsTransform, Value);
 		return super.set_exists(Value);
 	}
-	
-	override private function set_visible(Value:Bool):Bool
+
+	override function set_visible(Value:Bool):Bool
 	{
 		if (exists && visible != Value)
 			transformChildren(visibleTransform, Value);
 		return super.set_visible(Value);
 	}
-	
-	override private function set_active(Value:Bool):Bool
+
+	override function set_active(Value:Bool):Bool
 	{
 		if (exists && active != Value)
 			transformChildren(activeTransform, Value);
 		return super.set_active(Value);
 	}
-	
-	override private function set_alive(Value:Bool):Bool
+
+	override function set_alive(Value:Bool):Bool
 	{
 		if (alive != Value)
 			transformChildren(aliveTransform, Value);
 		return super.set_alive(Value);
 	}
-	
-	override private function set_x(Value:Float):Float
+
+	override function set_x(Value:Float):Float
 	{
 		if (!_skipTransformChildren && exists && x != Value)
 		{
 			var offset:Float = Value - x;
 			transformChildren(xTransform, offset);
 		}
-		
+
 		return x = Value;
 	}
-	
-	override private function set_y(Value:Float):Float
+
+	override function set_y(Value:Float):Float
 	{
 		if (!_skipTransformChildren && exists && y != Value)
 		{
 			var offset:Float = Value - y;
 			transformChildren(yTransform, offset);
 		}
-		
+
 		return y = Value;
 	}
-	
-	override private function set_angle(Value:Float):Float
+
+	override function set_angle(Value:Float):Float
 	{
 		if (exists && angle != Value)
 		{
@@ -697,11 +697,11 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		}
 		return angle = Value;
 	}
-	
-	override private function set_alpha(Value:Float):Float 
+
+	override function set_alpha(Value:Float):Float
 	{
 		Value = FlxMath.bound(Value, 0, 1);
-		
+
 		if (exists && alpha != Value)
 		{
 			var factor:Float = (alpha > 0) ? Value / alpha : 0;
@@ -709,99 +709,99 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		}
 		return alpha = Value;
 	}
-	
-	override private function set_facing(Value:Int):Int
+
+	override function set_facing(Value:Int):Int
 	{
 		if (exists && facing != Value)
 			transformChildren(facingTransform, Value);
 		return facing = Value;
 	}
-	
-	override private function set_flipX(Value:Bool):Bool
+
+	override function set_flipX(Value:Bool):Bool
 	{
 		if (exists && flipX != Value)
 			transformChildren(flipXTransform, Value);
 		return flipX = Value;
 	}
-	
-	override private function set_flipY(Value:Bool):Bool
+
+	override function set_flipY(Value:Bool):Bool
 	{
 		if (exists && flipY != Value)
 			transformChildren(flipYTransform, Value);
 		return flipY = Value;
 	}
-	
-	override private function set_moves(Value:Bool):Bool
+
+	override function set_moves(Value:Bool):Bool
 	{
 		if (exists && moves != Value)
 			transformChildren(movesTransform, Value);
 		return moves = Value;
 	}
-	
-	override private function set_immovable(Value:Bool):Bool
+
+	override function set_immovable(Value:Bool):Bool
 	{
 		if (exists && immovable != Value)
 			transformChildren(immovableTransform, Value);
 		return immovable = Value;
 	}
-	
-	override private function set_solid(Value:Bool):Bool 
+
+	override function set_solid(Value:Bool):Bool
 	{
 		if (exists && solid != Value)
 			transformChildren(solidTransform, Value);
 		return super.set_solid(Value);
 	}
-	
-	override private function set_color(Value:Int):Int 
+
+	override function set_color(Value:Int):Int
 	{
 		if (exists && color != Value)
 			transformChildren(gColorTransform, Value);
 		return color = Value;
 	}
-	
-	override private function set_blend(Value:BlendMode):BlendMode 
+
+	override function set_blend(Value:BlendMode):BlendMode
 	{
 		if (exists && blend != Value)
 			transformChildren(blendTransform, Value);
 		return blend = Value;
 	}
-	
+
 	override function set_clipRect(rect:FlxRect):FlxRect
 	{
 		if (exists)
 			transformChildren(clipRectTransform, rect);
 		return super.set_clipRect(rect);
 	}
-	
-	override private function set_pixelPerfectRender(Value:Bool):Bool
+
+	override function set_pixelPerfectRender(Value:Bool):Bool
 	{
 		if (exists && pixelPerfectRender != Value)
 			transformChildren(pixelPerfectTransform, Value);
 		return super.set_pixelPerfectRender(Value);
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 */
-	override private function set_width(Value:Float):Float
+	override function set_width(Value:Float):Float
 	{
 		return Value;
 	}
-	
-	override private function get_width():Float
+
+	override function get_width():Float
 	{
 		if (length == 0)
 			return 0;
-		
+
 		var minX:Float = Math.POSITIVE_INFINITY;
 		var maxX:Float = Math.NEGATIVE_INFINITY;
-		
+
 		for (member in _sprites)
 		{
 			if (member == null) continue;
 			var minMemberX:Float = member.x;
 			var maxMemberX:Float = minMemberX + member.width;
-			
+
 			if (maxMemberX > maxX)
 				maxX = maxMemberX;
 			if (minMemberX < minX)
@@ -809,31 +809,31 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		}
 		return maxX - minX;
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 */
-	override private function set_height(Value:Float):Float
+	override function set_height(Value:Float):Float
 	{
 		return Value;
 	}
-	
-	override private function get_height():Float
+
+	override function get_height():Float
 	{
 		if (length == 0)
 		{
 			return 0;
 		}
-		
+
 		var minY:Float = Math.POSITIVE_INFINITY;
 		var maxY:Float = Math.NEGATIVE_INFINITY;
-		
+
 		for (member in _sprites)
 		{
 			if (member == null) continue;
 			var minMemberY:Float = member.y;
 			var maxMemberY:Float = minMemberY + member.height;
-			
+
 			if (maxMemberY > maxY)
 				maxY = maxMemberY;
 			if (minMemberY < minY)
@@ -841,160 +841,160 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		}
 		return maxY - minY;
 	}
-	
+
 	// GROUP FUNCTIONS
-	
-	private inline function get_length():Int
+
+	inline function get_length():Int
 	{
 		return group.length;
 	}
-	
-	private inline function get_maxSize():Int
+
+	inline function get_maxSize():Int
 	{
 		return group.maxSize;
 	}
-	
-	private inline function set_maxSize(Size:Int):Int
+
+	inline function set_maxSize(Size:Int):Int
 	{
 		return group.maxSize = Size;
 	}
-	
-	private inline function get_members():Array<T>
+
+	inline function get_members():Array<T>
 	{
 		return group.members;
 	}
-	
-	// TRANSFORM FUNCTIONS - STATIC TYPING
-	
-	private inline function xTransform(Sprite:FlxSprite, X:Float)                          Sprite.x += X; // addition
-	private inline function yTransform(Sprite:FlxSprite, Y:Float)                          Sprite.y += Y; // addition
-	private inline function angleTransform(Sprite:FlxSprite, Angle:Float)                  Sprite.angle += Angle; // addition
-	private inline function alphaTransform(Sprite:FlxSprite, Alpha:Float)                  Sprite.alpha *= Alpha; // multiplication
-	private inline function facingTransform(Sprite:FlxSprite, Facing:Int)                  Sprite.facing = Facing;
-	private inline function flipXTransform(Sprite:FlxSprite, FlipX:Bool)                   Sprite.flipX = FlipX;
-	private inline function flipYTransform(Sprite:FlxSprite, FlipY:Bool)                   Sprite.flipY = FlipY;
-	private inline function movesTransform(Sprite:FlxSprite, Moves:Bool)                   Sprite.moves = Moves;
-	private inline function pixelPerfectTransform(Sprite:FlxSprite, PixelPerfect:Bool)     Sprite.pixelPerfectRender = PixelPerfect;
-	private inline function gColorTransform(Sprite:FlxSprite, Color:Int)                   Sprite.color = Color;
-	private inline function blendTransform(Sprite:FlxSprite, Blend:BlendMode)              Sprite.blend = Blend;
-	private inline function immovableTransform(Sprite:FlxSprite, Immovable:Bool)           Sprite.immovable = Immovable;
-	private inline function visibleTransform(Sprite:FlxSprite, Visible:Bool)               Sprite.visible = Visible;
-	private inline function activeTransform(Sprite:FlxSprite, Active:Bool)                 Sprite.active = Active;
-	private inline function solidTransform(Sprite:FlxSprite, Solid:Bool)                   Sprite.solid = Solid;
-	private inline function aliveTransform(Sprite:FlxSprite, Alive:Bool)                   Sprite.alive = Alive;
-	private inline function existsTransform(Sprite:FlxSprite, Exists:Bool)                 Sprite.exists = Exists;
-	private inline function camerasTransform(Sprite:FlxSprite, Cameras:Array<FlxCamera>)   Sprite.cameras = Cameras;
 
-	private inline function offsetTransform(Sprite:FlxSprite, Offset:FlxPoint)             Sprite.offset.copyFrom(Offset);
-	private inline function originTransform(Sprite:FlxSprite, Origin:FlxPoint)             Sprite.origin.copyFrom(Origin);
-	private inline function scaleTransform(Sprite:FlxSprite, Scale:FlxPoint)               Sprite.scale.copyFrom(Scale);
-	private inline function scrollFactorTransform(Sprite:FlxSprite, ScrollFactor:FlxPoint) Sprite.scrollFactor.copyFrom(ScrollFactor);
-	
-	private inline function clipRectTransform(Sprite:FlxSprite, ClipRect:FlxRect)
+	// TRANSFORM FUNCTIONS - STATIC TYPING
+
+	inline function xTransform(Sprite:FlxSprite, X:Float)                          Sprite.x += X; // addition
+	inline function yTransform(Sprite:FlxSprite, Y:Float)                          Sprite.y += Y; // addition
+	inline function angleTransform(Sprite:FlxSprite, Angle:Float)                  Sprite.angle += Angle; // addition
+	inline function alphaTransform(Sprite:FlxSprite, Alpha:Float)                  Sprite.alpha *= Alpha; // multiplication
+	inline function facingTransform(Sprite:FlxSprite, Facing:Int)                  Sprite.facing = Facing;
+	inline function flipXTransform(Sprite:FlxSprite, FlipX:Bool)                   Sprite.flipX = FlipX;
+	inline function flipYTransform(Sprite:FlxSprite, FlipY:Bool)                   Sprite.flipY = FlipY;
+	inline function movesTransform(Sprite:FlxSprite, Moves:Bool)                   Sprite.moves = Moves;
+	inline function pixelPerfectTransform(Sprite:FlxSprite, PixelPerfect:Bool)     Sprite.pixelPerfectRender = PixelPerfect;
+	inline function gColorTransform(Sprite:FlxSprite, Color:Int)                   Sprite.color = Color;
+	inline function blendTransform(Sprite:FlxSprite, Blend:BlendMode)              Sprite.blend = Blend;
+	inline function immovableTransform(Sprite:FlxSprite, Immovable:Bool)           Sprite.immovable = Immovable;
+	inline function visibleTransform(Sprite:FlxSprite, Visible:Bool)               Sprite.visible = Visible;
+	inline function activeTransform(Sprite:FlxSprite, Active:Bool)                 Sprite.active = Active;
+	inline function solidTransform(Sprite:FlxSprite, Solid:Bool)                   Sprite.solid = Solid;
+	inline function aliveTransform(Sprite:FlxSprite, Alive:Bool)                   Sprite.alive = Alive;
+	inline function existsTransform(Sprite:FlxSprite, Exists:Bool)                 Sprite.exists = Exists;
+	inline function camerasTransform(Sprite:FlxSprite, Cameras:Array<FlxCamera>)   Sprite.cameras = Cameras;
+
+	inline function offsetTransform(Sprite:FlxSprite, Offset:FlxPoint)             Sprite.offset.copyFrom(Offset);
+	inline function originTransform(Sprite:FlxSprite, Origin:FlxPoint)             Sprite.origin.copyFrom(Origin);
+	inline function scaleTransform(Sprite:FlxSprite, Scale:FlxPoint)               Sprite.scale.copyFrom(Scale);
+	inline function scrollFactorTransform(Sprite:FlxSprite, ScrollFactor:FlxPoint) Sprite.scrollFactor.copyFrom(ScrollFactor);
+
+	inline function clipRectTransform(Sprite:FlxSprite, ClipRect:FlxRect)
 	{
 		if (ClipRect == null) Sprite.clipRect = null;
 		else Sprite.clipRect = FlxRect.get(ClipRect.x - Sprite.x + x, ClipRect.y - Sprite.y + y, ClipRect.width, ClipRect.height);
 	}
 
 	// Functions for the FlxCallbackPoint
-	private inline function offsetCallback(Offset:FlxPoint)             transformChildren(offsetTransform, Offset);
-	private inline function originCallback(Origin:FlxPoint)             transformChildren(originTransform, Origin);
-	private inline function scaleCallback(Scale:FlxPoint)               transformChildren(scaleTransform, Scale);
-	private inline function scrollFactorCallback(ScrollFactor:FlxPoint) transformChildren(scrollFactorTransform, ScrollFactor);
-	
+	inline function offsetCallback(Offset:FlxPoint)             transformChildren(offsetTransform, Offset);
+	inline function originCallback(Origin:FlxPoint)             transformChildren(originTransform, Origin);
+	inline function scaleCallback(Scale:FlxPoint)               transformChildren(scaleTransform, Scale);
+	inline function scrollFactorCallback(ScrollFactor:FlxPoint) transformChildren(scrollFactorTransform, ScrollFactor);
+
 	// NON-SUPPORTED FUNCTIONALITY
 	// THESE METHODS ARE OVERRIDDEN FOR SAFETY PURPOSES
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 * @return this sprite group
 	 */
-	override public function loadGraphicFromSprite(Sprite:FlxSprite):FlxSprite 
+	override public function loadGraphicFromSprite(Sprite:FlxSprite):FlxSprite
 	{
 		#if FLX_DEBUG
 		throw "This function is not supported in FlxSpriteGroup";
 		#end
 		return this;
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 * @return this sprite group
 	 */
 	override public function loadGraphic(Graphic:FlxGraphicAsset, Animated:Bool = false, Width:Int = 0,
-		Height:Int = 0, Unique:Bool = false, ?Key:String):FlxSprite 
+		Height:Int = 0, Unique:Bool = false, ?Key:String):FlxSprite
 	{
 		return this;
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 * @return this sprite group
 	 */
 	override public function loadRotatedGraphic(Graphic:FlxGraphicAsset, Rotations:Int = 16, Frame:Int = -1,
-		AntiAliasing:Bool = false, AutoBuffer:Bool = false, ?Key:String):FlxSprite 
+		AntiAliasing:Bool = false, AutoBuffer:Bool = false, ?Key:String):FlxSprite
 	{
 		#if FLX_DEBUG
 		throw "This function is not supported in FlxSpriteGroup";
 		#end
 		return this;
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 * @return this sprite group
 	 */
 	override public function makeGraphic(Width:Int, Height:Int, Color:Int = FlxColor.WHITE, Unique:Bool = false,
-		?Key:String):FlxSprite 
+		?Key:String):FlxSprite
 	{
 		#if FLX_DEBUG
 		throw "This function is not supported in FlxSpriteGroup";
 		#end
 		return this;
 	}
-	
-	override private function set_pixels(Value:BitmapData):BitmapData 
+
+	override function set_pixels(Value:BitmapData):BitmapData
 	{
 		return Value;
 	}
-	
-	override private function set_frame(Value:FlxFrame):FlxFrame 
+
+	override function set_frame(Value:FlxFrame):FlxFrame
 	{
 		return Value;
 	}
-	
-	override private function get_pixels():BitmapData 
+
+	override function get_pixels():BitmapData
 	{
 		return null;
 	}
-	
+
 	/**
 	 * Internal function to update the current animation frame.
-	 * 
+	 *
 	 * @param	RunOnCpp	Whether the frame should also be recalculated if we're on a non-flash target
 	 */
-	override private inline function calcFrame(RunOnCpp:Bool = false):Void
+	override inline function calcFrame(RunOnCpp:Bool = false):Void
 	{
 		// Nothing to do here
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 */
-	override private inline function resetHelpers():Void {}
-	
+	override inline function resetHelpers():Void {}
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 */
 	override public inline function stamp(Brush:FlxSprite, X:Int = 0, Y:Int = 0):Void {}
-	
-	override function set_frames(Frames:FlxFramesCollection):FlxFramesCollection 
+
+	override function set_frames(Frames:FlxFramesCollection):FlxFramesCollection
 	{
 		return Frames;
 	}
-	
+
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 */
-	override private inline function updateColorTransform():Void {}
+	override inline function updateColorTransform():Void {}
 }

--- a/flixel/input/FlxAccelerometer.hx
+++ b/flixel/input/FlxAccelerometer.hx
@@ -7,7 +7,7 @@ import flash.sensors.Accelerometer;
 /**
  * A class providing access to the accelerometer data of the mobile device.
  */
-class FlxAccelerometer 
+class FlxAccelerometer
 {
 	/**
 	 * The x-axis value, in Gs (1G is roughly 9.8m/s/s), usually between -1 and 1.
@@ -24,29 +24,29 @@ class FlxAccelerometer
 	 * The z-axis runs perpendicular to the screen of the device. The acceleration is positive if the device is moving the direction the screen is facing.
 	 */
 	public var z(default, null):Float = 0;
-	
+
 	/**
 	 * Wether the accelerometer is supported on this mobile device
 	 */
 	public var isSupported(get, never):Bool;
-	
-	private var _sensor:Accelerometer;
-	
-	public function new() 
+
+	var _sensor:Accelerometer;
+
+	public function new()
 	{
-		if (Accelerometer.isSupported) 
+		if (Accelerometer.isSupported)
 		{
 			_sensor = new Accelerometer();
 			_sensor.addEventListener(AccelerometerEvent.UPDATE, updateCallback);
 		}
 	}
-	
-	inline function get_isSupported():Bool 
+
+	inline function get_isSupported():Bool
 	{
 		return Accelerometer.isSupported;
 	}
-	
-	private function updateCallback(Event:AccelerometerEvent):Void 
+
+	function updateCallback(Event:AccelerometerEvent):Void
 	{
 		#if android
 		x = Event.accelerationX;

--- a/flixel/input/FlxBaseKeyList.hx
+++ b/flixel/input/FlxBaseKeyList.hx
@@ -4,23 +4,23 @@ import flixel.input.FlxInput.FlxInputState;
 
 class FlxBaseKeyList
 {
-	private var status:FlxInputState;
-	private var keyManager:FlxKeyManager<Dynamic, Dynamic>;
-	
+	var status:FlxInputState;
+	var keyManager:FlxKeyManager<Dynamic, Dynamic>;
+
 	public function new(status:FlxInputState, keyManager:FlxKeyManager<Dynamic, Dynamic>)
 	{
 		this.status = status;
 		this.keyManager = keyManager;
 	}
-	
-	private inline function check(keyCode:Int):Bool
+
+	inline function check(keyCode:Int):Bool
 	{
 		return keyManager.checkStatus(keyCode, status);
 	}
-	
-	public var ANY(get, never):Bool; 
-	
-	private function get_ANY():Bool
+
+	public var ANY(get, never):Bool;
+
+	function get_ANY():Bool
 	{
 		for (key in keyManager._keyListArray)
 		{
@@ -29,7 +29,7 @@ class FlxBaseKeyList
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
 }

--- a/flixel/input/FlxInput.hx
+++ b/flixel/input/FlxInput.hx
@@ -3,52 +3,52 @@ package flixel.input;
 class FlxInput<T> implements IFlxInput
 {
 	public var ID:T;
-	
+
 	public var justReleased(get, never):Bool;
 	public var released(get, never):Bool;
 	public var pressed(get, never):Bool;
 	public var justPressed(get, never):Bool;
-	
+
 	public var current:FlxInputState = RELEASED;
 	public var last:FlxInputState = RELEASED;
-	
-	public function new(ID:T) 
+
+	public function new(ID:T)
 	{
 		this.ID = ID;
 	}
-	
+
 	public function press():Void
 	{
 		last = current;
 		current = pressed ? PRESSED : JUST_PRESSED;
 	}
-	
+
 	public function release():Void
 	{
 		last = current;
 		current = pressed ? JUST_RELEASED: RELEASED;
 	}
-	
+
 	public function update():Void
 	{
-		if (last == JUST_RELEASED && current == JUST_RELEASED) 
+		if (last == JUST_RELEASED && current == JUST_RELEASED)
 		{
 			current = RELEASED;
 		}
-		else if (last == JUST_PRESSED && current == JUST_PRESSED) 
+		else if (last == JUST_PRESSED && current == JUST_PRESSED)
 		{
 			current = PRESSED;
 		}
-		
+
 		last = current;
 	}
-	
+
 	public function reset():Void
 	{
 		current = RELEASED;
 		last = RELEASED;
 	}
-	
+
 	public function hasState(state:FlxInputState):Bool
 	{
 		return switch (state)
@@ -59,23 +59,23 @@ class FlxInput<T> implements IFlxInput
 			case JUST_PRESSED:  justPressed;
 		}
 	}
-	
-	private inline function get_justReleased():Bool
+
+	inline function get_justReleased():Bool
 	{
 		return current == JUST_RELEASED;
 	}
-	
-	private inline function get_released():Bool
+
+	inline function get_released():Bool
 	{
 		return current == RELEASED || justReleased;
 	}
-	
-	private inline function get_pressed():Bool
+
+	inline function get_pressed():Bool
 	{
 		return current == PRESSED || justPressed;
 	}
-	
-	private inline function get_justPressed():Bool
+
+	inline function get_justPressed():Bool
 	{
 		return current == JUST_PRESSED;
 	}

--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -11,12 +11,12 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	 */
 	public var enabled:Bool = true;
 	/**
-	 * List of keys on which preventDefault() is called, useful on HTML5 to stop 
+	 * List of keys on which preventDefault() is called, useful on HTML5 to stop
 	 * the browser from scrolling when pressing the up or down key for example, or
 	 * on android to prevent the default back key action.
 	 */
 	public var preventDefaultKeys:Array<Key> = [];
-	
+
 	/**
 	 * Helper class to check if a key is pressed.
 	 */
@@ -33,48 +33,48 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	 * Internal storage of input keys as an array, for efficient iteration.
 	 */
 	@:allow(flixel.input.FlxBaseKeyList)
-	private var _keyListArray:Array<FlxInput<Key>> = [];
+	var _keyListArray:Array<FlxInput<Key>> = [];
 	/**
 	 * Internal storage of input keys as a map, for efficient indexing.
 	 */
-	private var _keyListMap:Map<Int, FlxInput<Key>> = new Map<Int, FlxInput<Key>>();
-	
+	var _keyListMap:Map<Int, FlxInput<Key>> = new Map<Int, FlxInput<Key>>();
+
 	/**
 	 * Check to see if at least one key from an array of keys is pressed.
-	 * 
+	 *
 	 * @param	KeyArray 	An array of key names
 	 * @return	Whether at least one of the keys passed in is pressed.
 	 */
 	public inline function anyPressed(KeyArray:Array<Key>):Bool
-	{ 
+	{
 		return checkKeyArrayState(KeyArray, PRESSED);
 	}
-	
+
 	/**
 	 * Check to see if at least one key from an array of keys was just pressed.
-	 * 
+	 *
 	 * @param	KeyArray 	An array of key names
 	 * @return	Whether at least one of the keys passed was just pressed.
 	 */
 	public inline function anyJustPressed(KeyArray:Array<Key>):Bool
-	{ 
+	{
 		return checkKeyArrayState(KeyArray, JUST_PRESSED);
 	}
-	
+
 	/**
 	 * Check to see if at least one key from an array of keys was just released.
-	 * 
+	 *
 	 * @param	KeyArray 	An array of key names
 	 * @return	Whether at least one of the keys passed was just released.
 	 */
 	public inline function anyJustReleased(KeyArray:Array<Key>):Bool
-	{ 
+	{
 		return checkKeyArrayState(KeyArray, JUST_RELEASED);
 	}
-	
+
 	/**
 	 * Get the ID of the first key which is currently pressed.
-	 * 
+	 *
 	 * @return	The ID of the first pressed key or -1 if none are pressed.
 	 */
 	public function firstPressed():Int
@@ -88,10 +88,10 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 		}
 		return -1;
 	}
-	
+
 	/**
 	 * Get the ID of the first key which has just been pressed.
-	 * 
+	 *
 	 * @return	The ID of the key or -1 if none were just pressed.
 	 */
 	public function firstJustPressed():Int
@@ -105,10 +105,10 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 		}
 		return -1;
 	}
-	
+
 	/**
 	 * Get the ID of the first key which has just been released.
-	 * 
+	 *
 	 * @return	The ID of the key or -1 if none were just released.
 	 */
 	public function firstJustReleased():Int
@@ -122,10 +122,10 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 		}
 		return -1;
 	}
-	
+
 	/**
 	 * Check the status of a single of key
-	 * 
+	 *
 	 * @param	KeyCode		KeyCode to be checked.
 	 * @param	Status		The key state to check for.
 	 * @return	Whether the provided key has the specified status.
@@ -133,7 +133,7 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	public function checkStatus(KeyCode:Key, Status:FlxInputState):Bool
 	{
 		var key:FlxInput<Key> = getKey(KeyCode);
-		
+
 		if (key != null)
 		{
 			if (key.hasState(Status))
@@ -147,19 +147,19 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 			throw 'Invalid key code: $KeyCode.';
 		}
 		#end
-		
+
 		return false;
 	}
 
 	/**
 	 * Get an Array of Key that are in a pressed state
-	 * 
+	 *
 	 * @return	Array of keys that are currently pressed.
 	 */
 	public function getIsDown():Array<FlxInput<Key>>
 	{
 		var keysDown = new Array<FlxInput<Key>>();
-		
+
 		for (key in _keyListArray)
 		{
 			if (key != null && key.pressed)
@@ -178,7 +178,7 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 		_keyListArray = null;
 		_keyListMap = null;
 	}
-	
+
 	/**
 	 * Resets all the keys.
 	 */
@@ -192,49 +192,49 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 			}
 		}
 	}
-	
-	private function new(keyListClass:Class<FlxBaseKeyList>)
+
+	function new(keyListClass:Class<FlxBaseKeyList>)
 	{
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_UP, onKeyUp);
-		
+
 		pressed = cast Type.createInstance(keyListClass, [FlxInputState.PRESSED, this]);
 		justPressed = cast Type.createInstance(keyListClass, [FlxInputState.JUST_PRESSED, this]);
 		justReleased = cast Type.createInstance(keyListClass, [FlxInputState.JUST_RELEASED, this]);
 	}
-	
+
 	/**
 	 * Updates the key states (for tracking just pressed, just released, etc).
 	 */
-	private function update():Void
+	function update():Void
 	{
 		for (key in _keyListArray)
 		{
-			if (key != null) 
+			if (key != null)
 			{
 				key.update();
 			}
 		}
 	}
-	
+
 	/**
 	 * Helper function to check the status of an array of keys
-	 * 
+	 *
 	 * @param	KeyArray	An array of keys as Strings
 	 * @param	State		The key state to check for
 	 * @return	Whether at least one of the keys has the specified status
 	 */
-	private function checkKeyArrayState(KeyArray:Array<Key>, State:FlxInputState):Bool
+	function checkKeyArrayState(KeyArray:Array<Key>, State:FlxInputState):Bool
 	{
 		if (KeyArray == null)
 		{
 			return false;
 		}
-		
+
 		for (code in KeyArray)
 		{
 			var key:FlxInput<Key> = getKey(code);
-			
+
 			if (key != null)
 			{
 				if (key.hasState(State))
@@ -243,39 +243,39 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 				}
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Event handler so FlxGame can toggle keys.
 	 */
-	private function onKeyUp(event:KeyboardEvent):Void
+	function onKeyUp(event:KeyboardEvent):Void
 	{
 		var c:Int = resolveKeyCode(event);
 		handlePreventDefaultKeys(c, event);
-		
-		if (enabled) 
+
+		if (enabled)
 		{
 			updateKeyStates(c, false);
 		}
 	}
-	
+
 	/**
 	 * Internal event handler for input and focus.
 	 */
-	private function onKeyDown(event:KeyboardEvent):Void
+	function onKeyDown(event:KeyboardEvent):Void
 	{
 		var c:Int = resolveKeyCode(event);
 		handlePreventDefaultKeys(c, event);
-		
-		if (enabled) 
+
+		if (enabled)
 		{
 			updateKeyStates(c, true);
 		}
 	}
-	
-	private function handlePreventDefaultKeys(keyCode:Int, event:KeyboardEvent):Void
+
+	function handlePreventDefaultKeys(keyCode:Int, event:KeyboardEvent):Void
 	{
 		var key:FlxInput<Key> = getKey(keyCode);
 		if (key != null && preventDefaultKeys != null && preventDefaultKeys.indexOf(key.ID) != -1)
@@ -284,12 +284,12 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 			event.stopPropagation();
 		}
 	}
-	
+
 	/**
-	 * A Helper function to check whether an array of keycodes contains 
+	 * A Helper function to check whether an array of keycodes contains
 	 * a certain key safely (returns false if the array is null).
-	 */ 
-	private function inKeyArray(KeyArray:Array<Key>, Event:KeyboardEvent):Bool
+	 */
+	function inKeyArray(KeyArray:Array<Key>, Event:KeyboardEvent):Bool
 	{
 		if (KeyArray == null)
 		{
@@ -308,20 +308,20 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 		}
 		return false;
 	}
-	
-	private function resolveKeyCode(e:KeyboardEvent):Int
+
+	function resolveKeyCode(e:KeyboardEvent):Int
 	{
 		return e.keyCode;
 	}
-	
+
 	/**
 	 * A helper function to update the key states based on a keycode provided.
 	 */
-	private inline function updateKeyStates(KeyCode:Int, Down:Bool):Void
+	inline function updateKeyStates(KeyCode:Int, Down:Bool):Void
 	{
 		var key:FlxInput<Key> = getKey(KeyCode);
-		
-		if (key != null) 
+
+		if (key != null)
 		{
 			if (Down)
 			{
@@ -333,18 +333,18 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 			}
 		}
 	}
-	
-	private inline function onFocus():Void {}
 
-	private inline function onFocusLost():Void
+	inline function onFocus():Void {}
+
+	inline function onFocusLost():Void
 	{
 		reset();
 	}
-	
+
 	/**
 	 * Return a key from the key list, if found. Will return null if not found.
 	 */
-	private inline function getKey(KeyCode:Int):FlxInput<Key>
+	inline function getKey(KeyCode:Int):FlxInput<Key>
 	{
 		return _keyListMap.get(KeyCode);
 	}

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -9,22 +9,22 @@ class FlxPointer
 {
 	public var x(default, null):Int = 0;
 	public var y(default, null):Int = 0;
-	
+
 	public var screenX(default, null):Int = 0;
 	public var screenY(default, null):Int = 0;
-	
-	private var _globalScreenX:Int = 0;
-	private var _globalScreenY:Int = 0;
-	private static var _cachedPoint:FlxPoint = new FlxPoint();
-	
+
+	var _globalScreenX:Int = 0;
+	var _globalScreenY:Int = 0;
+	static var _cachedPoint:FlxPoint = new FlxPoint();
+
 	public function new() {}
-	
+
 	/**
 	 * Fetch the world position of the pointer on any given camera.
 	 * NOTE: x and y also store the world position of the pointer on the main camera.
-	 * 
+	 *
 	 * @param 	Camera	If unspecified, first/main global camera is used instead.
-	 * @param 	point	An existing point object to store the results (if you don't want a new one created). 
+	 * @param 	point	An existing point object to store the results (if you don't want a new one created).
 	 * @return 	The touch point's location in world space.
 	 */
 	public function getWorldPosition(?Camera:FlxCamera, ?point:FlxPoint):FlxPoint
@@ -42,13 +42,13 @@ class FlxPointer
 		point.y = _cachedPoint.y + Camera.scroll.y;
 		return point;
 	}
-	
+
 	/**
 	 * Fetch the screen position of the pointer on any given camera.
 	 * NOTE: screenX and screenY also store the screen position of the pointer on the main camera.
-	 * 
+	 *
 	 * @param 	Camera	If unspecified, first/main global camera is used instead.
-	 * @param 	point		An existing point object to store the results (if you don't want a new one created). 
+	 * @param 	point		An existing point object to store the results (if you don't want a new one created).
 	 * @return 	The touch point's location in screen space.
 	 */
 	public function getScreenPosition(?Camera:FlxCamera, ?point:FlxPoint):FlxPoint
@@ -61,18 +61,18 @@ class FlxPointer
 		{
 			point = FlxPoint.get();
 		}
-		
+
 		point.x = (_globalScreenX - Camera.x + 0.5 * Camera.width * (Camera.zoom - Camera.initialZoom)) / Camera.zoom;
 		point.y = (_globalScreenY - Camera.y + 0.5 * Camera.height * (Camera.zoom - Camera.initialZoom)) / Camera.zoom;
-		
+
 		return point;
 	}
-	
+
 	/**
 	 * Fetch the screen position of the pointer relative to given camera's viewport.
-	 * 
+	 *
 	 * @param 	Camera		If unspecified, first/main global camera is used instead.
-	 * @param 	point		An existing point object to store the results (if you don't want a new one created). 
+	 * @param 	point		An existing point object to store the results (if you don't want a new one created).
 	 * @return 	The touch point's location relative to camera's viewport.
 	 */
 	@:access(flixel.FlxCamera)
@@ -80,16 +80,16 @@ class FlxPointer
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		if (point == null)
 			point = FlxPoint.get();
-		
+
 		point.x = (_globalScreenX - Camera.x) / Camera.zoom + Camera.viewOffsetX;
 		point.y = (_globalScreenY - Camera.y) / Camera.zoom + Camera.viewOffsetY;
-		
+
 		return point;
 	}
-	
+
 	/**
 	 * Returns a FlxPoint with this input's x and y.
 	 */
@@ -99,12 +99,12 @@ class FlxPointer
 			point = FlxPoint.get();
 		return point.set(x, y);
 	}
-	
+
 	/**
 	 * Checks to see if some FlxObject overlaps this FlxObject or FlxGroup.
 	 * If the group has a LOT of things in it, it might be faster to use FlxG.overlaps().
 	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
-	 * 
+	 *
 	 * @param 	ObjectOrGroup The object or group being tested.
 	 * @param 	Camera Specify which game camera you want. If null getScreenPosition() will just grab the first global camera.
 	 * @return 	Whether or not the two objects overlap.
@@ -113,58 +113,58 @@ class FlxPointer
 	public function overlaps(ObjectOrGroup:FlxBasic, ?Camera:FlxCamera):Bool
 	{
 		var result:Bool = false;
-		
+
 		var group = FlxTypedGroup.resolveGroup(ObjectOrGroup);
 		if (group != null)
 		{
 			group.forEachExists(function(basic:FlxBasic)
 			{
-				if (overlaps(basic, Camera)) 
+				if (overlaps(basic, Camera))
 				{
 					result = true;
 					return;
 				}
 			});
 		}
-		else 
+		else
 		{
 			getPosition(_cachedPoint);
 			var object:FlxObject = cast ObjectOrGroup;
 			result = object.overlapsPoint(_cachedPoint, true, Camera);
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Directly set the underyling screen position variable. WARNING! You should never use
 	 * this unless you are trying to manually dispatch low-level mouse / touch events to the stage.
 	 */
-	public inline function setGlobalScreenPositionUnsafe(newX:Float, newY:Float):Void 
+	public inline function setGlobalScreenPositionUnsafe(newX:Float, newY:Float):Void
 	{
 		_globalScreenX = Std.int(newX / FlxG.scaleMode.scale.x);
 		_globalScreenY = Std.int(newY / FlxG.scaleMode.scale.y);
-		
+
 		updatePositions();
 	}
-	
+
 	public function toString():String
 	{
-		return FlxStringUtil.getDebugString([ 
+		return FlxStringUtil.getDebugString([
 			LabelValuePair.weak("x", x),
 			LabelValuePair.weak("y", y)]);
 	}
-	
+
 	/**
 	 * Helper function to update the cursor used by update() and playback().
 	 * Updates the x, y, screenX, and screenY variables based on the default camera.
 	 */
-	private function updatePositions():Void
+	function updatePositions():Void
 	{
 		getScreenPosition(FlxG.camera, _cachedPoint);
 		screenX = Std.int(_cachedPoint.x);
 		screenY = Std.int(_cachedPoint.y);
-		
+
 		getWorldPosition(FlxG.camera, _cachedPoint);
 		x = Std.int(_cachedPoint.x);
 		y = Std.int(_cachedPoint.y);

--- a/flixel/input/FlxSwipe.hx
+++ b/flixel/input/FlxSwipe.hx
@@ -10,22 +10,22 @@ import flixel.util.FlxStringUtil;
 class FlxSwipe
 {
 	/**
-	 * Either LEFT_MOUSE, MIDDLE_MOUSE or RIGHT_MOUSE, 
+	 * Either LEFT_MOUSE, MIDDLE_MOUSE or RIGHT_MOUSE,
 	 * or the touchPointID of a FlxTouch.
 	 */
 	public var ID(default, null):Int;
-	
+
 	public var startPosition(default, null):FlxPoint;
 	public var endPosition(default, null):FlxPoint;
-	
+
 	public var distance(get, never):Float;
 	public var angle(get, never):Float;
 	public var duration(get, never):Float;
-	
-	private var _startTimeInTicks:Int;
-	private var _endTimeInTicks:Int;
-	
-	private function new(ID:Int, StartPosition:FlxPoint, EndPosition:FlxPoint, StartTimeInTicks:Int)
+
+	var _startTimeInTicks:Int;
+	var _endTimeInTicks:Int;
+
+	function new(ID:Int, StartPosition:FlxPoint, EndPosition:FlxPoint, StartTimeInTicks:Int)
 	{
 		this.ID = ID;
 		startPosition = StartPosition;
@@ -33,29 +33,29 @@ class FlxSwipe
 		_startTimeInTicks = StartTimeInTicks;
 		_endTimeInTicks = FlxG.game.ticks;
 	}
-	
-	private inline function toString():String
+
+	inline function toString():String
 	{
 		return FlxStringUtil.getDebugString([
-			LabelValuePair.weak("ID", ID), 
+			LabelValuePair.weak("ID", ID),
 			LabelValuePair.weak("start", startPosition),
 			LabelValuePair.weak("end", endPosition),
 			LabelValuePair.weak("distance", distance),
 			LabelValuePair.weak("angle", angle),
 			LabelValuePair.weak("duration", duration)]);
 	}
-	
-	private inline function get_distance():Float
+
+	inline function get_distance():Float
 	{
 		return FlxMath.vectorLength(startPosition.x - endPosition.x, startPosition.y - endPosition.y);
 	}
-	
-	private inline function get_angle():Float
+
+	inline function get_angle():Float
 	{
-		return startPosition.angleBetween(endPosition); 
+		return startPosition.angleBetween(endPosition);
 	}
-	
-	private inline function get_duration():Float
+
+	inline function get_duration():Float
 	{
 		return (_endTimeInTicks - _startTimeInTicks) / 1000;
 	}

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -30,41 +30,41 @@ import flixel.math.FlxPoint;
 class FlxGamepad implements IFlxDestroyable
 {
 	public var id(default, null):Int;
-	
+
 	#if FLX_GAMEINPUT_API
 	/**
 	 * The device name. Used to determine the `model`.
 	 */
 	public var name(get, never):String;
 	#end
-	
+
 	/**
 	 * The gamepad model used for the mapping of the IDs.
 	 * Defaults to `detectedModel`, but can be changed manually.
 	 */
 	public var model(default, set):FlxGamepadModel;
-	
+
 	/**
 	 * The gamepad model this gamepad has been identified as.
 	 */
 	public var detectedModel(default, null):FlxGamepadModel;
-	
+
 	/**
 	 * The mapping that is used to map the raw hardware IDs to the values in `FlxGamepadInputID`.
 	 * Determined by the current `model`.
 	 * It's also possible to create a custom mapping and assign it here.
 	 */
 	public var mapping:FlxGamepadMapping;
-	
+
 	public var connected(default, null):Bool = true;
-	
+
 	/**
 	 * For gamepads that can have things plugged into them (the Wii Remote, basically).
-	 * Making the user set this helps Flixel properly interpret inputs properly. 
-	 * EX: if you plug a nunchuk into the Wii Remote, you will get different values for 
+	 * Making the user set this helps Flixel properly interpret inputs properly.
+	 * EX: if you plug a nunchuk into the Wii Remote, you will get different values for
 	 * certain buttons than with the Wii Remote alone.
 	 * (This is probably why Wii games ask the player what control scheme they are using.)
-	 * 
+	 *
 	 * In the future, this could also be used for any attachment that exposes new API features
 	 * to the controller, e.g. a microphone or headset
 	 */
@@ -79,7 +79,7 @@ class FlxGamepad implements IFlxDestroyable
 	 * Which dead zone mode to use for analog sticks.
 	 */
 	public var deadZoneMode:FlxGamepadDeadZoneMode = INDEPENDENT_AXES;
-	
+
 	/**
 	 * Helper class to check if a button is pressed.
 	 */
@@ -105,69 +105,69 @@ class FlxGamepad implements IFlxDestroyable
 	 * (contains continously updated X and Y coordinates, each between 0.0 and 1.0)
 	 */
 	public var pointer(default, null):FlxGamepadPointerValueList;
-	
+
 	#if FLX_JOYSTICK_API
 	public var hat(default, null):FlxPoint = FlxPoint.get();
 	public var ball(default, null):FlxPoint = FlxPoint.get();
 	#end
-	
-	private var axis:Array<Float> = [for (i in 0...6) 0];
-	private var axisActive:Bool = false;
-	
-	private var manager:FlxGamepadManager;
-	private var _deadZone:Float = 0.15;
-	
+
+	var axis:Array<Float> = [for (i in 0...6) 0];
+	var axisActive:Bool = false;
+
+	var manager:FlxGamepadManager;
+	var _deadZone:Float = 0.15;
+
 	#if FLX_GAMEINPUT_API
-	private var _device:GameInputDevice; 
+	var _device:GameInputDevice;
 	#end
-	
-	private var buttons:Array<FlxGamepadButton> = [];
-	
-	public function new(ID:Int, Manager:FlxGamepadManager, ?Model:FlxGamepadModel, ?Attachment:FlxGamepadAttachment) 
+
+	var buttons:Array<FlxGamepadButton> = [];
+
+	public function new(ID:Int, Manager:FlxGamepadManager, ?Model:FlxGamepadModel, ?Attachment:FlxGamepadAttachment)
 	{
 		id = ID;
-		
+
 		manager = Manager;
-		
+
 		pressed = new FlxGamepadButtonList(FlxInputState.PRESSED, this);
 		justPressed = new FlxGamepadButtonList(FlxInputState.JUST_PRESSED, this);
 		justReleased = new FlxGamepadButtonList(FlxInputState.JUST_RELEASED, this);
 		analog = new FlxGamepadAnalogList(this);
 		motion = new FlxGamepadMotionValueList(this);
 		pointer = new FlxGamepadPointerValueList(this);
-		
+
 		if (Model == null)
 			Model = XINPUT;
-			
+
 		if (Attachment == null)
 			Attachment = NONE;
-		
+
 		model = Model;
 		detectedModel = Model;
 	}
-	
-	private function getButton(RawID:Int):FlxGamepadButton
+
+	function getButton(RawID:Int):FlxGamepadButton
 	{
 		if (RawID == -1)
 			return null;
 		var gamepadButton:FlxGamepadButton = buttons[RawID];
-		
+
 		if (gamepadButton == null)
 		{
 			gamepadButton = new FlxGamepadButton(RawID);
 			buttons[RawID] = gamepadButton;
 		}
-		
+
 		return gamepadButton;
 	}
-	
-	private inline function applyAxisFlip(axisValue:Float, axisID:Int):Float
+
+	inline function applyAxisFlip(axisValue:Float, axisID:Int):Float
 	{
 		if (mapping.isAxisFlipped(axisID))
 			axisValue *= -1;
 		return axisValue;
 	}
-	
+
 	/**
 	 * Updates the key states (for tracking just pressed, just released, etc).
 	 */
@@ -176,26 +176,26 @@ class FlxGamepad implements IFlxDestroyable
 		#if FLX_GAMEINPUT_API
 		var control:GameInputControl;
 		var button:FlxGamepadButton;
-		
+
 		if (_device == null)
 			return;
-		
+
 		for (i in 0..._device.numControls)
 		{
 			control = _device.getControlAt(i);
-			
+
 			//quick absolute value for analog sticks
 			button = getButton(i);
-			
+
 			if (isAxisForAnalogStick(i))
 			{
 				handleAxisMove(i, control.value, button.value);
 			}
-			
+
 			button.value = control.value;
-			
+
 			var value = Math.abs(control.value);
-			
+
 			if (value < deadZone)
 			{
 				button.release();
@@ -205,7 +205,7 @@ class FlxGamepad implements IFlxDestroyable
 				button.press();
 			}
 		}
-		
+
 		#elseif FLX_JOYSTICK_API
 		for (i in 0...axis.length)
 		{
@@ -224,20 +224,20 @@ class FlxGamepad implements IFlxDestroyable
 					button.release();
 				}
 			}
-			
+
 			axisActive = false;
 		}
 		#end
-		
+
 		for (button in buttons)
 		{
-			if (button != null) 
+			if (button != null)
 			{
 				button.update();
 			}
 		}
 	}
-	
+
 	public function reset():Void
 	{
 		for (button in buttons)
@@ -247,40 +247,40 @@ class FlxGamepad implements IFlxDestroyable
 				button.reset();
 			}
 		}
-		
+
 		var numAxis:Int = axis.length;
-		
+
 		for (i in 0...numAxis)
 		{
 			axis[i] = 0;
 		}
-		
+
 		#if FLX_JOYSTICK_API
 		hat.set();
 		ball.set();
 		#end
 	}
-	
+
 	public function destroy():Void
 	{
 		connected = false;
-		
+
 		buttons = null;
 		axis = null;
 		manager = null;
-		
+
 		#if FLX_JOYSTICK_API
 		hat = FlxDestroyUtil.put(hat);
 		ball = FlxDestroyUtil.put(ball);
-		
+
 		hat  = null;
 		ball = null;
 		#end
 	}
-	
+
 	/**
 	 * Check the status of a "universal" button ID, auto-mapped to this gamepad (something like FlxGamepadInputID.A).
-	 * 
+	 *
 	 * @param	ID			"universal" gamepad input ID
 	 * @param	Status		The key state to check for
 	 * @return	Whether the provided button has the specified status
@@ -289,26 +289,26 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return checkStatusRaw(mapping.getRawID(ID), Status);
 	}
-	
+
 	/**
 	 * Check the status of a raw button ID (like XInputID.A).
-	 * 
+	 *
 	 * @param	RawID	Index into buttons array.
 	 * @param	Status	The key state to check for
 	 * @return	Whether the provided button has the specified status
 	 */
-	public function checkStatusRaw(RawID:Int, Status:FlxInputState):Bool 
-	{ 
+	public function checkStatusRaw(RawID:Int, Status:FlxInputState):Bool
+	{
 		if (buttons[RawID] != null)
 		{
 			return buttons[RawID].current == Status;
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Check if at least one button from an array of button IDs is pressed.
-	 * 
+	 *
 	 * @param	IDArray	An array of "universal" gamepad input IDs
 	 * @return	Whether at least one of the buttons is pressed
 	 */
@@ -327,10 +327,10 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Check if at least one button from an array of raw button IDs is pressed.
-	 * 
+	 *
 	 * @param	RawIDArray	An array of raw button IDs
 	 * @return	Whether at least one of the buttons is pressed
 	 */
@@ -344,13 +344,13 @@ class FlxGamepad implements IFlxDestroyable
 					return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Check if at least one button from an array of universal button IDs was just pressed.
-	 * 
+	 *
 	 * @param	IDArray	An array of "universal" gamepad input IDs
 	 * @return	Whether at least one of the buttons was just pressed
 	 */
@@ -365,13 +365,13 @@ class FlxGamepad implements IFlxDestroyable
 					return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Check if at least one button from an array of raw button IDs was just pressed.
-	 * 
+	 *
 	 * @param	RawIDArray	An array of raw button IDs
 	 * @return	Whether at least one of the buttons was just pressed
 	 */
@@ -385,13 +385,13 @@ class FlxGamepad implements IFlxDestroyable
 					return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Check if at least one button from an array of gamepad input IDs was just released.
-	 * 
+	 *
 	 * @param	IDArray	An array of "universal" gamepad input IDs
 	 * @return	Whether at least one of the buttons was just released
 	 */
@@ -406,13 +406,13 @@ class FlxGamepad implements IFlxDestroyable
 					return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Check if at least one button from an array of raw button IDs was just released.
-	 * 
+	 *
 	 * @param	RawArray	An array of raw button IDs
 	 * @return	Whether at least one of the buttons was just released
 	 */
@@ -426,10 +426,10 @@ class FlxGamepad implements IFlxDestroyable
 					return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Get the first found "universal" ID of the button which is currently pressed.
 	 * Returns NONE if no button is pressed.
@@ -438,7 +438,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return mapping.getID(firstPressedRawID());
 	}
-	
+
 	/**
 	 * Get the first found raw ID of the button which is currently pressed.
 	 * Returns -1 if no button is pressed.
@@ -454,7 +454,7 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		return -1;
 	}
-	
+
 	/**
 	 * Get the first found "universal" ButtonID of the button which has been just pressed.
 	 * Returns NONE if no button was just pressed.
@@ -463,7 +463,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return mapping.getID(firstJustPressedRawID());
 	}
-	
+
 	/**
 	 * Get the first found raw ID of the button which has been just pressed.
 	 * Returns -1 if no button was just pressed.
@@ -479,7 +479,7 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		return -1;
 	}
-	
+
 	/**
 	 * Get the first found "universal" ButtonID of the button which has been just released.
 	 * Returns NONE if no button was just released.
@@ -488,7 +488,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return mapping.getID(firstJustReleasedRawID());
 	}
-	
+
 	/**
 	 * Get the first found raw ID of the button which has been just released.
 	 * Returns -1 if no button was just released.
@@ -502,12 +502,12 @@ class FlxGamepad implements IFlxDestroyable
 				return button.ID;
 			}
 		}
-		return -1; 
+		return -1;
 	}
-	
+
 	/**
-	 * Gets the value of the specified axis using the "universal" ButtonID - 
-	 * use this only for things like FlxGamepadButtonID.LEFT_TRIGGER, 
+	 * Gets the value of the specified axis using the "universal" ButtonID -
+	 * use this only for things like FlxGamepadButtonID.LEFT_TRIGGER,
 	 * use getXAxis() / getYAxis() for analog sticks!
 	 */
 	public function getAxis(AxisButtonID:FlxGamepadInputID):Float
@@ -534,9 +534,9 @@ class FlxGamepad implements IFlxDestroyable
 		return 0;
 		#end
 	}
-	
+
 	/**
-	 * Gets the value of the specified axis using the raw ID - 
+	 * Gets the value of the specified axis using the raw ID -
 	 * use this only for things like XInputID.LEFT_TRIGGER,
 	 * use getXAxis() / getYAxis() for analog sticks!
 	 */
@@ -549,15 +549,15 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		return 0;
 	}
-	
-	private function isAxisForAnalogStick(AxisIndex:Int):Bool
+
+	function isAxisForAnalogStick(AxisIndex:Int):Bool
 	{
 		var leftStick = mapping.leftStick;
 		var rightStick = mapping.rightStick;
-		
+
 		if (leftStick != null)
 		{
-			if (AxisIndex == leftStick.x || AxisIndex == leftStick.y) 
+			if (AxisIndex == leftStick.x || AxisIndex == leftStick.y)
 				return true;
 		}
 		if (rightStick != null)
@@ -567,19 +567,19 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		return false;
 	}
-	
-	private inline function getAnalogStickByAxis(AxisIndex:Int):FlxGamepadAnalogStick
+
+	inline function getAnalogStickByAxis(AxisIndex:Int):FlxGamepadAnalogStick
 	{
 		var leftStick = mapping.leftStick;
 		var rightStick = mapping.rightStick;
-		
+
 		if (leftStick != null && AxisIndex == leftStick.x || AxisIndex == leftStick.y)
 			return leftStick;
 		if (rightStick != null && AxisIndex == rightStick.x || AxisIndex == rightStick.y)
 			return rightStick;
 		return null;
 	}
-	
+
 	/**
 	 * Given a ButtonID for an analog stick, gets the value of its x axis
 	 * @param	AxesButtonID an analog stick like FlxGamepadButtonID.LEFT_STICK
@@ -588,7 +588,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return getAnalogXAxisValue(mapping.getAnalogStick(AxesButtonID));
 	}
-	
+
 	/**
 	 * Given both raw IDs for the axes of an analog stick, gets the value of its x axis
 	 */
@@ -596,7 +596,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return getAnalogXAxisValue(Stick);
 	}
-	
+
 	/**
 	 * Given a ButtonID for an analog stick, gets the value of its y axis
 	 * @param	AxesButtonID an analog stick like FlxGamepadButtonID.LEFT_STICK
@@ -605,7 +605,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return getYAxisRaw(mapping.getAnalogStick(AxesButtonID));
 	}
-	
+
 	/**
 	 * Given both raw ID's for the axes of an analog stick, gets the value of its Y axis
 	 * (should be used in flash to correct the inverted y axis)
@@ -625,7 +625,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return FlxVector.get(getXAxis(AxesButtonID), getYAxis(AxesButtonID));
 	}
-	
+
 	/**
 	 * Whether any buttons have the specified input state.
 	 */
@@ -640,7 +640,7 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Check to see if any buttons are pressed right or Axis, Ball and Hat moved now.
 	 */
@@ -648,9 +648,9 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		if (anyButton())
 			return true;
-		
+
 		var numAxis:Int = axis.length;
-		
+
 		for (i in 0...numAxis)
 		{
 			if (axis[0] != 0)
@@ -658,26 +658,26 @@ class FlxGamepad implements IFlxDestroyable
 				return true;
 			}
 		}
-		
+
 		#if FLX_JOYSTICK_API
 		if (ball.x != 0 || ball.y != 0)
 		{
 			return true;
 		}
-		
+
 		if (hat.x != 0 || hat.y != 0)
 		{
 			return true;
 		}
 		#end
-		
+
 		return false;
 	}
-	
-	private function getAxisValue(AxisID:Int):Float
+
+	function getAxisValue(AxisID:Int):Float
 	{
 		var axisValue:Float = 0;
-		
+
 		#if FLX_GAMEINPUT_API
 		if (AxisID == -1)
 		{
@@ -692,19 +692,19 @@ class FlxGamepad implements IFlxDestroyable
 		{
 			return 0;
 		}
-		
+
 		axisValue = axis[AxisID];
 		#end
-		
+
 		if (isAxisForAnalogStick(AxisID))
 		{
 			axisValue = applyAxisFlip(axisValue, AxisID);
 		}
-		
+
 		return axisValue;
 	}
-	
-	private function getAnalogXAxisValue(stick:FlxGamepadAnalogStick):Float
+
+	function getAnalogXAxisValue(stick:FlxGamepadAnalogStick):Float
 	{
 		if (stick == null)
 			return 0;
@@ -713,8 +713,8 @@ class FlxGamepad implements IFlxDestroyable
 		else
 			getAnalogAxisValueIndependent(stick.x);
 	}
-	
-	private function getAnalogYAxisValue(stick:FlxGamepadAnalogStick):Float
+
+	function getAnalogYAxisValue(stick:FlxGamepadAnalogStick):Float
 	{
 		if (stick == null)
 			return 0;
@@ -723,56 +723,56 @@ class FlxGamepad implements IFlxDestroyable
 		else
 			getAnalogAxisValueIndependent(stick.y);
 	}
-	
-	private function getAnalogAxisValueCircular(stick:FlxGamepadAnalogStick, axisID:Int):Float
+
+	function getAnalogAxisValueCircular(stick:FlxGamepadAnalogStick, axisID:Int):Float
 	{
 		if (stick == null)
 			return 0;
 		var xAxis = getAxisValue(stick.x);
 		var yAxis = getAxisValue(stick.y);
-		
+
 		var vector = FlxVector.get(xAxis, yAxis);
 		var length = vector.length;
 		vector.put();
-		
+
 		if (length > deadZone)
 		{
 			return getAxisValue(axisID);
 		}
 		return 0;
 	}
-	
-	private function getAnalogAxisValueIndependent(axisID:Int):Float
+
+	function getAnalogAxisValueIndependent(axisID:Int):Float
 	{
 		var axisValue = getAxisValue(axisID);
 		if (Math.abs(axisValue) > deadZone)
 			return axisValue;
 		return 0;
 	}
-	
-	private function handleAxisMove(axis:Int, newValue:Float, oldValue:Float)
+
+	function handleAxisMove(axis:Int, newValue:Float, oldValue:Float)
 	{
 		newValue = applyAxisFlip(newValue, axis);
 		oldValue = applyAxisFlip(oldValue, axis);
-		
+
 		//check to see if we should send digital inputs as well as analog
 		var stick:FlxGamepadAnalogStick = getAnalogStickByAxis(axis);
 		if (stick.mode == ONLY_DIGITAL || stick.mode == BOTH)
 		{
 			handleAxisMoveSub(stick, axis, newValue, oldValue,  1.0);
 			handleAxisMoveSub(stick, axis, newValue, oldValue, -1.0);
-			
+
 			if (stick.mode == ONLY_DIGITAL)
 			{
 				//still haven't figured out how to suppress the analog inputs properly. Oh well.
 			}
 		}
 	}
-	
-	private function handleAxisMoveSub(stick:FlxGamepadAnalogStick, axis:Int, value:Float, oldValue:Float, sign:Float = 1.0)
+
+	function handleAxisMoveSub(stick:FlxGamepadAnalogStick, axis:Int, value:Float, oldValue:Float, sign:Float = 1.0)
 	{
 		var digitalButton = -1;
-		
+
 		if (axis == stick.x)
 		{
 			digitalButton = (sign < 0) ? stick.rawLeft : stick.rawRight;
@@ -781,11 +781,11 @@ class FlxGamepad implements IFlxDestroyable
 		{
 			digitalButton = (sign < 0) ? stick.rawUp : stick.rawDown;
 		}
-		
+
 		var threshold = stick.digitalThreshold;
 		var valueSign = value * sign;
 		var oldValueSign = oldValue * sign;
-		
+
 		if (valueSign > threshold && oldValueSign <= threshold)
 		{
 			var btn = getButton(digitalButton);
@@ -797,7 +797,7 @@ class FlxGamepad implements IFlxDestroyable
 			if (btn != null) btn.release();
 		}
 	}
-	private function createMappingForModel(model:FlxGamepadModel):FlxGamepadMapping
+	function createMappingForModel(model:FlxGamepadModel):FlxGamepadMapping
 	{
 		return switch (model)
 		{
@@ -813,41 +813,41 @@ class FlxGamepad implements IFlxDestroyable
 			case _: new XInputMapping(attachment);
 		}
 	}
-	
+
 	#if FLX_GAMEINPUT_API
-	private function get_name():String
+	function get_name():String
 	{
 		if (_device == null)
 			return null;
 		return _device.name;
 	}
 	#end
-	
-	private function set_model(Model:FlxGamepadModel):FlxGamepadModel
+
+	function set_model(Model:FlxGamepadModel):FlxGamepadModel
 	{
 		model = Model;
 		mapping = createMappingForModel(model);
-		
+
 		return model;
 	}
-	
-	private function set_attachment(Attachment:FlxGamepadAttachment):FlxGamepadAttachment
+
+	function set_attachment(Attachment:FlxGamepadAttachment):FlxGamepadAttachment
 	{
 		attachment = Attachment;
 		mapping.attachment = Attachment;
 		return attachment;
 	}
-	
-	private function get_deadZone():Float
+
+	function get_deadZone():Float
 	{
 		return (manager.globalDeadZone == null) ? _deadZone : manager.globalDeadZone;
 	}
-	
-	private inline function set_deadZone(deadZone:Float):Float
+
+	inline function set_deadZone(deadZone:Float):Float
 	{
 		return _deadZone = deadZone;
 	}
-	
+
 	public function toString():String
 	{
 		return FlxStringUtil.getDebugString([

--- a/flixel/input/gamepad/FlxGamepadButton.hx
+++ b/flixel/input/gamepad/FlxGamepadButton.hx
@@ -8,10 +8,10 @@ class FlxGamepadButton extends FlxInput<Int>
 	 * Optional analog value, so we can check when the value has changed from the last frame
 	 */
 	public var value:Float = 0;
-	
+
 	#if flash
-	private var _pressed:Bool = false;
-	
+	var _pressed:Bool = false;
+
 	override public function release():Void
 	{
 		// simulate button onUp event which does not exist on flash
@@ -20,10 +20,10 @@ class FlxGamepadButton extends FlxInput<Int>
 			return;
 		}
 		_pressed = false;
-		
+
 		super.release();
 	}
-	
+
 	override public function press():Void
 	{
 		// simulate button onDown event which does not exist on flash
@@ -32,7 +32,7 @@ class FlxGamepadButton extends FlxInput<Int>
 			return;
 		}
 		_pressed = true;
-		
+
 		super.press();
 	}
 	#end

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -25,34 +25,34 @@ class FlxGamepadManager implements IFlxInputManager
 	 * The last accessed gamepad - can be `null`!
 	 */
 	public var lastActive:FlxGamepad;
-	
+
 	/**
 	 * A counter for the number of active gamepads
 	 */
 	public var numActiveGamepads(get, null):Int;
-	
+
 	/**
 	 * Global Gamepad deadzone. The lower, the more sensitive the gamepad. Should be
 	 * between 0.0 and 1.0. Null by default, overrides the deadzone of gamepads if non-null.
 	 */
 	public var globalDeadZone:Null<Float>;
-	
+
 	/**
 	 * Stores all gamepads - can have null entries, but index matches event.device
 	 */
-	private var _gamepads:Array<FlxGamepad> = [];
+	var _gamepads:Array<FlxGamepad> = [];
 	/**
 	 * Stores all gamepads - no null entries, but index does *not* match event.device
 	 */
-	private var _activeGamepads:Array<FlxGamepad> = [];
-	
+	var _activeGamepads:Array<FlxGamepad> = [];
+
 	#if FLX_GAMEINPUT_API
 	/**
 	 * GameInput needs to be statically created, otherwise GameInput.numDevices will be zero during construction.
 	 */
-	private static var _gameInput:GameInput = new GameInput();
+	static var _gameInput:GameInput = new GameInput();
 	#end
-	
+
 	/**
 	 * Returns a FlxGamepad with the specified ID or null if none was found.
 	 * For example, if there are 4 gamepads connected, they will have the IDs 0-3.
@@ -61,35 +61,35 @@ class FlxGamepadManager implements IFlxInputManager
 	{
 		return _activeGamepads[GamepadID];
 	}
-	
-	private function removeByID(GamepadID:Int):Void
+
+	function removeByID(GamepadID:Int):Void
 	{
 		var gamepad:FlxGamepad = _gamepads[GamepadID];
 		if (gamepad != null)
 		{
 			FlxDestroyUtil.destroy(gamepad);
 			_gamepads[GamepadID] = null;
-			
+
 			var i = _activeGamepads.indexOf(gamepad);
 			if (i != -1)
 				_activeGamepads[i] = null;
 		}
-		
+
 		if (lastActive == gamepad)
 			lastActive = null;
-		
+
 		if (firstActive == gamepad)
 			firstActive = null;
 	}
-	
-	private function createByID(GamepadID:Int, ?Model:FlxGamepadModel):FlxGamepad
+
+	function createByID(GamepadID:Int, ?Model:FlxGamepadModel):FlxGamepad
 	{
 		var gamepad:FlxGamepad = _gamepads[GamepadID];
 		if (gamepad == null)
 		{
 			gamepad = new FlxGamepad(GamepadID, this, Model);
 			_gamepads[GamepadID] = gamepad;
-			
+
 			//fill the first "empty spot" in the array
 			var nullFound:Bool = false;
 			for (i in 0..._activeGamepads.length)
@@ -101,21 +101,21 @@ class FlxGamepadManager implements IFlxInputManager
 					break;
 				}
 			}
-			
+
 			if (!nullFound)
 				_activeGamepads.push(gamepad);
 		}
-		
+
 		lastActive = gamepad;
 		if (firstActive == null)
 			firstActive = gamepad;
-		
+
 		return gamepad;
 	}
-	
+
 	/**
 	 * Get array of ids for gamepads with any pressed buttons or moved Axis, Ball and Hat.
-	 * 
+	 *
 	 * @param	IDsArray	optional array to fill with ids
 	 * @return	array filled with active gamepad ids
 	 */
@@ -123,17 +123,17 @@ class FlxGamepadManager implements IFlxInputManager
 	{
 		if (IDsArray == null)
 			IDsArray = [];
-		
+
 		for (gamepad in _gamepads)
 			if (gamepad != null && gamepad.anyInput())
 				IDsArray.push(gamepad.id);
-		
+
 		return IDsArray;
 	}
-	
+
 	/**
 	 * Get array of gamepads with any pressed buttons or moved Axis, Ball and Hat.
-	 * 
+	 *
 	 * @param	GamepadArray	optional array to fill with active gamepads
 	 * @return	array filled with active gamepads
 	 */
@@ -141,14 +141,14 @@ class FlxGamepadManager implements IFlxInputManager
 	{
 		if (GamepadArray == null)
 			GamepadArray = [];
-		
+
 		for (gamepad in _gamepads)
 			if (gamepad != null && gamepad.anyInput())
 				GamepadArray.push(gamepad);
-		
+
 		return GamepadArray;
 	}
-	
+
 	/**
 	 * Get first found active gamepad id (with any pressed buttons or moved Axis, Ball and Hat).
 	 * Returns "-1" if no active gamepad has been found.
@@ -158,7 +158,7 @@ class FlxGamepadManager implements IFlxInputManager
 		var firstActive:FlxGamepad = getFirstActiveGamepad();
 		return (firstActive == null) ? -1 : firstActive.id;
 	}
-	
+
 	/**
 	 * Get first found active gamepad (with any pressed buttons or moved Axis, Ball and Hat).
 	 * Returns null if no active gamepad has been found.
@@ -168,10 +168,10 @@ class FlxGamepadManager implements IFlxInputManager
 		for (gamepad in _gamepads)
 			if (gamepad != null && gamepad.anyInput())
 				return gamepad;
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Whether any buttons have the specified input state on any gamepad.
 	 */
@@ -180,10 +180,10 @@ class FlxGamepadManager implements IFlxInputManager
 		for (gamepad in _gamepads)
 			if (gamepad != null && gamepad.anyButton(state))
 				return true;
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Whether there's any input at all on any gamepad.
 	 */
@@ -192,7 +192,7 @@ class FlxGamepadManager implements IFlxInputManager
 		for (gamepad in _gamepads)
 			if (gamepad != null && gamepad.anyInput())
 				return true;
-		
+
 		return false;
 	}
 
@@ -219,8 +219,8 @@ class FlxGamepadManager implements IFlxInputManager
 	{
 		return anyHasState(buttonID, FlxInputState.JUST_RELEASED);
 	}
-	
-	private function anyHasState(buttonID:FlxGamepadInputID, state:FlxInputState):Bool
+
+	function anyHasState(buttonID:FlxGamepadInputID, state:FlxInputState):Bool
 	{
 		for (gamepad in _gamepads)
 			if (gamepad != null && gamepad.checkStatus(buttonID, state))
@@ -228,10 +228,10 @@ class FlxGamepadManager implements IFlxInputManager
 
 		return false;
 	}
-	
+
 	/**
 	 * Check to see if the X axis is moved on any Gamepad.
-	 * 
+	 *
 	 * @param AxisID The axis id
 	 * @return Float Value from -1 to 1 or 0 if no X axes were moved
 	 */
@@ -246,13 +246,13 @@ class FlxGamepadManager implements IFlxInputManager
 			if (value != 0)
 				return value;
 		}
-		
+
 		return 0;
 	}
 
 	/**
 	 * Check to see if the Y axis is moved on any Gamepad.
-	 * 
+	 *
 	 * @param AxisID The axis id
 	 * @return Float Value from -1 to 1 or 0 if no Y axes were moved
 	 */
@@ -267,10 +267,10 @@ class FlxGamepadManager implements IFlxInputManager
 			if (value != 0)
 				return value;
 		}
-		
+
 		return 0;
 	}
-	
+
 	/**
 	 * Clean up memory. Internal use only.
 	 */
@@ -278,18 +278,18 @@ class FlxGamepadManager implements IFlxInputManager
 	public function destroy():Void
 	{
 		_gamepads = FlxDestroyUtil.destroyArray(_gamepads);
-		
+
 		firstActive = null;
 		lastActive = null;
 		_gamepads = null;
-		
+
 		#if FLX_GAMEINPUT_API
 		// not sure this is needed - can't imagine any use case where FlxGamepadManager would be destroyed
 		_gameInput.removeEventListener(GameInputEvent.DEVICE_ADDED, onDeviceAdded);
 		_gameInput.removeEventListener(GameInputEvent.DEVICE_REMOVED, onDeviceRemoved);
 		#end
 	}
-	
+
 	/**
 	 * Resets all the keys on all joys.
 	 */
@@ -299,9 +299,9 @@ class FlxGamepadManager implements IFlxInputManager
 			if (gamepad != null)
 				gamepad.reset();
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() 
+	function new()
 	{
 		#if FLX_JOYSTICK_API
 		FlxG.stage.addEventListener(JoystickEvent.AXIS_MOVE, handleAxisMove);
@@ -314,54 +314,54 @@ class FlxGamepadManager implements IFlxInputManager
 		#elseif FLX_GAMEINPUT_API
 		_gameInput.addEventListener(GameInputEvent.DEVICE_ADDED, onDeviceAdded);
 		_gameInput.addEventListener(GameInputEvent.DEVICE_REMOVED, onDeviceRemoved);
-		
+
 		for (i in 0...GameInput.numDevices)
 			addGamepad(GameInput.getDeviceAt(i));
 		#end
 	}
-	
+
 	#if FLX_GAMEINPUT_API
-	private function onDeviceAdded(Event:GameInputEvent):Void
+	function onDeviceAdded(Event:GameInputEvent):Void
 	{
 		addGamepad(Event.device);
 	}
-	
-	private function onDeviceRemoved(Event:GameInputEvent):Void
+
+	function onDeviceRemoved(Event:GameInputEvent):Void
 	{
 		removeGamepad(Event.device);
 	}
-	
-	private function findGamepadIndex(Device:GameInputDevice):Int
+
+	function findGamepadIndex(Device:GameInputDevice):Int
 	{
 		if (Device == null)
 			return - 1;
-		
+
 		for (i in 0...GameInput.numDevices)
 			if (GameInput.getDeviceAt(i) == Device)
 				return i;
 
 		return -1;
 	}
-	
-	private function addGamepad(Device:GameInputDevice):Void
+
+	function addGamepad(Device:GameInputDevice):Void
 	{
 		if (Device == null)
 			return;
-		
+
 		Device.enabled = true;
 		var id:Int = findGamepadIndex(Device);
 		if (id < 0)
 			return;
-		
+
 		var gamepad:FlxGamepad = createByID(id, getModelFromDeviceName(Device.name));
 		gamepad._device = Device;
 	}
-	
-	private function getModelFromDeviceName(name:String):FlxGamepadModel
+
+	function getModelFromDeviceName(name:String):FlxGamepadModel
 	{
 		//If we're actually running on console hardware, we know what controller hardware you're using
 		//TODO: add support for multiple controller types on console that support that (WiiU for instance)
-		
+
 		#if vita
 			return PSVITA;
 		#elseif ps4
@@ -372,7 +372,7 @@ class FlxGamepadManager implements IFlxInputManager
 
 		//"Sony PLAYSTATION(R)3 Controller" is the PS3 controller, but that is not supported as its PC drivers are terrible,
 		//and the most popular tools just turn it into a 360 controller
-		
+
 		name = name.toLowerCase().remove("-").remove("_");
 		return if (name.contains("ouya")) OUYA;                                      //"OUYA Game Controller"
 			else if (name.contains("wireless controller") || name.contains("ps4")) PS4; //"Wireless Controller" or "PS4 controller"
@@ -385,8 +385,8 @@ class FlxGamepadManager implements IFlxInputManager
 			else if (name.contains("mfi")) MFI;
 			else UNKNOWN;
 	}
-	
-	private function removeGamepad(Device:GameInputDevice):Void
+
+	function removeGamepad(Device:GameInputDevice):Void
 	{
 		if (Device == null)
 			return;
@@ -399,9 +399,9 @@ class FlxGamepadManager implements IFlxInputManager
 		}
 	}
 	#end
-	
+
 	#if FLX_JOYSTICK_API
-	private function getModelFromJoystick(id:Float):FlxGamepadModel
+	function getModelFromJoystick(id:Float):FlxGamepadModel
 	{
 		//id "1" is PS3, but that is not supported as its PC drivers are terrible,
 		// and the most popular tools just turn it into a 360 controller
@@ -415,44 +415,44 @@ class FlxGamepadManager implements IFlxInputManager
 			default: UNKNOWN;
 		}
 	}
-	
-	private function handleButtonDownEvent(event:JoystickEvent):Void
+
+	function handleButtonDownEvent(event:JoystickEvent):Void
 	{
 		handleButtonDown(event.device, event.id);
 	}
-	
-	private function handleButtonDown(device:Int, id:Int):Void
+
+	function handleButtonDown(device:Int, id:Int):Void
 	{
 		var button:FlxGamepadButton = createByID(device).getButton(id);
-		if (button != null) 
+		if (button != null)
 			button.press();
 	}
-	
-	private function handleButtonUpEvent(event:JoystickEvent):Void
+
+	function handleButtonUpEvent(event:JoystickEvent):Void
 	{
 		handleButtonUp(event.device, event.id);
 	}
-	
-	private function handleButtonUp(device:Int, id:Int):Void
+
+	function handleButtonUp(device:Int, id:Int):Void
 	{
 		var button:FlxGamepadButton = createByID(device).getButton(id);
-		if (button != null) 
+		if (button != null)
 			button.release();
 	}
-	
-	private function handleAxisMove(event:JoystickEvent):Void
+
+	function handleAxisMove(event:JoystickEvent):Void
 	{
 		var device:Int = event.device;
 		var gamepad:FlxGamepad = createByID(device);
-		
+
 		var oldAxis = gamepad.axis;
 		var newAxis = event.axis;
-		
+
 		for (i in 0...newAxis.length)
 		{
 			var isForStick = gamepad.isAxisForAnalogStick(i);
 			var isForMotion = gamepad.mapping.isAxisForMotion(i);
-			
+
 			if (!isForStick && !isForMotion)
 			{
 				// in legacy this returns a (-1, 1) range, but in flash/next it
@@ -464,88 +464,88 @@ class FlxGamepadManager implements IFlxInputManager
 				gamepad.handleAxisMove(i, newAxis[i], (i >= 0 && i < oldAxis.length) ? oldAxis[i] : 0);
 			}
 		}
-		
+
 		gamepad.axis = newAxis;
 		gamepad.axisActive = true;
 	}
-	
-	private function copyToPointWithDeadzone(gamepad:FlxGamepad, point:FlxPoint, event:JoystickEvent):Void
+
+	function copyToPointWithDeadzone(gamepad:FlxGamepad, point:FlxPoint, event:JoystickEvent):Void
 	{
 		point.x = (Math.abs(event.x) < gamepad.deadZone) ? 0 : event.x;
 		point.y = (Math.abs(event.y) < gamepad.deadZone) ? 0 : event.y;
 	}
-	
-	private function handleBallMove(event:JoystickEvent):Void
+
+	function handleBallMove(event:JoystickEvent):Void
 	{
 		var gamepad:FlxGamepad = createByID(event.device);
 		copyToPointWithDeadzone(gamepad, gamepad.ball, event);
 	}
-	
-	private function handleHatMove(event:JoystickEvent):Void
+
+	function handleHatMove(event:JoystickEvent):Void
 	{
 		var device:Int = event.device;
 		var gamepad:FlxGamepad = createByID(device);
-		
+
 		var oldX = gamepad.hat.x;
 		var oldY = gamepad.hat.y;
-		
+
 		copyToPointWithDeadzone(gamepad, gamepad.hat, event);
-		
+
 		checkDpadAxisChange(device, oldX, gamepad.hat.x,
 			FlxGamepadInputID.DPAD_LEFT, FlxGamepadInputID.DPAD_RIGHT);
 		checkDpadAxisChange(device, oldY, gamepad.hat.y,
 			FlxGamepadInputID.DPAD_UP, FlxGamepadInputID.DPAD_DOWN);
 	}
-	
-	private function checkDpadAxisChange(device:Int, oldValue:Float, newValue:Float,
+
+	function checkDpadAxisChange(device:Int, oldValue:Float, newValue:Float,
 		negativeID:FlxGamepadInputID, positiveID:FlxGamepadInputID):Void
 	{
 		if (oldValue == newValue)
 			return;
-		
+
 		var rawNegativeID = createByID(device).mapping.getRawID(negativeID);
 		var rawPositiveID = createByID(device).mapping.getRawID(positiveID);
-			
+
 		if (oldValue == -1)
 			handleButtonUp(device, rawNegativeID);
 		else if (oldValue == 1)
 			handleButtonUp(device, rawPositiveID);
-		
+
 		if (newValue == -1)
 			handleButtonDown(device, rawNegativeID);
 		else if (newValue == 1)
 			handleButtonDown(device, rawPositiveID);
 	}
-	
-	private function handleDeviceAdded(event:JoystickEvent):Void
+
+	function handleDeviceAdded(event:JoystickEvent):Void
 	{
 		createByID(event.device, getModelFromJoystick(event.x));
 	}
-	
-	private function handleDeviceRemoved(event:JoystickEvent):Void
+
+	function handleDeviceRemoved(event:JoystickEvent):Void
 	{
 		removeByID(event.device);
 	}
 	#end
-	
+
 	/**
 	 * Updates the key states (for tracking just pressed, just released, etc).
 	 */
-	private function update():Void
+	function update():Void
 	{
 		for (gamepad in _gamepads)
 			if (gamepad != null)
 				gamepad.update();
 	}
-	
-	private inline function onFocus():Void {}
 
-	private inline function onFocusLost():Void
+	inline function onFocus():Void {}
+
+	inline function onFocusLost():Void
 	{
 		reset();
 	}
 
-	private function get_numActiveGamepads():Int
+	function get_numActiveGamepads():Int
 	{
 		var count = 0;
 		for (gamepad in _gamepads)

--- a/flixel/input/gamepad/lists/FlxBaseGamepadList.hx
+++ b/flixel/input/gamepad/lists/FlxBaseGamepadList.hx
@@ -6,28 +6,28 @@ import flixel.input.gamepad.FlxGamepadInputID;
 
 class FlxBaseGamepadList
 {
-	private var status:FlxInputState;
-	private var gamepad:FlxGamepad;
-	
+	var status:FlxInputState;
+	var gamepad:FlxGamepad;
+
 	public function new(status:FlxInputState, gamepad:FlxGamepad)
 	{
 		this.status = status;
 		this.gamepad = gamepad;
 	}
-	
-	private inline function check(id:FlxGamepadInputID):Bool
+
+	inline function check(id:FlxGamepadInputID):Bool
 	{
 		return gamepad.checkStatus(id, status);
 	}
-	
-	private inline function checkRaw(id:Int):Bool
+
+	inline function checkRaw(id:Int):Bool
 	{
 		return gamepad.checkStatusRaw(id, status);
 	}
-	
-	public var ANY(get, never):Bool; 
-	
-	private function get_ANY():Bool
+
+	public var ANY(get, never):Bool;
+
+	function get_ANY():Bool
 	{
 		for (button in gamepad.buttons)
 		{
@@ -36,7 +36,7 @@ class FlxBaseGamepadList
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
 }

--- a/flixel/input/gamepad/lists/FlxGamepadAnalogStateList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadAnalogStateList.hx
@@ -10,56 +10,56 @@ import flixel.input.gamepad.FlxGamepadInputID;
 @:keep
 class FlxGamepadAnalogStateList
 {
-	private var gamepad:FlxGamepad;
-	private var status:FlxInputState;
-	
+	var gamepad:FlxGamepad;
+	var status:FlxInputState;
+
 	public var LEFT_STICK     (get, never):Bool; inline function get_LEFT_STICK()    return checkXY(FlxGamepadInputID.LEFT_ANALOG_STICK);
 	public var LEFT_STICK_X   (get, never):Bool; inline function get_LEFT_STICK_X()  return checkX(FlxGamepadInputID.LEFT_ANALOG_STICK);
 	public var LEFT_STICK_Y   (get, never):Bool; inline function get_LEFT_STICK_Y()  return checkY(FlxGamepadInputID.LEFT_ANALOG_STICK);
 	public var RIGHT_STICK    (get, never):Bool; inline function get_RIGHT_STICK()   return checkXY(FlxGamepadInputID.RIGHT_ANALOG_STICK);
 	public var RIGHT_STICK_X  (get, never):Bool; inline function get_RIGHT_STICK_X() return checkX(FlxGamepadInputID.RIGHT_ANALOG_STICK);
 	public var RIGHT_STICK_Y  (get, never):Bool; inline function get_RIGHT_STICK_Y() return checkY(FlxGamepadInputID.RIGHT_ANALOG_STICK);
-	
+
 	public function new(status:FlxInputState, gamepad:FlxGamepad)
 	{
 		this.status = status;
 		this.gamepad = gamepad;
 	}
-	
+
 	/**
 	 * Checks if the entire stick itself is in the given state
 	 */
-	private function checkXY(id:FlxGamepadInputID):Bool
+	function checkXY(id:FlxGamepadInputID):Bool
 	{
 		var stick = gamepad.mapping.getAnalogStick(id);
 		if (stick == null)
 			return false;
-		
-		//no matter what status we're checking for, we do two tests: 
+
+		//no matter what status we're checking for, we do two tests:
 		//easy : both values are exactly the same (both JUST_PRESSED, both JUST_RELEASED)
 		//!easy: one axis == status, other axis == RELEASED || JUST_RELEASED
-		
+
 		//if we're checking for JUST_RELEASED: one axis must be released and the other not pressed  (you just released one axis, and the other one is not pressed either)
 		//if we're checking for JUST_PRESSED:  one axis must be pressed  and the other not pressed  (it was released before, but now you have just moved it)
-		
+
 		var xVal = checkRaw(stick.x, status);
 		var yVal = checkRaw(stick.y, status);
-		
+
 		if (xVal && yVal)
 		{
 			return true;
 		}
-		
+
 		if (xVal)
 		{
 			var yReleased = checkRaw(stick.y, RELEASED);
 			var yJustReleased = checkRaw(stick.y, JUST_RELEASED);
-			if (yReleased || yJustReleased) 
+			if (yReleased || yJustReleased)
 			{
 				return true;
 			}
 		}
-		
+
 		if (yVal)
 		{
 			var xReleased = checkRaw(stick.x, RELEASED);
@@ -69,30 +69,30 @@ class FlxGamepadAnalogStateList
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
-	private inline function checkX(id:FlxGamepadInputID):Bool
+
+	inline function checkX(id:FlxGamepadInputID):Bool
 	{
 		var stick = gamepad.mapping.getAnalogStick(id);
 		if (stick == null)
 			return false;
 		return checkRaw(stick.x, status);
 	}
-	
-	private inline function checkY(id:FlxGamepadInputID):Bool
+
+	inline function checkY(id:FlxGamepadInputID):Bool
 	{
 		var stick = gamepad.mapping.getAnalogStick(id);
 		if (stick == null)
 			return false;
 		return checkRaw(stick.y, status);
 	}
-	
-	private inline function checkRaw(RawID:Int, Status:FlxInputState):Bool
+
+	inline function checkRaw(RawID:Int, Status:FlxInputState):Bool
 	{
 		#if FLX_JOYSTICK_API
-		//in legacy this is the axis index and not the RawID, 
+		//in legacy this is the axis index and not the RawID,
 		//so we do a reverse lookup to get the rawID for a "fake" button
 		RawID = gamepad.mapping.axisIndexToRawID(RawID);
 		#end

--- a/flixel/input/gamepad/lists/FlxGamepadAnalogValueList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadAnalogValueList.hx
@@ -9,34 +9,34 @@ import flixel.input.gamepad.FlxGamepadInputID;
 @:keep
 class FlxGamepadAnalogValueList
 {
-	private var gamepad:FlxGamepad;
-	
+	var gamepad:FlxGamepad;
+
 	public var LEFT_STICK_X   (get, never):Float; inline function get_LEFT_STICK_X()  return getXAxis(FlxGamepadInputID.LEFT_ANALOG_STICK);
 	public var LEFT_STICK_Y   (get, never):Float; inline function get_LEFT_STICK_Y()  return getYAxis(FlxGamepadInputID.LEFT_ANALOG_STICK);
 	public var RIGHT_STICK_X  (get, never):Float; inline function get_RIGHT_STICK_X() return getXAxis(FlxGamepadInputID.RIGHT_ANALOG_STICK);
 	public var RIGHT_STICK_Y  (get, never):Float; inline function get_RIGHT_STICK_Y() return getYAxis(FlxGamepadInputID.RIGHT_ANALOG_STICK);
 	public var LEFT_TRIGGER   (get, never):Float; inline function get_LEFT_TRIGGER()  return getAxis (FlxGamepadInputID.LEFT_TRIGGER);
 	public var RIGHT_TRIGGER  (get, never):Float; inline function get_RIGHT_TRIGGER() return getAxis (FlxGamepadInputID.RIGHT_TRIGGER);
-	
+
 	public var POINTER_X(get, never):Float; inline function get_POINTER_X() return getAxis (FlxGamepadInputID.POINTER_X);
 	public var POINTER_Y(get, never):Float; inline function get_POINTER_Y() return getAxis (FlxGamepadInputID.POINTER_Y);
-	
+
 	public function new(gamepad:FlxGamepad)
 	{
 		this.gamepad = gamepad;
 	}
-	
-	private inline function getAxis(id:FlxGamepadInputID):Float
+
+	inline function getAxis(id:FlxGamepadInputID):Float
 	{
 		return gamepad.getAxis(id);
 	}
-	
-	private inline function getXAxis(id:FlxGamepadInputID):Float
+
+	inline function getXAxis(id:FlxGamepadInputID):Float
 	{
 		return gamepad.getXAxis(id);
 	}
-	
-	private inline function getYAxis(id:FlxGamepadInputID):Float
+
+	inline function getYAxis(id:FlxGamepadInputID):Float
 	{
 		return gamepad.getYAxis(id);
 	}

--- a/flixel/input/gamepad/lists/FlxGamepadMotionValueList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadMotionValueList.hx
@@ -9,7 +9,7 @@ import flixel.input.gamepad.FlxGamepad;
 @:keep
 class FlxGamepadMotionValueList
 {
-	private var gamepad:FlxGamepad;
+	var gamepad:FlxGamepad;
 
 	@:allow(flixel.input.gamepad.FlxGamepad)
 	/**
@@ -31,14 +31,14 @@ class FlxGamepadMotionValueList
 		this.gamepad = gamepad;
 	}
 
-	private inline function getAxis(id:FlxGamepadInputID):Float
+	inline function getAxis(id:FlxGamepadInputID):Float
 	{
 		if (!isSupported)
 			return 0;
 		return gamepad.getAxis(id);
 	}
 
-	private inline function get_isSupported():Bool
+	inline function get_isSupported():Bool
 	{
 		return gamepad.mapping.supportsMotion;
 	}

--- a/flixel/input/gamepad/lists/FlxGamepadPointerValueList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadPointerValueList.hx
@@ -9,7 +9,7 @@ import flixel.input.gamepad.FlxGamepad;
 @:keep
 class FlxGamepadPointerValueList
 {
-	private var gamepad:FlxGamepad;
+	var gamepad:FlxGamepad;
 
 	/**
 	 * whether or not the current gamepad model supports any pointer features (IR Camera, touch surface, etc)
@@ -32,14 +32,14 @@ class FlxGamepadPointerValueList
 		this.gamepad = gamepad;
 	}
 
-	private inline function getAxis(id:FlxGamepadInputID):Float
+	inline function getAxis(id:FlxGamepadInputID):Float
 	{
 		if (!isSupported)
 			return 0;
 		return gamepad.getAxis(id);
 	}
 
-	private inline function get_isSupported():Bool
+	inline function get_isSupported():Bool
 	{
 		return gamepad.mapping.supportsPointer;
 	}

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -12,20 +12,20 @@ class FlxGamepadMapping
 {
 	public var supportsMotion:Bool = false;
 	public var supportsPointer:Bool = false;
-	
+
 	public var leftStick:FlxGamepadAnalogStick;
 	public var rightStick:FlxGamepadAnalogStick;
-	
+
 	@:allow(flixel.input.gamepad.FlxGamepad)
-	private var attachment(default, set):FlxGamepadAttachment = NONE;
-	
-	private var manufacturer:Manufacturer;
-	
-	public function new(?attachment:FlxGamepadAttachment) 
+	var attachment(default, set):FlxGamepadAttachment = NONE;
+
+	var manufacturer:Manufacturer;
+
+	public function new(?attachment:FlxGamepadAttachment)
 	{
 		if (attachment != null)
 			this.attachment = attachment;
-		
+
 		#if flash
 		manufacturer = switch (Capabilities.manufacturer)
 		{
@@ -34,12 +34,12 @@ class FlxGamepadMapping
 			default: Unknown;
 		}
 		#end
-		
+
 		initValues();
 	}
-	
-	private function initValues():Void {}
-	
+
+	function initValues():Void {}
+
 	public function getAnalogStick(ID:FlxGamepadInputID):FlxGamepadAnalogStick
 	{
 		return switch (ID)
@@ -52,7 +52,7 @@ class FlxGamepadMapping
 				null;
 		}
 	}
-	
+
 	/**
 	 * Given a raw hardware code, return the "universal" ID
 	 */
@@ -60,7 +60,7 @@ class FlxGamepadMapping
 	{
 		return FlxGamepadInputID.NONE;
 	}
-	
+
 	/**
 	 * Given an ID, return the raw hardware code
 	 */
@@ -68,12 +68,12 @@ class FlxGamepadMapping
 	{
 		return -1;
 	}
-	
+
 	public function isAxisForMotion(ID:FlxGamepadInputID):Bool
 	{
 		return false;
 	}
-	
+
 	/**
 	 * Whether this axis needs to be flipped
 	 */
@@ -81,7 +81,7 @@ class FlxGamepadMapping
 	{
 		return false;
 	}
-	
+
 	#if FLX_JOYSTICK_API
 	/**
 	 * Given an axis index value like 0-6, figures out which input that
@@ -91,14 +91,14 @@ class FlxGamepadMapping
 	{
 		return -1;
 	}
-	
+
 	public function checkForFakeAxis(ID:FlxGamepadInputID):Int
 	{
 		return -1;
 	}
 	#end
-	
-	private function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment
+
+	function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment
 	{
 		return this.attachment = attachment;
 	}

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -6,20 +6,20 @@ import flixel.input.gamepad.id.LogitechID;
 class LogitechMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API
-	private static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 20;
-	private static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 21;
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 20;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 21;
 
-	private static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 22;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 23;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 22;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 23;
 	#end
-	
-	override function initValues():Void 
+
+	override function initValues():Void
 	{
-		leftStick = LogitechID.LEFT_ANALOG_STICK; 
-		rightStick = LogitechID.RIGHT_ANALOG_STICK; 
+		leftStick = LogitechID.LEFT_ANALOG_STICK;
+		rightStick = LogitechID.RIGHT_ANALOG_STICK;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -52,7 +52,7 @@ class LogitechMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -88,9 +88,9 @@ class LogitechMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
+
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X;
 			else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y;

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -5,13 +5,13 @@ import flixel.input.gamepad.id.MFiID;
 
 class MFiMapping extends FlxGamepadMapping
 {
-	override function initValues():Void 
+	override function initValues():Void
 	{
 		leftStick = MFiID.LEFT_ANALOG_STICK;
 		rightStick = MFiID.RIGHT_ANALOG_STICK;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -41,8 +41,8 @@ class MFiMapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -78,9 +78,9 @@ class MFiMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
+
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		//the axis index values for this don't overlap with anything so we can just return the original values!
 		return axisID;

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -7,22 +7,22 @@ import flixel.input.gamepad.id.MayflashWiiRemoteID;
 class MayflashWiiRemoteMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API
-	private static inline var REMOTE_DPAD_X:Int = 16;
-	private static inline var REMOTE_DPAD_Y:Int = 17;
+	static inline var REMOTE_DPAD_X:Int = 16;
+	static inline var REMOTE_DPAD_Y:Int = 17;
 
-	private static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 18;
-	private static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 19;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 20;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 21;
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 18;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 19;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 20;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 21;
 	#end
-	
-	override function initValues():Void 
+
+	override function initValues():Void
 	{
 		// but you'll only get non-zero values for it when the Nunchuk is attached
 		supportsPointer = true;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (attachment)
 		{
@@ -31,8 +31,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case NONE: getIDDefault(rawID);
 		}
 	}
-	
-	private function getIDClassicController(rawID:Int):FlxGamepadInputID
+
+	function getIDClassicController(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -62,8 +62,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
-	private function getIDNunchuk(rawID:Int):FlxGamepadInputID
+
+	function getIDNunchuk(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -88,8 +88,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 				NONE;
 		}
 	}
-	
-	private function getIDDefault(rawID:Int):FlxGamepadInputID
+
+	function getIDDefault(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -107,8 +107,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			default: NONE;
 		}
 	}
-	
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (attachment)
 		{
@@ -117,8 +117,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case NONE: getRawDefault(ID);
 		}
 	}
-	
-	private function getRawClassicController(ID:FlxGamepadInputID):Int
+
+	function getRawClassicController(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -150,8 +150,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			default: getRawDefault(ID);
 		}
 	}
-	
-	private function getRawNunchuk(ID:FlxGamepadInputID):Int
+
+	function getRawNunchuk(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -177,8 +177,8 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
-	private function getRawDefault(ID:FlxGamepadInputID):Int
+
+	function getRawDefault(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -196,9 +196,9 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
+
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		if (attachment == WII_NUNCHUCK || attachment == WII_CLASSIC_CONTROLLER)
 		{
@@ -214,16 +214,16 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			else if (axisID == rightStick.y)
 				return REMOTE_DPAD_Y;
 		}
-		
+
 		if (axisID == leftStick.x)
 			return RIGHT_ANALOG_STICK_FAKE_X;
 		else if (axisID == rightStick.y)
 			return RIGHT_ANALOG_STICK_FAKE_Y;
-		
+
 		return axisID;
 	}
-	
-	override public function checkForFakeAxis(ID:FlxGamepadInputID):Int 
+
+	override public function checkForFakeAxis(ID:FlxGamepadInputID):Int
 	{
 		if (attachment == WII_NUNCHUCK)
 		{
@@ -240,21 +240,21 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		return -1;
 	}
 	#end
-	
-	override function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment 
+
+	override function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment
 	{
 		leftStick = switch (attachment)
 		{
 			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.LEFT_ANALOG_STICK;
 			case NONE: MayflashWiiRemoteID.REMOTE_DPAD;
 		}
-		
+
 		rightStick = switch (attachment)
 		{
 			case WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.RIGHT_ANALOG_STICK;
 			default: null;
 		}
-		
+
 		return super.set_attachment(attachment);
 	}
 }

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -6,20 +6,20 @@ import flixel.input.gamepad.id.OUYAID;
 class OUYAMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API
-	private static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 19;
-	private static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 20;
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 19;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 20;
 
-	private static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 21;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 22;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 21;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 22;
 	#end
-	
-	override function initValues():Void 
+
+	override function initValues():Void
 	{
 		leftStick = OUYAID.LEFT_ANALOG_STICK;
 		rightStick = OUYAID.RIGHT_ANALOG_STICK;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -49,8 +49,8 @@ class OUYAMapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -80,9 +80,9 @@ class OUYAMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
+
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X;
 			else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y;

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -6,23 +6,23 @@ import flixel.input.gamepad.id.PS4ID;
 class PS4Mapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API
-	private static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 21;
-	private static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 22;
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 21;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 22;
 
-	private static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 23;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 24;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 23;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 24;
 
-	private static inline var LEFT_TRIGGER_FAKE:Int = 25;
-	private static inline var RIGHT_TRIGGER_FAKE:Int = 26;
+	static inline var LEFT_TRIGGER_FAKE:Int = 25;
+	static inline var RIGHT_TRIGGER_FAKE:Int = 26;
 	#end
-	
-	override function initValues():Void 
+
+	override function initValues():Void
 	{
 		leftStick = PS4ID.LEFT_ANALOG_STICK;
 		rightStick = PS4ID.RIGHT_ANALOG_STICK;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -52,8 +52,8 @@ class PS4Mapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -89,9 +89,9 @@ class PS4Mapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
+
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		//Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X;

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -5,13 +5,13 @@ import flixel.input.gamepad.id.PSVitaID;
 
 class PSVitaMapping extends FlxGamepadMapping
 {
-	override function initValues():Void 
+	override function initValues():Void
 	{
 		leftStick = PSVitaID.LEFT_ANALOG_STICK;
 		rightStick = PSVitaID.RIGHT_ANALOG_STICK;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -38,8 +38,8 @@ class PSVitaMapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -66,8 +66,8 @@ class PSVitaMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
-	override public function isAxisFlipped(axisID:Int):Bool 
+
+	override public function isAxisFlipped(axisID:Int):Bool
 	{
 		return axisID == PSVitaID.LEFT_ANALOG_STICK.y ||
 			axisID == PSVitaID.RIGHT_ANALOG_STICK.y;

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -7,20 +7,20 @@ import flixel.input.gamepad.id.WiiRemoteID;
 class WiiRemoteMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API
-	private static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 20;
-	private static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 21;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 22;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 23;
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 20;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 21;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 22;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 23;
 	#end
-	
-	override function initValues():Void 
+
+	override function initValues():Void
 	{
 		supportsMotion = true;
 		//when Julian updates his driver, this can be set to "true"
 		supportsPointer = false;
 	}
-	
-	override public function getID(rawID:Int):FlxGamepadInputID 
+
+	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (attachment)
 		{
@@ -29,8 +29,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case NONE: getIDDefault(rawID);
 		}
 	}
-	
-	private function getIDClassicController(rawID:Int):FlxGamepadInputID
+
+	function getIDClassicController(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -62,8 +62,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
-	private function getIDNunchuk(rawID:Int):FlxGamepadInputID
+
+	function getIDNunchuk(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -88,8 +88,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 				NONE;
 		}
 	}
-	
-	private function getIDDefault(rawID:Int):FlxGamepadInputID
+
+	function getIDDefault(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -107,8 +107,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			default: NONE;
 		}
 	}
-	
-	override public function getRawID(ID:FlxGamepadInputID):Int 
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (attachment)
 		{
@@ -117,8 +117,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case NONE: getRawDefault(ID);
 		}
 	}
-	
-	private function getRawClassicController(ID:FlxGamepadInputID):Int
+
+	function getRawClassicController(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -150,8 +150,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
-	private function getRawNunchuk(ID:FlxGamepadInputID):Int
+
+	function getRawNunchuk(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -177,8 +177,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
-	private function getRawDefault(ID:FlxGamepadInputID):Int
+
+	function getRawDefault(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
 		{
@@ -198,8 +198,8 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
-	override public function isAxisForMotion(ID:FlxGamepadInputID):Bool 
+
+	override public function isAxisForMotion(ID:FlxGamepadInputID):Bool
 	{
 		if (attachment == NONE)
 		{
@@ -213,15 +213,15 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 		return false;
 	}
-	
-	override public function isAxisFlipped(axisID:Int):Bool 
+
+	override public function isAxisFlipped(axisID:Int):Bool
 	{
 		return axisID == WiiRemoteID.LEFT_TRIGGER_FAKE;
 	}
-	
+
 	#if FLX_JOYSTICK_API
 	//Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		//return null for this unused access so it doesn't overlap a button input
 		if (attachment == NONE && axisID == WiiRemoteID.REMOTE_NULL_AXIS)
@@ -229,7 +229,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		//return null for this unused access so it doesn't overlap a button input
 		else if (attachment == WII_NUNCHUCK && axisID == WiiRemoteID.NUNCHUK_NULL_AXIS)
 			return -1;
-		
+
 		if (attachment == WII_NUNCHUCK || attachment == WII_CLASSIC_CONTROLLER)
 		{
 			if (axisID == leftStick.x)
@@ -244,38 +244,38 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			else if (axisID == leftStick.y)
 				return WiiRemoteID.REMOTE_DPAD_Y;
 		}
-		
+
 		if (axisID == rightStick.x)
 			return RIGHT_ANALOG_STICK_FAKE_X;
 		else if (axisID == rightStick.y)
 			return RIGHT_ANALOG_STICK_FAKE_Y;
-		
+
 		return axisID;
 	}
 
-	override public function checkForFakeAxis(ID:FlxGamepadInputID):Int 
+	override public function checkForFakeAxis(ID:FlxGamepadInputID):Int
 	{
 		if (attachment == WII_NUNCHUCK && ID == FlxGamepadInputID.LEFT_TRIGGER)
 			return WiiRemoteID.NUNCHUK_Z;
-	
+
 		return -1;
 	}
 	#end
-	
-	override function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment 
+
+	override function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment
 	{
 		leftStick = switch (attachment)
 		{
 			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: WiiRemoteID.LEFT_ANALOG_STICK;
 			case NONE: WiiRemoteID.REMOTE_DPAD;
 		}
-		
+
 		rightStick = switch (attachment)
 		{
 			case WII_CLASSIC_CONTROLLER: WiiRemoteID.RIGHT_ANALOG_STICK;
 			default: null;
 		}
-		
+
 		return super.set_attachment(attachment);
 	}
 }

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -6,22 +6,22 @@ import flixel.input.gamepad.id.XInputID;
 class XInputMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API
-	private static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 15;
-	private static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 16;
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 15;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 16;
 
-	private static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 17;
-	private static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 18;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 17;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 18;
 
-	private static inline var LEFT_TRIGGER_FAKE:Int = 19;
-	private static inline var RIGHT_TRIGGER_FAKE:Int = 20;
+	static inline var LEFT_TRIGGER_FAKE:Int = 19;
+	static inline var RIGHT_TRIGGER_FAKE:Int = 20;
 	#end
-	
-	override function initValues():Void 
+
+	override function initValues():Void
 	{
 		leftStick = XInputID.LEFT_ANALOG_STICK;
 		rightStick = XInputID.RIGHT_ANALOG_STICK;
 	}
-	
+
 	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
@@ -59,7 +59,7 @@ class XInputMapping extends FlxGamepadMapping
 			case _: NONE;
 		}
 	}
-	
+
 	override public function getRawID(ID:FlxGamepadInputID):Int
 	{
 		return switch (ID)
@@ -96,20 +96,20 @@ class XInputMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-	
+
 	#if flash
 	override public function isAxisFlipped(axisID:Int):Bool
-	{ 
+	{
 		if (manufacturer == GooglePepper)
 			return false;
-		
+
 		return axisID == XInputID.LEFT_ANALOG_STICK.y ||
 			axisID == XInputID.RIGHT_ANALOG_STICK.y;
 	}
 	#end
-	
+
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int 
+	override public function axisIndexToRawID(axisID:Int):Int
 	{
 		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X;

--- a/flixel/input/keyboard/FlxKeyboard.hx
+++ b/flixel/input/keyboard/FlxKeyboard.hx
@@ -13,17 +13,17 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 {
 	#if !web
 	/**
-	 * Function and numpad keycodes on native targets are incorrect, 
+	 * Function and numpad keycodes on native targets are incorrect,
 	 * this workaround fixes that. Thanks @HaxePunk!
 	 * @see https://github.com/openfl/openfl-native/issues/193
 	 */
-	private var _nativeCorrection:Map<String, Int>;
+	var _nativeCorrection:Map<String, Int>;
 	#end
-	
+
 	public function new()
 	{
 		super(FlxKeyList);
-		
+
 		for (code in FlxKey.fromStringMap)
 		{
 			if (code != FlxKey.ANY && code != FlxKey.NONE)
@@ -33,10 +33,10 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 				_keyListMap.set(code, input);
 			}
 		}
-		
+
 		#if !web
 			_nativeCorrection = new Map<String, Int>();
-			
+
 			_nativeCorrection.set("0_64", FlxKey.INSERT);
 			_nativeCorrection.set("0_65", FlxKey.END);
 			_nativeCorrection.set("0_67", FlxKey.PAGEDOWN);
@@ -46,7 +46,7 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			_nativeCorrection.set("123_222", FlxKey.LBRACKET);
 			_nativeCorrection.set("125_187", FlxKey.RBRACKET);
 			_nativeCorrection.set("126_233", FlxKey.GRAVEACCENT);
-			
+
 			_nativeCorrection.set("0_80", FlxKey.F1);
 			_nativeCorrection.set("0_81", FlxKey.F2);
 			_nativeCorrection.set("0_82", FlxKey.F3);
@@ -58,7 +58,7 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			_nativeCorrection.set("0_88", FlxKey.F9);
 			_nativeCorrection.set("0_89", FlxKey.F10);
 			_nativeCorrection.set("0_90", FlxKey.F11);
-			
+
 			_nativeCorrection.set("48_224", FlxKey.ZERO);
 			_nativeCorrection.set("49_38", FlxKey.ONE);
 			_nativeCorrection.set("50_233", FlxKey.TWO);
@@ -69,7 +69,7 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			_nativeCorrection.set("55_232", FlxKey.SEVEN);
 			_nativeCorrection.set("56_95", FlxKey.EIGHT);
 			_nativeCorrection.set("57_231", FlxKey.NINE);
-			
+
 			_nativeCorrection.set("48_64", FlxKey.NUMPADZERO);
 			_nativeCorrection.set("49_65", FlxKey.NUMPADONE);
 			_nativeCorrection.set("50_66", FlxKey.NUMPADTWO);
@@ -80,7 +80,7 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			_nativeCorrection.set("55_71", FlxKey.NUMPADSEVEN);
 			_nativeCorrection.set("56_72", FlxKey.NUMPADEIGHT);
 			_nativeCorrection.set("57_73", FlxKey.NUMPADNINE);
-			
+
 			_nativeCorrection.set("43_75", FlxKey.NUMPADPLUS);
 			_nativeCorrection.set("45_77", FlxKey.NUMPADMINUS);
 			_nativeCorrection.set("47_79", FlxKey.SLASH);
@@ -88,11 +88,11 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			_nativeCorrection.set("42_74", FlxKey.NUMPADMULTIPLY);
 		#end
 	}
-	
-	override private function onKeyUp(event:KeyboardEvent):Void
+
+	override function onKeyUp(event:KeyboardEvent):Void
 	{
 		super.onKeyUp(event);
-		
+
 		// Debugger toggle
 		#if FLX_DEBUG
 			if (FlxG.game.debugger != null && inKeyArray(FlxG.debugger.toggleKeys, event))
@@ -101,11 +101,11 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			}
 		#end
 	}
-	
-	override private function onKeyDown(event:KeyboardEvent):Void
+
+	override function onKeyDown(event:KeyboardEvent):Void
 	{
 		super.onKeyDown(event);
-		
+
 		// Attempted to cancel the replay?
 		#if FLX_RECORD
 			if (FlxG.game.replaying && !inKeyArray(FlxG.debugger.toggleKeys, event) && inKeyArray(FlxG.vcr.cancelKeys, event))
@@ -114,8 +114,8 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			}
 		#end
 	}
-	
-	override private function resolveKeyCode(e:KeyboardEvent):Int
+
+	override function resolveKeyCode(e:KeyboardEvent):Int
 	{
 		#if web
 			return e.keyCode;
@@ -124,49 +124,49 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 			return (code == null) ? e.keyCode : code;
 		#end
 	}
-	
+
 	/**
 	 * If any keys are not "released",
 	 * this function will return an array indicating
 	 * which keys are pressed and what state they are in.
-	 * 
+	 *
 	 * @return	An array of key state data. Null if there is no data.
 	 */
 	@:allow(flixel.system.replay.FlxReplay)
-	private function record():Array<CodeValuePair>
+	function record():Array<CodeValuePair>
 	{
 		var data:Array<CodeValuePair> = null;
-		
+
 		for (key in _keyListArray)
 		{
 			if (key == null || key.released)
 			{
 				continue;
 			}
-			
+
 			if (data == null)
 			{
 				data = new Array<CodeValuePair>();
 			}
-			
+
 			data.push(new CodeValuePair(key.ID, key.current));
 		}
-		
+
 		return data;
 	}
-	
+
 	/**
 	 * Part of the keystroke recording system.
 	 * Takes data about key presses and sets it into array.
-	 * 
+	 *
 	 * @param	Record	Array of data about key states.
 	 */
 	@:allow(flixel.system.replay.FlxReplay)
-	private function playback(Record:Array<CodeValuePair>):Void
+	function playback(Record:Array<CodeValuePair>):Void
 	{
 		var i:Int = 0;
 		var l:Int = Record.length;
-		
+
 		while (i < l)
 		{
 			var o = Record[i++];

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -39,18 +39,18 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var enabled:Bool = true;
 	/**
-	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up, 
+	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up,
 	 * it will have a positive value and vice versa. Otherwise the value will be 0.
 	 */
 	public var wheel(default, null):Int = 0;
-	
+
 	/**
-	 * A display container for the mouse cursor. It is a child of FlxGame and 
+	 * A display container for the mouse cursor. It is a child of FlxGame and
 	 * sits at the right "height". Not used on flash with the native cursor API.
 	 */
 	public var cursorContainer(default, null):Sprite;
 	/**
-	 * Used to toggle the visiblity of the mouse cursor - works on both 
+	 * Used to toggle the visiblity of the mouse cursor - works on both
 	 * the flixel and the system cursor, depending on which one is active.
 	 */
 	public var visible(default, set):Bool = #if mobile false #else true #end;
@@ -118,64 +118,64 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var justPressedTimeInTicksMiddle(get, never):Int;
 	#end
-	
+
 	/**
 	 * The left mouse button.
 	 */
 	@:allow(flixel.input.mouse.FlxMouseButton)
-	private var _leftButton:FlxMouseButton;
-	
+	var _leftButton:FlxMouseButton;
+
 	#if FLX_MOUSE_ADVANCED
 	/**
 	 * The middle mouse button.
 	 */
 	@:allow(flixel.input.mouse.FlxMouseButton)
-	private var _middleButton:FlxMouseButton;
+	var _middleButton:FlxMouseButton;
 	/**
 	 * The right mouse button.
 	 */
 	@:allow(flixel.input.mouse.FlxMouseButton)
-	private var _rightButton:FlxMouseButton;
+	var _rightButton:FlxMouseButton;
 	#end
-	
+
 	/**
 	 * This is just a reference to the current cursor image, if there is one.
 	 */
-	private var _cursor:Bitmap = null;
-	private var _cursorBitmapData:BitmapData;
-	private var _wheelUsed:Bool = false;
-	private var _visibleWhenFocusLost:Bool = true;
-	
+	var _cursor:Bitmap = null;
+	var _cursorBitmapData:BitmapData;
+	var _wheelUsed:Bool = false;
+	var _visibleWhenFocusLost:Bool = true;
+
 	/**
 	 * Helper variables for recording purposes.
 	 */
-	private var _lastX:Int = 0;
-	private var _lastY:Int = 0;
-	private var _lastWheel:Int = 0;
-	private var _lastLeftButtonState:FlxInputState;
-	
+	var _lastX:Int = 0;
+	var _lastY:Int = 0;
+	var _lastWheel:Int = 0;
+	var _lastLeftButtonState:FlxInputState;
+
 	/**
 	 * Helper variables to see if the mouse has moved since the last update.
 	 */
-	private var _prevX:Int = 0;
-	private var _prevY:Int = 0;
-	
+	var _prevX:Int = 0;
+	var _prevY:Int = 0;
+
 	//Helper variable for cleaning up memory
-	private var _stage:Stage;
-	
+	var _stage:Stage;
+
 	/**
 	 * Helper variables for flash native cursors
 	 */
 	#if FLX_NATIVE_CURSOR
-	private var _cursorDefaultName:String = "defaultCursor";
-	private var _currentNativeCursor:String;
-	private var _matrix = new Matrix();
+	var _cursorDefaultName:String = "defaultCursor";
+	var _currentNativeCursor:String;
+	var _matrix = new Matrix();
 	#end
-	
+
 	/**
-	 * Load a new mouse cursor graphic - if you're using native cursors on flash, 
+	 * Load a new mouse cursor graphic - if you're using native cursors on flash,
 	 * check registerNativeCursor() for more control.
-	 * 
+	 *
 	 * @param   Graphic   The image you want to use for the cursor.
 	 * @param   Scale     Change the size of the cursor.
 	 * @param   XOffset   The number of pixels between the mouse's screen position and the graphic's top left corner.
@@ -191,12 +191,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			FlxDestroyUtil.removeChild(cursorContainer, _cursor);
 		}
 		#end
-		
+
 		if (Graphic == null)
 		{
 			Graphic = new GraphicCursor(0, 0);
 		}
-		
+
 		if (Std.is(Graphic, Class))
 		{
 			_cursor = Type.createInstance(Graphic, []);
@@ -213,29 +213,29 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			_cursor = new Bitmap(new GraphicCursor(0, 0));
 		}
-		
+
 		_cursor.x = XOffset;
 		_cursor.y = YOffset;
 		_cursor.scaleX = Scale;
 		_cursor.scaleY = Scale;
-		
+
 		#if FLX_NATIVE_CURSOR
 		if (XOffset < 0 || YOffset < 0)
 		{
 			throw "Negative offsets aren't supported for native cursors.";
 		}
-		
+
 		if (Scale < 0)
 		{
 			throw "Negative scale isn't supported for native cursors.";
 		}
-		
+
 		var scaledWidth:Int = Std.int(Scale * _cursor.bitmapData.width);
 		var scaledHeight:Int = Std.int(Scale * _cursor.bitmapData.height);
-		
+
 		var bitmapWidth:Int = scaledWidth + XOffset;
 		var bitmapHeight:Int = scaledHeight + YOffset;
-		
+
 		var cursorBitmap:BitmapData = new BitmapData(bitmapWidth, bitmapHeight, true, 0x0);
 		if (_matrix != null)
 		{
@@ -273,15 +273,15 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	/**
 	 * Set a Native cursor that has been registered by Name
 	 * Warning, you need to use registerNativeCursor() before you use it here
-	 * 
+	 *
 	 * @param   Name   The name ID used when registered
 	 */
 	public function setNativeCursor(Name:String):Void
 	{
 		_currentNativeCursor = Name;
-		
+
 		Mouse.show();
-		
+
 		//Flash requires the use of AUTO before a custom cursor to work
 		Mouse.cursor = MouseCursor.AUTO;
 		Mouse.cursor = _currentNativeCursor;
@@ -289,7 +289,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 	/**
 	 * Shortcut to register a native cursor in flash
-	 * 
+	 *
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 * @param   Show         Whether to call setNativeCursor afterwards
@@ -301,7 +301,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 	/**
 	 * Shortcut to register a simple MouseCursorData
-	 * 
+	 *
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 * @since   4.2.0
@@ -310,22 +310,22 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		var cursorVector = new Vector<BitmapData>();
 		cursorVector[0] = CursorBitmap;
-		
+
 		if (CursorBitmap.width > 32 || CursorBitmap.height > 32)
 			throw "BitmapData files used for native cursors cannot exceed 32x32 pixels due to an OS limitation.";
-		
+
 		var cursorData = new MouseCursorData();
 		cursorData.hotSpot = new Point(0, 0);
 		cursorData.data = cursorVector;
-		
+
 		registerNativeCursor(Name, cursorData);
-		
+
 		return cursorData;
 	}
 
 	/**
 	 * Shortcut to create and set a simple MouseCursorData
-	 * 
+	 *
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 */
@@ -337,7 +337,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		return data;
 	}
 	#end
-	
+
 	/**
 	 * Clean up memory. Internal use only.
 	 */
@@ -348,96 +348,96 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			_stage.removeEventListener(MouseEvent.MOUSE_DOWN, _leftButton.onDown);
 			_stage.removeEventListener(MouseEvent.MOUSE_UP, _leftButton.onUp);
-			
+
 			#if FLX_MOUSE_ADVANCED
 			_stage.removeEventListener(untyped MouseEvent.MIDDLE_MOUSE_DOWN, _middleButton.onDown);
 			_stage.removeEventListener(untyped MouseEvent.MIDDLE_MOUSE_UP, _middleButton.onUp);
 			_stage.removeEventListener(untyped MouseEvent.RIGHT_MOUSE_DOWN, _rightButton.onDown);
 			_stage.removeEventListener(untyped MouseEvent.RIGHT_MOUSE_UP, _rightButton.onUp);
-			
+
 			_stage.removeEventListener(Event.MOUSE_LEAVE, onMouseLeave);
 			#end
-			
+
 			_stage.removeEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
 		}
-		
+
 		cursorContainer = null;
 		_cursor = null;
-		
+
 		#if FLX_NATIVE_CURSOR
 		_matrix = null;
 		#end
-		
+
 		_leftButton = FlxDestroyUtil.destroy(_leftButton);
 		#if FLX_MOUSE_ADVANCED
 		_middleButton = FlxDestroyUtil.destroy(_middleButton);
 		_rightButton = FlxDestroyUtil.destroy(_rightButton);
 		#end
-		
+
 		_cursorBitmapData = FlxDestroyUtil.dispose(_cursorBitmapData);
 		FlxG.signals.gameStarted.remove(onGameStart);
 	}
-	
+
 	/**
 	 * Resets the just pressed/just released flags and sets mouse to not pressed.
 	 */
 	public function reset():Void
 	{
 		_leftButton.reset();
-		
+
 		#if FLX_MOUSE_ADVANCED
 		_middleButton.reset();
 		_rightButton.reset();
 		#end
 	}
-	
+
 	/**
 	 * @param   CursorContainer   The cursor container sprite passed by FlxGame
 	 */
 	@:allow(flixel.FlxG)
-	private function new(CursorContainer:Sprite)
+	function new(CursorContainer:Sprite)
 	{
 		super();
 		cursorContainer = CursorContainer;
 		cursorContainer.mouseChildren = false;
 		cursorContainer.mouseEnabled = false;
-		
+
 		_leftButton = new FlxMouseButton(FlxMouseButtonID.LEFT);
-		
+
 		_stage = Lib.current.stage;
 		_stage.addEventListener(MouseEvent.MOUSE_DOWN, _leftButton.onDown);
 		_stage.addEventListener(MouseEvent.MOUSE_UP, _leftButton.onUp);
-		
+
 		#if FLX_MOUSE_ADVANCED
 		_middleButton = new FlxMouseButton(FlxMouseButtonID.MIDDLE);
 		_rightButton = new FlxMouseButton(FlxMouseButtonID.RIGHT);
-		
+
 		_stage.addEventListener(untyped MouseEvent.MIDDLE_MOUSE_DOWN, _middleButton.onDown);
 		_stage.addEventListener(untyped MouseEvent.MIDDLE_MOUSE_UP, _middleButton.onUp);
 		_stage.addEventListener(untyped MouseEvent.RIGHT_MOUSE_DOWN, _rightButton.onDown);
 		_stage.addEventListener(untyped MouseEvent.RIGHT_MOUSE_UP, _rightButton.onUp);
-		
+
 		_stage.addEventListener(Event.MOUSE_LEAVE, onMouseLeave);
 		#end
-		
+
 		_stage.addEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
-		
+
 		FlxG.signals.gameStarted.add(onGameStart);
 		Mouse.hide();
 	}
-	
+
 	/**
 	 * Called by the internal game loop to update the mouse pointer's position in the game world.
 	 * Also updates the just pressed/just released flags.
 	 */
-	private function update():Void
+	function update():Void
 	{
 		_prevX = x;
 		_prevY = y;
-		
+
 		#if !FLX_UNIT_TEST // Travis segfaults when game.mouseX / Y is accessed
-		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY); 
-		
+		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY);
+
 		//actually position the flixel mouse cursor graphic
 		if (visible)
 		{
@@ -445,14 +445,14 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			cursorContainer.y = FlxG.game.mouseY;
 		}
 		#end
-		
+
 		// Update the buttons
 		_leftButton.update();
 		#if FLX_MOUSE_ADVANCED
 		_middleButton.update();
 		_rightButton.update();
 		#end
-		
+
 		// Update the wheel
 		if (!_wheelUsed)
 		{
@@ -460,17 +460,17 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		_wheelUsed = false;
 	}
-	
+
 	/**
 	 * Called from the main Event.ACTIVATE that is dispatched in FlxGame
 	 */
-	private function onFocus():Void
+	function onFocus():Void
 	{
 		reset();
-		
+
 		#if !FLX_NATIVE_CURSOR
 		set_useSystemCursor(useSystemCursor);
-		
+
 		visible = _visibleWhenFocusLost;
 		#end
 	}
@@ -478,31 +478,31 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	/**
 	 * Called from the main Event.DEACTIVATE that is dispatched in FlxGame
 	 */
-	private function onFocusLost():Void
+	function onFocusLost():Void
 	{
 		#if !FLX_NATIVE_CURSOR
 		_visibleWhenFocusLost = visible;
-		
+
 		if (visible)
 		{
 			visible = false;
 		}
-		
+
 		Mouse.show();
 		#end
 	}
-	
-	private function onGameStart():Void
+
+	function onGameStart():Void
 	{
 		// Call set_visible with the value visible has been initialized with
 		// (unless set in create() of the initial state)
 		set_visible(visible);
 	}
-	
+
 	/**
 	 * Internal event handler for input and focus.
 	 */
-	private function onMouseWheel(FlashEvent:MouseEvent):Void
+	function onMouseWheel(FlashEvent:MouseEvent):Void
 	{
 		if (enabled)
 		{
@@ -510,38 +510,38 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			wheel = FlashEvent.delta;
 		}
 	}
-	
+
 	#if FLX_MOUSE_ADVANCED
 	/**
-	 * We're detecting the mouse leave event to prevent a bug where `pressed` remains true 
+	 * We're detecting the mouse leave event to prevent a bug where `pressed` remains true
 	 * for the middle and right mouse button when pressed and dragged outside the window.
 	 */
-	private inline function onMouseLeave(_):Void
+	inline function onMouseLeave(_):Void
 	{
 		_rightButton.onUp();
 		_middleButton.onUp();
 	}
 	#end
-	
-	private inline function get_justMoved():Bool					 return _prevX != x || _prevY != y;
-	private inline function get_pressed():Bool                       return _leftButton.pressed;
-	private inline function get_justPressed():Bool                   return _leftButton.justPressed;
-	private inline function get_justReleased():Bool                  return _leftButton.justReleased;
-	private inline function get_justPressedTimeInTicks():Int         return _leftButton.justPressedTimeInTicks;
+
+	inline function get_justMoved():Bool					 return _prevX != x || _prevY != y;
+	inline function get_pressed():Bool                       return _leftButton.pressed;
+	inline function get_justPressed():Bool                   return _leftButton.justPressed;
+	inline function get_justReleased():Bool                  return _leftButton.justReleased;
+	inline function get_justPressedTimeInTicks():Int         return _leftButton.justPressedTimeInTicks;
 
 	#if FLX_MOUSE_ADVANCED
-	private inline function get_pressedRight():Bool                  return _rightButton.pressed;
-	private inline function get_justPressedRight():Bool              return _rightButton.justPressed;
-	private inline function get_justReleasedRight():Bool             return _rightButton.justReleased;
-	private inline function get_justPressedTimeInTicksRight():Int    return _rightButton.justPressedTimeInTicks;
-	
-	private inline function get_pressedMiddle():Bool                 return _middleButton.pressed;
-	private inline function get_justPressedMiddle():Bool             return _middleButton.justPressed;
-	private inline function get_justReleasedMiddle():Bool            return _middleButton.justReleased;
-	private inline function get_justPressedTimeInTicksMiddle():Int   return _middleButton.justPressedTimeInTicks;
+	inline function get_pressedRight():Bool                  return _rightButton.pressed;
+	inline function get_justPressedRight():Bool              return _rightButton.justPressed;
+	inline function get_justReleasedRight():Bool             return _rightButton.justReleased;
+	inline function get_justPressedTimeInTicksRight():Int    return _rightButton.justPressedTimeInTicks;
+
+	inline function get_pressedMiddle():Bool                 return _middleButton.pressed;
+	inline function get_justPressedMiddle():Bool             return _middleButton.justPressed;
+	inline function get_justReleasedMiddle():Bool            return _middleButton.justReleased;
+	inline function get_justPressedTimeInTicksMiddle():Int   return _middleButton.justPressedTimeInTicks;
 	#end
-	
-	private function showSystemCursor():Void
+
+	function showSystemCursor():Void
 	{
 		#if FLX_NATIVE_CURSOR
 		Mouse.cursor = MouseCursor.AUTO;
@@ -552,7 +552,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		Mouse.show();
 	}
 
-	private function hideSystemCursor():Void
+	function hideSystemCursor():Void
 	{
 		#if FLX_NATIVE_CURSOR
 		if (_currentNativeCursor != null)
@@ -561,38 +561,38 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		#else
 		Mouse.hide();
-		
+
 		if (visible)
 		{
 			cursorContainer.visible = true;
 		}
 		#end
 	}
-	
-	private function set_useSystemCursor(Value:Bool):Bool
+
+	function set_useSystemCursor(Value:Bool):Bool
 	{
 		if (Value)
 		{
 			showSystemCursor();
-		} 
-		else 
+		}
+		else
 		{
 			hideSystemCursor();
 		}
 		return useSystemCursor = Value;
 	}
-	
-	private function showCursor():Void
+
+	function showCursor():Void
 	{
 		if (useSystemCursor)
 		{
 			Mouse.show();
 		}
-		else 
+		else
 		{
 			if (_cursor == null)
 				load();
-		
+
 			#if FLX_NATIVE_CURSOR
 			Mouse.show();
 			#else
@@ -602,40 +602,40 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 	}
 
-	private function hideCursor():Void
+	function hideCursor():Void
 	{
 		cursorContainer.visible = false;
 		Mouse.hide();
 	}
 
-	private function set_visible(Value:Bool):Bool
+	function set_visible(Value:Bool):Bool
 	{
 		if (Value)
 			showCursor();
-		else 
+		else
 			hideCursor();
-		
+
 		return visible = Value;
 	}
-	
+
 	@:allow(flixel.system.replay.FlxReplay)
-	private function record():MouseRecord
+	function record():MouseRecord
 	{
-		if ((_lastX == _globalScreenX) && (_lastY == _globalScreenY) 
+		if ((_lastX == _globalScreenX) && (_lastY == _globalScreenY)
 			&& (_lastLeftButtonState == _leftButton.current) && (_lastWheel == wheel))
 		{
 			return null;
 		}
-		
+
 		_lastX = _globalScreenX;
 		_lastY = _globalScreenY;
 		_lastLeftButtonState = _leftButton.current;
 		_lastWheel = wheel;
 		return new MouseRecord(_lastX, _lastY, _leftButton.current, _lastWheel);
 	}
-	
+
 	@:allow(flixel.system.replay.FlxReplay)
-	private function playback(Record:MouseRecord):Void
+	function playback(Record:MouseRecord):Void
 	{
 		// Manually dispatch a MOUSE_UP event so that, e.g., FlxButtons click correctly on playback.
 		// Note: some clicks are fast enough to not pass through a frame where they are PRESSED

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -13,42 +13,42 @@ import flixel.util.FlxDestroyUtil;
 
 /**
  * Provides mouse event detection for FlxObjects and FlxSprites (pixel-perfect for those).
- * To use it, initialize the manager and register objects / sprites. 
- * 
+ * To use it, initialize the manager and register objects / sprites.
+ *
  *    FlxG.plugins.add(new FlxMouseEventManager());
  *    var object = new FlxObject();
  *    FlxMouseEventManager.add(object, onMouseDown, onMouseUp, onMouseOver, onMouseOut);
- * 
- * Or simply add a new object and this plugin will initialize itself: 
- * 
+ *
+ * Or simply add a new object and this plugin will initialize itself:
+ *
  *    FlxMouseEventManager.add(object, onMouseDown, onMouseUp, onMouseOver, onMouseOut);
- * 
+ *
  * Also implement the callbacks with the object's type as parameters:
- * 
+ *
  *    function onMouseDown(object:FlxObject) {}
  *    function onMouseUp(object:FlxObject) {}
  *    function onMouseOver(object:FlxObject) {}
- *    function onMouseOut(object:FlxObject) {} 
- * 
+ *    function onMouseOut(object:FlxObject) {}
+ *
  * @author TiagoLr (~~~ ProG4mr ~~~)
  */
 class FlxMouseEventManager extends FlxBasic
 {
-	private static var _registeredObjects:Array<ObjectMouseData<FlxObject>> = [];
-	private static var _mouseOverObjects:Array<ObjectMouseData<FlxObject>> = [];
-	private static var _mouseDownObjects:Array<ObjectMouseData<FlxObject>> = [];
-	private static var _mouseClickedObjects:Array<ObjectMouseData<FlxObject>> = [];
-	
-	private static var _mouseClickedTime:Int = -1;
+	static var _registeredObjects:Array<ObjectMouseData<FlxObject>> = [];
+	static var _mouseOverObjects:Array<ObjectMouseData<FlxObject>> = [];
+	static var _mouseDownObjects:Array<ObjectMouseData<FlxObject>> = [];
+	static var _mouseClickedObjects:Array<ObjectMouseData<FlxObject>> = [];
 
-	private static var _point:FlxPoint = FlxPoint.get();
-	
+	static var _mouseClickedTime:Int = -1;
+
+	static var _point:FlxPoint = FlxPoint.get();
+
 	/**
 	 * The maximum amount of time between two clicks that is considered a double click, in milliseconds.
 	 * @since 4.4.0
 	 */
 	public static var maxDoubleClickDelay:Int = 500;
-	
+
 	/**
 	 * As alternative you can call FlxMouseEventManager.init().
 	 */
@@ -57,7 +57,7 @@ class FlxMouseEventManager extends FlxBasic
 		if (FlxG.plugins.get(FlxMouseEventManager) == null)
 			FlxG.plugins.add(new FlxMouseEventManager());
 	}
-	
+
 	/**
 	 * Adds an object to the FlxMouseEventManager registry. Automatically initializes the plugin.
 	 *
@@ -78,19 +78,19 @@ class FlxMouseEventManager extends FlxBasic
 		?OnMouseOut:T->Void, MouseChildren = false, MouseEnabled = true, PixelPerfect = true, ?MouseButtons:Array<FlxMouseButtonID>):T
 	{
 		init(); // MEManager is initialized and added to plugins if it was not there already.
-		
+
 		var newReg = new ObjectMouseData<T>(Object, OnMouseDown, OnMouseUp, OnMouseOver,
 			OnMouseOut, MouseChildren, MouseEnabled, PixelPerfect, MouseButtons);
-		
+
 		if (Std.is(Object, FlxSprite))
 		{
 			newReg.sprite = cast Object;
 		}
-		
+
 		_registeredObjects.unshift(cast newReg);
 		return Object;
 	}
-	
+
 	/**
 	 * Removes a registered object from the registry.
 	 */
@@ -119,7 +119,7 @@ class FlxMouseEventManager extends FlxBasic
 				reg.destroy();
 			}
 		}
-		
+
 		_registeredObjects.splice(0, _registeredObjects.length);
 		_mouseOverObjects = [];
 		_mouseDownObjects = [];
@@ -138,11 +138,11 @@ class FlxMouseEventManager extends FlxBasic
 		var orderedObjects = new Array<ObjectMouseData<FlxObject>>();
 
 		traverseFlxGroup(FlxG.state, orderedObjects);
-		
+
 		orderedObjects.reverse();
 		_registeredObjects = orderedObjects;
 	}
-	
+
 	/**
 	 * Sets the mouseDown callback associated with an object.
 	 *
@@ -151,13 +151,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseDownCallback<T:FlxObject>(Object:T, OnMouseDown:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseDown = OnMouseDown;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseUp callback associated with an object.
 	 *
@@ -167,13 +167,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseUpCallback<T:FlxObject>(Object:T, OnMouseUp:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseUp = OnMouseUp;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseClick callback associated with an object.
 	 *
@@ -184,13 +184,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseClickCallback<T:FlxObject>(Object:T, OnMouseClick:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseClick = OnMouseClick;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseDoubleClick callback associated with an object.
 	 *
@@ -201,13 +201,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseDoubleClickCallback<T:FlxObject>(Object:T, OnMouseDoubleClick:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseDoubleClick = OnMouseDoubleClick;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseOver callback associated with an object.
 	 *
@@ -217,13 +217,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseOverCallback<T:FlxObject>(Object:T, OnMouseOver:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseOver = OnMouseOver;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseOut callback associated with an object.
 	 *
@@ -233,13 +233,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseOutCallback<T:FlxObject>(Object:T, OnMouseOut:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseOut = OnMouseOut;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseMove callback associated with an object.
 	 *
@@ -250,13 +250,13 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseMoveCallback<T:FlxObject>(Object:T, OnMouseMove:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseMove = OnMouseMove;
 		}
 	}
-	
+
 	/**
 	 * Sets the mouseWheel callback associated with an object.
 	 *
@@ -267,35 +267,35 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setMouseWheelCallback<T:FlxObject>(Object:T, OnMouseWheel:T->Void):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.onMouseWheel = OnMouseWheel;
 		}
 	}
-	
+
 	/**
 	 * Enables/disables mouse behavior for an object.
-	 * 
+	 *
 	 * @param   MouseEnabled   Whether this object will be tested for mouse events.
 	 */
 	public static function setObjectMouseEnabled<T:FlxObject>(Object:T, MouseEnabled:Bool):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.mouseEnabled = MouseEnabled;
 		}
 	}
-	
+
 	/**
 	 * Checks if a registered object is mouseEnabled.
 	 */
 	public static function isObjectMouseEnabled<T:FlxObject>(Object:T):Bool
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			return reg.mouseEnabled;
@@ -305,7 +305,7 @@ class FlxMouseEventManager extends FlxBasic
 			return false;
 		}
 	}
-	
+
 	/**
 	 * Enables/disables mouseChildren for an object.
 	 *
@@ -314,20 +314,20 @@ class FlxMouseEventManager extends FlxBasic
 	public static function setObjectMouseChildren<T:FlxObject>(Object:T, MouseChildren:Bool):Void
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			reg.mouseChildren = MouseChildren;
 		}
 	}
-	
+
 	/**
 	 * Checks if an object allows mouseChildren.
 	 */
 	public static function isObjectMouseChildren<T:FlxObject>(Object:T):Bool
 	{
 		var reg = getRegister(Object);
-		
+
 		if (reg != null)
 		{
 			return reg.mouseChildren;
@@ -337,22 +337,22 @@ class FlxMouseEventManager extends FlxBasic
 			throw new Error("FlxMouseEventManager , isObjectMouseChildren() : object not found");
 		}
 	}
-	
+
 	/**
 	 * @param   MouseButtons    The mouse buttons that can trigger callbacks. Left only by default.
 	 */
 	public static function setObjectMouseButtons<T:FlxObject>(object:T, mouseButtons:Array<FlxMouseButtonID>):Void
 	{
 		var reg = getRegister(object);
-		
+
 		if (reg != null)
 		{
 			reg.mouseButtons = mouseButtons;
 		}
 	}
-	
+
 	@:access(flixel.group.FlxTypedGroup.resolveGroup)
-	private static function traverseFlxGroup(Group:FlxTypedGroup<Dynamic>, OrderedObjects:Array<ObjectMouseData<Dynamic>>):Void
+	static function traverseFlxGroup(Group:FlxTypedGroup<Dynamic>, OrderedObjects:Array<ObjectMouseData<Dynamic>>):Void
 	{
 		for (basic in Group.members)
 		{
@@ -364,7 +364,7 @@ class FlxMouseEventManager extends FlxBasic
 			if (Std.is(basic, FlxObject))
 			{
 				var reg = getRegister(cast basic);
-				
+
 				if (reg != null)
 				{
 					OrderedObjects.push(reg);
@@ -373,13 +373,13 @@ class FlxMouseEventManager extends FlxBasic
 		}
 	}
 
-	private static function getRegister<T:FlxObject>(Object:T, ?Register:Array<ObjectMouseData<FlxObject>>):ObjectMouseData<T>
+	static function getRegister<T:FlxObject>(Object:T, ?Register:Array<ObjectMouseData<FlxObject>>):ObjectMouseData<T>
 	{
 		if (Register == null)
 		{
 			Register = _registeredObjects;
 		}
-		
+
 		for (reg in Register)
 		{
 			if (reg.object == Object)
@@ -387,14 +387,14 @@ class FlxMouseEventManager extends FlxBasic
 				return cast reg;
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	public function new()
 	{
 		super();
-		
+
 		if (_registeredObjects != null)
 		{
 			clearRegistry();
@@ -406,7 +406,7 @@ class FlxMouseEventManager extends FlxBasic
 
 		FlxG.signals.stateSwitched.add(removeAll);
 	}
-	
+
 	override public function destroy():Void
 	{
 		clearRegistry();
@@ -414,45 +414,45 @@ class FlxMouseEventManager extends FlxBasic
 		FlxG.signals.stateSwitched.remove(removeAll);
 		super.destroy();
 	}
-	
+
 	override public function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
-		
+
 		var currentOverObjects = new Array<ObjectMouseData<FlxObject>>();
-		
+
 		for (reg in _registeredObjects)
 		{
 			if (!reg.object.alive || !reg.object.exists || !reg.object.visible || !reg.mouseEnabled)
 			{
 				continue;
 			}
-			
+
 			if (checkOverlap(reg))
 			{
 				currentOverObjects.push(reg);
-				
+
 				if (!reg.mouseChildren)
 				{
 					break;
 				}
 			}
 		}
-		
+
 		// MouseOut - Look for objects that lost mouse over.
 		for (over in _mouseOverObjects)
 		{
 			if (over.onMouseOut != null)
 			{
 				// slightly different logic here - objects whose exists or visible
-				// property has been set to false should also receive a mouse out! 
+				// property has been set to false should also receive a mouse out!
 				if (!over.object.exists || !over.object.visible || getRegister(over.object, currentOverObjects) == null)
 				{
 					over.onMouseOut(over.object);
 				}
 			}
 		}
-		
+
 		// MouseOver - Look for new objects with mouse over.
 		for (current in currentOverObjects)
 		{
@@ -464,7 +464,7 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
-		
+
 		#if FLX_MOUSE
 		// MouseMove - Look for objects with mouse over that have mouseMove callbacks
 		if (FlxG.mouse.justMoved)
@@ -477,7 +477,7 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
-		
+
 		// MouseDown - Look for objects with mouse over when user presses mouse button.
 		for (current in currentOverObjects)
 		{
@@ -492,7 +492,7 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
-		
+
 		// MouseClick/MouseDoubleClick - Look for objects with mouse down first.
 		if (FlxG.mouse.justPressed)
 		{
@@ -504,7 +504,7 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
-		
+
 		// MouseUp - Look for objects with mouse over when user releases mouse button.
 		for (current in currentOverObjects)
 		{
@@ -519,25 +519,25 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
-		
+
 		// MouseClick - Look for objects that had mouse down and now have mouse over when the user releases the mouse button.
 		// DoubleClick - Look for objects that were recently clicked and have just been clicked again.
 		if (_mouseClickedObjects.length > 0 && FlxG.game.ticks - _mouseClickedTime > maxDoubleClickDelay)
 		{
 			_mouseClickedObjects = [];
 		}
-		
+
 		if (FlxG.mouse.justReleased)
 		{
 			_mouseClickedTime = FlxG.game.ticks;
-			
+
 			var previousClickedObjects = _mouseClickedObjects;
-			
+
 			if (_mouseClickedObjects.length > 0)
 			{
 				_mouseClickedObjects = [];
 			}
-			
+
 			for (down in _mouseDownObjects)
 			{
 				if (down.object != null && down.object.exists && down.object.visible && getRegister(down.object, currentOverObjects) != null)
@@ -546,14 +546,14 @@ class FlxMouseEventManager extends FlxBasic
 					{
 						down.onMouseClick(down.object);
 					}
-					
+
 					if (down.onMouseDoubleClick != null)
 					{
 						if (getRegister(down.object, previousClickedObjects) != null)
 						{
 							down.onMouseDoubleClick(down.object);
 						}
-						
+
 						else
 						{
 							_mouseClickedObjects.push(down);
@@ -562,13 +562,13 @@ class FlxMouseEventManager extends FlxBasic
 				}
 			}
 		}
-		
+
 		if (_mouseDownObjects.length > 0 && !FlxG.mouse.pressed)
 		{
 			// if the user just released the mouse OR if the user released the mouse while the window was tabbed out
 			_mouseDownObjects = [];
 		}
-		
+
 		// MouseWheel - Look for objects with mouse over when user spins the mouse wheel.
 		if (FlxG.mouse.wheel != 0)
 		{
@@ -581,11 +581,11 @@ class FlxMouseEventManager extends FlxBasic
 			}
 		}
 		#end
-		
+
 		_mouseOverObjects = currentOverObjects;
 	}
-	
-	private function clearRegistry():Void
+
+	function clearRegistry():Void
 	{
 		_mouseOverObjects = null;
 		_mouseDownObjects = null;
@@ -593,7 +593,7 @@ class FlxMouseEventManager extends FlxBasic
 		_registeredObjects = FlxDestroyUtil.destroyArray(_registeredObjects);
 	}
 
-	private function checkOverlap<T:FlxObject>(Register:ObjectMouseData<T>):Bool
+	function checkOverlap<T:FlxObject>(Register:ObjectMouseData<T>):Bool
 	{
 		for (camera in Register.object.cameras)
 		{
@@ -602,14 +602,14 @@ class FlxMouseEventManager extends FlxBasic
 			if (camera.containsPoint(_point))
 			{
 				_point = FlxG.mouse.getWorldPosition(camera, _point);
-				
+
 				if (checkOverlapWithPoint(Register, _point, camera))
 				{
 					return true;
 				}
 			}
 			#end
-			
+
 			#if FLX_TOUCH
 			for (touch in FlxG.touches.list)
 			{
@@ -617,7 +617,7 @@ class FlxMouseEventManager extends FlxBasic
 				if (camera.containsPoint(_point))
 				{
 					_point = touch.getWorldPosition(camera, _point);
-					
+
 					if (checkOverlapWithPoint(Register, _point, camera))
 					{
 						return true;
@@ -626,23 +626,23 @@ class FlxMouseEventManager extends FlxBasic
 			}
 			#end
 		}
-		
+
 		return false;
 	}
-	
-	private inline function checkOverlapWithPoint<T:FlxObject>(Register:ObjectMouseData<T>, Point:FlxPoint, Camera:FlxCamera):Bool
+
+	inline function checkOverlapWithPoint<T:FlxObject>(Register:ObjectMouseData<T>, Point:FlxPoint, Camera:FlxCamera):Bool
 	{
 		if (Register.pixelPerfect && (Register.sprite != null))
 		{
 			return checkPixelPerfectOverlap(Point, Register.sprite, Camera);
 		}
-		else 
+		else
 		{
 			return Register.object.overlapsPoint(Point, true, Camera);
 		}
 	}
-	
-	private inline function checkPixelPerfectOverlap(Point:FlxPoint, Sprite:FlxSprite, Camera:FlxCamera):Bool
+
+	inline function checkPixelPerfectOverlap(Point:FlxPoint, Sprite:FlxSprite, Camera:FlxCamera):Bool
 	{
 		if (Sprite.angle != 0)
 		{
@@ -670,8 +670,8 @@ private class ObjectMouseData<T:FlxObject> implements IFlxDestroyable
 	public var sprite:FlxSprite;
 	public var mouseButtons:Array<FlxMouseButtonID>;
 	public var currentMouseButton:Null<FlxMouseButtonID>;
-	
-	public function new(object:T, onMouseDown:T->Void, onMouseUp:T->Void, onMouseOver:T->Void, onMouseOut:T->Void, 
+
+	public function new(object:T, onMouseDown:T->Void, onMouseUp:T->Void, onMouseOver:T->Void, onMouseOut:T->Void,
 		mouseChildren:Bool, mouseEnabled:Bool, pixelPerfect:Bool, mouseButtons:Array<FlxMouseButtonID>)
 	{
 		this.object = object;
@@ -684,7 +684,7 @@ private class ObjectMouseData<T:FlxObject> implements IFlxDestroyable
 		this.pixelPerfect = pixelPerfect;
 		this.mouseButtons = (mouseButtons == null) ? [FlxMouseButtonID.LEFT] : mouseButtons;
 	}
-	
+
 	public function destroy():Void
 	{
 		object = null;

--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -15,22 +15,22 @@ import flixel.util.FlxDestroyUtil;
  */
 @:allow(flixel.input.touch.FlxTouchManager)
 class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInput
-{	
+{
 	/**
 	 * The _unique_ ID of this touch. You should not make not any further assumptions
 	 * about this value - IDs are not guaranteed to start from 0 or ascend in order.
 	 * The behavior may vary from device to device.
 	 */
 	public var touchPointID(get, never):Int;
-	
+
 	public var justReleased(get, never):Bool;
 	public var released(get, never):Bool;
 	public var pressed(get, never):Bool;
 	public var justPressed(get, never):Bool;
-	
-	private var input:FlxInput<Int>;
-	private var flashPoint = new Point();
-	
+
+	var input:FlxInput<Int>;
+	var flashPoint = new Point();
+
 	public var justPressedPosition(default, null) = FlxPoint.get();
 	public var justPressedTimeInTicks(default, null):Int = -1;
 
@@ -50,27 +50,27 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		input.ID = pointID;
 		input.reset();
 	}
-	
+
 	/**
 	 * @param	X			stageX touch coordinate
 	 * @param	Y			stageX touch coordinate
 	 * @param	PointID		touchPointID of the touch
 	 */
-	private function new(x:Int = 0, y:Int = 0, pointID:Int = 0)
+	function new(x:Int = 0, y:Int = 0, pointID:Int = 0)
 	{
 		super();
-		
+
 		input = new FlxInput(pointID);
 		setXY(x, y);
 	}
-	
+
 	/**
 	 * Called by the internal game loop to update the just pressed/just released flags.
 	 */
-	private function update():Void
+	function update():Void
 	{
 		input.update();
-		
+
 		if (justPressed)
 		{
 			justPressedPosition.set(screenX, screenY);
@@ -83,42 +83,42 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		}
 		#end
 	}
-	
+
 	/**
 	 * Function for updating touch coordinates. Called by the TouchManager.
-	 * 
+	 *
 	 * @param	X	stageX touch coordinate
 	 * @param	Y	stageY touch coordinate
 	 */
-	private function setXY(X:Int, Y:Int):Void
+	function setXY(X:Int, Y:Int):Void
 	{
 		flashPoint.setTo(X, Y);
 		flashPoint = FlxG.game.globalToLocal(flashPoint);
-		
+
 		setGlobalScreenPositionUnsafe(flashPoint.x, flashPoint.y);
 	}
-	
-	private inline function get_touchPointID():Int
+
+	inline function get_touchPointID():Int
 	{
 		return input.ID;
 	}
-	
-	private inline function get_justReleased():Bool
+
+	inline function get_justReleased():Bool
 	{
 		return input.justReleased;
 	}
-	
-	private inline function get_released():Bool
+
+	inline function get_released():Bool
 	{
 		return input.released;
 	}
-	
-	private inline function get_pressed():Bool
+
+	inline function get_pressed():Bool
 	{
 		return input.pressed;
 	}
-	
-	private inline function get_justPressed():Bool
+
+	inline function get_justPressed():Bool
 	{
 		return input.justPressed;
 	}

--- a/flixel/input/touch/FlxTouchManager.hx
+++ b/flixel/input/touch/FlxTouchManager.hx
@@ -16,21 +16,21 @@ class FlxTouchManager implements IFlxInputManager
 	 * The maximum number of concurrent touch points supported by the current device.
 	 */
 	public static var maxTouchPoints:Int = 0;
-	
+
 	/**
 	 * All active touches including just created, moving and just released.
 	 */
 	public var list:Array<FlxTouch>;
-	
+
 	/**
 	 * Storage for inactive touches (some sort of cache for them).
 	 */
-	private var _inactiveTouches:Array<FlxTouch>;
+	var _inactiveTouches:Array<FlxTouch>;
 	/**
 	 * Helper storage for active touches (for faster access)
 	 */
-	private var _touchesCache:Map<Int, FlxTouch>;
-	
+	var _touchesCache:Map<Int, FlxTouch>;
+
 	/**
 	 * WARNING: can be null if no active touch with the provided ID could be found
 	 */
@@ -38,7 +38,7 @@ class FlxTouchManager implements IFlxInputManager
 	{
 		return _touchesCache.get(TouchPointID);
 	}
-	
+
 	/**
 	 * Return the first touch if there is one, beware of null
 	 */
@@ -53,7 +53,7 @@ class FlxTouchManager implements IFlxInputManager
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Clean up memory. Internal use only.
 	 */
@@ -65,19 +65,19 @@ class FlxTouchManager implements IFlxInputManager
 			touch.destroy();
 		}
 		list = null;
-		
+
 		for (touch in _inactiveTouches)
 		{
 			touch.destroy();
 		}
 		_inactiveTouches = null;
-		
+
 		_touchesCache = null;
 	}
-	
+
 	/**
 	 * Gets all touches which were just started
-	 * 
+	 *
 	 * @param	TouchArray	Optional array to fill with touch objects
 	 * @return	Array with touches
 	 */
@@ -87,14 +87,14 @@ class FlxTouchManager implements IFlxInputManager
 		{
 			TouchArray = new Array<FlxTouch>();
 		}
-		
+
 		var touchLen:Int = TouchArray.length;
-		
+
 		if (touchLen > 0)
 		{
 			TouchArray.splice(0, touchLen);
 		}
-		
+
 		for (touch in list)
 		{
 			if (touch.justPressed)
@@ -102,13 +102,13 @@ class FlxTouchManager implements IFlxInputManager
 				TouchArray.push(touch);
 			}
 		}
-		
+
 		return TouchArray;
 	}
-	
+
 	/**
 	 * Gets all touches which were just ended
-	 * 
+	 *
 	 * @param	TouchArray	Optional array to fill with touch objects
 	 * @return	Array with touches
 	 */
@@ -118,13 +118,13 @@ class FlxTouchManager implements IFlxInputManager
 		{
 			TouchArray = new Array<FlxTouch>();
 		}
-		
+
 		var touchLen:Int = TouchArray.length;
 		if (touchLen > 0)
 		{
 			TouchArray.splice(0, touchLen);
 		}
-		
+
 		for (touch in list)
 		{
 			if (touch.justReleased)
@@ -132,10 +132,10 @@ class FlxTouchManager implements IFlxInputManager
 				TouchArray.push(touch);
 			}
 		}
-		
+
 		return TouchArray;
 	}
-	
+
 	/**
 	 * Resets all touches to inactive state.
 	 */
@@ -145,39 +145,39 @@ class FlxTouchManager implements IFlxInputManager
 		{
 			_touchesCache.remove(key);
 		}
-		
+
 		for (touch in list)
 		{
 			touch.input.reset();
 			_inactiveTouches.push(touch);
 		}
-		
+
 		list.splice(0, list.length);
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() 
+	function new()
 	{
 		list = new Array<FlxTouch>();
 		_inactiveTouches = new Array<FlxTouch>();
 		_touchesCache = new Map<Int, FlxTouch>();
 		maxTouchPoints = Multitouch.maxTouchPoints;
 		Multitouch.inputMode = MultitouchInputMode.TOUCH_POINT;
-		
+
 		Lib.current.stage.addEventListener(TouchEvent.TOUCH_BEGIN, handleTouchBegin);
 		Lib.current.stage.addEventListener(TouchEvent.TOUCH_END, handleTouchEnd);
 		Lib.current.stage.addEventListener(TouchEvent.TOUCH_MOVE, handleTouchMove);
 	}
-	
+
 	/**
 	 * Event handler so FlxGame can update touches.
 	 */
-	private function handleTouchBegin(FlashEvent:TouchEvent):Void
+	function handleTouchBegin(FlashEvent:TouchEvent):Void
 	{
 		var touch:FlxTouch = _touchesCache.get(FlashEvent.touchPointID);
 		if (touch != null)
 		{
-			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY)); 
+			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
 		}
 		else
 		{
@@ -185,55 +185,55 @@ class FlxTouchManager implements IFlxInputManager
 		}
 		touch.input.press();
 	}
-	
+
 	/**
 	 * Event handler so FlxGame can update touches.
 	 */
-	private function handleTouchEnd(FlashEvent:TouchEvent):Void
+	function handleTouchEnd(FlashEvent:TouchEvent):Void
 	{
 		var touch:FlxTouch = _touchesCache.get(FlashEvent.touchPointID);
-		
+
 		if (touch != null)
 		{
 			touch.input.release();
 		}
 	}
-	
+
 	/**
 	 * Event handler so FlxGame can update touches.
 	 */
-	private function handleTouchMove(FlashEvent:TouchEvent):Void
+	function handleTouchMove(FlashEvent:TouchEvent):Void
 	{
 		var touch:FlxTouch = _touchesCache.get(FlashEvent.touchPointID);
-		
+
 		if (touch != null)
 		{
-			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY)); 
+			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
 		}
 	}
-	
+
 	/**
 	 * Internal function for adding new touches to the manager
-	 * 
+	 *
 	 * @param	Touch	A new FlxTouch object
 	 * @return	The added FlxTouch object
 	 */
-	private function add(Touch:FlxTouch):FlxTouch
+	function add(Touch:FlxTouch):FlxTouch
 	{
 		list.push(Touch);
-		_touchesCache.set(Touch.touchPointID, Touch); 
+		_touchesCache.set(Touch.touchPointID, Touch);
 		return Touch;
 	}
-	
+
 	/**
 	 * Internal function for touch reuse
-	 * 
+	 *
 	 * @param	X			stageX touch coordinate
 	 * @param	Y			stageY touch coordinate
 	 * @param	PointID		id of the touch
 	 * @return	A recycled touch object
 	 */
-	private function recycle(X:Int, Y:Int, PointID:Int):FlxTouch
+	function recycle(X:Int, Y:Int, PointID:Int):FlxTouch
 	{
 		if (_inactiveTouches.length > 0)
 		{
@@ -241,23 +241,23 @@ class FlxTouchManager implements IFlxInputManager
 			touch.recycle(X, Y, PointID);
 			return add(touch);
 		}
-		
+
 		return add(new FlxTouch(X, Y, PointID));
 	}
-	
+
 	/**
 	 * Called by the internal game loop to update the touch position in the game world.
 	 * Also updates the just pressed/just released flags.
 	 */
-	private function update():Void
+	function update():Void
 	{
 		var i:Int = list.length - 1;
 		var touch:FlxTouch;
-		
+
 		while (i >= 0)
 		{
 			touch = list[i];
-			
+
 			// Touch ended at previous frame
 			if (touch.released && !touch.justReleased)
 			{
@@ -270,14 +270,14 @@ class FlxTouchManager implements IFlxInputManager
 			{
 				touch.update();
 			}
-			
+
 			i--;
 		}
 	}
 
-	private function onFocus():Void {}
+	function onFocus():Void {}
 
-	private function onFocusLost():Void
+	function onFocusLost():Void
 	{
 		reset();
 	}

--- a/flixel/math/FlxAngle.hx
+++ b/flixel/math/FlxAngle.hx
@@ -18,10 +18,10 @@ class FlxAngle
 {
 	/**
 	 * Generate a sine and cosine table during compilation
-	 * 
-	 * The parameters allow you to specify the length, amplitude and frequency of the wave. 
+	 *
+	 * The parameters allow you to specify the length, amplitude and frequency of the wave.
 	 * You have to call this function with constant parameters and either use it on your own or assign it to FlxAngle.sincos
-	 * 
+	 *
 	 * @param length 		The length of the wave
 	 * @param sinAmplitude 	The amplitude to apply to the sine table (default 1.0) if you need values between say -+ 125 then give 125 as the value
 	 * @param cosAmplitude 	The amplitude to apply to the cosine table (default 1.0) if you need values between say -+ 125 then give 125 as the value
@@ -31,14 +31,14 @@ class FlxAngle
 	public static macro function sinCosGenerator(length:Int = 360, sinAmplitude:Float = 1.0, cosAmplitude:Float = 1.0, frequency:Float = 1.0):Expr
 	{
 		var table = { cos: [], sin: [] };
-		
+
 		for (c in 0...length)
 		{
 			var radian = c * frequency * Math.PI / 180;
 			table.cos.push(Math.cos(radian) * cosAmplitude);
 			table.sin.push(Math.sin(radian) * sinAmplitude);
 		}
-		
+
 		return Context.makeExpr(table, Context.currentPos());
 	}
 
@@ -51,14 +51,14 @@ class FlxAngle
 	 * Convert degrees to radians by multiplying it with this value.
 	 */
 	public static var TO_RAD(get, never):Float;
-	
+
 	/**
 	 * Keeps an angle value between -180 and +180 by wrapping it
 	 * e.g an angle of +270 will be converted to -90
 	 * Should be called whenever the angle is updated on a FlxSprite to stop it from going insane.
-	 * 
+	 *
 	 * @param	angle	The angle value to check
-	 * 
+	 *
 	 * @return	The new angle value, returns the same as the input angle if it was within bounds
 	 */
 	public static function wrapAngle(angle:Float):Float
@@ -71,14 +71,14 @@ class FlxAngle
 		{
 			angle = wrapAngle(angle + 360);
 		}
-		
+
 		return angle;
 	}
-	
+
 	/**
 	 * Converts a Radian value into a Degree
 	 * Converts the radians value into degrees and returns
-	 * 
+	 *
 	 * @param 	radians 	The value in radians
 	 * @return	Degrees
 	 */
@@ -86,11 +86,11 @@ class FlxAngle
 	{
 		return radians * TO_DEG;
 	}
-	
+
 	/**
 	 * Converts a Degrees value into a Radian
 	 * Converts the degrees value into radians and returns
-	 * 
+	 *
 	 * @param 	degrees The value in degrees
 	 * @return	Radians
 	 */
@@ -98,11 +98,11 @@ class FlxAngle
 	{
 		return degrees * TO_RAD;
 	}
-	
+
 	/**
 	 * Find the angle (in radians) between the two FlxSprite, taking their x/y and origin into account.
 	 * The angle is calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
-	 * 
+	 *
 	 * @param	SpriteA		The FlxSprite to test from
 	 * @param	SpriteB		The FlxSprite to test to
 	 * @param	AsDegrees	If you need the value in degrees instead of radians, set to true
@@ -112,17 +112,17 @@ class FlxAngle
 	{
 		var dx:Float = (SpriteB.x + SpriteB.origin.x) - (SpriteA.x + SpriteA.origin.x);
 		var dy:Float = (SpriteB.y + SpriteB.origin.y) - (SpriteA.y + SpriteA.origin.y);
-		
+
 		if (AsDegrees)
 			return asDegrees(Math.atan2(dy, dx));
 		else
 			return Math.atan2(dy, dx);
 	}
-	
+
 	/**
 	 * Find the angle (in radians) between an FlxSprite and an FlxPoint. The source sprite takes its x/y and origin into account.
 	 * The angle is calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
-	 * 
+	 *
 	 * @param	Sprite		The FlxSprite to test from
 	 * @param	Target		The FlxPoint to angle the FlxSprite towards
 	 * @param	AsDegrees	If you need the value in degrees instead of radians, set to true
@@ -132,20 +132,20 @@ class FlxAngle
 	{
 		var dx:Float = (Target.x) - (Sprite.x + Sprite.origin.x);
 		var dy:Float = (Target.y) - (Sprite.y + Sprite.origin.y);
-		
+
 		Target.putWeak();
-		
+
 		if (AsDegrees)
 			return asDegrees(Math.atan2(dy, dx));
 		else
 			return Math.atan2(dy, dx);
 	}
-	
+
 	#if FLX_MOUSE
 	/**
 	 * Find the angle (in radians) between an FlxSprite and the mouse, taking their x/y and origin into account.
 	 * The angle is calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
-	 * 
+	 *
 	 * @param	Object		The FlxObject to test from
 	 * @param	AsDegrees	If you need the value in degrees instead of radians, set to true
 	 * @return	The angle (in radians unless AsDegrees is true)
@@ -155,26 +155,26 @@ class FlxAngle
 		//	In order to get the angle between the object and mouse, we need the objects screen coordinates (rather than world coordinates)
 		if (Object == null)
 			return 0;
-		
+
 		var p:FlxPoint = Object.getScreenPosition();
-		
+
 		var dx:Float = FlxG.mouse.screenX - p.x;
 		var dy:Float = FlxG.mouse.screenY - p.y;
-		
+
 		p.put();
-		
+
 		if (AsDegrees)
 			return asDegrees(Math.atan2(dy, dx));
 		else
 			return Math.atan2(dy, dx);
 	}
 	#end
-	
+
 	#if FLX_TOUCH
 	/**
 	 * Find the angle (in radians) between an FlxSprite and a FlxTouch, taking their x/y and origin into account.
 	 * The angle is calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
-	 * 
+	 *
 	 * @param	Object		The FlxObject to test from
 	 * @param	Touch		The FlxTouch to test to
 	 * @param	AsDegrees	If you need the value in degrees instead of radians, set to true
@@ -184,28 +184,28 @@ class FlxAngle
 	{
 		// In order to get the angle between the object and mouse, we need the objects screen coordinates (rather than world coordinates)
 		var p:FlxPoint = Object.getScreenPosition();
-		
+
 		var dx:Float = Touch.screenX - p.x;
 		var dy:Float = Touch.screenY - p.y;
-		
+
 		p.put();
-		
+
 		if (AsDegrees)
 			return asDegrees(Math.atan2(dy, dx));
 		else
 			return Math.atan2(dy, dx);
 	}
 	#end
-	
+
 	/**
 	 *  Translate an object's facing to angle.
-	 * 
+	 *
 	 * @param	FacingBitmask	Bitmask from which to calculate the angle, as in FlxSprite::facing
 	 * @param	AsDegrees		If you need the value in degrees instead of radians, set to true
 	 * @return	The angle (in radians unless AsDegrees is true)
 	 */
 	public static function angleFromFacing(FacingBitmask:Int, AsDegrees:Bool = false):Float
-	{		
+	{
 		var degrees = switch (FacingBitmask)
 		{
 			case FlxObject.LEFT: 180;
@@ -220,10 +220,10 @@ class FlxAngle
 		}
 		return AsDegrees ? degrees : asRadians(degrees);
 	}
-	
+
 	/**
 	 * Convert polar coordinates (radius + angle) to cartesian coordinates (x + y)
-	 * 
+	 *
 	 * @param	Radius	The radius
 	 * @param	Angle	The angle, in degrees
 	 * @param	point	Optional FlxPoint if you don't want a new one created
@@ -234,15 +234,15 @@ class FlxAngle
 		var p = point;
 		if (p == null)
 			p = FlxPoint.get();
-		
+
 		p.x = Radius * Math.cos(Angle * TO_RAD);
 		p.y = Radius * Math.sin(Angle * TO_RAD);
 		return p;
 	}
-	
+
 	/**
-	 * Convert cartesian coordinates (x + y) to polar coordinates (radius + angle) 
-	 * 
+	 * Convert cartesian coordinates (x + y) to polar coordinates (radius + angle)
+	 *
 	 * @param	X		x position
 	 * @param	Y		y position
 	 * @param	point	Optional FlxPoint if you don't want a new one created
@@ -253,18 +253,18 @@ class FlxAngle
 		var p = point;
 		if (p == null)
 			p = FlxPoint.get();
-		
+
 		p.x = Math.sqrt((X * X) + (Y * Y));
 		p.y = Math.atan2(Y, X) * TO_DEG;
 		return p;
 	}
-	
-	private static inline function get_TO_DEG():Float
+
+	static inline function get_TO_DEG():Float
 	{
 		return 180 / Math.PI;
 	}
-	
-	private static inline function get_TO_RAD():Float
+
+	static inline function get_TO_RAD():Float
 	{
 		return Math.PI / 180;
 	}

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -12,13 +12,13 @@ import openfl.geom.Matrix;
 class FlxPoint implements IFlxPooled
 {
 	public static var pool(get, never):IFlxPool<FlxPoint>;
-	
-	private static var _pool = new FlxPool<FlxPoint>(FlxPoint);
-	
+
+	static var _pool = new FlxPool<FlxPoint>(FlxPoint);
+
 	/**
-	 * Recycle or create a new FlxPoint. 
+	 * Recycle or create a new FlxPoint.
 	 * Be sure to put() them back into the pool after you're done with them!
-	 * 
+	 *
 	 * @param	X		The X-coordinate of the point in space.
 	 * @param	Y		The Y-coordinate of the point in space.
 	 * @return	This point.
@@ -29,11 +29,11 @@ class FlxPoint implements IFlxPooled
 		point._inPool = false;
 		return point;
 	}
-	
+
 	/**
-	 * Recycle or create a new FlxPoint which will automatically be released 
+	 * Recycle or create a new FlxPoint which will automatically be released
 	 * to the pool when passed into a flixel function.
-	 * 
+	 *
 	 * @param	X		The X-coordinate of the point in space.
 	 * @param	Y		The Y-coordinate of the point in space.
 	 * @return	This point.
@@ -44,19 +44,19 @@ class FlxPoint implements IFlxPooled
 		point._weak = true;
 		return point;
 	}
-	
+
 	public var x(default, set):Float = 0;
 	public var y(default, set):Float = 0;
-	
-	private var _weak:Bool = false;
-	private var _inPool:Bool = false;
-	
+
+	var _weak:Bool = false;
+	var _inPool:Bool = false;
+
 	@:keep
-	public function new(X:Float = 0, Y:Float = 0) 
+	public function new(X:Float = 0, Y:Float = 0)
 	{
 		set(X, Y);
 	}
-	
+
 	/**
 	 * Add this FlxPoint to the recycling pool.
 	 */
@@ -69,7 +69,7 @@ class FlxPoint implements IFlxPooled
 			_pool.putUnsafe(this);
 		}
 	}
-	
+
 	/**
 	 * Add this FlxPoint to the recycling pool if it's a weak reference (allocated via weak()).
 	 */
@@ -80,10 +80,10 @@ class FlxPoint implements IFlxPooled
 			put();
 		}
 	}
-	
+
 	/**
 	 * Set the coordinates of this point.
-	 * 
+	 *
 	 * @param	X	The X-coordinate of the point in space.
 	 * @param	Y	The Y-coordinate of the point in space.
 	 * @return	This point.
@@ -94,10 +94,10 @@ class FlxPoint implements IFlxPooled
 		y = Y;
 		return this;
 	}
-	
+
 	/**
 	 * Adds to the coordinates of this point.
-	 * 
+	 *
 	 * @param	X	Amount to add to x
 	 * @param	Y	Amount to add to y
 	 * @return	This point.
@@ -108,10 +108,10 @@ class FlxPoint implements IFlxPooled
 		y += Y;
 		return this;
 	}
-	
+
 	/**
 	 * Adds the coordinates of another point to the coordinates of this point.
-	 * 
+	 *
 	 * @param	point	The point to add to this point
 	 * @return	This point.
 	 */
@@ -122,10 +122,10 @@ class FlxPoint implements IFlxPooled
 		point.putWeak();
 		return this;
 	}
-	
+
 	/**
 	 * Subtracts from the coordinates of this point.
-	 * 
+	 *
 	 * @param	X	Amount to subtract from x
 	 * @param	Y	Amount to subtract from y
 	 * @return	This point.
@@ -136,10 +136,10 @@ class FlxPoint implements IFlxPooled
 		y -= Y;
 		return this;
 	}
-	
+
 	/**
 	 * Subtracts the coordinates of another point from the coordinates of this point.
-	 * 
+	 *
 	 * @param	point	The point to subtract from this point
 	 * @return	This point.
 	 */
@@ -150,10 +150,10 @@ class FlxPoint implements IFlxPooled
 		point.putWeak();
 		return this;
 	}
-	
+
 	/**
 	 * Scale this point.
-	 * 
+	 *
 	 * @param	k - scale coefficient
 	 * @return	scaled point
 	 * @since   4.1.0
@@ -164,10 +164,10 @@ class FlxPoint implements IFlxPooled
 		y *= k;
 		return this;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from the specified point.
-	 * 
+	 *
 	 * @param	point	Any FlxPoint.
 	 * @return	A reference to itself.
 	 */
@@ -178,10 +178,10 @@ class FlxPoint implements IFlxPooled
 		point.putWeak();
 		return this;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from this point to the specified point.
-	 * 
+	 *
 	 * @param	Point	Any FlxPoint.
 	 * @return	A reference to the altered point parameter.
 	 */
@@ -195,10 +195,10 @@ class FlxPoint implements IFlxPooled
 		point.y = y;
 		return point;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from the specified Flash point.
-	 * 
+	 *
 	 * @param	Point	Any Point.
 	 * @return	A reference to itself.
 	 */
@@ -208,10 +208,10 @@ class FlxPoint implements IFlxPooled
 		y = FlashPoint.y;
 		return this;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from this point to the specified Flash point.
-	 * 
+	 *
 	 * @param	Point	Any Point.
 	 * @return	A reference to the altered point parameter.
 	 */
@@ -221,7 +221,7 @@ class FlxPoint implements IFlxPooled
 		{
 			FlashPoint = new Point();
 		}
-		
+
 		FlashPoint.x = x;
 		FlashPoint.y = y;
 		return FlashPoint;
@@ -229,7 +229,7 @@ class FlxPoint implements IFlxPooled
 
 	/**
 	 * Helper function, just increases the values of the specified Flash point by the values of this point.
-	 * 
+	 *
 	 * @param	Point	Any Point.
 	 * @return	A reference to the altered point parameter.
 	 */
@@ -243,7 +243,7 @@ class FlxPoint implements IFlxPooled
 
 	/**
 	 * Helper function, just decreases the values of the specified Flash point by the values of this point.
-	 * 
+	 *
 	 * @param	Point	Any Point.
 	 * @return	A reference to the altered point parameter.
 	 */
@@ -254,10 +254,10 @@ class FlxPoint implements IFlxPooled
 
 		return FlashPoint;
 	}
-	
+
 	/**
 	 * Returns true if this point is within the given rectangular block
-	 * 
+	 *
 	 * @param	RectX		The X value of the region to test within
 	 * @param	RectY		The Y value of the region to test within
 	 * @param	RectWidth	The width of the region to test within
@@ -268,10 +268,10 @@ class FlxPoint implements IFlxPooled
 	{
 		return FlxMath.pointInCoordinates(x, y, RectX, RectY, RectWidth, RectHeight);
 	}
-	
+
 	/**
 	 * Returns true if this point is within the given rectangular block
-	 * 
+	 *
 	 * @param	Rect	The FlxRect to test within
 	 * @return	True if pointX/pointY is within the FlxRect, otherwise false
 	 */
@@ -279,10 +279,10 @@ class FlxPoint implements IFlxPooled
 	{
 		return FlxMath.pointInFlxRect(x, y, Rect);
 	}
-	
+
 	/**
 	 * Calculate the distance to another point.
-	 * 
+	 *
 	 * @param 	AnotherPoint	A FlxPoint object to calculate the distance to.
 	 * @return	The distance between the two points as a Float.
 	 */
@@ -293,7 +293,7 @@ class FlxPoint implements IFlxPooled
 		point.putWeak();
 		return FlxMath.vectorLength(dx, dy);
 	}
-	
+
 	/**
 	 * Rounds x and y using Math.floor()
 	 */
@@ -303,7 +303,7 @@ class FlxPoint implements IFlxPooled
 		y = Math.floor(y);
 		return this;
 	}
-	
+
 	/**
 	 * Rounds x and y using Math.ceil()
 	 */
@@ -313,7 +313,7 @@ class FlxPoint implements IFlxPooled
 		y = Math.ceil(y);
 		return this;
 	}
-	
+
 	/**
 	 * Rounds x and y using Math.round()
 	 */
@@ -323,10 +323,10 @@ class FlxPoint implements IFlxPooled
 		y = Math.round(y);
 		return this;
 	}
-	
+
 	/**
 	 * Rotates this point clockwise in 2D space around another point by the given angle.
-	 * 
+	 *
 	 * @param   Pivot   The pivot you want to rotate this point around
 	 * @param   Angle   Rotate the point by this many degrees clockwise.
 	 * @return  A FlxPoint containing the coordinates of the rotated point.
@@ -336,19 +336,19 @@ class FlxPoint implements IFlxPooled
 		var radians:Float = Angle * FlxAngle.TO_RAD;
 		var sin:Float = FlxMath.fastSin(radians);
 		var cos:Float = FlxMath.fastCos(radians);
-		
+
 		var dx:Float = x - Pivot.x;
 		var dy:Float = y - Pivot.y;
 		x = cos * dx - sin * dy + Pivot.x;
 		y = sin * dx + cos * dy + Pivot.y;
-		
+
 		Pivot.putWeak();
 		return this;
 	}
-	
+
 	/**
 	 * Calculates the angle between this and another point. 0 degrees points straight up.
-	 * 
+	 *
 	 * @param   point   The other point.
 	 * @return  The angle in degrees, between -180 and 180.
 	 */
@@ -357,13 +357,13 @@ class FlxPoint implements IFlxPooled
 		var x:Float = point.x - x;
 		var y:Float = point.y - y;
 		var angle:Float = 0;
-		
+
 		if ((x != 0) || (y != 0))
 		{
 			var c1:Float = Math.PI * 0.25;
 			var c2:Float = 3 * c1;
 			var ay:Float = (y < 0) ? -y : y;
-			
+
 			if (x >= 0)
 			{
 				angle = c1 - c1 * ((x - ay) / (x + ay));
@@ -373,7 +373,7 @@ class FlxPoint implements IFlxPooled
 				angle = c2 - c1 * ((x + ay) / (ay - x));
 			}
 			angle = ((y < 0) ? -angle : angle) * FlxAngle.TO_DEG;
-			
+
 			if (angle > 90)
 			{
 				angle = angle - 270;
@@ -383,7 +383,7 @@ class FlxPoint implements IFlxPooled
 				angle += 90;
 			}
 		}
-		
+
 		point.putWeak();
 		return angle;
 	}
@@ -396,10 +396,10 @@ class FlxPoint implements IFlxPooled
 	{
 		return FlxVector.get(x, y);
 	}
-	
+
 	/**
 	 * Function to compare this FlxPoint to another.
-	 * 
+	 *
 	 * @param	point  The other FlxPoint to compare to this one.
 	 * @return	True if the FlxPoints have the same x and y value, false otherwise.
 	 */
@@ -409,12 +409,12 @@ class FlxPoint implements IFlxPooled
 		point.putWeak();
 		return result;
 	}
-	
+
 	/**
 	 * Necessary for IFlxDestroyable.
 	 */
 	public function destroy() {}
-	
+
 	/**
 	 * Applies transformation matrix to this point
 	 * @param	matrix	transformation matrix
@@ -424,37 +424,37 @@ class FlxPoint implements IFlxPooled
 	{
 		var x1:Float = x * matrix.a + y * matrix.c + matrix.tx;
 		var y1:Float = x * matrix.b + y * matrix.d + matrix.ty;
-		
+
 		return set(x1, y1);
 	}
-	
+
 	/**
 	 * Convert object to readable string name. Useful for debugging, save games, etc.
 	 */
 	public inline function toString():String
 	{
-		return FlxStringUtil.getDebugString([ 
+		return FlxStringUtil.getDebugString([
 			LabelValuePair.weak("x", x),
 			LabelValuePair.weak("y", y)]);
 	}
-	
+
 	/**
 	 * Necessary for FlxCallbackPoint.
 	 */
-	private function set_x(Value:Float):Float 
-	{ 
+	function set_x(Value:Float):Float
+	{
 		return x = Value;
 	}
-	
+
 	/**
 	 * Necessary for FlxCallbackPoint.
 	 */
-	private function set_y(Value:Float):Float
+	function set_y(Value:Float):Float
 	{
-		return y = Value; 
+		return y = Value;
 	}
-	
-	private static function get_pool():IFlxPool<FlxPoint>
+
+	static function get_pool():IFlxPool<FlxPoint>
 	{
 		return _pool;
 	}
@@ -466,13 +466,13 @@ class FlxPoint implements IFlxPooled
  */
 class FlxCallbackPoint extends FlxPoint
 {
-	private var _setXCallback:FlxPoint->Void;
-	private var _setYCallback:FlxPoint->Void;
-	private var _setXYCallback:FlxPoint->Void;
-	
+	var _setXCallback:FlxPoint->Void;
+	var _setYCallback:FlxPoint->Void;
+	var _setXYCallback:FlxPoint->Void;
+
 	/**
 	 * If you only specify one callback function, then the remaining two will use the same.
-	 * 
+	 *
 	 * @param	setXCallback	Callback for set_x()
 	 * @param	setYCallback	Callback for set_y()
 	 * @param	setXYCallback	Callback for set()
@@ -480,11 +480,11 @@ class FlxCallbackPoint extends FlxPoint
 	public function new(setXCallback:FlxPoint->Void, ?setYCallback:FlxPoint->Void, ?setXYCallback:FlxPoint->Void)
 	{
 		super();
-		
+
 		_setXCallback = setXCallback;
 		_setYCallback = setXYCallback;
 		_setXYCallback = setXYCallback;
-		
+
 		if (_setXCallback != null)
 		{
 			if (_setYCallback == null)
@@ -493,7 +493,7 @@ class FlxCallbackPoint extends FlxPoint
 				_setXYCallback = setXCallback;
 		}
 	}
-	
+
 	override public inline function set(X:Float = 0, Y:Float = 0):FlxCallbackPoint
 	{
 		super.set(X, Y);
@@ -501,23 +501,23 @@ class FlxCallbackPoint extends FlxPoint
 			_setXYCallback(this);
 		return this;
 	}
-	
-	override private inline function set_x(Value:Float):Float
+
+	override inline function set_x(Value:Float):Float
 	{
 		super.set_x(Value);
 		if (_setXCallback != null)
 			_setXCallback(this);
 		return Value;
 	}
-	
-	override private inline function set_y(Value:Float):Float
+
+	override inline function set_y(Value:Float):Float
 	{
 		super.set_y(Value);
 		if (_setYCallback != null)
 			_setYCallback(this);
 		return Value;
 	}
-	
+
 	override public function destroy():Void
 	{
 		super.destroy();
@@ -525,6 +525,6 @@ class FlxCallbackPoint extends FlxPoint
 		_setYCallback = null;
 		_setXYCallback = null;
 	}
-	
+
 	override public function put():Void {} // don't pool FlxCallbackPoints
 }

--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -13,16 +13,16 @@ class FlxRandom
 	 * Altering this yourself may break recording functionality!
 	 */
 	public var initialSeed(default, set):Int = 1;
-	
+
 	/**
 	 * Current seed used to generate new random numbers. You can retrieve this value if,
 	 * for example, you want to store the seed that was used to randomly generate a level.
 	 */
 	public var currentSeed(get, set):Int;
-	
+
 	/**
 	 * Create a new FlxRandom object.
-	 * 
+	 *
 	 * @param	InitialSeed  The first seed of this FlxRandom object. If ignored, a random seed will be generated.
 	 */
 	public function new(?InitialSeed:Int)
@@ -36,24 +36,24 @@ class FlxRandom
 			resetInitialSeed();
 		}
 	}
-	
+
 	/**
 	 * Function to easily set the global seed to a new random number.
 	 * Please note that this function is not deterministic!
 	 * If you call it in your game, recording may not function as expected.
-	 * 
+	 *
 	 * @return  The new initial seed.
 	 */
 	public inline function resetInitialSeed():Int
 	{
 		return initialSeed = rangeBound(Std.int(Math.random() * FlxMath.MAX_VALUE_INT));
 	}
-	
+
 	/**
 	 * Returns a pseudorandom integer between Min and Max, inclusive.
 	 * Will not return a number in the Excludes array, if provided.
 	 * Please note that large Excludes arrays can slow calculations.
-	 * 
+	 *
 	 * @param   Min        The minimum value that should be returned. 0 by default.
 	 * @param   Max        The maximum value that should be returned. 2,147,483,647 by default.
 	 * @param   Excludes   Optional array of values that should not be returned.
@@ -77,7 +77,7 @@ class FlxRandom
 				Max = Min - Max;
 				Min = Min - Max;
 			}
-			
+
 			if (Excludes == null)
 			{
 				return Math.floor(Min + generate() / MODULUS * (Max - Min + 1));
@@ -85,23 +85,23 @@ class FlxRandom
 			else
 			{
 				var result:Int = 0;
-				
+
 				do
 				{
 					result = Math.floor(Min + generate() / MODULUS * (Max - Min + 1));
 				}
 				while (Excludes.indexOf(result) >= 0);
-				
+
 				return result;
 			}
 		}
 	}
-	
+
 	/**
 	 * Returns a pseudorandom float value between Min and Max, inclusive.
 	 * Will not return a number in the Excludes array, if provided.
 	 * Please note that large Excludes arrays can slow calculations.
-	 * 
+	 *
 	 * @param   Min        The minimum value that should be returned. 0 by default.
 	 * @param   Max        The maximum value that should be returned. 1 by default.
 	 * @param   Excludes   Optional array of values that should not be returned.
@@ -109,7 +109,7 @@ class FlxRandom
 	public function float(Min:Float = 0, Max:Float = 1, ?Excludes:Array<Float>):Float
 	{
 		var result:Float = 0;
-		
+
 		if (Min == 0 && Max == 1 && Excludes == null)
 		{
 			return generate() / MODULUS;
@@ -127,7 +127,7 @@ class FlxRandom
 				Max = Min - Max;
 				Min = Min - Max;
 			}
-			
+
 			if (Excludes == null)
 			{
 				result = Min + (generate() / MODULUS) * (Max - Min);
@@ -141,24 +141,24 @@ class FlxRandom
 				while (Excludes.indexOf(result) >= 0);
 			}
 		}
-		
+
 		return result;
 	}
-	
+
 	//helper variables for floatNormal -- it produces TWO random values with each call so we have to store some state outside the function
-	private var _hasFloatNormalSpare:Bool = false;
-	private var _floatNormalRand1:Float = 0;
-	private var _floatNormalRand2:Float = 0;
-	private var _twoPI:Float = Math.PI * 2;
-	private var _floatNormalRho:Float = 0;
-	
+	var _hasFloatNormalSpare:Bool = false;
+	var _floatNormalRand1:Float = 0;
+	var _floatNormalRand2:Float = 0;
+	var _twoPI:Float = Math.PI * 2;
+	var _floatNormalRho:Float = 0;
+
 	/**
 	 * Returns a pseudorandom float value in a statistical normal distribution centered on Mean with a standard deviation size of StdDev.
 	 * (This uses the Box-Muller transform algorithm for gaussian pseudorandom numbers)
-	 * 
+	 *
 	 * Normal distribution: 68% values are within 1 standard deviation, 95% are in 2 StdDevs, 99% in 3 StdDevs.
 	 * See this image: https://github.com/HaxeFlixel/flixel-demos/blob/dev/Performance/FlxRandom/normaldistribution.png
-	 * 
+	 *
 	 * @param	Mean		The Mean around which the normal distribution is centered
 	 * @param	StdDev		Size of the standard deviation
 	 */
@@ -170,24 +170,24 @@ class FlxRandom
 			var scale:Float = StdDev * _floatNormalRho;
 			return Mean + scale * _floatNormalRand2;
 		}
-		
+
 		_hasFloatNormalSpare = true;
-		
+
 		var theta:Float = _twoPI * (generate() / MODULUS);
 		_floatNormalRho = Math.sqrt( -2 * Math.log(1 - (generate() / MODULUS)));
 		var scale:Float = StdDev * _floatNormalRho;
-		
+
 		_floatNormalRand1 = Math.cos(theta);
 		_floatNormalRand2 = Math.sin(theta);
-		
+
 		return Mean + scale * _floatNormalRand1;
 	}
-	
+
 	/**
-	 * Returns true or false based on the chance value (default 50%). 
+	 * Returns true or false based on the chance value (default 50%).
 	 * For example if you wanted a player to have a 30.5% chance of getting a bonus,
 	 * call bool(30.5) - true means the chance passed, false means it failed.
-	 * 
+	 *
 	 * @param   Chance   The chance of receiving the value.
 	 *                   Should be given as a number between 0 and 100 (effectively 0% to 100%)
 	 * @return  Whether the roll passed or not.
@@ -196,10 +196,10 @@ class FlxRandom
 	{
 		return float(0, 100) < Chance;
 	}
-	
+
 	/**
-	 * Returns either a 1 or -1. 
-	 * 
+	 * Returns either a 1 or -1.
+	 *
 	 * @param   Chance   The chance of receiving a positive value.
 	 *                   Should be given as a number between 0 and 100 (effectively 0% to 100%)
 	 * @return  1 or -1
@@ -208,13 +208,13 @@ class FlxRandom
 	{
 		return bool(Chance) ? 1 : -1;
 	}
-	
+
 	/**
 	 * Pseudorandomly select from an array of weighted options. For example, if you passed in an array of [50, 30, 20]
 	 * there would be a 50% chance of returning a 0, a 30% chance of returning a 1, and a 20% chance of returning a 2.
 	 * Note that the values in the array do not have to add to 100 or any other number.
 	 * The percent chance will be equal to a given value in the array divided by the total of all values in the array.
-	 * 
+	 *
 	 * @param   WeightsArray   An array of weights.
 	 * @return  A value between 0 and (SelectionArray.length - 1), with a probability equivalent to the values in SelectionArray.
 	 */
@@ -222,14 +222,14 @@ class FlxRandom
 	{
 		var totalWeight:Float = 0;
 		var pick:Int = 0;
-		
+
 		for (i in WeightsArray)
 		{
 			totalWeight += i;
 		}
-		
+
 		totalWeight = float(0, totalWeight);
-		
+
 		for (i in 0...WeightsArray.length)
 		{
 			if (totalWeight < WeightsArray[i])
@@ -237,16 +237,16 @@ class FlxRandom
 				pick = i;
 				break;
 			}
-			
+
 			totalWeight -= WeightsArray[i];
 		}
-		
+
 		return pick;
 	}
-	
+
 	/**
 	 * Returns a random object from an array.
-	 * 
+	 *
 	 * @param   Objects        An array from which to return an object.
 	 * @param   WeightsArray   Optional array of weights which will determine the likelihood of returning a given value from Objects.
 	 * 						   If none is passed, all objects in the Objects array will have an equal likelihood of being returned.
@@ -259,22 +259,22 @@ class FlxRandom
 	public function getObject<T>(Objects:Array<T>, ?WeightsArray:Array<Float>, StartIndex:Int = 0, ?EndIndex:Null<Int>):T
 	{
 		var selected:Null<T> = null;
-		
+
 		if (Objects.length != 0)
 		{
 			if (WeightsArray == null)
 			{
 				WeightsArray = [for (i in 0...Objects.length) 1];
 			}
-			
+
 			if (EndIndex == null)
 			{
 				EndIndex = Objects.length - 1;
 			}
-			
+
 			StartIndex = Std.int(FlxMath.bound(StartIndex, 0, Objects.length - 1));
 			EndIndex = Std.int(FlxMath.bound(EndIndex, 0, Objects.length - 1));
-			
+
 			// Swap values if reversed
 			if (EndIndex < StartIndex)
 			{
@@ -282,24 +282,24 @@ class FlxRandom
 				EndIndex = StartIndex - EndIndex;
 				StartIndex = StartIndex - EndIndex;
 			}
-			
+
 			if (EndIndex > WeightsArray.length - 1)
 			{
 				EndIndex = WeightsArray.length - 1;
 			}
-			
+
 			_arrayFloatHelper = [for (i in StartIndex...EndIndex + 1) WeightsArray[i]];
 			selected = Objects[StartIndex + weightedPick(_arrayFloatHelper)];
 		}
-		
+
 		return selected;
 	}
-	
+
 	/**
 	 * Shuffles the entries in an array into a new pseudorandom order.
-	 * 
+	 *
 	 * @param   Objects        An array to shuffle.
-	 * @param   HowManyTimes   How many swaps to perform during the shuffle operation. 
+	 * @param   HowManyTimes   How many swaps to perform during the shuffle operation.
 	 *                         A good rule of thumb is 2-4 times the number of objects in the list.
 	 * @return  The newly shuffled array.
 	 */
@@ -308,19 +308,19 @@ class FlxRandom
 	public function shuffleArray<T>(Objects:Array<T>, HowManyTimes:Int):Array<T>
 	{
 		HowManyTimes = Std.int(Math.max(HowManyTimes, 0));
-		
+
 		var tempObject:Null<T> = null;
-		
+
 		for (i in 0...HowManyTimes)
 		{
 			var pick1:Int = int(0, Objects.length - 1);
 			var pick2:Int = int(0, Objects.length - 1);
-			
+
 			tempObject = Objects[pick1];
 			Objects[pick1] = Objects[pick2];
 			Objects[pick2] = tempObject;
 		}
-		
+
 		return Objects;
 	}
 
@@ -343,10 +343,10 @@ class FlxRandom
 			array[j] = tmp;
 		}
 	}
-	
+
 	/**
 	 * Returns a random color.
-	 * 
+	 *
 	 * @param   Min        An optional FlxColor representing the lower bounds for the generated color.
 	 * @param   Max        An optional FlxColor representing the upper bounds for the generated color.
 	 * @param 	Alpha      An optional value for the alpha channel of the generated color.
@@ -359,7 +359,7 @@ class FlxRandom
 		var green:Int;
 		var blue:Int;
 		var alpha:Int;
-		
+
 		if (Min == null && Max == null)
 		{
 			red = int(0, 255);
@@ -388,117 +388,117 @@ class FlxRandom
 			blue = GreyScale ? red : int(Min.blue, Max.blue);
 			alpha = Alpha == null ? int(Min.alpha, Max.alpha) : Alpha;
 		}
-		
+
 		return FlxColor.fromRGB(red, green, blue, alpha);
 	}
-	
+
 	/**
 	 * Internal method to quickly generate a pseudorandom number. Used only by other functions of this class.
 	 * Also updates the internal seed, which will then be used to generate the next pseudorandom number.
-	 * 
+	 *
 	 * @return  A new pseudorandom number.
 	 */
-	private inline function generate():Float
+	inline function generate():Float
 	{
 		return internalSeed = (internalSeed * MULTIPLIER) % MODULUS;
 	}
-	
+
 	/**
 	 * The actual internal seed. Stored as a Float value to prevent inaccuracies due to
 	 * integer overflow in the generate() equation.
 	 */
-	private var internalSeed:Float = 1;
-	
+	var internalSeed:Float = 1;
+
 	/**
 	 * Internal function to update the current seed whenever the initial seed is reset,
 	 * and keep the initial seed's value in range.
 	 */
-	private inline function set_initialSeed(NewSeed:Int):Int
+	inline function set_initialSeed(NewSeed:Int):Int
 	{
 		return initialSeed = currentSeed = rangeBound(NewSeed);
 	}
-	
+
 	/**
 	 * Returns the internal seed as an integer.
 	 */
-	private inline function get_currentSeed():Int
+	inline function get_currentSeed():Int
 	{
 		return Std.int(internalSeed);
 	}
-	
+
 	/**
 	 * Sets the internal seed to an integer value.
 	 */
-	private inline function set_currentSeed(NewSeed:Int):Int
+	inline function set_currentSeed(NewSeed:Int):Int
 	{
 		return Std.int(internalSeed = rangeBound(NewSeed));
 	}
-	
+
 	/**
 	 * Internal shared function to ensure an arbitrary value is in the valid range of seed values.
 	 */
-	private static inline function rangeBound(Value:Int):Int
+	static inline function rangeBound(Value:Int):Int
 	{
 		return Std.int(FlxMath.bound(Value, 1, MODULUS - 1));
 	}
-	
+
 	/**
 	 * Internal shared helper variable. Used by getObject().
 	 */
-	private static var _arrayFloatHelper:Array<Float> = null;
-	
+	static var _arrayFloatHelper:Array<Float> = null;
+
 	/**
 	 * Constants used in the pseudorandom number generation equation.
 	 * These are the constants suggested by the revised MINSTD pseudorandom number generator,
 	 * and they use the full range of possible integer values.
-	 * 
+	 *
 	 * @see http://en.wikipedia.org/wiki/Linear_congruential_generator
 	 * @see Stephen K. Park and Keith W. Miller and Paul K. Stockmeyer (1988).
 	 *      "Technical Correspondence". Communications of the ACM 36 (7): 105–110.
 	 */
-	private static inline var MULTIPLIER:Float = 48271.0;
-	private static inline var MODULUS:Int = FlxMath.MAX_VALUE_INT;
-	
+	static inline var MULTIPLIER:Float = 48271.0;
+	static inline var MODULUS:Int = FlxMath.MAX_VALUE_INT;
+
 	#if FLX_RECORD
 	/**
 	 * Internal storage for the seed used to generate the most recent state.
 	 */
-	private static var _stateSeed:Int = 1;
-	
+	static var _stateSeed:Int = 1;
+
 	/**
 	 * The seed to be used by the recording requested in FlxGame.
 	 */
-	private static var _recordingSeed:Int = 1;
-	
+	static var _recordingSeed:Int = 1;
+
 	/**
 	 * Update the seed that was used to create the most recent state.
 	 * Called by FlxGame, needed for replays.
-	 * 
+	 *
 	 * @return  The new value of the state seed.
 	 */
 	@:allow(flixel.FlxGame)
-	private static inline function updateStateSeed():Int
+	static inline function updateStateSeed():Int
 	{
 		return _stateSeed = FlxG.random.currentSeed;
 	}
-	
+
 	/**
 	 * Used to store the seed for a requested recording. If StandardMode is false, this will also reset the global seed!
 	 * This ensures that the state is created in the same way as just before the recording was requested.
-	 * 
+	 *
 	 * @param   StandardMode   If true, entire game will be reset, else just the current state will be reset.
 	 */
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
-	private static inline function updateRecordingSeed(StandardMode:Bool = true):Int
+	static inline function updateRecordingSeed(StandardMode:Bool = true):Int
 	{
 		return _recordingSeed = FlxG.random.initialSeed = StandardMode ? FlxG.random.initialSeed : _stateSeed;
 	}
-	
+
 	/**
 	 * Returns the seed to use for the requested recording.
 	 */
 	@:allow(flixel.FlxGame.handleReplayRequests)
-	private static inline function getRecordingSeed():Int
+	static inline function getRecordingSeed():Int
 	{
 		return _recordingSeed;
 	}

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -11,9 +11,9 @@ import flixel.util.FlxStringUtil;
 class FlxRect implements IFlxPooled
 {
 	public static var pool(get, never):IFlxPool<FlxRect>;
-	
-	private static var _pool = new FlxPool<FlxRect>(FlxRect);
-	
+
+	static var _pool = new FlxPool<FlxRect>(FlxRect);
+
 	/**
 	 * Recycle or create new FlxRect.
 	 * Be sure to put() them back into the pool after you're done with them!
@@ -24,9 +24,9 @@ class FlxRect implements IFlxPooled
 		rect._inPool = false;
 		return rect;
 	}
-	
+
 	/**
-	 * Recycle or create a new FlxRect which will automatically be released 
+	 * Recycle or create a new FlxRect which will automatically be released
 	 * to the pool when passed into a flixel function.
 	 */
 	public static inline function weak(X:Float = 0, Y:Float = 0, Width:Float = 0, Height:Float = 0):FlxRect
@@ -35,46 +35,46 @@ class FlxRect implements IFlxPooled
 		rect._weak = true;
 		return rect;
 	}
-	
+
 	public var x:Float;
 	public var y:Float;
 	public var width:Float;
 	public var height:Float;
-	
+
 	/**
 	 * The x coordinate of the left side of the rectangle.
 	 */
 	public var left(get, set):Float;
-	
+
 	/**
 	 * The x coordinate of the right side of the rectangle.
 	 */
 	public var right(get, set):Float;
-	
+
 	/**
 	 * The x coordinate of the top of the rectangle.
 	 */
 	public var top(get, set):Float;
-	
+
 	/**
 	 * The y coordinate of the bottom of the rectangle.
 	 */
 	public var bottom(get, set):Float;
-	
+
 	/**
 	 * Whether width or height of this rectangle is equal to zero or not.
 	 */
 	public var isEmpty(get, null):Bool;
-	
-	private var _weak:Bool = false;
-	private var _inPool:Bool = false;
-	
+
+	var _weak:Bool = false;
+	var _inPool:Bool = false;
+
 	@:keep
 	public function new(X:Float = 0, Y:Float = 0, Width:Float = 0, Height:Float = 0)
 	{
 		set(X, Y, Width, Height);
 	}
-	
+
 	/**
 	 * Add this FlxRect to the recycling pool.
 	 */
@@ -87,7 +87,7 @@ class FlxRect implements IFlxPooled
 			_pool.putUnsafe(this);
 		}
 	}
-	
+
 	/**
 	 * Add this FlxPoint to the recycling pool if it's a weak reference (allocated via weak()).
 	 */
@@ -98,10 +98,10 @@ class FlxRect implements IFlxPooled
 			put();
 		}
 	}
-	
+
 	/**
 	 * Shortcut for setting both width and Height.
-	 * 
+	 *
 	 * @param	Width	The new sprite width.
 	 * @param	Height	The new sprite height.
 	 */
@@ -111,7 +111,7 @@ class FlxRect implements IFlxPooled
 		height = Height;
 		return this;
 	}
-	
+
 	/**
 	 * Shortcut for setting both x and y.
 	 */
@@ -121,10 +121,10 @@ class FlxRect implements IFlxPooled
 		this.y = y;
 		return this;
 	}
-	
+
 	/**
 	 * Fill this rectangle with the data provided.
-	 * 
+	 *
 	 * @param	X		The X-coordinate of the point in space.
 	 * @param	Y		The Y-coordinate of the point in space.
 	 * @param	Width	Desired width of the rectangle.
@@ -142,7 +142,7 @@ class FlxRect implements IFlxPooled
 
 	/**
 	 * Helper function, just copies the values from the specified rectangle.
-	 * 
+	 *
 	 * @param	Rect	Any FlxRect.
 	 * @return	A reference to itself.
 	 */
@@ -152,14 +152,14 @@ class FlxRect implements IFlxPooled
 		y = Rect.y;
 		width = Rect.width;
 		height = Rect.height;
-		
+
 		Rect.putWeak();
 		return this;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from this rectangle to the specified rectangle.
-	 * 
+	 *
 	 * @param	Point	Any FlxRect.
 	 * @return	A reference to the altered rectangle parameter.
 	 */
@@ -169,14 +169,14 @@ class FlxRect implements IFlxPooled
 		Rect.y = y;
 		Rect.width = width;
 		Rect.height = height;
-		
+
 		Rect.putWeak();
 		return Rect;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from the specified Flash rectangle.
-	 * 
+	 *
 	 * @param	FlashRect	Any Rectangle.
 	 * @return	A reference to itself.
 	 */
@@ -188,10 +188,10 @@ class FlxRect implements IFlxPooled
 		height = FlashRect.height;
 		return this;
 	}
-	
+
 	/**
 	 * Helper function, just copies the values from this rectangle to the specified Flash rectangle.
-	 * 
+	 *
 	 * @param	Point	Any Rectangle.
 	 * @return	A reference to the altered rectangle parameter.
 	 */
@@ -201,17 +201,17 @@ class FlxRect implements IFlxPooled
 		{
 			FlashRect = new Rectangle();
 		}
-		
+
 		FlashRect.x = x;
 		FlashRect.y = y;
 		FlashRect.width = width;
 		FlashRect.height = height;
 		return FlashRect;
 	}
-	
+
 	/**
 	 * Checks to see if some FlxRect object overlaps this FlxRect object.
-	 * 
+	 *
 	 * @param	Rect	The rectangle being tested.
 	 * @return	Whether or not the two rectangles overlap.
 	 */
@@ -225,10 +225,10 @@ class FlxRect implements IFlxPooled
 		Rect.putWeak();
 		return result;
 	}
-	
+
 	/**
 	 * Returns true if this FlxRect contains the FlxPoint
-	 * 
+	 *
 	 * @param	Point	The FlxPoint to check
 	 * @return	True if the FlxPoint is within this FlxRect, otherwise false
 	 */
@@ -238,11 +238,11 @@ class FlxRect implements IFlxPooled
 		Point.putWeak();
 		return result;
 	}
-	
+
 	/**
-	 * Add another rectangle to this one by filling in the 
+	 * Add another rectangle to this one by filling in the
 	 * horizontal and vertical space between the two rectangles.
-	 * 
+	 *
 	 * @param	Rect	The second FlxRect to add to this one
 	 * @return	The changed FlxRect
 	 */
@@ -252,11 +252,11 @@ class FlxRect implements IFlxPooled
 		var minY:Float = Math.min(y, Rect.y);
 		var maxX:Float = Math.max(right, Rect.right);
 		var maxY:Float = Math.max(bottom, Rect.bottom);
-		
+
 		Rect.putWeak();
 		return set(minX, minY, maxX - minX, maxY - minY);
 	}
-	
+
 	/**
 	 * Rounds x, y, width and height using Math.floor()
 	 */
@@ -268,7 +268,7 @@ class FlxRect implements IFlxPooled
 		height = Math.floor(height);
 		return this;
 	}
-	
+
 	/**
 	 * Rounds x, y, width and height using Math.ceil()
 	 */
@@ -280,7 +280,7 @@ class FlxRect implements IFlxPooled
 		height = Math.ceil(height);
 		return this;
 	}
-	
+
 	/**
 	 * Rounds x, y, width and height using Math.round()
 	 */
@@ -292,10 +292,10 @@ class FlxRect implements IFlxPooled
 		height = Math.round(height);
 		return this;
 	}
-	
+
 	/**
 	 * Calculation of bounding box for two points
-	 * 
+	 *
 	 * @param	point1	first point to calculate bounding box
 	 * @param	point2	second point to calculate bounding box
 	 * @return	this rectangle filled with the position and size of bounding box for two specified points
@@ -304,19 +304,19 @@ class FlxRect implements IFlxPooled
 	{
 		var minX:Float = Math.min(Point1.x, Point2.x);
 		var minY:Float = Math.min(Point1.y, Point2.y);
-		
+
 		var maxX:Float = Math.max(Point1.x, Point2.x);
 		var maxY:Float = Math.max(Point1.y, Point2.y);
-		
+
 		Point1.putWeak();
 		Point2.putWeak();
 		return this.set(minX, minY, maxX - minX, maxY - minY);
 	}
-	
+
 	/**
-	 * Add another point to this rectangle one by filling in the 
+	 * Add another point to this rectangle one by filling in the
 	 * horizontal and vertical space between the point and this rectangle.
-	 * 
+	 *
 	 * @param	Point	point to add to this one
 	 * @return	The changed FlxRect
 	 */
@@ -326,26 +326,26 @@ class FlxRect implements IFlxPooled
 		var minY:Float = Math.min(y, Point.y);
 		var maxX:Float = Math.max(right, Point.x);
 		var maxY:Float = Math.max(bottom, Point.y);
-		
+
 		Point.putWeak();
 		return set(minX, minY, maxX - minX, maxY - minY);
 	}
-	
+
 	public inline function offset(dx:Float, dy:Float):FlxRect
 	{
 		x += dx;
 		y += dy;
 		return this;
 	}
-	
+
 	/**
 	 * Necessary for IFlxDestroyable.
 	 */
 	public function destroy() {}
-	
+
 	/**
 	 * Checks if this rectangle's properties are equal to properties of provided rect.
-	 * 
+	 *
 	 * @param	rect	Rectangle to check equality to.
 	 * @return	Whether both rectangles are equal.
 	 */
@@ -359,11 +359,11 @@ class FlxRect implements IFlxPooled
 		rect.putWeak();
 		return result;
 	}
-	
+
 	/**
-	 * Returns the area of intersection with specified rectangle. 
+	 * Returns the area of intersection with specified rectangle.
 	 * If the rectangles do not intersect, this method returns an empty rectangle.
-	 * 
+	 *
 	 * @param	rect	Rectangle to check intersection against.
 	 * @return	The area of intersection of two rectangles.
 	 */
@@ -371,27 +371,27 @@ class FlxRect implements IFlxPooled
 	{
 		if (result == null)
 			result = FlxRect.get();
-		
+
 		var x0:Float = x < rect.x ? rect.x : x;
 		var x1:Float = right > rect.right ? rect.right : right;
-		if (x1 <= x0) 
-		{	
+		if (x1 <= x0)
+		{
 			rect.putWeak();
 			return result;
 		}
-		
+
 		var y0:Float = y < rect.y ? rect.y : y;
 		var y1:Float = bottom > rect.bottom ? rect.bottom : bottom;
-		if (y1 <= y0) 
-		{	
+		if (y1 <= y0)
+		{
 			rect.putWeak();
 			return result;
 		}
-		
+
 		rect.putWeak();
 		return result.set(x0, y0, x1 - x0, y1 - y0);
 	}
-	
+
 	/**
 	 * Convert object to readable string name. Useful for debugging, save games, etc.
 	 */
@@ -403,57 +403,57 @@ class FlxRect implements IFlxPooled
 			LabelValuePair.weak("w", width),
 			LabelValuePair.weak("h", height)]);
 	}
-	
-	private inline function get_left():Float
+
+	inline function get_left():Float
 	{
 		return x;
 	}
-	
-	private inline function set_left(Value:Float):Float
+
+	inline function set_left(Value:Float):Float
 	{
 		width -= Value - x;
 		return x = Value;
 	}
-	
-	private inline function get_right():Float
+
+	inline function get_right():Float
 	{
 		return x + width;
 	}
-	
-	private inline function set_right(Value:Float):Float
+
+	inline function set_right(Value:Float):Float
 	{
 		width = Value - x;
 		return Value;
 	}
-	
-	private inline function get_top():Float
+
+	inline function get_top():Float
 	{
 		return y;
 	}
-	
-	private inline function set_top(Value:Float):Float
+
+	inline function set_top(Value:Float):Float
 	{
 		height -= Value - y;
 		return y = Value;
 	}
-	
-	private inline function get_bottom():Float
+
+	inline function get_bottom():Float
 	{
 		return y + height;
 	}
-	
-	private inline function set_bottom(Value:Float):Float
+
+	inline function set_bottom(Value:Float):Float
 	{
 		height = Value - y;
 		return Value;
 	}
-	
-	private inline function get_isEmpty():Bool
+
+	inline function get_isEmpty():Bool
 	{
 		return width == 0 || height == 0;
 	}
-	
-	private static function get_pool():IFlxPool<FlxRect>
+
+	static function get_pool():IFlxPool<FlxRect>
 	{
 		return _pool;
 	}

--- a/flixel/math/FlxVector.hx
+++ b/flixel/math/FlxVector.hx
@@ -9,17 +9,17 @@ class FlxVector extends FlxPoint
 {
 	public static inline var EPSILON:Float = 0.0000001;
 	public static inline var EPSILON_SQUARED:Float = EPSILON * EPSILON;
-	
-	private static var _pool = new FlxPool<FlxVector>(FlxVector);
-	
-	private static var _vector1:FlxVector = new FlxVector();
-	private static var _vector2:FlxVector = new FlxVector();
-	private static var _vector3:FlxVector = new FlxVector();
-	
+
+	static var _pool = new FlxPool<FlxVector>(FlxVector);
+
+	static var _vector1:FlxVector = new FlxVector();
+	static var _vector2:FlxVector = new FlxVector();
+	static var _vector3:FlxVector = new FlxVector();
+
 	/**
 	 * Recycle or create new FlxVector.
 	 * Be sure to put() them back into the pool after you're done with them!
-	 * 
+	 *
 	 * @param	X		The X-coordinate of the point in space.
 	 * @param	Y		The Y-coordinate of the point in space.
 	 */
@@ -29,7 +29,7 @@ class FlxVector extends FlxPoint
 		vector._inPool = false;
 		return vector;
 	}
-	
+
 	/**
 	 * Add this FlxVector to the recycling pool.
 	 */
@@ -41,7 +41,7 @@ class FlxVector extends FlxPoint
 			_pool.putUnsafe(this);
 		}
 	}
-	
+
 	/**
 	 * The horizontal component of the unit vector
 	 */
@@ -82,10 +82,10 @@ class FlxVector extends FlxPoint
 	 * The vertical component of the left normal of the vector
 	 */
 	public var ly(get, never):Float;
-	
+
 	/**
 	 * Set the coordinates of this point object.
-	 * 
+	 *
 	 * @param	X		The X-coordinate of the point in space.
 	 * @param	Y		The Y-coordinate of the point in space.
 	 */
@@ -95,10 +95,10 @@ class FlxVector extends FlxPoint
 		y = Y;
 		return this;
 	}
-	
+
 	/**
 	 * Scale this vector.
-	 * 
+	 *
 	 * @param	k - scale coefficient
 	 * @return	scaled vector
 	 */
@@ -107,10 +107,10 @@ class FlxVector extends FlxPoint
 		super.scale(k);
 		return this;
 	}
-	
+
 	/**
 	 * Returns scaled copy of this vector.
-	 * 
+	 *
 	 * @param	k - scale coefficient
 	 * @return	scaled vector
 	 */
@@ -118,10 +118,10 @@ class FlxVector extends FlxPoint
 	{
 		return clone().scale(k);
 	}
-	
+
 	/**
 	 * Return new vector which equals to sum of this vector and passed v vector.
-	 * 
+	 *
 	 * @param	v	vector to add
 	 * @return	addition result
 	 */
@@ -131,10 +131,10 @@ class FlxVector extends FlxPoint
 		nv.addPoint(v);
 		return nv;
 	}
-	
+
 	/**
 	 * Returns new vector which is result of subtraction of v vector from this vector.
-	 * 
+	 *
 	 * @param	v	vector to subtract
 	 * @return	subtraction result
 	 */
@@ -144,10 +144,10 @@ class FlxVector extends FlxPoint
 		nv.subtractPoint(v);
 		return nv;
 	}
-	
+
 	/**
 	 * Dot product between two vectors.
-	 * 
+	 *
 	 * @param	v	vector to multiply
 	 * @return	dot product of two vectors
 	 */
@@ -155,10 +155,10 @@ class FlxVector extends FlxPoint
 	{
 		return x * v.x + y * v.y;
 	}
-	
+
 	/**
 	 * Dot product of vectors with normalization of the second vector.
-	 * 
+	 *
 	 * @param	v	vector to multiply
 	 * @return	dot product of two vectors
 	 */
@@ -167,10 +167,10 @@ class FlxVector extends FlxPoint
 		var normalized:FlxVector = v.clone(_vector1).normalize();
 		return dotProduct(normalized);
 	}
-	
+
 	/**
 	 * Check the perpendicularity of two vectors.
-	 * 
+	 *
 	 * @param	v	vector to check
 	 * @return	true - if they are perpendicular
 	 */
@@ -178,10 +178,10 @@ class FlxVector extends FlxPoint
 	{
 		return Math.abs(dotProduct(v)) < EPSILON_SQUARED;
 	}
-	
+
 	/**
 	 * Find the length of cross product between two vectors.
-	 * 
+	 *
 	 * @param	v	vector to multiply
 	 * @return	the length of cross product of two vectors
 	 */
@@ -189,10 +189,10 @@ class FlxVector extends FlxPoint
 	{
 		return x * v.y - y * v.x;
 	}
-	
+
 	/**
 	 * Check for parallelism of two vectors.
-	 * 
+	 *
 	 * @param	v	vector to check
 	 * @return	true - if they are parallel
 	 */
@@ -200,17 +200,17 @@ class FlxVector extends FlxPoint
 	{
 		return Math.abs(crossProductLength(v)) < EPSILON_SQUARED;
 	}
-	
+
 	/**
 	 * Check if this vector has zero length.
-	 * 
+	 *
 	 * @return	true - if the vector is zero
 	 */
 	public inline function isZero():Bool
 	{
 		return Math.abs(x) < EPSILON && Math.abs(y) < EPSILON;
 	}
-	
+
 	/**
 	 * Vector reset
 	 */
@@ -219,19 +219,19 @@ class FlxVector extends FlxPoint
 		x = y = 0;
 		return this;
 	}
-	
+
 	/**
 	 * Normalization of the vector (reduction to unit length)
 	 */
 	public function normalize():FlxVector
 	{
-		if (isZero()) 
+		if (isZero())
 		{
 			return this;
 		}
 		return scale(1 / length);
 	}
-	
+
 	/**
 	 * Check the vector for unit length
 	 */
@@ -239,10 +239,10 @@ class FlxVector extends FlxPoint
 	{
 		return Math.abs(lengthSquared - 1) < EPSILON_SQUARED;
 	}
-	
+
 	/**
 	 * Rotate the vector for a given angle.
-	 * 
+	 *
 	 * @param	rads	angle to rotate
 	 * @return	rotated vector
 	 */
@@ -251,16 +251,16 @@ class FlxVector extends FlxPoint
 		var s:Float = Math.sin(rads);
 		var c:Float = Math.cos(rads);
 		var tempX:Float = x;
-		
+
 		x = tempX * c - y * s;
 		y = tempX * s + y * c;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Rotate the vector for a given angle.
-	 * 
+	 *
 	 * @param	degs	angle to rotate
 	 * @return	rotated vector
 	 */
@@ -268,10 +268,10 @@ class FlxVector extends FlxPoint
 	{
 		return rotateByRadians(degs * FlxAngle.TO_RAD);
 	}
-	
+
 	/**
 	 * Rotate the vector with the values of sine and cosine of the angle of rotation.
-	 * 
+	 *
 	 * @param	sin	the value of sine of the angle of rotation
 	 * @param	cos	the value of cosine of the angle of rotation
 	 * @return	rotated vector
@@ -283,52 +283,52 @@ class FlxVector extends FlxPoint
 		y = tempX * sin + y * cos;
 		return this;
 	}
-	
+
 	/**
 	 * Right normal of the vector
 	 */
 	public function rightNormal(?vec:FlxVector):FlxVector
-	{ 
+	{
 		if (vec == null)
 		{
 			vec = FlxVector.get();
 		}
 		vec.set( -y, x);
-		return vec; 
+		return vec;
 	}
-	
+
 	/**
 	 * Left normal of the vector
 	 */
 	public function leftNormal(?vec:FlxVector):FlxVector
-	{ 
+	{
 		if (vec == null)
 		{
 			vec = FlxVector.get();
 		}
 		vec.set(y, -x);
-		return vec; 
+		return vec;
 	}
-	
+
 	/**
 	 * Change direction of the vector to opposite
 	 */
 	public inline function negate():FlxVector
-	{ 
+	{
 		x *= -1;
 		y *= -1;
 		return this;
 	}
-	
+
 	public inline function negateNew():FlxVector
 	{
 		return clone().negate();
 	}
-	
+
 	/**
-	 * The projection of this vector to vector that is passed as an argument 
+	 * The projection of this vector to vector that is passed as an argument
 	 * (without modifying the original Vector!).
-	 * 
+	 *
 	 * @param	v	vector to project
 	 * @param	proj	optional argument - result vector
 	 * @return	projection of the vector
@@ -337,18 +337,18 @@ class FlxVector extends FlxPoint
 	{
 		var dp:Float = dotProduct(v);
 		var lenSq:Float = v.lengthSquared;
-		
+
 		if (proj == null)
 		{
 			proj = FlxVector.get();
 		}
-		
+
 		return proj.set(dp * v.x / lenSq, dp * v.y / lenSq);
 	}
-		
+
 	/**
 	 * Projecting this vector on the normalized vector v.
-	 * 
+	 *
 	 * @param	v	this vector has to be normalized, ie have unit length
 	 * @param	proj	optional argument - result vector
 	 * @return	projection of the vector
@@ -356,15 +356,15 @@ class FlxVector extends FlxPoint
 	public function projectToNormalized(v:FlxVector, ?proj:FlxVector):FlxVector
 	{
 		var dp:Float = dotProduct(v);
-		
+
 		if (proj == null)
 		{
 			proj = FlxVector.get();
 		}
-		
+
 		return proj.set(dp * v.x, dp * v.y);
 	}
-		
+
 	/**
 	 * Dot product of left the normal vector and vector v
 	 */
@@ -372,10 +372,10 @@ class FlxVector extends FlxPoint
 	{
 		return lx * v.x + ly * v.y;
 	}
-	
+
 	/**
 	 * Find the ratio between the perpProducts of this vector and v vector. This helps to find the intersection point.
-	 * 
+	 *
 	 * @param	a	start point of the vector
 	 * @param	b	start point of the v vector
 	 * @param	v	the second vector
@@ -385,16 +385,16 @@ class FlxVector extends FlxPoint
 	{
 		if (isParallel(v)) return Math.NaN;
 		if (lengthSquared < EPSILON_SQUARED || v.lengthSquared < EPSILON_SQUARED) return Math.NaN;
-		
+
 		_vector1 = b.clone(_vector1);
 		_vector1.subtractPoint(a);
-		
+
 		return _vector1.perpProduct(v) / perpProduct(v);
 	}
-		
+
 	/**
 	 * Finding the point of intersection of vectors.
-	 * 
+	 *
 	 * @param	a	start point of the vector
 	 * @param	b	start point of the v vector
 	 * @param	v	the second vector
@@ -403,23 +403,23 @@ class FlxVector extends FlxPoint
 	public function findIntersection(a:FlxVector, b:FlxVector, v:FlxVector, ?intersection:FlxVector):FlxVector
 	{
 		var t:Float = ratio(a, b, v);
-		
+
 		if (intersection == null)
 		{
 			intersection = FlxVector.get();
 		}
-		
+
 		if (Math.isNaN(t))
 		{
 			return intersection.set(Math.NaN, Math.NaN);
 		}
-		
+
 		return intersection.set(a.x + t * x, a.y + t * y);
 	}
-	
+
 	/**
 	 * Finding the point of intersection of vectors if it is in the "bounds" of the vectors.
-	 * 
+	 *
 	 * @param	a	start point of the vector
 	 * @param	b	start point of the v vector
 	 * @param	v	the second vector
@@ -431,20 +431,20 @@ class FlxVector extends FlxPoint
 		{
 			intersection = FlxVector.get();
 		}
-		
+
 		var t1:Float = ratio(a, b, v);
 		var t2:Float = v.ratio(b, a, this);
 		if (!Math.isNaN(t1) && !Math.isNaN(t2) && t1 > 0 && t1 <= 1 && t2 > 0 && t2 <= 1)
 		{
 			return intersection.set(a.x + t1 * x, a.y + t1 * y);
 		}
-		
+
 		return intersection.set(Math.NaN, Math.NaN);
 	}
-	
+
 	/**
 	 * Limit the length of this vector.
-	 * 
+	 *
 	 * @param	max	maximum length of this vector
 	 */
 	public inline function truncate(max:Float):FlxVector
@@ -452,10 +452,10 @@ class FlxVector extends FlxPoint
 		length = Math.min(max, length);
 		return this;
 	}
-	
+
 	/**
 	 * Get the angle between vectors (in radians).
-	 * 
+	 *
 	 * @param	v	second vector, which we find the angle
 	 * @return	the angle in radians
 	 */
@@ -463,10 +463,10 @@ class FlxVector extends FlxPoint
 	{
 		return Math.acos(dotProduct(v) / (length * v.length));
 	}
-	
+
 	/**
 	 * The angle between vectors (in degrees).
-	 * 
+	 *
 	 * @param	v	second vector, which we find the angle
 	 * @return	the angle in radians
 	 */
@@ -474,10 +474,10 @@ class FlxVector extends FlxPoint
 	{
 		return radiansBetween(v) * FlxAngle.TO_DEG;
 	}
-	
+
 	/**
 	 * The sign of half-plane of point with respect to the vector through the a and b points.
-	 * 
+	 *
 	 * @param	a	start point of the wall-vector
 	 * @param	b	end point of the wall-vector
 	 */
@@ -490,7 +490,7 @@ class FlxVector extends FlxPoint
 		}
 		return Math.round(signFl / Math.abs(signFl));
 	}
-	
+
 	/**
 	 * The distance between points
 	 */
@@ -498,7 +498,7 @@ class FlxVector extends FlxPoint
 	{
 		return Math.sqrt(distSquared(v));
 	}
-	
+
 	/**
 	 * The squared distance between points
 	 */
@@ -508,10 +508,10 @@ class FlxVector extends FlxPoint
 		var dy:Float = v.y - y;
 		return dx * dx + dy * dy;
 	}
-		
+
 	/**
 	 * Reflect the vector with respect to the normal of the "wall".
-	 * 
+	 *
 	 * @param normal left normal of the "wall". It must be normalized (no checks)
 	 * @param bounceCoeff bounce coefficient (0 <= bounceCoeff <= 1)
 	 * @return reflected vector (angle of incidence equals to angle of reflection)
@@ -523,10 +523,10 @@ class FlxVector extends FlxPoint
 		y -= d * normal.y;
 		return this;
 	}
-	
+
 	/**
 	 * Reflect the vector with respect to the normal. This operation takes "friction" into account.
-	 * 
+	 *
 	 * @param normal left normal of the "wall". It must be normalized (no checks)
 	 * @param bounceCoeff bounce coefficient (0 <= bounceCoeff <= 1)
 	 * @param friction friction coefficient
@@ -544,20 +544,20 @@ class FlxVector extends FlxPoint
 		y = bounceY * bounceCoeff + frictionY * friction;
 		return this;
 	}
-	
+
 	/**
 	 * Checking if this is a valid vector.
-	 * 
+	 *
 	 * @return	true - if the vector is valid
 	 */
 	public inline function isValid():Bool
-	{ 
-		return !Math.isNaN(x) && !Math.isNaN(y) && Math.isFinite(x) && Math.isFinite(y); 
+	{
+		return !Math.isNaN(x) && !Math.isNaN(y) && Math.isFinite(x) && Math.isFinite(y);
 	}
-	
+
 	/**
 	 * Copies this vector.
-	 * 
+	 *
 	 * @param	vec		optional vector to copy this vector to
 	 * @return	copy	of this vector
 	 */
@@ -567,32 +567,32 @@ class FlxVector extends FlxPoint
 		{
 			vec = FlxVector.get();
 		}
-		
+
 		vec.x = x;
 		vec.y = y;
 		return vec;
 	}
-	
-	private inline function get_dx():Float
+
+	inline function get_dx():Float
 	{
 		if (isZero()) return 0;
-		
+
 		return x / length;
 	}
-	
-	private inline function get_dy():Float
+
+	inline function get_dy():Float
 	{
 		if (isZero()) return 0;
-		
+
 		return y / length;
 	}
-	
-	private inline function get_length():Float
+
+	inline function get_length():Float
 	{
 		return Math.sqrt(lengthSquared);
 	}
-	
-	private inline function set_length(l:Float):Float
+
+	inline function set_length(l:Float):Float
 	{
 		if (!isZero())
 		{
@@ -602,55 +602,55 @@ class FlxVector extends FlxPoint
 		}
 		return l;
 	}
-	
-	private inline function get_lengthSquared():Float
+
+	inline function get_lengthSquared():Float
 	{
 		return x * x + y * y;
 	}
-	
-	private inline function get_degrees():Float
+
+	inline function get_degrees():Float
 	{
 		return radians * FlxAngle.TO_DEG;
 	}
-	
-	private inline function set_degrees(degs:Float):Float
+
+	inline function set_degrees(degs:Float):Float
 	{
 		radians = degs * FlxAngle.TO_RAD;
 		return degs;
 	}
-	
-	private function get_radians():Float
+
+	function get_radians():Float
 	{
 		if (isZero()) return 0;
-		
+
 		return Math.atan2(y, x);
 	}
-	
-	private inline function set_radians(rads:Float):Float
+
+	inline function set_radians(rads:Float):Float
 	{
 		var len:Float = length;
-		
+
 		x = len * Math.cos(rads);
 		y = len * Math.sin(rads);
 		return rads;
 	}
-	
-	private inline function get_rx():Float
+
+	inline function get_rx():Float
 	{
 		return -y;
 	}
-	
-	private inline function get_ry():Float
+
+	inline function get_ry():Float
 	{
 		return x;
 	}
-	
-	private inline function get_lx():Float
+
+	inline function get_lx():Float
 	{
 		return y;
 	}
-	
-	private inline function get_ly():Float
+
+	inline function get_ly():Float
 	{
 		return -x;
 	}

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -83,12 +83,12 @@ class FlxBasePreloader extends NMEPreloader
 		+ "Thank you for your interest in this game! Please support the developer by "
 		+ "visiting the following website to play the game:";
 
-	private var _percent:Float = 0;
-	private var _width:Int;
-	private var _height:Int;
-	private var _loaded:Bool = false;
-	private var _urlChecked:Bool = false;
-	private var _startTime:Float;
+	var _percent:Float = 0;
+	var _width:Int;
+	var _height:Int;
+	var _loaded:Bool = false;
+	var _urlChecked:Bool = false;
+	var _startTime:Float;
 
 	/**
 	 * FlxBasePreloader Constructor.
@@ -114,7 +114,7 @@ class FlxBasePreloader extends NMEPreloader
 	/**
 	 * Override this to create your own preloader objects.
 	 */
-	private function create():Void {}
+	function create():Void {}
 
 	/**
 	 * This function is called externally to initialize the Preloader.
@@ -152,7 +152,7 @@ class FlxBasePreloader extends NMEPreloader
 	 * This function is triggered on each 'frame'.
 	 * It is highly recommended that you do NOT override this.
 	 */
-	private function onEnterFrame(E:Event):Void
+	function onEnterFrame(E:Event):Void
 	{
 		var time = Date.now().getTime() - _startTime;
 		var min = minDisplayTime * 1000;
@@ -173,14 +173,14 @@ class FlxBasePreloader extends NMEPreloader
 	 * This function is called when the project has finished loading.
 	 * Override it to remove all of your objects.
 	 */
-	private function destroy():Void {}
+	function destroy():Void {}
 
 	/**
 	 * Override to draw your preloader objects in response to the Percent
 	 *
 	 * @param	Percent		How much of the program has loaded.
 	 */
-	private function update(Percent:Float):Void {}
+	function update(Percent:Float):Void {}
 
 	/**
 	 * This function is called EXTERNALLY once the movie has actually finished being loaded.
@@ -202,7 +202,7 @@ class FlxBasePreloader extends NMEPreloader
 	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new Bitmap instance is passed as an argument.
 	 * @return  The Bitmap instance that was created.
 	 */
-	private function createBitmap(bitmapDataClass:Class<BitmapData>, onLoad:Bitmap->Void):Bitmap
+	function createBitmap(bitmapDataClass:Class<BitmapData>, onLoad:Bitmap->Void):Bitmap
 	{
 		#if html5
 		var bmp = new Bitmap();
@@ -226,7 +226,7 @@ class FlxBasePreloader extends NMEPreloader
 	 * @param	onLoad				Executed once the bitmap data is finished loading in HTML5, and immediately in Flash. The new BitmapData instance is passed as an argument.
 	 * @return  The BitmapData instance that was created.
 	 */
-	private function loadBitmapData(bitmapDataClass:Class<BitmapData>, onLoad:BitmapData->Void):BitmapData
+	function loadBitmapData(bitmapDataClass:Class<BitmapData>, onLoad:BitmapData->Void):BitmapData
 	{
 		#if html5
 		return Type.createInstance(bitmapDataClass, [0, 0, true, 0xFFFFFFFF, onLoad]);
@@ -240,7 +240,7 @@ class FlxBasePreloader extends NMEPreloader
 	/**
 	 * Site-locking Functionality
 	 */
-	private function checkSiteLock():Void
+	function checkSiteLock():Void
 	{
 		#if web
 		if (_urlChecked)
@@ -265,14 +265,14 @@ class FlxBasePreloader extends NMEPreloader
 	 * When overridden, allows the customized creation of the sitelock failure screen.
 	 * @since 4.3.0
 	 */
-	private function createSiteLockFailureScreen():Void
+	function createSiteLockFailureScreen():Void
 	{
 		addChild(createSiteLockFailureBackground(0xffffff, 0xe5e5e5));
 		addChild(createSiteLockFailureIcon(0xe5e5e5, 0.9));
 		addChild(createSiteLockFailureText(30));
 	}
 
-	private function createSiteLockFailureBackground(innerColor:FlxColor, outerColor:FlxColor):Shape
+	function createSiteLockFailureBackground(innerColor:FlxColor, outerColor:FlxColor):Shape
 	{
 		var shape = new Shape();
 		var graphics = shape.graphics;
@@ -290,7 +290,7 @@ class FlxBasePreloader extends NMEPreloader
 		return shape;
 	}
 
-	private function createSiteLockFailureIcon(color:FlxColor, scale:Float):Shape
+	function createSiteLockFailureIcon(color:FlxColor, scale:Float):Shape
 	{
 		var shape = new Shape();
 		var graphics = shape.graphics;
@@ -318,7 +318,7 @@ class FlxBasePreloader extends NMEPreloader
 		return shape;
 	}
 
-	private function createSiteLockFailureText(margin:Float):Sprite
+	function createSiteLockFailureText(margin:Float):Sprite
 	{
 		var sprite = new Sprite();
 		var bounds = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
@@ -373,9 +373,9 @@ class FlxBasePreloader extends NMEPreloader
 	 * When overridden, allows the customization of the text fields in the sitelock failure screen.
 	 * @since 4.3.0
 	 */
-	private function adjustSiteLockTextFields(titleText:TextField, bodyText:TextField, hyperlinkText:TextField):Void {}
+	function adjustSiteLockTextFields(titleText:TextField, bodyText:TextField, hyperlinkText:TextField):Void {}
 
-	private function goToMyURL(?e:MouseEvent):Void
+	function goToMyURL(?e:MouseEvent):Void
 	{
 		//if the chosen URL isn't "local", use FlxG's openURL() function.
 		if (allowedURLs[siteLockURLIndex] != FlxBasePreloader.LOCAL)
@@ -384,7 +384,7 @@ class FlxBasePreloader extends NMEPreloader
 			Lib.getURL(new URLRequest(allowedURLs[siteLockURLIndex]));
 	}
 
-	private function isHostUrlAllowed():Bool
+	function isHostUrlAllowed():Bool
 	{
 		if (allowedURLs.length == 0)
 			return true;

--- a/flixel/system/FlxLinkedList.hx
+++ b/flixel/system/FlxLinkedList.hx
@@ -15,8 +15,8 @@ class FlxLinkedList implements IFlxDestroyable
 	 * to this collection, and when they get recycled they get removed.
 	 */
 	public static var  _NUM_CACHED_FLX_LIST:Int = 0;
-	private static var _cachedListsHead:FlxLinkedList;
-	
+	static var _cachedListsHead:FlxLinkedList;
+
 	/**
 	 * Recycle a cached Linked List, or creates a new one if needed.
 	 */
@@ -27,7 +27,7 @@ class FlxLinkedList implements IFlxDestroyable
 			var cachedList:FlxLinkedList = _cachedListsHead;
 			_cachedListsHead = _cachedListsHead.next;
 			_NUM_CACHED_FLX_LIST--;
-			
+
 			cachedList.exists = true;
 			cachedList.next = null;
 			return cachedList;
@@ -35,12 +35,12 @@ class FlxLinkedList implements IFlxDestroyable
 		else
 			return new FlxLinkedList();
 	}
-	
+
 	/**
 	 * Clear cached List nodes. You might want to do this when loading new levels
 	 * (probably not though, no need to clear cache unless you run into memory problems).
 	 */
-	public static function clearCache():Void 
+	public static function clearCache():Void
 	{
 		// null out next pointers to help out garbage collector
 		while (_cachedListsHead != null)
@@ -52,7 +52,7 @@ class FlxLinkedList implements IFlxDestroyable
 		}
 		_NUM_CACHED_FLX_LIST = 0;
 	}
-	
+
 	/**
 	 * Stores a reference to a FlxObject.
 	 */
@@ -61,14 +61,14 @@ class FlxLinkedList implements IFlxDestroyable
 	 * Stores a reference to the next link in the list.
 	 */
 	public var next:FlxLinkedList;
-	
+
 	public var exists:Bool = true;
-	
+
 	/**
 	 * Private, use recycle instead.
 	 */
-	private function new() {}
-	
+	function new() {}
+
 	/**
 	 * Clean up memory.
 	 */
@@ -77,14 +77,14 @@ class FlxLinkedList implements IFlxDestroyable
 		// ensure we haven't been destroyed already
 		if (!exists)
 			return;
-		
+
 		object = null;
 		if (next != null)
 		{
 			next.destroy();
 		}
 		exists = false;
-		
+
 		// Deposit this list into the linked list for reusal.
 		next = _cachedListsHead;
 		_cachedListsHead = this;

--- a/flixel/system/FlxPreloader.hx
+++ b/flixel/system/FlxPreloader.hx
@@ -16,21 +16,21 @@ private class GraphicLogoLight extends BitmapData {}
 private class GraphicLogoCorners extends BitmapData {}
 
 /**
- * This is the Default HaxeFlixel Themed Preloader 
+ * This is the Default HaxeFlixel Themed Preloader
  * You can make your own style of Preloader by overriding `FlxPreloaderBase` and using this class as an example.
  * To use your Preloader, simply change `Project.xml` to say: `<app preloader="class.path.MyPreloader" />`
  */
 class FlxPreloader extends FlxBasePreloader
 {
-	private var _buffer:Sprite;
-	private var _bmpBar:Bitmap;
-	private var _text:TextField;
-	private var _logo:Sprite;
-	private var _logoGlow:Sprite;
-	
+	var _buffer:Sprite;
+	var _bmpBar:Bitmap;
+	var _text:TextField;
+	var _logo:Sprite;
+	var _logoGlow:Sprite;
+
 	/**
 	 * Initialize your preloader here.
-	 * 
+	 *
 	 * ```haxe
 	 * super(0, ["test.com", FlxPreloaderBase.LOCAL]); // example of site-locking
 	 * super(10); // example of long delay (10 seconds)
@@ -40,13 +40,13 @@ class FlxPreloader extends FlxBasePreloader
 	{
 		super(MinDisplayTime, AllowedURLs);
 	}
-	
+
 	/**
 	 * This class is called as soon as the FlxPreloaderBase has finished initializing.
 	 * Override it to draw all your graphics and things - make sure you also override update
 	 * Make sure you call super.create()
 	 */
-	override private function create():Void
+	override function create():Void
 	{
 		_buffer = new Sprite();
 		_buffer.scaleX = _buffer.scaleY = 2;
@@ -54,7 +54,7 @@ class FlxPreloader extends FlxBasePreloader
 		_width = Std.int(Lib.current.stage.stageWidth / _buffer.scaleX);
 		_height = Std.int(Lib.current.stage.stageHeight / _buffer.scaleY);
 		_buffer.addChild(new Bitmap(new BitmapData(_width, _height, false, 0x00345e)));
-		
+
 		var logoLight = createBitmap(GraphicLogoLight, function(logoLight:Bitmap)
 		{
 			logoLight.width = logoLight.height = _height;
@@ -66,7 +66,7 @@ class FlxPreloader extends FlxBasePreloader
 		_bmpBar.x = 4;
 		_bmpBar.y = _height - 11;
 		_buffer.addChild(_bmpBar);
-		
+
 		_text = new TextField();
 		_text.defaultTextFormat = new TextFormat(FlxAssets.FONT_DEFAULT, 8, 0x5f6aff);
 		_text.embedFonts = true;
@@ -76,7 +76,7 @@ class FlxPreloader extends FlxBasePreloader
 		_text.y = _bmpBar.y - 11;
 		_text.width = 200;
 		_buffer.addChild(_text);
-		
+
 		_logo = new Sprite();
 		FlxAssets.drawLogo(_logo.graphics);
 		_logo.scaleX = _logo.scaleY = _height / 8 * 0.04;
@@ -97,7 +97,7 @@ class FlxPreloader extends FlxBasePreloader
 		});
 		corners.smoothing = true;
 		_buffer.addChild(corners);
-		
+
 		var bitmap = new Bitmap(new BitmapData(_width, _height, false, 0xffffff));
 		var i:Int = 0;
 		var j:Int = 0;
@@ -113,17 +113,17 @@ class FlxPreloader extends FlxBasePreloader
 		bitmap.blendMode = BlendMode.OVERLAY;
 		bitmap.alpha = 0.25;
 		_buffer.addChild(bitmap);
-		
+
 		super.create();
 	}
-	
+
 	/**
 	 * Cleanup your objects!
 	 * Make sure you call super.destroy()!
 	 */
-	override private function destroy():Void
+	override function destroy():Void
 	{
-		if (_buffer != null)	
+		if (_buffer != null)
 		{
 			removeChild(_buffer);
 		}
@@ -134,7 +134,7 @@ class FlxPreloader extends FlxBasePreloader
 		_logoGlow = null;
 		super.destroy();
 	}
-	
+
 	/**
 	 * Update is called every frame, passing the current percent loaded. Use this to change your loading bar or whatever.
 	 * @param	Percent	The percentage that the project is loaded
@@ -143,7 +143,7 @@ class FlxPreloader extends FlxBasePreloader
 	{
 		_bmpBar.scaleX = Percent * (_width - 8);
 		_text.text = Std.string(FlxG.VERSION) + " " + Std.int(Percent * 100) + "%";
-		
+
 		if (Percent < 0.1)
 		{
 			_logoGlow.alpha = 0;

--- a/flixel/system/FlxQuadTree.hx
+++ b/flixel/system/FlxQuadTree.hx
@@ -27,181 +27,181 @@ class FlxQuadTree extends FlxRect
 	 * Controls the granularity of the quad tree.  Default is 6 (decent performance on large and small worlds).
 	 */
 	public static var divisions:Int;
-	
+
 	public var exists:Bool;
-	
+
 	/**
 	 * Whether this branch of the tree can be subdivided or not.
 	 */
-	private var _canSubdivide:Bool;
-	
+	var _canSubdivide:Bool;
+
 	/**
 	 * Refers to the internal A and B linked lists,
 	 * which are used to store objects in the leaves.
 	 */
-	private var _headA:FlxLinkedList;
+	var _headA:FlxLinkedList;
 	/**
 	 * Refers to the internal A and B linked lists,
 	 * which are used to store objects in the leaves.
 	 */
-	private var _tailA:FlxLinkedList;
+	var _tailA:FlxLinkedList;
 	/**
 	 * Refers to the internal A and B linked lists,
 	 * which are used to store objects in the leaves.
 	 */
-	private var _headB:FlxLinkedList;
+	var _headB:FlxLinkedList;
 	/**
 	 * Refers to the internal A and B linked lists,
 	 * which are used to store objects in the leaves.
 	 */
-	private var _tailB:FlxLinkedList;
+	var _tailB:FlxLinkedList;
 
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private static var _min:Int;
+	static var _min:Int;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _northWestTree:FlxQuadTree;
+	var _northWestTree:FlxQuadTree;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _northEastTree:FlxQuadTree;
+	var _northEastTree:FlxQuadTree;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _southEastTree:FlxQuadTree;
+	var _southEastTree:FlxQuadTree;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _southWestTree:FlxQuadTree;
+	var _southWestTree:FlxQuadTree;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _leftEdge:Float;
+	var _leftEdge:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _rightEdge:Float;
+	var _rightEdge:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _topEdge:Float;
+	var _topEdge:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _bottomEdge:Float;
+	var _bottomEdge:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _halfWidth:Float;
+	var _halfWidth:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _halfHeight:Float;
+	var _halfHeight:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _midpointX:Float;
+	var _midpointX:Float;
 	/**
 	 * Internal, governs and assists with the formation of the tree.
 	 */
-	private var _midpointY:Float;
-	
+	var _midpointY:Float;
+
 	/**
 	 * Internal, used to reduce recursive method parameters during object placement and tree formation.
 	 */
-	private static var _object:FlxObject;
+	static var _object:FlxObject;
 	/**
 	 * Internal, used to reduce recursive method parameters during object placement and tree formation.
 	 */
-	private static var _objectLeftEdge:Float;
+	static var _objectLeftEdge:Float;
 	/**
 	 * Internal, used to reduce recursive method parameters during object placement and tree formation.
 	 */
-	private static var _objectTopEdge:Float;
+	static var _objectTopEdge:Float;
 	/**
 	 * Internal, used to reduce recursive method parameters during object placement and tree formation.
 	 */
-	private static var _objectRightEdge:Float;
+	static var _objectRightEdge:Float;
 	/**
 	 * Internal, used to reduce recursive method parameters during object placement and tree formation.
 	 */
-	private static var _objectBottomEdge:Float;
-	
+	static var _objectBottomEdge:Float;
+
 	/**
 	 * Internal, used during tree processing and overlap checks.
 	 */
-	private static var _list:Int;
+	static var _list:Int;
 	/**
 	 * Internal, used during tree processing and overlap checks.
 	 */
-	private static var _useBothLists:Bool;
+	static var _useBothLists:Bool;
 	/**
 	 * Internal, used during tree processing and overlap checks.
 	 */
-	private static var _processingCallback:FlxObject->FlxObject->Bool;
+	static var _processingCallback:FlxObject->FlxObject->Bool;
 	/**
 	 * Internal, used during tree processing and overlap checks.
 	 */
-	private static var _notifyCallback:FlxObject->FlxObject->Void;
+	static var _notifyCallback:FlxObject->FlxObject->Void;
 	/**
 	 * Internal, used during tree processing and overlap checks.
 	 */
-	private static var _iterator:FlxLinkedList;
-	
+	static var _iterator:FlxLinkedList;
+
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _objectHullX:Float;
+	static var _objectHullX:Float;
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _objectHullY:Float;
+	static var _objectHullY:Float;
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _objectHullWidth:Float;
+	static var _objectHullWidth:Float;
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _objectHullHeight:Float;
-	
+	static var _objectHullHeight:Float;
+
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _checkObjectHullX:Float;
+	static var _checkObjectHullX:Float;
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _checkObjectHullY:Float;
+	static var _checkObjectHullY:Float;
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _checkObjectHullWidth:Float;
+	static var _checkObjectHullWidth:Float;
 	/**
 	 * Internal, helpers for comparing actual object-to-object overlap - see overlapNode().
 	 */
-	private static var _checkObjectHullHeight:Float;
-	
+	static var _checkObjectHullHeight:Float;
+
 	/**
 	 * Pooling mechanism, turn FlxQuadTree into a linked list, when FlxQuadTrees are destroyed, they get added to the list, and when they get recycled they get removed.
 	 */
 	public static  var _NUM_CACHED_QUAD_TREES:Int = 0;
-	private static var _cachedTreesHead:FlxQuadTree;
-	private var next:FlxQuadTree;
-	
+	static var _cachedTreesHead:FlxQuadTree;
+	var next:FlxQuadTree;
+
 	/**
 	 * Private, use recycle instead.
 	 */
-	private function new(X:Float, Y:Float, Width:Float, Height:Float, ?Parent:FlxQuadTree)
+	function new(X:Float, Y:Float, Width:Float, Height:Float, ?Parent:FlxQuadTree)
 	{
 		super();
 		set(X, Y, Width, Height);
 		reset(X, Y, Width, Height, Parent);
 	}
-	
+
 	/**
 	 * Recycle a cached Quad Tree node, or creates a new one if needed.
 	 * @param	X			The X-coordinate of the point in space.
@@ -217,7 +217,7 @@ class FlxQuadTree extends FlxRect
 			var cachedTree:FlxQuadTree = _cachedTreesHead;
 			_cachedTreesHead = _cachedTreesHead.next;
 			_NUM_CACHED_QUAD_TREES--;
-			
+
 			cachedTree.reset(X, Y, Width, Height, Parent);
 			return cachedTree;
 		}
@@ -227,7 +227,7 @@ class FlxQuadTree extends FlxRect
 	/**
 	 * Clear cached Quad Tree nodes. You might want to do this when loading new levels (probably not though, no need to clear cache unless you run into memory problems).
 	 */
-	public static function clearCache():Void 
+	public static function clearCache():Void
 	{
 		// null out next pointers to help out garbage collector
 		while (_cachedTreesHead != null)
@@ -238,16 +238,16 @@ class FlxQuadTree extends FlxRect
 		}
 		_NUM_CACHED_QUAD_TREES = 0;
 	}
-	
+
 	public function reset(X:Float, Y:Float, Width:Float, Height:Float, ?Parent:FlxQuadTree):Void
 	{
 		exists = true;
-		
+
 		set(X, Y, Width, Height);
-		
+
 		_headA = _tailA = FlxLinkedList.recycle();
 		_headB = _tailB = FlxLinkedList.recycle();
-		
+
 		//Copy the parent's children (if there are any)
 		if (Parent != null)
 		{
@@ -289,7 +289,7 @@ class FlxQuadTree extends FlxRect
 			_min = Math.floor((width + height) / (2 * divisions));
 		}
 		_canSubdivide = (width > _min) || (height > _min);
-		
+
 		//Set up comparison/sort helpers
 		_northWestTree = null;
 		_northEastTree = null;
@@ -304,7 +304,7 @@ class FlxQuadTree extends FlxRect
 		_halfHeight = height / 2;
 		_midpointY = _topEdge + _halfHeight;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -318,16 +318,16 @@ class FlxQuadTree extends FlxRect
 
 		_northWestTree = FlxDestroyUtil.destroy(_northWestTree);
 		_northEastTree = FlxDestroyUtil.destroy(_northEastTree);
-		
+
 		_southWestTree = FlxDestroyUtil.destroy(_southWestTree);
 		_southEastTree = FlxDestroyUtil.destroy(_southEastTree);
 
 		_object = null;
 		_processingCallback = null;
 		_notifyCallback = null;
-		
+
 		exists = false;
-		
+
 		// Deposit this tree into the linked list for reusal.
 		next = _cachedTreesHead;
 		_cachedTreesHead = this;
@@ -340,8 +340,8 @@ class FlxQuadTree extends FlxRect
 	 * Load objects and/or groups into the quad tree, and register notify and processing callbacks.
 	 * @param ObjectOrGroup1	Any object that is or extends FlxObject or FlxGroup.
 	 * @param ObjectOrGroup2	Any object that is or extends FlxObject or FlxGroup.  If null, the first parameter will be checked against itself.
-	 * @param NotifyCallback	A function with the form myFunction(Object1:FlxObject,Object2:FlxObject):void that is called whenever two objects are found to overlap in world space, and either no ProcessCallback is specified, or the ProcessCallback returns true. 
-	 * @param ProcessCallback	A function with the form myFunction(Object1:FlxObject,Object2:FlxObject):Boolean that is called whenever two objects are found to overlap in world space.  The NotifyCallback is only called if this function returns true.  See FlxObject.separate(). 
+	 * @param NotifyCallback	A function with the form myFunction(Object1:FlxObject,Object2:FlxObject):void that is called whenever two objects are found to overlap in world space, and either no ProcessCallback is specified, or the ProcessCallback returns true.
+	 * @param ProcessCallback	A function with the form myFunction(Object1:FlxObject,Object2:FlxObject):Boolean that is called whenever two objects are found to overlap in world space.  The NotifyCallback is only called if this function returns true.  See FlxObject.separate().
 	 */
 	public function load(ObjectOrGroup1:FlxBasic, ?ObjectOrGroup2:FlxBasic, ?NotifyCallback:FlxObject->FlxObject->Void, ?ProcessCallback:FlxObject->FlxObject->Bool):Void
 	{
@@ -358,7 +358,7 @@ class FlxQuadTree extends FlxRect
 		_notifyCallback = NotifyCallback;
 		_processingCallback = ProcessCallback;
 	}
-	
+
 	/**
 	 * Call this function to add an object to the root of the tree.
 	 * This function will recursively add all group members, but
@@ -370,7 +370,7 @@ class FlxQuadTree extends FlxRect
 	public function add(ObjectOrGroup:FlxBasic, list:Int):Void
 	{
 		_list = list;
-		
+
 		var group = FlxTypedGroup.resolveGroup(ObjectOrGroup);
 		if (group != null)
 		{
@@ -416,12 +416,12 @@ class FlxQuadTree extends FlxRect
 			}
 		}
 	}
-	
+
 	/**
 	 * Internal function for recursively navigating and creating the tree
 	 * while adding objects to the appropriate nodes.
 	 */
-	private function addObject():Void
+	function addObject():Void
 	{
 		//If this quad (not its children) lies entirely inside this object, add it here
 		if (!_canSubdivide || (_leftEdge >= _objectLeftEdge && _rightEdge <= _objectRightEdge && _topEdge >= _objectTopEdge && _bottomEdge <= _objectBottomEdge))
@@ -429,7 +429,7 @@ class FlxQuadTree extends FlxRect
 			addToList();
 			return;
 		}
-		
+
 		//See if the selected object fits completely inside any of the quadrants
 		if ((_objectLeftEdge > _leftEdge) && (_objectRightEdge < _midpointX))
 		{
@@ -473,7 +473,7 @@ class FlxQuadTree extends FlxRect
 				return;
 			}
 		}
-		
+
 		//If it wasn't completely contained we have to check out the partial overlaps
 		if ((_objectRightEdge > _leftEdge) && (_objectLeftEdge < _midpointX) && (_objectBottomEdge > _topEdge) && (_objectTopEdge < _midpointY))
 		{
@@ -508,11 +508,11 @@ class FlxQuadTree extends FlxRect
 			_southWestTree.addObject();
 		}
 	}
-	
+
 	/**
 	 * Internal function for recursively adding objects to leaf lists.
 	 */
-	private function addToList():Void
+	function addToList():Void
 	{
 		var ot:FlxLinkedList;
 		if (_list == A_LIST)
@@ -556,7 +556,7 @@ class FlxQuadTree extends FlxRect
 			_southWestTree.addToList();
 		}
 	}
-	
+
 	/**
 	 * FlxQuadTree's other main function.  Call this after adding objects
 	 * using FlxQuadTree.load() to compare the objects that you loaded.
@@ -565,7 +565,7 @@ class FlxQuadTree extends FlxRect
 	public function execute():Bool
 	{
 		var overlapProcessed:Bool = false;
-		
+
 		if (_headA.object != null)
 		{
 			var iterator = _headA;
@@ -580,7 +580,7 @@ class FlxQuadTree extends FlxRect
 				{
 					_iterator = iterator.next;
 				}
-				if (_object != null && _object.exists && _object.allowCollisions > 0 && 
+				if (_object != null && _object.exists && _object.allowCollisions > 0 &&
 					_iterator != null && _iterator.object != null && overlapNode())
 				{
 					overlapProcessed = true;
@@ -588,7 +588,7 @@ class FlxQuadTree extends FlxRect
 				iterator = iterator.next;
 			}
 		}
-		
+
 		//Advance through the tree by calling overlap on each child
 		if ((_northWestTree != null) && _northWestTree.execute())
 		{
@@ -606,15 +606,15 @@ class FlxQuadTree extends FlxRect
 		{
 			overlapProcessed = true;
 		}
-		
+
 		return overlapProcessed;
 	}
-	
+
 	/**
 	 * An internal function for comparing an object against the contents of a node.
 	 * @return	Whether or not any overlaps were found.
 	 */
-	private function overlapNode():Bool
+	function overlapNode():Bool
 	{
 		//Calculate bulk hull for _object
 		_objectHullX = (_object.x < _object.last.x) ? _object.x : _object.last.x;
@@ -623,11 +623,11 @@ class FlxQuadTree extends FlxRect
 		_objectHullWidth = _object.width + ((_objectHullWidth > 0) ? _objectHullWidth : -_objectHullWidth);
 		_objectHullHeight = _object.y - _object.last.y;
 		_objectHullHeight = _object.height + ((_objectHullHeight > 0) ? _objectHullHeight : -_objectHullHeight);
-		
+
 		//Walk the list and check for overlaps
 		var overlapProcessed:Bool = false;
 		var checkObject:FlxObject;
-		
+
 		while (_iterator != null)
 		{
 			checkObject = _iterator.object;
@@ -636,7 +636,7 @@ class FlxQuadTree extends FlxRect
 				_iterator = _iterator.next;
 				continue;
 			}
-			
+
 			//Calculate bulk hull for checkObject
 			_checkObjectHullX = (checkObject.x < checkObject.last.x) ? checkObject.x : checkObject.last.x;
 			_checkObjectHullY = (checkObject.y < checkObject.last.y) ? checkObject.y : checkObject.last.y;
@@ -644,7 +644,7 @@ class FlxQuadTree extends FlxRect
 			_checkObjectHullWidth = checkObject.width + ((_checkObjectHullWidth > 0) ? _checkObjectHullWidth : -_checkObjectHullWidth);
 			_checkObjectHullHeight = checkObject.y - checkObject.last.y;
 			_checkObjectHullHeight = checkObject.height + ((_checkObjectHullHeight > 0) ? _checkObjectHullHeight : -_checkObjectHullHeight);
-			
+
 			//Check for intersection of the two hulls
 			if ((_objectHullX + _objectHullWidth > _checkObjectHullX) &&
 				(_objectHullX < _checkObjectHullX + _checkObjectHullWidth) &&
@@ -666,7 +666,7 @@ class FlxQuadTree extends FlxRect
 				_iterator = _iterator.next;
 			}
 		}
-		
+
 		return overlapProcessed;
 	}
 }

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -62,7 +62,7 @@ class FlxSound extends FlxBasic
 	 */
 	public var autoDestroy:Bool;
 	/**
-	 * Tracker for sound complete callback. If assigned, will be called 
+	 * Tracker for sound complete callback. If assigned, will be called
 	 * each time when sound reaches its end. Works only on flash and desktop targets.
 	 */
 	public var onComplete:Void->Void;
@@ -121,58 +121,58 @@ class FlxSound extends FlxBasic
 	/**
 	 * Internal tracker for a Flash sound object.
 	 */
-	private var _sound:Sound;
+	var _sound:Sound;
 	/**
 	 * Internal tracker for a Flash sound channel object.
 	 */
-	private var _channel:SoundChannel;
+	var _channel:SoundChannel;
 	/**
 	 * Internal tracker for a Flash sound transform object.
 	 */
-	private var _transform:SoundTransform;
+	var _transform:SoundTransform;
 	/**
 	 * Internal tracker for whether the sound is paused or not (not the same as stopped).
 	 */
-	private var _paused:Bool;
+	var _paused:Bool;
 	/**
 	 * Internal tracker for volume.
 	 */
-	private var _volume:Float;
+	var _volume:Float;
 	/**
 	 * Internal tracker for sound channel position.
 	 */
-	private var _time:Float = 0;
+	var _time:Float = 0;
 	/**
 	 * Internal tracker for sound length, so that length can still be obtained while a sound is paused, because _sound becomes null.
 	 */
-	private var _length:Float = 0;
+	var _length:Float = 0;
 	#if (sys && openfl_legacy)
 	/**
 	 * Internal tracker for pitch.
 	 */
-	private var _pitch:Float = 1.0;
+	var _pitch:Float = 1.0;
 	#end
 	/**
 	 * Internal tracker for total volume adjustment.
 	 */
-	private var _volumeAdjust:Float = 1.0;
+	var _volumeAdjust:Float = 1.0;
 	/**
 	 * Internal tracker for the sound's "target" (for proximity and panning).
 	 */
-	private var _target:FlxObject;
+	var _target:FlxObject;
 	/**
 	 * Internal tracker for the maximum effective radius of this sound (for proximity and panning).
 	 */
-	private var _radius:Float;
+	var _radius:Float;
 	/**
 	 * Internal tracker for whether to pan the sound left and right.  Default is false.
 	 */
-	private var _proximityPan:Bool;
+	var _proximityPan:Bool;
 	/**
 	 * Helper var to prevent the sound from playing after focus was regained when it was already paused.
 	 */
-	private var _alreadyPaused:Bool = false;
-	
+	var _alreadyPaused:Bool = false;
+
 	/**
 	 * The FlxSound constructor gets all the variables initialized, but NOT ready to play a sound yet.
 	 */
@@ -181,17 +181,17 @@ class FlxSound extends FlxBasic
 		super();
 		reset();
 	}
-	
+
 	/**
 	 * An internal function for clearing all the variables used by sounds.
 	 */
-	private function reset():Void
+	function reset():Void
 	{
 		destroy();
-		
+
 		x = 0;
 		y = 0;
-		
+
 		_time = 0;
 		_paused = false;
 		_volume = 1.0;
@@ -207,12 +207,12 @@ class FlxSound extends FlxBasic
 		amplitudeLeft = 0;
 		amplitudeRight = 0;
 		autoDestroy = false;
-		
+
 		if (_transform == null)
 			_transform = new SoundTransform();
 		_transform.pan = 0;
 	}
-	
+
 	override public function destroy():Void
 	{
 		_transform = null;
@@ -221,25 +221,25 @@ class FlxSound extends FlxBasic
 		_target = null;
 		name = null;
 		artist = null;
-		
+
 		if (_channel != null)
 		{
 			_channel.removeEventListener(Event.SOUND_COMPLETE, stopped);
 			_channel.stop();
 			_channel = null;
 		}
-		
+
 		if (_sound != null)
 		{
 			_sound.removeEventListener(Event.ID3, gotID3);
 			_sound = null;
 		}
-		
+
 		onComplete = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Handles fade out, fade in, panning, proximity, and amplitude operations each frame.
 	 */
@@ -247,11 +247,11 @@ class FlxSound extends FlxBasic
 	{
 		if (!playing)
 			return;
-		
+
 		_time = _channel.position;
-		
+
 		var radialMultiplier:Float = 1.0;
-		
+
 		// Distance-based volume control
 		if (_target != null)
 		{
@@ -259,17 +259,17 @@ class FlxSound extends FlxBasic
 			radialMultiplier = targetPosition.distanceTo(FlxPoint.weak(x, y)) / _radius;
 			targetPosition.put();
 			radialMultiplier = 1 - FlxMath.bound(radialMultiplier, 0, 1);
-			
+
 			if (_proximityPan)
 			{
 				var d:Float = (x - _target.x) / _radius;
 				_transform.pan = FlxMath.bound(d, -1, 1);
 			}
 		}
-		
+
 		_volumeAdjust = radialMultiplier;
 		updateTransform();
-		
+
 		if (_transform.volume > 0)
 		{
 			amplitudeLeft = _channel.leftPeak / _transform.volume;
@@ -282,23 +282,23 @@ class FlxSound extends FlxBasic
 			amplitudeRight = 0;
 			amplitude = 0;
 		}
-		
-		if (endTime != null && _time >= endTime) 
+
+		if (endTime != null && _time >= endTime)
 			stopped();
 	}
-	
+
 	override public function kill():Void
 	{
 		super.kill();
 		cleanup(false);
 	}
-	
+
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from an embedded MP3.
-	 * 
+	 *
 	 * @param	EmbeddedSound	An embedded Class object representing an MP3 file.
 	 * @param	Looped			Whether or not this sound should loop endlessly.
-	 * @param	AutoDestroy		Whether or not this FlxSound instance should be destroyed when the sound finishes playing. 
+	 * @param	AutoDestroy		Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
 	 * 							Default value is false, but `FlxG.sound.play()` and `FlxG.sound.stream()` will set it to true by default.
 	 * @return	This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
@@ -306,9 +306,9 @@ class FlxSound extends FlxBasic
 	{
 		if (EmbeddedSound == null)
 			return this;
-		
+
 		cleanup(true);
-		
+
 		if (Std.is(EmbeddedSound, Sound))
 		{
 			_sound = EmbeddedSound;
@@ -325,14 +325,14 @@ class FlxSound extends FlxBasic
 			else
 				FlxG.log.error('Could not find a Sound asset with an ID of \'$EmbeddedSound\'.');
 		}
-		
+
 		// NOTE: can't pull ID3 info from embedded sound currently
 		return init(Looped, AutoDestroy, OnComplete);
 	}
-	
+
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a URL.
-	 * 
+	 *
 	 * @param	SoundURL		A string representing the URL of the MP3 file you want to play.
 	 * @param	Looped			Whether or not this sound should loop endlessly.
 	 * @param	AutoDestroy		Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
@@ -342,18 +342,18 @@ class FlxSound extends FlxBasic
 	public function loadStream(SoundURL:String, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{
 		cleanup(true);
-		
+
 		_sound = new Sound();
 		_sound.addEventListener(Event.ID3, gotID3);
 		_sound.load(new URLRequest(SoundURL));
 
 		return init(Looped, AutoDestroy, OnComplete);
 	}
-	
+
 	#if flash11
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a ByteArray.
-	 * 
+	 *
 	 * @param	Bytes 			A ByteArray object.
 	 * @param	Looped			Whether or not this sound should loop endlessly.
 	 * @param	AutoDestroy		Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
@@ -363,16 +363,16 @@ class FlxSound extends FlxBasic
 	public function loadByteArray(Bytes:ByteArray, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{
 		cleanup(true);
-		
+
 		_sound = new Sound();
 		_sound.addEventListener(Event.ID3, gotID3);
 		_sound.loadCompressedDataFromByteArray(Bytes, Bytes.length);
-		
+
 		return init(Looped, AutoDestroy, OnComplete);
 	}
 	#end
 
-	private function init(Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
+	function init(Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{
 		looped = Looped;
 		autoDestroy = AutoDestroy;
@@ -383,7 +383,7 @@ class FlxSound extends FlxBasic
 		endTime = _length;
 		return this;
 	}
-	
+
 	/**
 	 * Call this function if you want this sound's volume to change
 	 * based on distance from a particular FlxObject.
@@ -404,11 +404,11 @@ class FlxSound extends FlxBasic
 		_proximityPan = Pan;
 		return this;
 	}
-	
+
 	/**
 	 * Call this function to play the sound - also works on paused sounds.
-	 * 
-	 * @param   ForceRestart   Whether to start the sound over or not. 
+	 *
+	 * @param   ForceRestart   Whether to start the sound over or not.
 	 *                         Default value is false, meaning if the sound is already playing or was
 	 *                         paused when you call play(), it will continue playing from its current
 	 *                         position, NOT start again from the beginning.
@@ -425,16 +425,16 @@ class FlxSound extends FlxBasic
 			cleanup(false, true);
 		else if (playing) // Already playing sound
 			return this;
-		
+
 		if (_paused)
 			resume();
 		else
 			startSound(StartTime);
-		
+
 		endTime = EndTime;
 		return this;
 	}
-	
+
 	/**
 	 * Unpause a sound. Only works on sounds that have been paused.
 	 */
@@ -444,7 +444,7 @@ class FlxSound extends FlxBasic
 			startSound(_time);
 		return this;
 	}
-	
+
 	/**
 	 * Call this function to pause this sound.
 	 */
@@ -458,7 +458,7 @@ class FlxSound extends FlxBasic
 		cleanup(false, false);
 		return this;
 	}
-	
+
 	/**
 	 * Call this function to stop this sound.
 	 */
@@ -467,10 +467,10 @@ class FlxSound extends FlxBasic
 		cleanup(autoDestroy, true);
 		return this;
 	}
-	
+
 	/**
 	 * Helper function that tweens this sound's volume.
-	 * 
+	 *
 	 * @param	Duration	The amount of time the fade-out operation should take.
 	 * @param	To			The volume to tween to, 0 by default.
 	 */
@@ -479,13 +479,13 @@ class FlxSound extends FlxBasic
 		if (fadeTween != null)
 			fadeTween.cancel();
 		fadeTween = FlxTween.num(volume, To, Duration, { onComplete: onComplete }, volumeTween);
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Helper function that tweens this sound's volume.
-	 * 
+	 *
 	 * @param	Duration	The amount of time the fade-in operation should take.
 	 * @param	From		The volume to tween from, 0 by default.
 	 * @param	To			The volume to tween to, 1 by default.
@@ -501,26 +501,26 @@ class FlxSound extends FlxBasic
 		fadeTween = FlxTween.num(From, To, Duration, { onComplete: onComplete }, volumeTween);
 		return this;
 	}
-	
-	private function volumeTween(f:Float):Void
+
+	function volumeTween(f:Float):Void
 	{
 		volume = f;
 	}
-	
+
 	/**
 	 * Returns the currently selected "real" volume of the sound (takes fades and proximity into account).
-	 * 
+	 *
 	 * @return	The adjusted volume of the sound.
 	 */
 	public inline function getActualVolume():Float
 	{
 		return _volume * _volumeAdjust;
 	}
-	
+
 	/**
 	 * Helper function to set the coordinates of this object.
 	 * Sound positioning is used in conjunction with proximity/panning.
-	 * 
+	 *
 	 * @param        X        The new x position
 	 * @param        Y        The new y position
 	 */
@@ -529,32 +529,32 @@ class FlxSound extends FlxBasic
 		x = X;
 		y = Y;
 	}
-	
+
 	/**
 	 * Call after adjusting the volume to update the sound channel's settings.
 	 */
 	@:allow(flixel.system.FlxSoundGroup)
-	private function updateTransform():Void
+	function updateTransform():Void
 	{
 		_transform.volume =
 			#if FLX_SOUND_SYSTEM
 			(FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume *
 			#end
 			(group != null ? group.volume : 1) * _volume * _volumeAdjust;
-		
+
 		if (_channel != null)
 			_channel.soundTransform = _transform;
 	}
-	
+
 	/**
 	 * An internal helper function used to attempt to start playing
 	 * the sound and populate the _channel variable.
 	 */
-	private function startSound(StartTime:Float):Void
+	function startSound(StartTime:Float):Void
 	{
 		if (_sound == null)
 			return;
-		
+
 		_time = StartTime;
 		_paused = false;
 		_channel = _sound.play(_time, 0, _transform);
@@ -572,16 +572,16 @@ class FlxSound extends FlxBasic
 			active = false;
 		}
 	}
-	
+
 	/**
 	 * An internal helper function used to help Flash
 	 * clean up finished sounds or restart looped sounds.
 	 */
-	private function stopped(?_):Void
+	function stopped(?_):Void
 	{
 		if (onComplete != null)
 			onComplete();
-		
+
 		if (looped)
 		{
 			cleanup(false);
@@ -590,31 +590,31 @@ class FlxSound extends FlxBasic
 		else
 			cleanup(autoDestroy);
 	}
-	
+
 	/**
 	 * An internal helper function used to help Flash clean up (and potentially re-use) finished sounds.
 	 * Will stop the current sound and destroy the associated SoundChannel, plus,
 	 * any other commands ordered by the passed in parameters.
-	 * 
+	 *
 	 * @param  destroySound    Whether or not to destroy the sound. If this is true,
 	 *                         the position and fading will be reset as well.
 	 * @param  resetPosition   Whether or not to reset the position of the sound.
 	 */
-	private function cleanup(destroySound:Bool, resetPosition:Bool = true):Void
+	function cleanup(destroySound:Bool, resetPosition:Bool = true):Void
 	{
 		if (destroySound)
 		{
 			reset();
 			return;
 		}
-		
+
 		if (_channel != null)
 		{
 			_channel.removeEventListener(Event.SOUND_COMPLETE, stopped);
 			_channel.stop();
 			_channel = null;
 		}
-		
+
 		active = false;
 
 		if (resetPosition)
@@ -623,100 +623,100 @@ class FlxSound extends FlxBasic
 			_paused = false;
 		}
 	}
-	
+
 	/**
 	 * Internal event handler for ID3 info (i.e. fetching the song name).
 	 */
-	private function gotID3(_):Void
+	function gotID3(_):Void
 	{
 		name = _sound.id3.songName;
 		artist = _sound.id3.artist;
 		_sound.removeEventListener(Event.ID3, gotID3);
 	}
-	
+
 	#if FLX_SOUND_SYSTEM
 	@:allow(flixel.system.frontEnds.SoundFrontEnd)
-	private function onFocus():Void
+	function onFocus():Void
 	{
 		if (!_alreadyPaused)
 			resume();
 	}
-	
+
 	@:allow(flixel.system.frontEnds.SoundFrontEnd)
-	private function onFocusLost():Void
+	function onFocusLost():Void
 	{
 		_alreadyPaused = _paused;
 		pause();
 	}
 	#end
-	
-	private function set_group(group:FlxSoundGroup):FlxSoundGroup
-	{	
+
+	function set_group(group:FlxSoundGroup):FlxSoundGroup
+	{
 		if (this.group != group)
 		{
 			var oldGroup:FlxSoundGroup = this.group;
-			
+
 			// New group must be set before removing sound to prevent infinite recursion
 			this.group = group;
-			
+
 			if (oldGroup != null)
 				oldGroup.remove(this);
-			
+
 			if (group != null)
 				group.add(this);
-			
+
 			updateTransform();
 		}
 		return group;
 	}
-	
-	private inline function get_playing():Bool
+
+	inline function get_playing():Bool
 	{
 		return _channel != null;
 	}
-	
-	private inline function get_volume():Float
+
+	inline function get_volume():Float
 	{
 		return _volume;
 	}
-	
-	private function set_volume(Volume:Float):Float
+
+	function set_volume(Volume:Float):Float
 	{
 		_volume = FlxMath.bound(Volume, 0, 1);
 		updateTransform();
 		return Volume;
 	}
-	
+
 	#if (sys && openfl_legacy)
-	private inline function get_pitch():Float
+	inline function get_pitch():Float
 	{
 		return _pitch;
 	}
-	
-	private function set_pitch(v:Float):Float
+
+	function set_pitch(v:Float):Float
 	{
 		if (_channel != null)
 			_channel.pitch = v;
 		return _pitch = v;
 	}
 	#end
-	
-	private inline function get_pan():Float
+
+	inline function get_pan():Float
 	{
 		return _transform.pan;
 	}
-	
-	private inline function set_pan(pan:Float):Float
+
+	inline function set_pan(pan:Float):Float
 	{
 		return _transform.pan = pan;
 	}
-	
-	private inline function get_time():Float
+
+	inline function get_time():Float
 	{
 		return _time;
 	}
-	
-	private function set_time(time:Float):Float
+
+	function set_time(time:Float):Float
 	{
 		if (playing)
 		{
@@ -726,11 +726,11 @@ class FlxSound extends FlxBasic
 		return _time = time;
 	}
 
-	private inline function get_length():Float
+	inline function get_length():Float
 	{
 		return _length;
 	}
-	
+
 	override public function toString():String
 	{
 		return FlxStringUtil.getDebugString([

--- a/flixel/system/FlxSoundGroup.hx
+++ b/flixel/system/FlxSoundGroup.hx
@@ -9,12 +9,12 @@ class FlxSoundGroup
 	 * The sounds in this group
 	 */
 	public var sounds:Array<FlxSound> = [];
-	
+
 	/**
 	 * The volume of this group
 	 */
 	public var volume(default, set):Float;
-	
+
 	/**
 	 * Create a new sound group
 	 * @param	volume  The initial volume of this group
@@ -23,7 +23,7 @@ class FlxSoundGroup
 	{
 		this.volume = volume;
 	}
-	
+
 	/**
 	 * Add a sound to this group
 	 * @param	sound The sound to add to this group
@@ -39,7 +39,7 @@ class FlxSoundGroup
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Remove a sound from this group
 	 * @param	sound The sound to remove
@@ -54,7 +54,7 @@ class FlxSoundGroup
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Call this function to pause all sounds in this group.
 	 * @since 4.3.0
@@ -64,7 +64,7 @@ class FlxSoundGroup
 		for (sound in sounds)
 			sound.pause();
 	}
-	
+
 	/**
 	 * Unpauses all sounds in this group. Only works on sounds that have been paused.
 	 * @since 4.3.0
@@ -74,8 +74,8 @@ class FlxSoundGroup
 		for (sound in sounds)
 			sound.resume();
 	}
-	
-	private function set_volume(volume:Float):Float
+
+	function set_volume(volume:Float):Float
 	{
 		this.volume = volume;
 		for (sound in sounds)

--- a/flixel/system/FlxSplash.hx
+++ b/flixel/system/FlxSplash.hx
@@ -16,51 +16,51 @@ import flixel.util.FlxTimer;
 class FlxSplash extends FlxState
 {
 	public static var nextState:Class<FlxState>;
-	
-	private var _sprite:Sprite;
-	private var _gfx:Graphics;
-	private var _text:TextField;
-	
-	private var _times:Array<Float>;
-	private var _colors:Array<Int>;
-	private var _functions:Array<Void->Void>;
-	private var _curPart:Int = 0;
-	private var _cachedBgColor:FlxColor;
-	private var _cachedTimestep:Bool;
-	private var _cachedAutoPause:Bool;
-	
+
+	var _sprite:Sprite;
+	var _gfx:Graphics;
+	var _text:TextField;
+
+	var _times:Array<Float>;
+	var _colors:Array<Int>;
+	var _functions:Array<Void->Void>;
+	var _curPart:Int = 0;
+	var _cachedBgColor:FlxColor;
+	var _cachedTimestep:Bool;
+	var _cachedAutoPause:Bool;
+
 	override public function create():Void
 	{
 		_cachedBgColor = FlxG.cameras.bgColor;
 		FlxG.cameras.bgColor = FlxColor.BLACK;
-		
+
 		// This is required for sound and animation to synch up properly
 		_cachedTimestep = FlxG.fixedTimestep;
-		FlxG.fixedTimestep = false; 
-		
+		FlxG.fixedTimestep = false;
+
 		_cachedAutoPause = FlxG.autoPause;
 		FlxG.autoPause = false;
-		
+
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = false;
 		#end
-		
+
 		_times = [0.041, 0.184, 0.334, 0.495, 0.636];
 		_colors = [0x00b922, 0xffc132, 0xf5274e, 0x3641ff, 0x04cdfb];
 		_functions = [drawGreen, drawYellow, drawRed, drawBlue, drawLightBlue];
-		
+
 		for (time in _times)
 		{
 			new FlxTimer().start(time, timerCallback);
 		}
-		
+
 		var stageWidth:Int = Lib.current.stage.stageWidth;
 		var stageHeight:Int = Lib.current.stage.stageHeight;
-		
+
 		_sprite = new Sprite();
 		FlxG.stage.addChild(_sprite);
 		_gfx = _sprite.graphics;
-		
+
 		_text = new TextField();
 		_text.selectable = false;
 		_text.embedFonts = true;
@@ -69,15 +69,15 @@ class FlxSplash extends FlxState
 		_text.defaultTextFormat = dtf;
 		_text.text = "HaxeFlixel";
 		FlxG.stage.addChild(_text);
-		
+
 		onResize(stageWidth, stageHeight);
-		
-		#if FLX_SOUND_SYSTEM 
+
+		#if FLX_SOUND_SYSTEM
 		FlxG.sound.load(FlxAssets.getSound("flixel/sounds/flixel")).play();
 		#end
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		_sprite = null;
 		_gfx = null;
@@ -87,29 +87,29 @@ class FlxSplash extends FlxState
 		_functions = null;
 		super.destroy();
 	}
-	
-	override public function onResize(Width:Int, Height:Int):Void 
+
+	override public function onResize(Width:Int, Height:Int):Void
 	{
 		super.onResize(Width, Height);
-		
+
 		_sprite.x = (Width / 2);
 		_sprite.y = (Height / 2) - 20 * FlxG.game.scaleY;
-		
+
 		_text.width = Width / FlxG.game.scaleX;
 		_text.x = 0;
 		_text.y = _sprite.y + 80 * FlxG.game.scaleY;
-		
+
 		_sprite.scaleX = _text.scaleX = FlxG.game.scaleX;
 		_sprite.scaleY = _text.scaleY = FlxG.game.scaleY;
 	}
-	
-	private function timerCallback(Timer:FlxTimer):Void
+
+	function timerCallback(Timer:FlxTimer):Void
 	{
 		_functions[_curPart]();
 		_text.textColor = _colors[_curPart];
 		_text.text = "HaxeFlixel";
 		_curPart++;
-		
+
 		if (_curPart == 5)
 		{
 			// Make the logo a tad bit longer, so our users fully appreciate our hard work :D
@@ -117,8 +117,8 @@ class FlxSplash extends FlxState
 			FlxTween.tween(_text, { alpha: 0 }, 3.0, { ease: FlxEase.quadOut } );
 		}
 	}
-	
-	private function drawGreen():Void
+
+	function drawGreen():Void
 	{
 		_gfx.beginFill(0x00b922);
 		_gfx.moveTo(0, -37);
@@ -132,8 +132,8 @@ class FlxSplash extends FlxState
 		_gfx.lineTo(0, -37);
 		_gfx.endFill();
 	}
-	
-	private function drawYellow():Void
+
+	function drawYellow():Void
 	{
 		_gfx.beginFill(0xffc132);
 		_gfx.moveTo(-50, -50);
@@ -144,8 +144,8 @@ class FlxSplash extends FlxState
 		_gfx.lineTo(-50, -50);
 		_gfx.endFill();
 	}
-	
-	private function drawRed():Void
+
+	function drawRed():Void
 	{
 		_gfx.beginFill(0xf5274e);
 		_gfx.moveTo(50, -50);
@@ -156,8 +156,8 @@ class FlxSplash extends FlxState
 		_gfx.lineTo(50, -50);
 		_gfx.endFill();
 	}
-	
-	private function drawBlue():Void
+
+	function drawBlue():Void
 	{
 		_gfx.beginFill(0x3641ff);
 		_gfx.moveTo(-50, 50);
@@ -168,8 +168,8 @@ class FlxSplash extends FlxState
 		_gfx.lineTo(-50, 50);
 		_gfx.endFill();
 	}
-	
-	private function drawLightBlue():Void
+
+	function drawLightBlue():Void
 	{
 		_gfx.beginFill(0x04cdfb);
 		_gfx.moveTo(50, 50);
@@ -180,8 +180,8 @@ class FlxSplash extends FlxState
 		_gfx.lineTo(50, 50);
 		_gfx.endFill();
 	}
-	
-	private function onComplete(Tween:FlxTween):Void
+
+	function onComplete(Tween:FlxTween):Void
 	{
 		FlxG.cameras.bgColor = _cachedBgColor;
 		FlxG.fixedTimestep = _cachedTimestep;

--- a/flixel/system/debug/DebuggerUtil.hx
+++ b/flixel/system/debug/DebuggerUtil.hx
@@ -18,7 +18,7 @@ class DebuggerUtil
 	{
 		return initTextField(new TextField(), X, Y, Color, Size);
 	}
-	
+
 	public static function initTextField<T:TextField>(tf:T, X:Float = 0, Y:Float = 0, Color:FlxColor = FlxColor.WHITE, Size:Int = 12):T
 	{
 		tf.x = X;
@@ -36,15 +36,15 @@ class DebuggerUtil
 		tf.autoSize = TextFieldAutoSize.LEFT;
 		return tf;
 	}
-	
+
 	@:allow(flixel.system)
-	private static function fixSize(bitmapData:BitmapData):BitmapData
+	static function fixSize(bitmapData:BitmapData):BitmapData
 	{
 		#if html5 // dirty hack for openfl/openfl#682
 		Reflect.setProperty(bitmapData, "width", 11);
 		Reflect.setProperty(bitmapData, "height", 11);
 		#end
-		
+
 		return bitmapData;
 	}
 }

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -32,7 +32,7 @@ private class GraphicDrawDebug extends BitmapData {}
 @:bitmap("assets/images/debugger/buttons/log.png")
 class GraphicLog extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/stats.png") 
+@:bitmap("assets/images/debugger/buttons/stats.png")
 class GraphicStats extends BitmapData {}
 
 @:bitmap("assets/images/debugger/buttons/watch.png")
@@ -41,13 +41,13 @@ class GraphicWatch extends BitmapData {}
 @:bitmap("assets/images/debugger/buttons/bitmapLog.png")
 class GraphicBitmapLog extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/console.png") 
+@:bitmap("assets/images/debugger/buttons/console.png")
 class GraphicConsole extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/arrowLeft.png") 
+@:bitmap("assets/images/debugger/buttons/arrowLeft.png")
 class GraphicArrowLeft extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/arrowRight.png") 
+@:bitmap("assets/images/debugger/buttons/arrowRight.png")
 class GraphicArrowRight extends BitmapData {}
 
 @:bitmap("assets/images/debugger/buttons/close.png")
@@ -71,7 +71,7 @@ class FlxDebugger extends Sprite
 	 * Internal, used to space out windows from the edges.
 	 */
 	public static inline var TOP_HEIGHT:Int = 20;
-	
+
 	public var stats:Stats;
 	public var log:Log;
 	public var watch:Watch;
@@ -79,56 +79,56 @@ class FlxDebugger extends Sprite
 	public var vcr:VCR;
 	public var console:Console;
 	public var interaction:Interaction;
-	private var completionList:CompletionList;
+	var completionList:CompletionList;
 
 	/**
 	 * Internal, tracks what debugger window layout user has currently selected.
 	 */
-	private var _layout:FlxDebuggerLayout = FlxDebuggerLayout.STANDARD;
+	var _layout:FlxDebuggerLayout = FlxDebuggerLayout.STANDARD;
 	/**
 	 * Internal, stores width and height of the game.
 	 */
-	private var _screen:Point = new Point();
+	var _screen:Point = new Point();
 	/**
 	 * Stores the bounds in which the windows can move.
 	 */
-	private var _screenBounds:Rectangle;
-	
-	private var _buttons:Map<FlxHorizontalAlign, Array<FlxSystemButton>> =
+	var _screenBounds:Rectangle;
+
+	var _buttons:Map<FlxHorizontalAlign, Array<FlxSystemButton>> =
 		[LEFT => [], CENTER => [], RIGHT => []];
-	
+
 	/**
 	 * The flash Sprite used for the top bar of the debugger ui
 	 **/
-	private var _topBar:Sprite;
-	
-	private var _windows:Array<Window> = [];
+	var _topBar:Sprite;
 
-	private var _usingSystemCursor = false;
-	private var _wasMouseVisible:Bool = true;
-	private var _wasUsingSystemCursor:Bool = false;
+	var _windows:Array<Window> = [];
+
+	var _usingSystemCursor = false;
+	var _wasMouseVisible:Bool = true;
+	var _wasUsingSystemCursor:Bool = false;
 
 	/**
 	 * Instantiates the debugger overlay.
-	 * 
+	 *
 	 * @param   Width    The width of the screen.
 	 * @param   Height   The height of the screen.
 	 */
 	@:allow(flixel.FlxGame)
-	private function new(Width:Float, Height:Float)
+	function new(Width:Float, Height:Float)
 	{
 		super();
-		
+
 		visible = false;
-		
+
 		Tooltip.init(this);
-		
+
 		_topBar = new Sprite();
 		_topBar.graphics.beginFill(0x000000, 0xAA / 255);
 		_topBar.graphics.drawRect(0, 0, FlxG.stage.stageWidth, TOP_HEIGHT);
 		_topBar.graphics.endFill();
 		addChild(_topBar);
-		
+
 		var txt = new TextField();
 		txt.height = 20;
 		txt.selectable = false;
@@ -139,7 +139,7 @@ class FlxDebugger extends Sprite
 		txt.defaultTextFormat = format;
 		txt.autoSize = TextFieldAutoSize.LEFT;
 		txt.text = Std.string(FlxG.VERSION);
-		
+
 		addWindow(log = new Log());
 		addWindow(bitmapLog = new BitmapLog());
 		addWindow(watch = new Watch());
@@ -147,41 +147,41 @@ class FlxDebugger extends Sprite
 		addWindow(console = new Console(completionList));
 		addWindow(stats = new Stats());
 		addWindow(interaction = new Interaction(this));
-		
+
 		vcr = new VCR(this);
-		
+
 		addButton(LEFT, new GraphicFlixel(0, 0), openHomepage);
 		addButton(LEFT, null, openGitHub).addChild(txt);
-		
+
 		addWindowToggleButton(interaction, GraphicInteractive);
 		addWindowToggleButton(bitmapLog, GraphicBitmapLog);
 		addWindowToggleButton(log, GraphicLog);
-		
+
 		addWindowToggleButton(watch, GraphicWatch);
 		addWindowToggleButton(console, GraphicConsole);
 		addWindowToggleButton(stats, GraphicStats);
-		
+
 		var drawDebugButton = addButton(RIGHT, new GraphicDrawDebug(0, 0), toggleDrawDebug, true);
 		drawDebugButton.toggled = !FlxG.debugger.drawDebug;
 		FlxG.debugger.drawDebugChanged.add(function()
-		{ 
+		{
 			drawDebugButton.toggled = !FlxG.debugger.drawDebug;
 		});
-		
+
 		#if FLX_RECORD
 		addButton(CENTER).addChild(vcr.runtimeDisplay);
 		#end
-		
+
 		addChild(completionList);
-		
+
 		onResize(Width, Height);
-		
+
 		addEventListener(MouseEvent.MOUSE_OVER, onMouseOver);
 		addEventListener(MouseEvent.MOUSE_OUT, onMouseOut);
-		
+
 		FlxG.signals.stateSwitched.add(Tracker.onStateSwitch);
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -189,10 +189,10 @@ class FlxDebugger extends Sprite
 	{
 		_screen = null;
 		_buttons = null;
-		
+
 		removeChild(_topBar);
 		_topBar = null;
-		
+
 		if (log != null)
 		{
 			removeChild(log);
@@ -217,28 +217,28 @@ class FlxDebugger extends Sprite
 			stats.destroy();
 			stats = null;
 		}
-		if (console != null) 
+		if (console != null)
 		{
 			removeChild(console);
 			console.destroy();
 			console = null;
 		}
-		
+
 		_windows = null;
-		
+
 		removeEventListener(MouseEvent.MOUSE_OVER, onMouseOver);
 		removeEventListener(MouseEvent.MOUSE_OUT, onMouseOut);
 	}
-	
+
 	public function update():Void
 	{
 		for (window in _windows)
 			window.update();
 	}
-	
+
 	/**
 	 * Change the way the debugger's windows are laid out.
-	 * 
+	 *
 	 * @param   Layout   The layout codes can be found in FlxDebugger, for example FlxDebugger.MICRO
 	 */
 	public inline function setLayout(Layout:FlxDebuggerLayout):Void
@@ -246,7 +246,7 @@ class FlxDebugger extends Sprite
 		_layout = Layout;
 		resetLayout();
 	}
-	
+
 	/**
 	 * Forces the debugger windows to reset to the last specified layout.
 	 * The default layout is STANDARD.
@@ -317,12 +317,12 @@ class FlxDebugger extends Sprite
 				bitmapLog.reposition(0, log.y - GUTTER - bitmapLog.height);
 		}
 	}
-	
+
 	public function onResize(Width:Float, Height:Float):Void
 	{
 		_screen.x = Width;
 		_screen.y = Height;
-		
+
 		updateBounds();
 		_topBar.width = FlxG.stage.stageWidth;
 		resetButtonLayout();
@@ -331,8 +331,8 @@ class FlxDebugger extends Sprite
 		x = -FlxG.scaleMode.offset.x;
 		y = -FlxG.scaleMode.offset.y;
 	}
-	
-	private function updateBounds():Void
+
+	function updateBounds():Void
 	{
 		_screenBounds = new Rectangle(GUTTER, TOP_HEIGHT + GUTTER / 2, _screen.x - GUTTER * 2, _screen.y - GUTTER * 2 - TOP_HEIGHT);
 		for (window in _windows)
@@ -344,11 +344,11 @@ class FlxDebugger extends Sprite
 	/**
 	 * Align an array of debugger buttons, used for the middle and right layouts
 	 */
-	private function hAlignButtons(Sprites:Array<FlxSystemButton>, Padding:Float = 0, Set:Bool = true, LeftOffset:Float = 0):Float
+	function hAlignButtons(Sprites:Array<FlxSystemButton>, Padding:Float = 0, Set:Bool = true, LeftOffset:Float = 0):Float
 	{
 		var width:Float = 0;
 		var last:Float = LeftOffset;
-		
+
 		for (i in 0...Sprites.length)
 		{
 			var o:Sprite = Sprites[i];
@@ -357,27 +357,27 @@ class FlxDebugger extends Sprite
 				o.x = last;
 			last = o.x + o.width + Padding;
 		}
-		
+
 		return width;
 	}
 
 	/**
 	 * Position the debugger buttons
 	 */
-	private function resetButtonLayout():Void
+	function resetButtonLayout():Void
 	{
 		hAlignButtons(_buttons[FlxHorizontalAlign.LEFT], 10, true, 10);
-		
+
 		var offset = FlxG.stage.stageWidth * 0.5 - hAlignButtons(_buttons[FlxHorizontalAlign.CENTER], 10, false) * 0.5;
 		hAlignButtons(_buttons[FlxHorizontalAlign.CENTER], 10, true, offset);
-		
+
 		var offset = FlxG.stage.stageWidth - hAlignButtons(_buttons[FlxHorizontalAlign.RIGHT], 10, false);
 		hAlignButtons(_buttons[FlxHorizontalAlign.RIGHT], 10, true, offset);
 	}
-	
+
 	/**
 	 * Create and add a new debugger button.
-	 * 
+	 *
 	 * @param   Position       Either LEFT, CENTER or RIGHT.
 	 * @param   Icon           The icon to use for the button
 	 * @param   UpHandler      The function to be called when the button is pressed.
@@ -391,16 +391,16 @@ class FlxDebugger extends Sprite
 		button.y = (TOP_HEIGHT / 2) - (button.height / 2);
 		_buttons[Position].push(button);
 		addChild(button);
-		
+
 		if (UpdateLayout)
 			resetButtonLayout();
-		
+
 		return button;
 	}
-	
+
 	/**
 	 * Removes and destroys a button from the debugger.
-	 * 
+	 *
 	 * @param   Button         The FlxSystemButton instance to remove.
 	 * @param   UpdateLayout   Whether to update the button layout.
 	 */
@@ -408,15 +408,15 @@ class FlxDebugger extends Sprite
 	{
 		removeChild(Button);
 		Button.destroy();
-		
+
 		_buttons[FlxHorizontalAlign.LEFT].remove(Button);
 		_buttons[FlxHorizontalAlign.CENTER].remove(Button);
 		_buttons[FlxHorizontalAlign.RIGHT].remove(Button);
-		
+
 		if (UpdateLayout)
 			resetButtonLayout();
 	}
-	
+
 	public function addWindowToggleButton(window:Window, icon:Class<BitmapData>):Void
 	{
 		var button = addButton(RIGHT, Type.createInstance(icon, [0, 0]),
@@ -436,15 +436,15 @@ class FlxDebugger extends Sprite
 		}
 		return window;
 	}
-	
+
 	public inline function removeWindow(window:Window):Void
 	{
 		if (contains(window))
 			removeChild(window);
 		_windows.fastSplice(window);
 	}
-	
-	override public function addChild(child:DisplayObject):DisplayObject 
+
+	override public function addChild(child:DisplayObject):DisplayObject
 	{
 		var result = super.addChild(child);
 		// hack to make sure the completion list always stays on top
@@ -452,11 +452,11 @@ class FlxDebugger extends Sprite
 			super.addChild(completionList);
 		return result;
 	}
-	
+
 	/**
 	 * Mouse handler that helps with fake "mouse focus" type behavior.
 	 */
-	private function onMouseOver(_):Void
+	function onMouseOver(_):Void
 	{
 		onMouseFocus();
 	}
@@ -464,12 +464,12 @@ class FlxDebugger extends Sprite
 	/**
 	 * Mouse handler that helps with fake "mouse focus" type behavior.
 	 */
-	private function onMouseOut(_):Void
+	function onMouseOut(_):Void
 	{
 		onMouseFocusLost();
 	}
 
-	private function onMouseFocus():Void
+	function onMouseFocus():Void
 	{
 		#if FLX_MOUSE
 		FlxG.mouse.enabled = false;
@@ -479,9 +479,9 @@ class FlxDebugger extends Sprite
 		_usingSystemCursor = true;
 		#end
 	}
-	
+
 	@:allow(flixel.system.debug)
-	private function onMouseFocusLost():Void
+	function onMouseFocusLost():Void
 	{
 		if (_usingSystemCursor)
 		{
@@ -490,20 +490,20 @@ class FlxDebugger extends Sprite
 			FlxG.mouse.useSystemCursor = _wasUsingSystemCursor;
 			FlxG.mouse.visible = _wasMouseVisible;
 			#end
-		}	
+		}
 	}
 
-	private inline function toggleDrawDebug():Void
+	inline function toggleDrawDebug():Void
 	{
 		FlxG.debugger.drawDebug = !FlxG.debugger.drawDebug;
 	}
-	
-	private inline function openHomepage():Void
+
+	inline function openHomepage():Void
 	{
 		FlxG.openURL("http://www.haxeflixel.com");
 	}
-	
-	private inline function openGitHub():Void
+
+	inline function openGitHub():Void
 	{
 		var url = "https://github.com/HaxeFlixel/flixel";
 		if (FlxVersion.sha != "")

--- a/flixel/system/debug/Tooltip.hx
+++ b/flixel/system/debug/Tooltip.hx
@@ -15,26 +15,26 @@ import flixel.util.FlxDestroyUtil;
  */
 class Tooltip
 {
-	private static var _tooltips:Array<TooltipOverlay> = [];
-	private static var _container:Sprite;
-	
+	static var _tooltips:Array<TooltipOverlay> = [];
+	static var _container:Sprite;
+
 	public static function init(container:Sprite):Void
 	{
 		_container = container;
 	}
-	
+
 	public static function add(element:Sprite, text:String):Void
 	{
 		var tooltip = new TooltipOverlay(element, text);
-		
+
 		_container.addChild(tooltip);
 		_tooltips.push(tooltip);
 	}
-	
+
 	public static function remove(element:Sprite):Bool
 	{
 		var removed:Bool = false;
-		
+
 		for (i in 0..._tooltips.length)
 		{
 			if (_tooltips[i] != null && _tooltips[i].owner == element)
@@ -45,7 +45,7 @@ class Tooltip
 				break;
 			}
 		}
-		
+
 		return removed;
 	}
 }
@@ -58,53 +58,53 @@ class TooltipOverlay extends Sprite
 	/**
 	 * The background color of all tooltips.
 	 */
-	private static inline var BG_COLOR:FlxColor = 0xFF3A3A3A;
-	
+	static inline var BG_COLOR:FlxColor = 0xFF3A3A3A;
+
 	/**
 	 * Alpha applied to the tooltips text.
 	 */
-	private static inline var TEXT_ALPHA:Float = 0.8;
-	
+	static inline var TEXT_ALPHA:Float = 0.8;
+
 	/**
 	 * How many pixels the tooltip should be away from the target in the x axis.
 	 */
-	private static inline var MARGIN_X:Int = 10;
-	
+	static inline var MARGIN_X:Int = 10;
+
 	/**
 	 * How many pixels the tooltip should be away from the target in the y axis.
 	 */
-	private static inline var MARGIN_Y:Float = 10;
-	
+	static inline var MARGIN_Y:Float = 10;
+
 	/**
 	 * Width of the tooltip. Using Sprite.width is super unreliable for some reason!
 	 */
-	private var _width:Int;
+	var _width:Int;
 	/**
 	 * Height of the tooltip. Using Sprite.height is super unreliable for some reason!
 	 */
-	private var _height:Int;
-	
+	var _height:Int;
+
 	/**
 	 * Main elements
-	 */ 
-	private var _background:Bitmap;
-	private var _shadow:Bitmap;
-	private var _text:TextField;
-	
+	 */
+	var _background:Bitmap;
+	var _shadow:Bitmap;
+	var _text:TextField;
+
 	/**
 	 * The element the tooltip is attached to.
 	 */
 	public var owner(default, null):Sprite;
-	
+
 	/**
 	 * Maximum size allowed for the tooltip. A negative value (or zero) makes
 	 * the tooltip auto-adjust its size to properly house its text.
 	 */
 	public var maxSize:Point;
-	
+
 	/**
 	 * Creates a new tooltip.
-	 * 
+	 *
 	 * @param	target	Element where the tooltip will be attached to.
 	 * @param	text	Text displayed with this tooltip.
 	 * @param	width	Width of the tooltip.  If a negative value (or zero) is specified, the tooltip will adjust its width to properly accommodate the text.
@@ -113,30 +113,30 @@ class TooltipOverlay extends Sprite
 	public function new(target:Sprite, text:String, width:Float = 0, height:Float = 0)
 	{
 		super();
-		
+
 		owner = target;
-		
+
 		maxSize = new Point(width, height);
-		
+
 		_shadow = new Bitmap(new BitmapData(1, 2, true, FlxColor.BLACK));
 		_background = new Bitmap(new BitmapData(1, 1, true, BG_COLOR));
-		
+
 		_text = DebuggerUtil.createTextField(2, 1);
 		_text.alpha = TEXT_ALPHA;
 		_text.text = text;
 		_text.wordWrap = true;
-		
+
 		addChild(_shadow);
 		addChild(_background);
 		addChild(_text);
-		
+
 		updateSize();
 		setVisible(false);
-		
+
 		owner.addEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
 		owner.addEventListener(MouseEvent.MOUSE_OUT, handleMouseEvents);
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -146,12 +146,12 @@ class TooltipOverlay extends Sprite
 		_background = FlxDestroyUtil.removeChild(this, _background);
 		_text = FlxDestroyUtil.removeChild(this, _text);
 		maxSize = null;
-		
+
 		owner.removeEventListener(MouseEvent.MOUSE_OVER, handleMouseEvents);
 		owner.removeEventListener(MouseEvent.MOUSE_OUT, handleMouseEvents);
 		owner = null;
 	}
-	
+
 	/**
 	 * Resize the tooltip. Subject to pre-specified minimums, maximums, and bounding rectangles.
 	 *
@@ -164,10 +164,10 @@ class TooltipOverlay extends Sprite
 		maxSize.y = Std.int(Math.abs(Height));
 		updateSize();
 	}
-	
+
 	/**
 	 * Change the position of the tooltip.
-	 * 
+	 *
 	 * @param 	X	Desired X position of top left corner of the tooltip.
 	 * @param 	Y	Desired Y position of top left corner of the tooltip.
 	 */
@@ -177,34 +177,34 @@ class TooltipOverlay extends Sprite
 		y = Y;
 		ensureOnScreen();
 	}
-	
+
 	public function setVisible(Value:Bool):Void
 	{
 		visible = Value;
-	
+
 		if (visible)
 		{
 			putOnTop();
 			ensureOnScreen();
 		}
 	}
-	
+
 	public function toggleVisible():Void
 	{
 		setVisible(!visible);
 	}
-	
+
 	public inline function putOnTop():Void
 	{
 		parent.addChild(this);
 	}
-	
+
 	public function update():Void {}
-	
+
 	/**
 	 * Update the Flash shapes to match the new size, and reposition the header, shadow, and handle accordingly.
 	 */
-	private function updateSize():Void
+	function updateSize():Void
 	{
 		_width = Std.int(maxSize.x <= 0 ? _text.textWidth : Math.abs(maxSize.x)) + 8;
 		_height = Std.int(maxSize.y <= 0 ? _text.textHeight : Math.abs(maxSize.y)) + 8;
@@ -214,30 +214,30 @@ class TooltipOverlay extends Sprite
 		_shadow.y = _height;
 		_text.width = _width;
 	}
-	
-	private function ensureOnScreen():Void
+
+	function ensureOnScreen():Void
 	{
 		// Move the tooltip back to the screen if top-left corner
 		// is out of the screen.
 		x = x < 0 ? 0 : x;
 		y = y < 0 ? 0 : y;
-		
+
 		// Calculate any adjustments to ensure that part of the
 		// tooltip is not outside of the screen.
 		var offsetX = x + width >= FlxG.stage.stageWidth ? FlxG.stage.stageWidth - (x + width) : 0;
 		var offsetY = y + height >= FlxG.stage.stageHeight ? FlxG.stage.stageHeight - (y + height) : 0;
-		
+
 		x += offsetX;
 		y += offsetY;
 	}
-	
-	private function handleMouseEvents(event:MouseEvent):Void
+
+	function handleMouseEvents(event:MouseEvent):Void
 	{
 		if (event.type == MouseEvent.MOUSE_OVER && !visible)
 		{
 			x = event.stageX + MARGIN_X;
 			y = event.stageY + MARGIN_Y;
-			
+
 			setVisible(true);
 		}
 		else if (event.type == MouseEvent.MOUSE_OUT)

--- a/flixel/system/debug/VCR.hx
+++ b/flixel/system/debug/VCR.hx
@@ -16,7 +16,7 @@ private class GraphicOpen extends BitmapData {}
 @:bitmap("assets/images/debugger/buttons/pause.png")
 private class GraphicPause extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/record_off.png") 
+@:bitmap("assets/images/debugger/buttons/record_off.png")
 private class GraphicRecordOff extends BitmapData {}
 
 @:bitmap("assets/images/debugger/buttons/record_on.png")
@@ -40,7 +40,7 @@ class VCR
 	 * Texfield that displays the runtime display data for a game replay
 	 */
 	public var runtimeDisplay:TextField;
-	
+
 	public var runtime:Float = 0;
 
 	/**
@@ -71,11 +71,11 @@ class VCR
 		#end
 		playbackToggleBtn = Debugger.addButton(CENTER, new GraphicPause(0, 0), onManualPause);
 		stepBtn = Debugger.addButton(CENTER, new GraphicStep(0, 0), onStep);
-		
+
 		#if FLX_RECORD
 		runtimeDisplay = DebuggerUtil.createTextField(0, -9);
 		updateRuntime(0);
-		
+
 		var runtimeBtn = Debugger.addButton(CENTER);
 		runtimeBtn.addChild(runtimeDisplay);
 		#end
@@ -101,7 +101,7 @@ class VCR
 		recordBtn.changeIcon(new GraphicRecordOn(0, 0));
 		recordBtn.upHandler = FlxG.vcr.startRecording.bind(true);
 	}
-	
+
 	/**
 	 * Usually called by FlxGame when a replay has been stopped.
 	 * Just updates the VCR GUI so the buttons are in the right state.
@@ -111,7 +111,7 @@ class VCR
 		recordBtn.changeIcon(new GraphicRecordOff(0, 0));
 		recordBtn.upHandler = FlxG.vcr.startRecording.bind(true);
 	}
-	
+
 	/**
 	 * Usually called by FlxGame when a requested replay has begun.
 	 * Just updates the VCR GUI so the buttons are in the right state.
@@ -121,7 +121,7 @@ class VCR
 		recordBtn.changeIcon(new GraphicStop(0, 0));
 		recordBtn.upHandler = FlxG.vcr.stopReplay;
 	}
-	
+
 	/**
 	 * Just updates the VCR GUI so the runtime displays roughly the right thing.
 	 */
@@ -136,7 +136,7 @@ class VCR
 	}
 	#end
 
-	private function onManualPause()
+	function onManualPause()
 	{
 		manualPause = true;
 		FlxG.vcr.pause();

--- a/flixel/system/debug/Window.hx
+++ b/flixel/system/debug/Window.hx
@@ -27,63 +27,63 @@ class Window extends Sprite
 	 * The background color of the window.
 	 */
 	public static inline var BG_COLOR:FlxColor = 0xDD5F5F5F;
-	
+
 	public static inline var HEADER_COLOR:FlxColor = 0xBB000000;
 	public static inline var HEADER_ALPHA:Float = 0.8;
 	public static inline var HEADER_HEIGHT:Int = 15;
-	
+
 	/**
 	 * How many windows there are currently in total.
 	 */
-	private static var WINDOW_AMOUNT:Int = 0;
+	static var WINDOW_AMOUNT:Int = 0;
 
 	public var minSize:Point;
 	public var maxSize:Point;
 	public var toggleButton:FlxSystemButton;
-	
+
 	/**
 	 * Width of the window. Using Sprite.width is super unreliable for some reason!
 	 */
-	private var _width:Int;
+	var _width:Int;
 	/**
 	 * Height of the window. Using Sprite.height is super unreliable for some reason!
 	 */
-	private var _height:Int;
+	var _height:Int;
 	/**
 	 * Controls where the window is allowed to be positioned.
 	 */
-	private var _bounds:Rectangle;
-	
+	var _bounds:Rectangle;
+
 	/**
 	 * Window elements
-	 */ 
-	private var _background:Bitmap;
-	private var _header:Bitmap;
-	private var _shadow:Bitmap;
-	private var _title:TextField;
-	private var _handle:Bitmap;
-	private var _closeButton:FlxSystemButton;
-	
+	 */
+	var _background:Bitmap;
+	var _header:Bitmap;
+	var _shadow:Bitmap;
+	var _title:TextField;
+	var _handle:Bitmap;
+	var _closeButton:FlxSystemButton;
+
 	/**
 	 * Interaction helpers.
 	 */
-	private var _overHeader:Bool;
-	private var _overHandle:Bool;
-	private var _drag:Point;
-	private var _dragging:Bool;
-	private var _resizing:Bool;
-	private var _resizable:Bool;
-	
-	private var _closable:Bool;
-	
+	var _overHeader:Bool;
+	var _overHandle:Bool;
+	var _drag:Point;
+	var _dragging:Bool;
+	var _resizing:Bool;
+	var _resizable:Bool;
+
+	var _closable:Bool;
+
 	/**
 	 * The ID of this window.
 	 */
-	private var _id:Int;
-	
+	var _id:Int;
+
 	/**
 	 * Creates a new window object.  This Flash-based class is mainly (only?) used by FlxDebugger.
-	 * 
+	 *
 	 * @param   Title       The name of the window, displayed in the header bar.
 	 * @param   Icon	    The icon to use for the window header.
 	 * @param   Width       The initial width of the window.
@@ -96,30 +96,30 @@ class Window extends Sprite
 		?Bounds:Rectangle, Closable:Bool = false)
 	{
 		super();
-		
+
 		minSize = new Point(50, 30);
-		
+
 		_width = Std.int(Math.abs(Width));
 		_height = Std.int(Math.abs(Height));
 		updateBounds(Bounds);
 		_drag = new Point();
 		_resizable = Resizable;
 		_closable = Closable;
-		
+
 		_shadow = new Bitmap(new BitmapData(1, 2, true, FlxColor.BLACK));
 		_background = new Bitmap(new BitmapData(1, 1, true, BG_COLOR));
 		_header = new Bitmap(new BitmapData(1, HEADER_HEIGHT, true, HEADER_COLOR));
 		_background.y = _header.height;
-		
+
 		_title = DebuggerUtil.createTextField(2, -1);
 		_title.alpha = HEADER_ALPHA;
 		_title.text = Title;
-		
+
 		addChild(_shadow);
 		addChild(_background);
 		addChild(_header);
 		addChild(_title);
-		
+
 		if (Icon != null)
 		{
 			DebuggerUtil.fixSize(Icon);
@@ -130,35 +130,35 @@ class Window extends Sprite
 			_title.x = icon.x + icon.width + 2;
 			addChild(icon);
 		}
-		
+
 		if (_resizable)
 		{
 			_handle = new Bitmap(DebuggerUtil.fixSize(new GraphicWindowHandle(0, 0)));
 			addChild(_handle);
 		}
-		
+
 		if (Closable)
 		{
 			_closeButton = new FlxSystemButton(new GraphicCloseButton(0, 0), close);
 			_closeButton.alpha = HEADER_ALPHA;
 			addChild(_closeButton);
 		}
-		else 
+		else
 		{
 			_id = WINDOW_AMOUNT;
 			loadSaveData();
 			WINDOW_AMOUNT++;
 		}
-		
+
 		if ((_width != 0) || (_height != 0))
 		{
 			updateSize();
 		}
 		bound();
-		
+
 		addEventListener(Event.ENTER_FRAME, init);
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -194,7 +194,7 @@ class Window extends Sprite
 		_handle = null;
 		_drag = null;
 		_closeButton = FlxDestroyUtil.destroy(_closeButton);
-		
+
 		var stage = FlxG.stage;
 		if (stage.hasEventListener(MouseEvent.MOUSE_MOVE))
 		{
@@ -209,7 +209,7 @@ class Window extends Sprite
 			stage.removeEventListener(MouseEvent.MOUSE_UP, onMouseUp);
 		}
 	}
-	
+
 	/**
 	 * Resize the window.  Subject to pre-specified minimums, maximums, and bounding rectangles.
 	 *
@@ -222,10 +222,10 @@ class Window extends Sprite
 		_height = Std.int(Math.abs(Height));
 		updateSize();
 	}
-	
+
 	/**
 	 * Change the position of the window.  Subject to pre-specified bounding rectangles.
-	 * 
+	 *
 	 * @param 	X	Desired X position of top left corner of the window.
 	 * @param 	Y	Desired Y position of top left corner of the window.
 	 */
@@ -235,7 +235,7 @@ class Window extends Sprite
 		y = Y;
 		bound();
 	}
-	
+
 	public function updateBounds(Bounds:Rectangle):Void
 	{
 		_bounds = Bounds;
@@ -248,35 +248,35 @@ class Window extends Sprite
 			maxSize = new Point(FlxMath.MAX_VALUE_FLOAT, FlxMath.MAX_VALUE_FLOAT);
 		}
 	}
-	
+
 	public function setVisible(Value:Bool):Void
 	{
 		visible = Value;
-		
+
 		if (!_closable)
 		{
 			FlxG.save.data.windowSettings[_id] = visible;
 			FlxG.save.flush();
 		}
-		
+
 		if (toggleButton != null)
 			toggleButton.toggled = !visible;
-	
+
 		if (visible)
 			putOnTop();
 	}
-	
+
 	public function toggleVisible():Void
 	{
 		setVisible(!visible);
 	}
-	
+
 	public inline function putOnTop():Void
 	{
 		parent.addChild(this);
 	}
-	
-	private function loadSaveData():Void
+
+	function loadSaveData():Void
 	{
 		if (FlxG.save.data.windowSettings != null)
 		{
@@ -288,8 +288,8 @@ class Window extends Sprite
 			loadSaveData();
 		}
 	}
-	
-	private function initSaveData():Void
+
+	function initSaveData():Void
 	{
 		var settings:Array<Bool> = [];
 		for (i in 0...10) // arbitrary max of windows
@@ -299,15 +299,15 @@ class Window extends Sprite
 		FlxG.save.data.windowSettings = settings;
 		FlxG.save.flush();
 	}
-	
+
 	public function update():Void {}
-	
+
 	//***EVENT HANDLERS***//
-	
+
 	/**
 	 * Used to set up basic mouse listeners..
 	 */
-	private function init(?E:Event):Void
+	function init(?E:Event):Void
 	{
 		#if flash
 		if (root == null)
@@ -318,29 +318,29 @@ class Window extends Sprite
 			return;
 		}
 		removeEventListener(Event.ENTER_FRAME, init);
-		
+
 		stage.addEventListener(MouseEvent.MOUSE_MOVE, onMouseMove);
 		stage.addEventListener(MouseEvent.MOUSE_UP, onMouseUp);
-		// it's important that the mouse down event listener is added to the window sprite, not the stage - this way 
+		// it's important that the mouse down event listener is added to the window sprite, not the stage - this way
 		// only the window on top receives the event and we don't have to deal with overlapping windows ourselves.
 		addEventListener(MouseEvent.MOUSE_DOWN, onMouseDown);
 	}
-	
+
 	/**
 	 * Mouse movement handler.  Figures out if mouse is over handle or header bar or what.
 	 */
-	private function onMouseMove(?E:MouseEvent):Void
+	function onMouseMove(?E:MouseEvent):Void
 	{
 		// mouseX / Y can be negative, which messes with the resizing if dragging in the opposite direction
 		var mouseX:Float = (this.mouseX < 0) ? 0 : this.mouseX;
 		var mouseY:Float = (this.mouseY < 0) ? 0 : this.mouseY;
-		
+
 		if (!parent.visible)
 		{
 			_overHandle = _overHeader = false;
 			return;
 		}
-		
+
 		if (_dragging) //user is moving the window around
 		{
 			_overHeader = true;
@@ -364,11 +364,11 @@ class Window extends Sprite
 			_overHandle = _overHeader = false;
 		}
 	}
-	
+
 	/**
 	 * Figure out if window is being repositioned (clicked on header) or resized (clicked on handle).
 	 */
-	private function onMouseDown(?E:MouseEvent):Void
+	function onMouseDown(?E:MouseEvent):Void
 	{
 		if (_overHeader)
 		{
@@ -385,18 +385,18 @@ class Window extends Sprite
 			_drag.y = _height - mouseY;
 		}
 	}
-	
+
 	/**
 	 * User let go of header bar or handler (or nothing), so turn off drag and resize behaviors.
 	 */
-	private function onMouseUp(?E:MouseEvent):Void
+	function onMouseUp(?E:MouseEvent):Void
 	{
 		_dragging = false;
 		_resizing = false;
 	}
-		
+
 	/**
-	 * Keep the window within the pre-specified bounding rectangle. 
+	 * Keep the window within the pre-specified bounding rectangle.
 	 */
 	public function bound():Void
 	{
@@ -406,15 +406,15 @@ class Window extends Sprite
 			y = FlxMath.bound(y, _bounds.top, _bounds.bottom - _height);
 		}
 	}
-	
+
 	/**
 	 * Update the Flash shapes to match the new size, and reposition the header, shadow, and handle accordingly.
 	 */
-	private function updateSize():Void
+	function updateSize():Void
 	{
 		_width = Std.int(FlxMath.bound(_width, minSize.x, maxSize.x));
 		_height = Std.int(FlxMath.bound(_height, minSize.y, maxSize.y));
-		
+
 		_header.scaleX = _width;
 		_background.scaleX = _width;
 		_background.scaleY = _height - _header.height;
@@ -432,7 +432,7 @@ class Window extends Sprite
 			_closeButton.y = 3;
 		}
 	}
-	
+
 	public function close():Void
 	{
 		destroy();

--- a/flixel/system/debug/completion/CompletionList.hx
+++ b/flixel/system/debug/completion/CompletionList.hx
@@ -12,59 +12,59 @@ class CompletionList extends Sprite
 	public var completed:String->Void;
 	public var selectionChanged:String->Void;
 	public var closed:Void->Void;
-	
+
 	public var filter(default, set):String;
-	
+
 	public var items(default, null):Array<String>;
-	
-	private var entries:Array<CompletionListEntry> = [];
-	private var originalItems:Array<String>;
-	private var selectedIndex:Int = 0;
-	private var lowerVisibleIndex:Int = 0;
-	private var upperVisibleIndex:Int = 0;
-	private var scrollBar:CompletionListScrollBar;
-	private var actualHeight:Int;
-	
-	public function new(capacity:Int) 
+
+	var entries:Array<CompletionListEntry> = [];
+	var originalItems:Array<String>;
+	var selectedIndex:Int = 0;
+	var lowerVisibleIndex:Int = 0;
+	var upperVisibleIndex:Int = 0;
+	var scrollBar:CompletionListScrollBar;
+	var actualHeight:Int;
+
+	public function new(capacity:Int)
 	{
 		super();
-		
+
 		visible = false;
 		upperVisibleIndex = capacity - 1;
-		actualHeight = capacity * CompletionListEntry.HEIGHT; 
-		
+		actualHeight = capacity * CompletionListEntry.HEIGHT;
+
 		createPopupEntries(capacity);
 		createScrollBar();
 		updateSelectedItem();
-		
+
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
 	}
-	
+
 	public function show(x:Float, items:Array<String>)
 	{
 		visible = true;
 		this.x = x;
 		this.originalItems = items;
 		filter = "";
-		
+
 		updateEntries();
 	}
-	
+
 	public function setY(y:Float)
 	{
 		this.y = y - actualHeight;
 	}
-	
+
 	public function close()
 	{
 		visible = false;
 		filter = null;
-		
+
 		if (closed != null)
 			closed();
 	}
-	
-	private function createPopupEntries(amount:Int)
+
+	function createPopupEntries(amount:Int)
 	{
 		for (i in 0...amount)
 		{
@@ -74,75 +74,75 @@ class CompletionList extends Sprite
 			entry.y = CompletionListEntry.HEIGHT * i;
 		}
 	}
-	
-	private function createScrollBar()
+
+	function createScrollBar()
 	{
 		scrollBar = new CompletionListScrollBar(
 			CompletionListEntry.WIDTH, 0, 5, actualHeight);
 		addChild(scrollBar);
 	}
-	
-	private function onKeyDown(e:KeyboardEvent)
+
+	function onKeyDown(e:KeyboardEvent)
 	{
 		if (!visible)
 			return;
-		
+
 		switch (e.keyCode)
 		{
 			case Keyboard.DOWN:
 				updateIndices(1);
-			
+
 			case Keyboard.UP:
 				updateIndices( -1);
-			
+
 			case Keyboard.ENTER:
 				if (completed != null)
 					completed(items[selectedIndex]);
 				close();
 				return;
-			
+
 			case Keyboard.ESCAPE:
 				close();
 				return;
 		}
-		
+
 		updateEntries();
 	}
-	
-	private function updateIndices(modifier:Int)
+
+	function updateIndices(modifier:Int)
 	{
 		selectedIndex = bound(selectedIndex + modifier);
 		if (FlxMath.inBounds(selectedIndex, lowerVisibleIndex, upperVisibleIndex))
 			return;
-		
+
 		// scroll visible area
 		lowerVisibleIndex = bound(lowerVisibleIndex + modifier);
 		upperVisibleIndex = bound(upperVisibleIndex + modifier);
 		var range = upperVisibleIndex - lowerVisibleIndex;
-			
+
 		if (range == items.length)
 			return;
-		
+
 		// hit lower or upper end
 		if (lowerVisibleIndex == 0)
 			upperVisibleIndex = entries.length - 1;
 		else if (upperVisibleIndex == items.length - 1)
 			lowerVisibleIndex = items.length - entries.length;
 	}
-	
-	private function bound(index:Int)
+
+	function bound(index:Int)
 	{
 		return Std.int(FlxMath.bound(index, 0, items.length - 1));
 	}
-	
-	private function updateEntries()
+
+	function updateEntries()
 	{
 		updateLabels();
 		updateSelectedItem();
 		scrollBar.updateHandle(lowerVisibleIndex, items.length, entries.length);
 	}
-	
-	private function updateLabels()
+
+	function updateLabels()
 	{
 		for (i in 0...entries.length)
 		{
@@ -152,53 +152,53 @@ class CompletionList extends Sprite
 			entries[i].setItem(selectedItem);
 		}
 	}
-	
-	private function updateSelectedItem()
+
+	function updateSelectedItem()
 	{
 		for (entry in entries)
 			entry.selected = false;
 		entries[selectedIndex - lowerVisibleIndex].selected = true;
-		
+
 		if (selectionChanged != null)
 			selectionChanged(items[selectedIndex]);
 	}
-	
-	private function setItems(items:Array<String>)
+
+	function setItems(items:Array<String>)
 	{
 		if (items == null)
 			return;
 		if (items.length == 0)
 			close();
-		
+
 		this.items = items;
-		
+
 		selectedIndex = 0;
 		lowerVisibleIndex = 0;
 		upperVisibleIndex = entries.length - 1;
 		updateEntries();
 	}
-	
-	private function filterItems(filter:String):Array<String>
+
+	function filterItems(filter:String):Array<String>
 	{
 		if (filter == null)
 			filter = "";
-		
+
 		return sortItems(filter, originalItems.filter(function(item)
 		{
 			return item.toLowerCase().contains(filter.toLowerCase());
 		}));
 	}
-	
+
 	/**
 	 * sort items so that:
 	 *   - strings starting with the filter have a higher priority than those only containing it
 	 *   - of those, shorter items (-> closer to the filter) have a higher priority
 	 */
-	private function sortItems(filter:String, items:Array<String>):Array<String>
+	function sortItems(filter:String, items:Array<String>):Array<String>
 	{
 		if (filter == "")
 			return items;
-		
+
 		items.sort(function(a, b)
 		{
 			var valueA = startsWithExt(a, filter);
@@ -207,18 +207,18 @@ class CompletionList extends Sprite
 				return -valueA;
 			if (valueB > valueA)
 				return valueB;
-			
+
 			if (valueA == valueB)
 				return Std.int(a.length - b.length);
 			return 0;
 		});
 		return items;
 	}
-	
+
 	/**
 	 * Custom startsWith() that ignores leading underscores.
 	 */
-	private function startsWithExt(s:String, start:String):Int
+	function startsWithExt(s:String, start:String):Int
 	{
 		if (s.startsWith(start))
 			return 2;
@@ -226,12 +226,12 @@ class CompletionList extends Sprite
 			return 1;
 		return 0;
 	}
-	
-	private function set_filter(filter:String):String
+
+	function set_filter(filter:String):String
 	{
 		if (filter == this.filter)
 			return filter;
-		
+
 		setItems(filterItems(filter));
 		return this.filter = filter;
 	}

--- a/flixel/system/debug/completion/CompletionListEntry.hx
+++ b/flixel/system/debug/completion/CompletionListEntry.hx
@@ -10,41 +10,41 @@ class CompletionListEntry extends Sprite
 {
 	public static inline var WIDTH = 150;
 	public static inline var HEIGHT = 20;
-	
-	private static inline var COLOR_NORMAL = 0xFF5F5F5F;
-	private static inline var COLOR_HIGHLIGHT = 0xFF6D6D6D;
-	private static inline var GUTTER = 4;
-	
-	private static var normalBitmapData:BitmapData;
-	private static var highlightBitmapData:BitmapData;
+
+	static inline var COLOR_NORMAL = 0xFF5F5F5F;
+	static inline var COLOR_HIGHLIGHT = 0xFF6D6D6D;
+	static inline var GUTTER = 4;
+
+	static var normalBitmapData:BitmapData;
+	static var highlightBitmapData:BitmapData;
 
 	public var selected(default, set):Bool = false;
-	
-	private var background:Bitmap;
-	private var label:TextField;
-	
-	public function new() 
-	{	
+
+	var background:Bitmap;
+	var label:TextField;
+
+	public function new()
+	{
 		super();
-		
+
 		initBitmapDatas();
-		
+
 		addChild(background = new Bitmap());
 		background.bitmapData = normalBitmapData;
-		
+
 		label = DebuggerUtil.createTextField();
 		label.x = GUTTER;
 		addChild(label);
 	}
-	
-	private function initBitmapDatas()
+
+	function initBitmapDatas()
 	{
 		if (normalBitmapData == null)
 			normalBitmapData = new BitmapData(WIDTH, HEIGHT, true, COLOR_NORMAL);
 		if (highlightBitmapData == null)
 			highlightBitmapData = new BitmapData(WIDTH, HEIGHT, true, COLOR_HIGHLIGHT);
 	}
-	
+
 	public function setItem(item:String)
 	{
 		label.text = item;
@@ -54,15 +54,15 @@ class CompletionListEntry extends Sprite
 			label.autoSize = TextFieldAutoSize.NONE;
 		}
 	}
-	
-	private function set_selected(selected:Bool):Bool
+
+	function set_selected(selected:Bool):Bool
 	{
 		if (selected == this.selected)
 			return selected;
-		
+
 		background.bitmapData = selected ?
 			highlightBitmapData : normalBitmapData;
-		
+
 		return this.selected = selected;
 	}
 }

--- a/flixel/system/debug/completion/CompletionListScrollBar.hx
+++ b/flixel/system/debug/completion/CompletionListScrollBar.hx
@@ -7,23 +7,23 @@ import openfl.display.Sprite;
 
 class CompletionListScrollBar extends Sprite
 {
-	private static inline var BG_COLOR = 0xFF444444;
-	private static inline var HANDLE_COLOR = 0xFF222222;
-	
-	private var handle:Bitmap;
-	
-	public function new(x:Int, y:Int, width:Int, height:Int) 
+	static inline var BG_COLOR = 0xFF444444;
+	static inline var HANDLE_COLOR = 0xFF222222;
+
+	var handle:Bitmap;
+
+	public function new(x:Int, y:Int, width:Int, height:Int)
 	{
 		super();
-		
+
 		this.x = x;
 		this.y = y;
-		
+
 		addChild(new Bitmap(new BitmapData(width, height, true, BG_COLOR)));
 		handle = new Bitmap(new BitmapData(width, 1, true, HANDLE_COLOR));
 		addChild(handle);
 	}
-	
+
 	public function updateHandle(lower:Int, items:Int, entries:Int)
 	{
 		handle.scaleY = Math.min((height / items) * entries, height);

--- a/flixel/system/debug/console/Console.hx
+++ b/flixel/system/debug/console/Console.hx
@@ -23,7 +23,7 @@ using StringTools;
 #end
 
 /**
- * A powerful console for the flixel debugger screen with supports custom commands, registering 
+ * A powerful console for the flixel debugger screen with supports custom commands, registering
  * objects and functions and saves the last 25 commands used. Inspired by Eric Smith's "CoolConsole".
  * @see http://www.youtube.com/watch?v=QWfpw7elWk8
  */
@@ -32,10 +32,10 @@ class Console extends Window
 	/**
 	 * The text that is displayed in the console's input field by default.
 	 */
-	private static inline var DEFAULT_TEXT:String = #if hscript
+	static inline var DEFAULT_TEXT:String = #if hscript
 		"(Click here / press [Tab] to enter command. Type 'help' for help.)" #else
 		"Using the console requires hscript - please run 'haxelib install hscript'." #end;
-	
+
 	/**
 	 * Map containing all registered Objects. You can use registerObject() or add them directly to this map.
 	 */
@@ -48,51 +48,51 @@ class Console extends Window
 	 * Map containing all registered help text. Set these values from registerObject() or registerFunction().
 	 */
 	public var registeredHelp:Map<String, String> = new Map<String, String>();
-	
+
 	/**
 	 * Internal helper var containing all the FlxObjects created via the create command.
 	 */
 	public var objectStack:Array<FlxObject> = [];
-	
+
 	/**
 	 * The input textfield used to enter commands.
 	 */
-	private var input:TextField;
-	
+	var input:TextField;
+
 	#if (!next && sys)
-	private var inputMouseDown:Bool = false;
-	private var stageMouseDown:Bool = false;
+	var inputMouseDown:Bool = false;
+	var stageMouseDown:Bool = false;
 	#end
-	
+
 	public var history:ConsoleHistory;
-	
-	private var completionList:CompletionList;
-	
+
+	var completionList:CompletionList;
+
 	/**
 	 * Creates a new console window object.
-	 */	
+	 */
 	public function new(completionList:CompletionList)
-	{	
+	{
 		super("Console", new GraphicConsole(0, 0), 0, 0, false);
 		this.completionList = completionList;
 		completionList.setY(y + Window.HEADER_HEIGHT);
-		
+
 		#if hscript
 		ConsoleUtil.init();
 		#end
-		
+
 		history = new ConsoleHistory();
 		createInputTextField();
 		new CompletionHandler(completionList, input);
 		registerEventListeners();
-		
+
 		// Install commands
 		#if FLX_DEBUG
 		new ConsoleCommands(this);
 		#end
 	}
-	
-	private function createInputTextField()
+
+	function createInputTextField()
 	{
 		// Create the input textfield
 		input = new TextField();
@@ -106,8 +106,8 @@ class Console extends Window
 		input.y = 15;
 		addChild(input);
 	}
-	
-	private function registerEventListeners()
+
+	function registerEventListeners()
 	{
 		#if hscript
 		input.type = TextFieldType.INPUT;
@@ -115,7 +115,7 @@ class Console extends Window
 		input.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		input.addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
 		#end
-		
+
 		#if (!next && sys) // workaround for broken TextField focus on native
 		input.addEventListener(MouseEvent.MOUSE_DOWN, function(_)
 		{
@@ -127,133 +127,133 @@ class Console extends Window
 		});
 		#end
 	}
-	
+
 	#if (!next && sys)
 	@:access(flixel.FlxGame.onFocus)
 	override public function update()
 	{
 		super.update();
-		
+
 		if (FlxG.stage.focus == input && stageMouseDown && !inputMouseDown)
 		{
 			FlxG.stage.focus = null;
 			// setting focus to null will trigger a focus lost event, let's undo that
 			FlxG.game.onFocus(null);
 		}
-		
+
 		stageMouseDown = false;
 		inputMouseDown = false;
 	}
 	#end
-	
+
 	@:access(flixel.FlxGame)
-	private function onFocus(_)
+	function onFocus(_)
 	{
 		#if (sys && next)
 		if (!FlxG.game._lostFocus)
 			return;
 		#end
-		
+
 		#if FLX_DEBUG
 		// Pause game
 		if (FlxG.console.autoPause)
 			FlxG.vcr.pause();
-		
+
 		// Block keyboard input
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = false;
 		#end
-		
-		if (input.text == Console.DEFAULT_TEXT) 
+
+		if (input.text == Console.DEFAULT_TEXT)
 			input.text = "";
 		#end
 	}
-	
+
 	@:access(flixel.FlxGame)
-	private function onFocusLost(_)
+	function onFocusLost(_)
 	{
 		#if (sys && next)
 		if (FlxG.game._lostFocus)
 			return;
 		#end
-		
+
 		#if FLX_DEBUG
 		// Unpause game
 		if (FlxG.console.autoPause && !FlxG.game.debugger.vcr.manualPause)
 			FlxG.vcr.resume();
-		
+
 		// Unblock keyboard input
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = true;
 		#end
-		
-		if (input.text == "") 
+
+		if (input.text == "")
 			input.text = Console.DEFAULT_TEXT;
 		#end
-		
+
 		completionList.close();
 		FlxG.game.debugger.onMouseFocusLost();
 	}
-	
+
 	#if hscript
-	private function onKeyDown(e:KeyboardEvent)
+	function onKeyDown(e:KeyboardEvent)
 	{
 		if (completionList.visible)
 			return;
-		
+
 		switch (e.keyCode)
 		{
 			case Keyboard.ENTER:
 				if (input.text != "")
 					processCommand();
-			
+
 			case Keyboard.ESCAPE:
 				FlxG.stage.focus = null;
-			
+
 			case Keyboard.DELETE:
 				input.text = "";
-			
+
 			case Keyboard.UP:
-				if (!history.isEmpty) 
+				if (!history.isEmpty)
 					setText(history.getPreviousCommand());
-			
+
 			case Keyboard.DOWN:
-				if (!history.isEmpty) 
+				if (!history.isEmpty)
 					setText(history.getNextCommand());
 		}
 	}
-	
-	private function setText(text:String)
+
+	function setText(text:String)
 	{
 		input.text = text;
 		// Set caret to the end of the command
 		input.setSelection(text.length, text.length);
 	}
-	
-	private function processCommand()
+
+	function processCommand()
 	{
 		try
 		{
 			var text = input.text.trim();
-			
+
 			// Force registered functions to have "()" if the command doesn't already include them
 			// so when the user types "help" or "resetGame", something useful happens
 			if (registeredFunctions.get(text) != null)
 				text += "()";
-			
+
 			// Attempt to parse, run, and output the command
 			var output = ConsoleUtil.runCommand(text);
 			if (output != null)
 				ConsoleUtil.log(output);
-			
+
 			history.addCommand(input.text);
-			
+
 			// Step forward one frame to see the results of the command
 			#if FLX_DEBUG
 			if (FlxG.vcr.paused && FlxG.console.stepAfterCommand)
 				FlxG.game.debugger.vcr.onStep();
 			#end
-			
+
 			input.text = "";
 		}
 		catch (e:Dynamic)
@@ -262,7 +262,7 @@ class Console extends Window
 			FlxG.log.error("Console: Invalid syntax: '" + e + "'");
 		}
 	}
-	
+
 	override public function reposition(X:Float, Y:Float)
 	{
 		super.reposition(X, Y);
@@ -270,10 +270,10 @@ class Console extends Window
 		completionList.close();
 	}
 	#end
-	
+
 	/**
 	 * Register a new function to use in any command.
-	 * 
+	 *
 	 * @param 	FunctionAlias	The name with which you want to access the function.
 	 * @param 	Function		The function to register.
 	 * @param 	HelpText		An optional string to trace to the console using the "help" command.
@@ -284,14 +284,14 @@ class Console extends Window
 		#if hscript
 		ConsoleUtil.registerFunction(functionAlias, func);
 		#end
-		
+
 		if (helpText != null)
 			registeredHelp.set(functionAlias, helpText);
 	}
-	
+
 	/**
 	 * Register a new object to use in any command.
-	 * 
+	 *
 	 * @param 	ObjectAlias		The name with which you want to access the object.
 	 * @param 	AnyObject		The object to register.
 	 */
@@ -302,10 +302,10 @@ class Console extends Window
 		ConsoleUtil.registerObject(objectAlias, anyObject);
 		#end
 	}
-	
+
 	/**
 	 * Register a new class to use in any command.
-	 * 
+	 *
 	 * @param	cl	The class to register.
 	 */
 	public inline function registerClass(cl:Class<Dynamic>)
@@ -315,7 +315,7 @@ class Console extends Window
 
 	/**
 	 * Register a new enum to use in any command.
-	 * 
+	 *
 	 * @param	e	The enum to register.
 	 * @since 4.4.0
 	 */
@@ -323,37 +323,37 @@ class Console extends Window
 	{
 		registerObject(FlxStringUtil.getEnumName(e, true), e);
 	}
-	
+
 	override public function destroy()
 	{
 		super.destroy();
-		
+
 		#if hscript
 		input.removeEventListener(FocusEvent.FOCUS_IN, onFocus);
 		input.removeEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		input.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
 		#end
-		
-		if (input != null) 
+
+		if (input != null)
 		{
 			removeChild(input);
 			input = null;
 		}
-		
+
 		registeredObjects = null;
 		registeredFunctions = null;
 		registeredHelp = null;
-		
+
 		objectStack = null;
 	}
-	
+
 	/**
 	 * Adjusts the width and height of the text field accordingly.
 	 */
-	override private function updateSize()
+	override function updateSize()
 	{
 		super.updateSize();
-		
+
 		input.width = _width - 4;
 		input.height = _height - 15;
 	}

--- a/flixel/system/debug/console/ConsoleCommands.hx
+++ b/flixel/system/debug/console/ConsoleCommands.hx
@@ -14,40 +14,40 @@ using StringTools;
 
 class ConsoleCommands
 {
-	private var _console:Console;
+	var _console:Console;
 	/**
 	 * Helper variable for toggling the mouse coords in the watch window.
 	 */
-	private var _watchingMouse:Bool = false;
-	
+	var _watchingMouse:Bool = false;
+
 	public function new(console:Console):Void
 	{
 		_console = console;
-		
+
 		console.registerFunction("help", help, "Displays the help text of a registered object or function. See \"help\".");
 		console.registerFunction("close", close, "Closes the debugger overlay.");
-		
+
 		console.registerFunction("clearHistory", _console.history.clear, "Closes the debugger overlay.");
 		console.registerFunction("clearLog", FlxG.log.clear, "Clears the command history.");
-		
+
 		console.registerFunction("fields", fields, "Lists the fields of a class or instance");
-		
+
 		console.registerFunction("listObjects", listObjects, "Lists the aliases of all registered objects.");
 		console.registerFunction("listFunctions", listFunctions, "Lists the aliases of all registered functions.");
-		
+
 		console.registerFunction("step", step, "Steps the game forward one frame if currently paused. No effect if unpaused.");
 		console.registerFunction("pause", pause, "Toggles the game between paused and unpaused.");
-		
+
 		console.registerFunction("clearBitmapLog", FlxG.bitmapLog.clear, "Clears the bitmapLog window.");
 		console.registerFunction("viewCache", FlxG.bitmapLog.viewCache, "Adds the cache to the bitmapLog window.");
-		
+
 		console.registerFunction("create", create, "Creates a new FlxObject and registers it - by default at the mouse position. \"create(ObjClass:Class<T>, PlaceAtMouse:Bool, ExtraParams:Array<Dynamic>)\" Ex: \"create(FlxSprite, false, [100, 100])\"");
-		
+
 		console.registerFunction("watch", FlxG.watch.add, "Adds the specified field of an object to the watch window.");
 		console.registerFunction("watchExpression", FlxG.watch.addExpression, "Adds the specified expression to the watch window. Be sure any objects, functions, and classes used are registered!");
 		console.registerFunction("watchMouse", watchMouse, "Adds the mouse coordinates to the watch window.");
 		console.registerFunction("track", FlxG.debugger.track, "Adds a tracker window for the specified object or class.");
-		
+
 		// Default classes to include
 		console.registerClass(Math);
 		console.registerClass(Reflect);
@@ -66,15 +66,15 @@ class ConsoleCommands
 		console.registerClass(FlxCamera);
 		console.registerClass(FlxPoint);
 		console.registerClass(FlxRect);
-		
+
 		console.registerEnum(FlxDebuggerLayout);
 
 		console.registerObject("selection", null);
 	}
-	
-	private function help(?Alias:String):String
+
+	function help(?Alias:String):String
 	{
-		if (Alias == null || Alias.length == 0) 
+		if (Alias == null || Alias.length == 0)
 		{
 			var output:String = "System classes and commands: ";
 			for (obj in _console.registeredObjects.keys())
@@ -85,15 +85,15 @@ class ConsoleCommands
 			{
 				output += func + "(), ";
 			}
-			return output + "\nTry 'help(\"command\")' for more information about a specific command."; 
+			return output + "\nTry 'help(\"command\")' for more information about a specific command.";
 		}
-		else 
+		else
 		{
 			if (_console.registeredHelp.exists(Alias))
 			{
 				return Alias + (_console.registeredFunctions.exists(Alias) ? "()" : "") + ": " + _console.registeredHelp.get(Alias);
 			}
-			
+
 			else
 			{
 				FlxG.log.error("Help: The command '" + Alias + "' does not have help text.");
@@ -101,89 +101,89 @@ class ConsoleCommands
 			}
 		}
 	}
-	
-	private inline function close():Void
+
+	inline function close():Void
 	{
 		FlxG.debugger.visible = false;
 	}
-	
-	private function create<T:FlxObject>(ObjClass:Class<T>, MousePos:Bool = true, ?Params:Array<Dynamic>):Void
+
+	function create<T:FlxObject>(ObjClass:Class<T>, MousePos:Bool = true, ?Params:Array<Dynamic>):Void
 	{
 		if (Params == null)
 			Params = [];
-		
+
 		var obj:FlxObject = Type.createInstance(ObjClass, Params);
-		
+
 		if (obj == null) return;
-		
+
 		if (MousePos)
 		{
 			obj.x = FlxG.game.mouseX;
 			obj.y = FlxG.game.mouseY;
 		}
-		
+
 		FlxG.state.add(obj);
-		
+
 		if (Params.length == 0)
 			ConsoleUtil.log("create: New " + ObjClass + " created at X = " + obj.x + " Y = " + obj.y);
 		else
 			ConsoleUtil.log("create: New " + ObjClass + " created at X = " + obj.x + " Y = " + obj.y + " with params " + Params);
-		
+
 		_console.objectStack.push(obj);
-		
+
 		var name = "Object_" + _console.objectStack.length;
 		_console.registerObject(name, obj);
-		
+
 		ConsoleUtil.log("create: " + ObjClass + " registered as '" + name + "'");
 	}
-	
-	private function fields(Object:Dynamic):String
+
+	function fields(Object:Dynamic):String
 	{
 		return 'Fields of ${Type.getClassName(Object)}:\n' +
 			ConsoleUtil.getFields(Object).join("\n").trim();
 	}
-	
-	private function listObjects():Void
+
+	function listObjects():Void
 	{
-		ConsoleUtil.log("Objects registered: \n" + FlxStringUtil.formatStringMap(_console.registeredObjects)); 
+		ConsoleUtil.log("Objects registered: \n" + FlxStringUtil.formatStringMap(_console.registeredObjects));
 	}
-	
-	private function listFunctions():Void
+
+	function listFunctions():Void
 	{
-		ConsoleUtil.log("Functions registered: \n" + FlxStringUtil.formatStringMap(_console.registeredFunctions)); 
+		ConsoleUtil.log("Functions registered: \n" + FlxStringUtil.formatStringMap(_console.registeredFunctions));
 	}
-	
-	private function watchMouse():Void
+
+	function watchMouse():Void
 	{
-		if (!_watchingMouse) 
+		if (!_watchingMouse)
 		{
 			FlxG.watch.addMouse();
 			ConsoleUtil.log("watchMouse: Mouse position added to watch window");
 		}
-		else 
+		else
 		{
 			FlxG.watch.removeMouse();
 			ConsoleUtil.log("watchMouse: Mouse position removed from watch window");
 		}
-		
+
 		_watchingMouse = !_watchingMouse;
 	}
-	
-	private function pause():Void
+
+	function pause():Void
 	{
-		if (FlxG.vcr.paused) 
+		if (FlxG.vcr.paused)
 		{
 			FlxG.vcr.resume();
 			ConsoleUtil.log("pause: Game unpaused");
 		}
-		else 
+		else
 		{
 			FlxG.vcr.pause();
 			ConsoleUtil.log("pause: Game paused");
 		}
 	}
-	
-	private function step():Void
+
+	function step():Void
 	{
 		if (FlxG.vcr.paused)
 			FlxG.game.debugger.vcr.onStep();

--- a/flixel/system/debug/console/ConsoleHistory.hx
+++ b/flixel/system/debug/console/ConsoleHistory.hx
@@ -2,64 +2,64 @@ package flixel.system.debug.console;
 
 class ConsoleHistory
 {
-	private static inline var MAX_LENGTH:Int = 50;
-	
+	static inline var MAX_LENGTH:Int = 50;
+
 	public var commands:Array<String>;
-	
+
 	public var isEmpty(get, never):Bool;
-	
-	private var index:Int = 0;
-	
-	public function new() 
+
+	var index:Int = 0;
+
+	public function new()
 	{
-		if (FlxG.save.data.history != null) 
+		if (FlxG.save.data.history != null)
 		{
 			commands = FlxG.save.data.history;
 			index = commands.length;
 		}
-		else 
+		else
 		{
 			commands = [];
 			FlxG.save.data.history = commands;
 		}
 	}
-	
+
 	public function getPreviousCommand():String
 	{
 		if (index > 0)
 			index--;
 		return commands[index];
 	}
-	
+
 	public function getNextCommand():String
 	{
 		if (index < commands.length)
 			index++;
 		return (commands[index] != null) ? commands[index] : "";
 	}
-	
+
 	public function addCommand(command:String)
 	{
-		// Only save new commands 
+		// Only save new commands
 		if (isEmpty || getPreviousCommand() != command)
 		{
 			commands.push(command);
 			FlxG.save.flush();
-			
+
 			if (commands.length > MAX_LENGTH)
 				commands.shift();
 		}
-		
+
 		index = commands.length;
 	}
-	
+
 	public function clear()
 	{
 		commands.splice(0, commands.length);
 		FlxG.save.flush();
 	}
-	
-	private function get_isEmpty():Bool
+
+	function get_isEmpty():Bool
 	{
 		return commands.length == 0;
 	}

--- a/flixel/system/debug/console/ConsoleUtil.hx
+++ b/flixel/system/debug/console/ConsoleUtil.hx
@@ -11,7 +11,7 @@ import hscript.Expr;
 import hscript.Parser;
 #end
 
-/** 
+/**
  * A set of helper functions used by the console.
  */
 class ConsoleUtil
@@ -20,12 +20,12 @@ class ConsoleUtil
 	/**
 	 * The hscript parser to make strings into haxe code.
 	 */
-	private static var parser:Parser;
+	static var parser:Parser;
 	/**
 	 * The custom hscript interpreter to run the haxe code from the parser.
 	 */
 	public static var interp:Interp;
-	
+
 	/**
 	 * Sets up the hscript parser and interpreter.
 	 */
@@ -34,13 +34,13 @@ class ConsoleUtil
 		parser = new Parser();
 		parser.allowJSON = true;
 		parser.allowTypes = true;
-		
+
 		interp = new Interp();
 	}
-	
+
 	/**
 	 * Converts the input string into its AST form to be executed.
-	 * 
+	 *
 	 * @param	Input	The user's input command.
 	 * @return	The parsed out AST.
 	 */
@@ -50,10 +50,10 @@ class ConsoleUtil
 			Input = Input.substr(0, -1);
 		return parser.parseString(Input);
 	}
-	
+
 	/**
 	 * Parses and runs the input command.
-	 * 
+	 *
 	 * @param	Input	The user's input command.
 	 * @return	Whatever the input code evaluates to.
 	 */
@@ -61,7 +61,7 @@ class ConsoleUtil
 	{
 		return interp.expr(parseCommand(Input));
 	}
-	
+
 	/**
 	 * Runs the input expression.
 	 * @param	Parsed	The parsed form of the user's input command.
@@ -71,10 +71,10 @@ class ConsoleUtil
 	{
 		return interp.expr(expr);
 	}
-	
+
 	/**
 	 * Register a new object to use in any command.
-	 * 
+	 *
 	 * @param	ObjectAlias	The name with which you want to access the object.
 	 * @param	AnyObject	The object to register.
 	 */
@@ -83,10 +83,10 @@ class ConsoleUtil
 		if (AnyObject == null || Reflect.isObject(AnyObject))
 			interp.variables.set(ObjectAlias, AnyObject);
 	}
-	
+
 	/**
 	 * Register a new function to use in any command.
-	 * 
+	 *
 	 * @param 	FunctionAlias	The name with which you want to access the function.
 	 * @param 	Function		The function to register.
 	 */
@@ -96,7 +96,7 @@ class ConsoleUtil
 			interp.variables.set(FunctionAlias, Function);
 	}
 	#end
-	
+
 	public static function getFields(Object:Dynamic):Array<String>
 	{
 		var fields = [];
@@ -106,7 +106,7 @@ class ConsoleUtil
 			fields = Type.getEnumConstructs(Object);
 		else if (Reflect.isObject(Object)) // get instance fields
 			fields = Type.getInstanceFields(Type.getClass(Object));
-		
+
 		// on Flash, enums are classes, so Std.is(_, Enum) fails
 		fields.remove("__constructs__");
 
@@ -124,14 +124,14 @@ class ConsoleUtil
 			else
 				filteredFields.push(field);
 		}
-		
+
 		return sortFields(filteredFields);
 	}
-	
-	private static function sortFields(fields:Array<String>):Array<String>
+
+	static function sortFields(fields:Array<String>):Array<String>
 	{
 		var underscoreList = [];
-		
+
 		fields = fields.filter(function(field)
 		{
 			if (field.startsWith("_"))
@@ -141,16 +141,16 @@ class ConsoleUtil
 			}
 			return true;
 		});
-		
+
 		fields.sortAlphabetically();
 		underscoreList.sortAlphabetically();
-		
+
 		return fields.concat(underscoreList);
 	}
-	
+
 	/**
 	 * Shortcut to log a text with the Console LogStyle.
-	 * 
+	 *
 	 * @param	Text	The text to log.
 	 */
 	public static inline function log(Text:Dynamic):Void
@@ -163,28 +163,28 @@ class ConsoleUtil
  * hscript doesn't use property access by default... have to make our own.
  */
 #if hscript
-private class Interp extends hscript.Interp
+class Interp extends hscript.Interp
 {
 	public function getGlobals():Array<String>
 	{
 		return toArray(locals.keys()).concat(toArray(variables.keys()));
 	}
-	
-	private function toArray<T>(iterator:Iterator<T>):Array<T>
+
+	function toArray<T>(iterator:Iterator<T>):Array<T>
 	{
 		var array = [];
 		for (element in iterator)
 			array.push(element);
 		return array;
 	}
-	
+
 	override function get(o:Dynamic, f:String):Dynamic
 	{
 		if (o == null)
 			error(EInvalidAccess(f));
 		return Reflect.getProperty(o, f);
 	}
-	
+
 	override function set(o:Dynamic, f:String, v:Dynamic):Dynamic
 	{
 		if (o == null)

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -28,67 +28,67 @@ import flash.display.Bitmap;
  * Adds a new functionality to Flixel debugger that allows any object
  * on the screen to be dragged, moved or deleted while the game is
  * still running.
- * 
+ *
  * @author	Fernando Bevilacqua (dovyski@gmail.com)
  */
 class Interaction extends Window
 {
 	public var activeTool(default, null):Tool;
 	public var selectedItems(default, null):FlxTypedGroup<FlxObject> = new FlxTypedGroup();
-	
+
 	public var flixelPointer:FlxPoint = new FlxPoint();
 	public var pointerJustPressed:Bool = false;
 	public var pointerJustReleased:Bool = false;
 	public var pointerPressed:Bool = false;
-	
-	private var _container:Sprite;
-	private var _customCursor:Sprite;
-	private var _tools:Array<Tool> = [];
-	private var _turn:Int = 2;
-	private var _keysDown:Map<Int, Bool> = new Map();
-	private var _keysUp:Map<Int, Int> = new Map();
-	private var _wasMouseVisible:Bool;
-	private var _wasUsingSystemCursor:Bool;
-	private var _debuggerInteraction:Bool = false;
-	private var _flixelPointer:FlxPointer = new FlxPointer();
-	
+
+	var _container:Sprite;
+	var _customCursor:Sprite;
+	var _tools:Array<Tool> = [];
+	var _turn:Int = 2;
+	var _keysDown:Map<Int, Bool> = new Map();
+	var _keysUp:Map<Int, Int> = new Map();
+	var _wasMouseVisible:Bool;
+	var _wasUsingSystemCursor:Bool;
+	var _debuggerInteraction:Bool = false;
+	var _flixelPointer:FlxPointer = new FlxPointer();
+
 	public function new(container:Sprite)
 	{
 		super("Tools", new GraphicInteractive(0, 0), 40, 25, false);
 		reposition(2, 100);
 		_container = container;
-		
+
 		_customCursor = new Sprite();
 		_customCursor.mouseEnabled = false;
 		_container.addChild(_customCursor);
-		
+
 		// Add all built-in tools
 		addTool(new Pointer());
 		addTool(new Mover());
 		addTool(new Eraser());
-		
+
 		FlxG.signals.postDraw.add(postDraw);
 		FlxG.debugger.visibilityChanged.add(handleDebuggerVisibilityChanged);
-		
+
 		FlxG.stage.addEventListener(MouseEvent.MOUSE_MOVE, updateMouse);
 		FlxG.stage.addEventListener(MouseEvent.MOUSE_DOWN, handleMouseClick);
 		FlxG.stage.addEventListener(MouseEvent.MOUSE_UP, handleMouseClick);
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, handleKeyEvent);
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_UP, handleKeyEvent);
-		
+
 		_container.addEventListener(MouseEvent.MOUSE_OVER, handleMouseInDebugger);
 		_container.addEventListener(MouseEvent.MOUSE_OUT, handleMouseInDebugger);
 	}
-	
-	private function handleDebuggerVisibilityChanged():Void
+
+	function handleDebuggerVisibilityChanged():Void
 	{
 		if (FlxG.debugger.visible)
 			saveSystemCursorInfo();
 		else
 			restoreSystemCursor();
 	}
-	
-	private function updateMouse(event:MouseEvent):Void
+
+	function updateMouse(event:MouseEvent):Void
 	{
 		#if (neko || js) // openfl/openfl#1305
 		if (event.stageX == null || event.stageY == null)
@@ -97,7 +97,7 @@ class Interaction extends Window
 
 		var offsetX = 0.0;
 		var offsetY = 0.0;
-		
+
 		// If the active tool has a custom cursor, we assume its
 		// "point of click" is the center of the cursor icon.
 		if (activeTool != null)
@@ -109,38 +109,38 @@ class Interaction extends Window
 				offsetY = cursorIcon.height / FlxG.scaleMode.scale.y / 2;
 			}
 		}
-		
+
 		_customCursor.x = event.stageX + offsetX;
 		_customCursor.y = event.stageY + offsetY;
-		
+
 		#if FLX_MOUSE
 		// Calculate in-game coordinates based on mouse position and camera.
 		_flixelPointer.setGlobalScreenPositionUnsafe(event.stageX, event.stageY);
-		
+
 		// Store Flixel mouse coordinates to speed up all
 		// internal calculations (overlap, etc)
 		flixelPointer.x = _flixelPointer.x + offsetX;
 		flixelPointer.y = _flixelPointer.y + offsetY;
 		#end
 	}
-	
-	private function handleMouseClick(event:MouseEvent):Void 
+
+	function handleMouseClick(event:MouseEvent):Void
 	{
 		// Did the user click a debugger UI element instead of performing
 		// a click related to a tool?
 		if (event.type == MouseEvent.MOUSE_DOWN && belongsToDebugger(event.target))
 			return;
-		
+
 		pointerJustPressed = event.type == MouseEvent.MOUSE_DOWN;
 		pointerJustReleased = event.type == MouseEvent.MOUSE_UP;
-		
+
 		if (pointerJustPressed)
 			pointerPressed = true;
 		else if (pointerJustReleased)
 			pointerPressed = false;
 	}
 
-	private function belongsToDebugger(object:DisplayObject):Bool
+	function belongsToDebugger(object:DisplayObject):Bool
 	{
 		if (object == null)
 			return false;
@@ -148,23 +148,23 @@ class Interaction extends Window
 			return true;
 		return belongsToDebugger(object.parent);
 	}
-	
-	private function handleMouseInDebugger(event:MouseEvent):Void 
+
+	function handleMouseInDebugger(event:MouseEvent):Void
 	{
 		// If we are not active, we don't really care about
 		// mouse events in the debugger.
 		if (!isActive())
 			return;
-		
+
 		if (event.type == MouseEvent.MOUSE_OVER)
 			_debuggerInteraction = true;
 		else if (event.type == MouseEvent.MOUSE_OUT)
 			_debuggerInteraction = false;
-		
+
 		event.stopPropagation();
 	}
-	
-	private function handleKeyEvent(event:KeyboardEvent):Void
+
+	function handleKeyEvent(event:KeyboardEvent):Void
 	{
 		if (event.type == KeyboardEvent.KEY_DOWN)
 			_keysDown.set(event.keyCode, true);
@@ -174,12 +174,12 @@ class Interaction extends Window
 			_keysUp.set(event.keyCode, _turn);
 		}
 	}
-	
-	private function addTool(tool:Tool):Void
+
+	function addTool(tool:Tool):Void
 	{
 		tool.init(this);
 		_tools.push(tool);
-		
+
 		// If the tool has a button, add it to the interaction window
 		var button = tool.button;
 		if (button == null)
@@ -188,10 +188,10 @@ class Interaction extends Window
 		button.x = -10 + _tools.length * 20; // TODO: fix this hardcoded number
 		button.y = 20;
 		addChild(button);
-		
+
 		resize(Math.max(_tools.length * 20, 55), 35);  // TODO: fix this hardcoded number
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -199,67 +199,67 @@ class Interaction extends Window
 	{
 		FlxG.signals.postDraw.remove(postDraw);
 		FlxG.debugger.visibilityChanged.remove(handleDebuggerVisibilityChanged);
-		
+
 		FlxG.stage.removeEventListener(MouseEvent.MOUSE_MOVE, updateMouse);
 		FlxG.stage.removeEventListener(MouseEvent.MOUSE_DOWN, handleMouseClick);
 		FlxG.stage.removeEventListener(MouseEvent.MOUSE_UP, handleMouseClick);
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, handleKeyEvent);
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_UP, handleKeyEvent);
-		
+
 		if (_container != null)
 		{
 			_container.removeEventListener(MouseEvent.MOUSE_OVER, handleMouseInDebugger);
 			_container.removeEventListener(MouseEvent.MOUSE_OUT, handleMouseInDebugger);
 		}
-		
+
 		if (_customCursor != null)
 		{
 			_customCursor.parent.removeChild(_customCursor);
 			_customCursor = null;
 		}
-		
+
 		_tools = FlxDestroyUtil.destroyArray(_tools);
 		selectedItems = FlxDestroyUtil.destroy(selectedItems);
 		flixelPointer = FlxDestroyUtil.destroy(flixelPointer);
-		
+
 		_keysDown = null;
 		_keysUp = null;
 	}
-	
+
 	public function isActive():Bool
 	{
 		return FlxG.debugger.visible && visible;
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		if (!isActive())
 			return;
 
 		updateCustomCursors();
-		
+
 		for (tool in _tools)
 			tool.update();
-		
+
 		pointerJustPressed = false;
 		pointerJustReleased = false;
 		_turn++;
 	}
-	
+
 	/**
 	 * Called after the game state has been drawn.
 	 */
-	private function postDraw():Void
+	function postDraw():Void
 	{
 		if (!isActive())
 			return;
-		
+
 		for (tool in _tools)
 			tool.draw();
-		
+
 		drawItemsSelection();
 	}
-	
+
 	public function getDebugGraphics():Graphics
 	{
 		if (FlxG.renderBlit)
@@ -267,20 +267,20 @@ class Interaction extends Window
 			FlxSpriteUtil.flashGfx.clear();
 			return FlxSpriteUtil.flashGfx;
 		}
-		
+
 		#if FLX_DEBUG
 		return FlxG.camera.debugLayer.graphics;
 		#end
-		
+
 		return null;
 	}
-	
-	private function drawItemsSelection():Void 
+
+	function drawItemsSelection():Void
 	{
 		var gfx:Graphics = getDebugGraphics();
 		if (gfx == null)
 			return;
-		
+
 		for (member in selectedItems)
 		{
 			if (member != null && member.scrollFactor != null && member.isOnScreen())
@@ -292,24 +292,24 @@ class Interaction extends Window
 					member.width * 1.0, member.height * 1.0);
 			}
 		}
-		
+
 		// Draw the debug info to the main camera buffer.
 		if (FlxG.renderBlit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
 	}
-	
-	private function getTool(className:Class<Tool>):Tool
+
+	function getTool(className:Class<Tool>):Tool
 	{
 		for (tool in _tools)
 			if (Std.is(tool, className))
 				return tool;
 		return null;
 	}
-	
-	override public function toggleVisible():Void 
+
+	override public function toggleVisible():Void
 	{
 		super.toggleVisible();
-		
+
 		if (!visible)
 		{
 			// De-select any activate tool
@@ -317,12 +317,12 @@ class Interaction extends Window
 			restoreSystemCursor();
 		}
 	}
-	
+
 	public function registerCustomCursor(name:String, icon:BitmapData):Void
 	{
 		if (icon == null)
 			return;
-	
+
 		#if (FLX_NATIVE_CURSOR && FLX_MOUSE)
 		FlxG.mouse.registerSimpleNativeCursorData(name, icon);
 		#else
@@ -333,7 +333,7 @@ class Interaction extends Window
 		_customCursor.addChild(sprite);
 		#end
 	}
-	
+
 	public function updateCustomCursors():Void
 	{
 		#if FLX_MOUSE
@@ -375,16 +375,16 @@ class Interaction extends Window
 		}
 		#end
 	}
-	
-	private function saveSystemCursorInfo():Void
+
+	function saveSystemCursorInfo():Void
 	{
 		#if FLX_MOUSE
 		_wasMouseVisible = FlxG.mouse.visible;
 		_wasUsingSystemCursor = FlxG.mouse.useSystemCursor;
 		#end
 	}
-	
-	private function restoreSystemCursor():Void
+
+	function restoreSystemCursor():Void
 	{
 		#if FLX_MOUSE
 		FlxG.mouse.useSystemCursor = _wasUsingSystemCursor;
@@ -392,7 +392,7 @@ class Interaction extends Window
 		_customCursor.visible = false;
 		#end
 	}
-	
+
 	public function setActiveTool(value:Tool):Void
 	{
 		if (activeTool != null)
@@ -400,17 +400,17 @@ class Interaction extends Window
 			activeTool.deactivate();
 			activeTool.button.toggled = true;
 		}
-		
+
 		if (activeTool == value)
 			value = null;
-		
+
 		activeTool = value;
-		
+
 		if (activeTool != null)
 		{
 			// A tool is active. Enable cursor specific cursors
 			setToolsCursorVisibility(true);
-			
+
 			activeTool.button.toggled = false;
 			activeTool.activate();
 			updateCustomCursors();
@@ -422,48 +422,48 @@ class Interaction extends Window
 			setSystemCursorVisibility(true);
 		}
 	}
-	
-	private function setSystemCursorVisibility(status:Bool):Void
+
+	function setSystemCursorVisibility(status:Bool):Void
 	{
 		#if FLX_MOUSE
 		FlxG.mouse.useSystemCursor = status;
 		#end
 		_customCursor.visible = !status;
 	}
-	
-	private function setToolsCursorVisibility(status:Bool):Void
+
+	function setToolsCursorVisibility(status:Bool):Void
 	{
 		#if FLX_MOUSE
 		FlxG.mouse.useSystemCursor = #if FLX_NATIVE_CURSOR status #else false #end;
 		#end
 		_customCursor.visible = status;
-		
+
 		if (status)
 			return;
-		
+
 		// Hide any display-list-based custom cursor.
 		// The proper cursor will be marked as visible
 		// in the update loop.
 		for (i in 0..._customCursor.numChildren)
 			_customCursor.getChildAt(i).visible = false;
 	}
-	
+
 	public function clearSelection():Void
 	{
 		selectedItems.clear();
 	}
-	
+
 	public function keyPressed(key:Int):Bool
 	{
 		return _keysDown.get(key);
 	}
-	
+
 	public function keyJustPressed(key:Int):Bool
 	{
 		var value:Int = _keysUp.get(key) == null ? 0 : _keysUp.get(key);
 		return (_turn - value) == 1;
 	}
-	
+
 	public function findItemsWithinState(items:Array<FlxBasic>, state:FlxState, area:FlxRect):Void
 	{
 		findItemsWithinArea(items, state.members, area);
@@ -476,7 +476,7 @@ class Interaction extends Window
 	 * the method has no return, you must pass an array where items will be placed. The method decides
 	 * if an item is within the searching area or not by checking if the item's hitbox (obtained from
 	 * `getHitbox()`) overlaps the area parameter.
-	 * 
+	 *
 	 * @param	items		array where the method will place all found items. Any previous content in the array will be preserved.
 	 * @param	members		array where the method will recursively search for items.
 	 * @param	area		a rectangle that describes the area where the method should search within.

--- a/flixel/system/debug/interaction/tools/Eraser.hx
+++ b/flixel/system/debug/interaction/tools/Eraser.hx
@@ -7,38 +7,38 @@ import flixel.FlxG;
 import flixel.group.FlxGroup;
 import flixel.system.debug.interaction.Interaction;
 
-@:bitmap("assets/images/debugger/buttons/eraser.png") 
+@:bitmap("assets/images/debugger/buttons/eraser.png")
 class GraphicEraserTool extends BitmapData {}
 
 /**
  * A tool to delete items from the screen.
- * 
+ *
  * @author Fernando Bevilacqua (dovyski@gmail.com)
  */
 class Eraser extends Tool
-{			
-	override public function init(Brain:Interaction):Tool 
+{
+	override public function init(Brain:Interaction):Tool
 	{
 		super.init(Brain);
 		_name = "Eraser";
 		return this;
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		if (_brain.keyJustPressed(Keyboard.DELETE))
 			doDeletion(_brain.keyPressed(Keyboard.SHIFT));
 	}
-	
-	override public function activate():Void 
+
+	override public function activate():Void
 	{
 		doDeletion(_brain.keyPressed(Keyboard.SHIFT));
-		
+
 		// No need to stay active
 		_brain.setActiveTool(null);
 	}
-	
-	private function doDeletion(remove:Bool):Void
+
+	function doDeletion(remove:Bool):Void
 	{
 		var selectedItems = _brain.selectedItems;
 		if (selectedItems != null)
@@ -47,14 +47,14 @@ class Eraser extends Tool
 			selectedItems.clear();
 		}
 	}
-	
-	private function findAndDelete(items:FlxTypedGroup<FlxObject>, remove:Bool = false):Void
+
+	function findAndDelete(items:FlxTypedGroup<FlxObject>, remove:Bool = false):Void
 	{
 		for (member in items)
 		{
 			if (member == null)
 				continue;
-			
+
 			if (Std.is(member, FlxTypedGroup))
 			{
 				// TODO: walk in the group, removing all members.
@@ -67,14 +67,14 @@ class Eraser extends Tool
 			}
 		}
 	}
-	
-	private function removeFromMemory(item:FlxBasic, parentGroup:FlxGroup):Void
+
+	function removeFromMemory(item:FlxBasic, parentGroup:FlxGroup):Void
 	{
 		for (member in parentGroup.members)
 		{
 			if (member == null)
 				continue;
-			
+
 			if (Std.is(member, FlxTypedGroup))
 				removeFromMemory(item, cast member);
 			else if (member == item)

--- a/flixel/system/debug/interaction/tools/Mover.hx
+++ b/flixel/system/debug/interaction/tools/Mover.hx
@@ -6,20 +6,20 @@ import flixel.FlxObject;
 import flixel.math.FlxPoint;
 import flixel.system.debug.interaction.Interaction;
 
-@:bitmap("assets/images/debugger/buttons/mover.png") 
+@:bitmap("assets/images/debugger/buttons/mover.png")
 class GraphicMoverTool extends BitmapData {}
 
 /**
  * A tool to move selected items.
- * 
+ *
  * @author Fernando Bevilacqua (dovyski@gmail.com)
  */
 class Mover extends Tool
 {
-	private var _dragging:Bool = false;
-	private var _lastCursorPosition:FlxPoint;
-	
-	override public function init(brain:Interaction):Tool 
+	var _dragging:Bool = false;
+	var _lastCursorPosition:FlxPoint;
+
+	override public function init(brain:Interaction):Tool
 	{
 		super.init(brain);
 		_lastCursorPosition = new FlxPoint(brain.flixelPointer.x, brain.flixelPointer.x);
@@ -31,48 +31,48 @@ class Mover extends Tool
 
 		return this;
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		// Is the tool active or its hotkey pressed?
 		if (!isActive() && !_brain.keyPressed(Keyboard.SHIFT))
 			return;
-		
+
 		if (_brain.pointerPressed && !_dragging)
-			startDragging();	
+			startDragging();
 		else if (_brain.pointerPressed && _dragging)
 			doDragging();
 		else if (_brain.pointerJustReleased)
 			stopDragging();
-		
+
 		_lastCursorPosition.x = _brain.flixelPointer.x;
 		_lastCursorPosition.y = _brain.flixelPointer.y;
 	}
-	
-	private function stopDragging():Void
+
+	function stopDragging():Void
 	{
 		_dragging = false;
 	}
-	
-	private function startDragging():Void
+
+	function startDragging():Void
 	{
 		if (_dragging)
 			return;
-			
+
 		_dragging = true;
-		
+
 		// If we are not active, it means things are being moved around using
 		// the mover's shortcut key. If the pointer is the active tool, it should
 		// not do any selection of items while things are being moved/dragged.
 		if (!isActive() && Std.is(_brain.activeTool, Pointer))
 			cast(_brain.activeTool, Pointer).cancelSelection();
 	}
-	
-	private function doDragging():Void
+
+	function doDragging():Void
 	{
 		var dx:Float = _brain.flixelPointer.x - _lastCursorPosition.x;
 		var dy:Float = _brain.flixelPointer.y - _lastCursorPosition.y;
-		
+
 		for (member in _brain.selectedItems.members)
 		{
 			if (!Std.is(member, FlxObject))

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -15,35 +15,35 @@ class GraphicCursorCross extends BitmapData {}
 
 /**
  * A tool to use the mouse cursor to select game elements.
- * 
+ *
  * @author Fernando Bevilacqua (dovyski@gmail.com)
  */
 class Pointer extends Tool
-{		
-	private var _selectionStartPoint:FlxPoint = new FlxPoint();
-	private var _selectionEndPoint:FlxPoint = new FlxPoint();
-	private var _selectionHappening:Bool = false;
-	private var _selectionCancelled:Bool = false;
-	private var _selectionArea:FlxRect = new FlxRect();
-	private var _itemsInSelectionArea:Array<FlxBasic> = [];
-	
-	override public function init(brain:Interaction):Tool 
+{
+	var _selectionStartPoint:FlxPoint = new FlxPoint();
+	var _selectionEndPoint:FlxPoint = new FlxPoint();
+	var _selectionHappening:Bool = false;
+	var _selectionCancelled:Bool = false;
+	var _selectionArea:FlxRect = new FlxRect();
+	var _itemsInSelectionArea:Array<FlxBasic> = [];
+
+	override public function init(brain:Interaction):Tool
 	{
 		super.init(brain);
-		
+
 		_name = "Pointer";
 		setButton(GraphicCursorCross);
 		setCursor(new GraphicCursorCross(0, 0));
-		
+
 		return this;
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		// If the tool is active, update the custom cursor cursor
 		if (!isActive())
 			return;
-		
+
 		if (_brain.pointerJustPressed && !_selectionHappening)
 			startSelection();
 
@@ -52,7 +52,7 @@ class Pointer extends Tool
 			_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);
 			calculateSelectionArea();
 		}
-			
+
 		// Check clicks on the screen
 		if (!_brain.pointerJustReleased)
 			return;
@@ -71,29 +71,29 @@ class Pointer extends Tool
 			// User clicked an empty space without holding the "add more items" key,
 			// so it's time to unselect everything.
 			_brain.clearSelection();
-			
+
 	}
-	
-	private function calculateSelectionArea():Void
+
+	function calculateSelectionArea():Void
 	{
 		_selectionArea.x = _selectionStartPoint.x;
 		_selectionArea.y = _selectionStartPoint.y;
 		_selectionArea.width = _selectionEndPoint.x - _selectionArea.x;
 		_selectionArea.height = _selectionEndPoint.y - _selectionArea.y;
-		
+
 		if (_selectionArea.width < 0)
 		{
 			_selectionArea.width *= -1;
 			_selectionArea.x = _selectionArea.x - _selectionArea.width;
 		}
-		
+
 		if (_selectionArea.height < 0)
 		{
 			_selectionArea.height *= -1;
 			_selectionArea.y = _selectionArea.y - _selectionArea.height;
 		}
 	}
-	
+
 	/**
 	 * Start a selection area. A selection area is a rectangular shaped area
 	 * whose boundaries will be used to select game elements.
@@ -106,32 +106,32 @@ class Pointer extends Tool
 		_itemsInSelectionArea.clearArray();
 		updateConsoleSelection();
 	}
-	
+
 	/**
 	 * Cancel any selection activity that is happening, removing the selection rectangle from the screen.
 	 * Any item within the (canceled) selection area will be ignored. If you want to stop the selection
 	 * and actually process the action/items, use `stopSelection()`.
 	 */
 	public function cancelSelection():Void
-	{	
+	{
 		if (!_selectionHappening)
 			return;
-		
+
 		_selectionCancelled = true;
 		stopSelection(false);
 	}
-	
+
 	/**
-	 * Stop any selection activity that is happening. 
-	 * 
+	 * Stop any selection activity that is happening.
+	 *
 	 * @param	findItems	If `true` (default), all items within the (stopped) selection area will be included in the list of selected items of the tool.
 	 */
 	public function stopSelection(findItems:Bool = true):Void
-	{	
+	{
 		if (!_selectionHappening)
 			return;
-		
-		_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);	
+
+		_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);
 		calculateSelectionArea();
 
 		if (findItems)
@@ -139,7 +139,7 @@ class Pointer extends Tool
 			_brain.findItemsWithinState(_itemsInSelectionArea, FlxG.state, _selectionArea);
 			updateConsoleSelection();
 		}
-		
+
 		// Clear everything
 		_selectionHappening = false;
 		_selectionArea.set(0, 0, 0, 0);
@@ -148,7 +148,7 @@ class Pointer extends Tool
 	/**
 	 * We register the current selection to the console for easy interaction.
 	 */
-	private function updateConsoleSelection()
+	function updateConsoleSelection()
 	{
 		FlxG.console.registerObject("selection", switch (_itemsInSelectionArea.length)
 		{
@@ -157,21 +157,21 @@ class Pointer extends Tool
 			case _: _itemsInSelectionArea;
 		});
 	}
-	
-	private function handleItemAddition(itemsInSelectionArea:Array<FlxBasic>):Void
+
+	function handleItemAddition(itemsInSelectionArea:Array<FlxBasic>):Void
 	{
 		// We add things to the selection list if the user is pressing the "add-new-item" key
 		var adding = _brain.keyPressed(Keyboard.CONTROL);
 		var selectedItems = _brain.selectedItems;
-		
+
 		if (itemsInSelectionArea.length == 0)
 			return;
-			
+
 		// If we are not selectively adding items, just clear
 		// the brain's list of selected items.
 		if (!adding)
 			_brain.clearSelection();
-		
+
 		for (item in itemsInSelectionArea)
 		{
 			if (selectedItems.members.contains(cast item) && adding)
@@ -180,13 +180,13 @@ class Pointer extends Tool
 				selectedItems.add(cast item);
 		}
 	}
-		
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		var gfx:Graphics = _brain.getDebugGraphics();
 		if (gfx == null)
 			return;
-		
+
 		if (_selectionHappening)
 		{
 			// Render the selection rectangle

--- a/flixel/system/debug/interaction/tools/Tool.hx
+++ b/flixel/system/debug/interaction/tools/Tool.hx
@@ -7,62 +7,62 @@ import flixel.system.ui.FlxSystemButton;
 import flixel.util.FlxDestroyUtil.IFlxDestroyable;
 
 /**
- * The base class of all tools in the interactive debug. 
- * 
+ * The base class of all tools in the interactive debug.
+ *
  * @author Fernando Bevilacqua (dovyski@gmail.com)
  */
 class Tool extends Sprite implements IFlxDestroyable
 {
 	public var button(default, null):FlxSystemButton;
 	public var cursor(default, null):BitmapData;
-	
-	private var _name:String = "(Unknown tool)";
-	private var _shortcut:String;
-	private var _brain:Interaction;
-	
+
+	var _name:String = "(Unknown tool)";
+	var _shortcut:String;
+	var _brain:Interaction;
+
 	public function init(brain:Interaction):Tool
 	{
 		_brain = brain;
 		return this;
 	}
-	
+
 	public function update():Void {}
-	
+
 	public function draw():Void {}
-	
+
 	public function activate():Void	{}
-	
+
 	public function deactivate():Void {}
-	
+
 	public function destroy():Void {}
-	
+
 	public function isActive():Bool
 	{
 		return _brain.activeTool == this && _brain.visible;
 	}
-	
-	private function setButton(Icon:Class<BitmapData>):Void
+
+	function setButton(Icon:Class<BitmapData>):Void
 	{
 		button = new FlxSystemButton(Type.createInstance(Icon, [0, 0]), onButtonClicked, true);
 		button.toggled = true;
-		
+
 		var tooltip = _name;
 		if (_shortcut != null)
 			tooltip += ' ($_shortcut)';
 		Tooltip.add(button, tooltip);
 	}
-	
-	private function setCursor(Icon:BitmapData):Void
+
+	function setCursor(Icon:BitmapData):Void
 	{
 		cursor = Icon;
 		_brain.registerCustomCursor(_name, cursor);
 	}
-	
-	private function onButtonClicked():Void
+
+	function onButtonClicked():Void
 	{
 		_brain.setActiveTool(this);
 	}
-	
+
 	public function getName():String
 	{
 		return _name;

--- a/flixel/system/debug/log/BitmapLog.hx
+++ b/flixel/system/debug/log/BitmapLog.hx
@@ -28,25 +28,25 @@ class BitmapLog extends Window
 {
 	public var zoom(default, set):Float = 1;
 
-	private var _canvas(get, never):BitmapData;
-	private var _canvasBitmap:Bitmap;
-	private var _entries:Array<BitmapLogEntry> = [];
-	private var _curIndex:Int = 0;
-	private var _curEntry(get, never):BitmapLogEntry;
-	private var _curBitmap(get, never):BitmapData;
-	private var _point:FlxPoint = FlxPoint.get();
-	private var _lastMousePos:FlxPoint = FlxPoint.get();
-	private var _curMouseOffset:FlxPoint = FlxPoint.get();
-	private var _matrix:Matrix = new Matrix();
-	private var _buttonLeft:FlxSystemButton;
-	private var _buttonText:FlxSystemButton;
-	private var _buttonRight:FlxSystemButton;
-	private var _counterText:TextField;
-	private var _dimensionsText:TextField;
-	private var _ui:Sprite;
-	private var _middleMouseDown:Bool = false;
-	private var _footer:Bitmap;
-	private var _footerText:TextField;
+	var _canvas(get, never):BitmapData;
+	var _canvasBitmap:Bitmap;
+	var _entries:Array<BitmapLogEntry> = [];
+	var _curIndex:Int = 0;
+	var _curEntry(get, never):BitmapLogEntry;
+	var _curBitmap(get, never):BitmapData;
+	var _point:FlxPoint = FlxPoint.get();
+	var _lastMousePos:FlxPoint = FlxPoint.get();
+	var _curMouseOffset:FlxPoint = FlxPoint.get();
+	var _matrix:Matrix = new Matrix();
+	var _buttonLeft:FlxSystemButton;
+	var _buttonText:FlxSystemButton;
+	var _buttonRight:FlxSystemButton;
+	var _counterText:TextField;
+	var _dimensionsText:TextField;
+	var _ui:Sprite;
+	var _middleMouseDown:Bool = false;
+	var _footer:Bitmap;
+	var _footerText:TextField;
 
 	public function new()
 	{
@@ -82,7 +82,7 @@ class BitmapLog extends Window
 		removeChild(_shadow);
 	}
 
-	private function createHeaderUI():Void
+	function createHeaderUI():Void
 	{
 		_ui = new Sprite();
 		_ui.y = 2;
@@ -113,7 +113,7 @@ class BitmapLog extends Window
 		addChild(_dimensionsText);
 	}
 
-	private function createFooterUI():Void
+	function createFooterUI():Void
 	{
 		_footer = new Bitmap(new BitmapData(1, Window.HEADER_HEIGHT, true, Window.HEADER_COLOR));
 		_footer.alpha = Window.HEADER_ALPHA;
@@ -158,7 +158,7 @@ class BitmapLog extends Window
 		}
 	}
 
-	override private function updateSize():Void
+	override function updateSize():Void
 	{
 		super.updateSize();
 		// account for the footer
@@ -207,7 +207,7 @@ class BitmapLog extends Window
 	/**
 	 * Show the next logged BitmapData in memory
 	 */
-	private inline function next():Void
+	inline function next():Void
 	{
 		resetSettings();
 		refreshCanvas(_curIndex + 1);
@@ -216,13 +216,13 @@ class BitmapLog extends Window
 	/**
 	 * Show the previous logged BitmapData in memory
 	 */
-	private inline function previous():Void
+	inline function previous():Void
 	{
 		resetSettings();
 		refreshCanvas(_curIndex - 1);
 	}
 
-	private inline function resetSettings():Void
+	inline function resetSettings():Void
 	{
 		zoom = 1;
 		_curMouseOffset.set();
@@ -278,7 +278,7 @@ class BitmapLog extends Window
 		_footerText.text = "";
 	}
 
-	private function refreshCanvas(?Index:Null<Int>):Bool
+	function refreshCanvas(?Index:Null<Int>):Bool
 	{
 		if (_entries == null || _entries.length <= 0)
 		{
@@ -324,7 +324,7 @@ class BitmapLog extends Window
 		return true;
 	}
 
-	private function refreshTexts():Void
+	function refreshTexts():Void
 	{
 		_dimensionsText.text = _curBitmap.width + "x" + _curBitmap.height;
 		_counterText.text = '${_curIndex + 1}/${_entries.length}';
@@ -336,7 +336,7 @@ class BitmapLog extends Window
 		resizeTexts();
 	}
 
-	private function drawBoundingBox(bitmap:BitmapData):Void
+	function drawBoundingBox(bitmap:BitmapData):Void
 	{
 		var gfx:Graphics = FlxSpriteUtil.flashGfx;
 		gfx.clear();
@@ -345,24 +345,24 @@ class BitmapLog extends Window
 		gfx.drawRect(-offset, -offset, bitmap.width + offset, bitmap.height + offset);
 	}
 
-	private function onMouseWheel(e:MouseEvent):Void
+	function onMouseWheel(e:MouseEvent):Void
 	{
 		zoom += FlxMath.signOf(e.delta) * 0.25 * zoom;
 		refreshCanvas();
 	}
 
-	private function onMiddleDown(e:MouseEvent):Void
+	function onMiddleDown(e:MouseEvent):Void
 	{
 		_middleMouseDown = true;
 		_lastMousePos.set(mouseX, mouseY);
 	}
 
-	private function onMiddleUp(e:MouseEvent):Void
+	function onMiddleUp(e:MouseEvent):Void
 	{
 		_middleMouseDown = false;
 	}
 
-	private function set_zoom(Value:Float):Float
+	function set_zoom(Value:Float):Float
 	{
 		if (Value < 0)
 		{
@@ -371,17 +371,17 @@ class BitmapLog extends Window
 		return zoom = Value;
 	}
 
-	private inline function get__canvas():BitmapData
+	inline function get__canvas():BitmapData
 	{
 		return _canvasBitmap.bitmapData;
 	}
 
-	private inline function get__curEntry():BitmapLogEntry
+	inline function get__curEntry():BitmapLogEntry
 	{
 		return _entries[_curIndex];
 	}
 
-	private inline function get__curBitmap():BitmapData
+	inline function get__curBitmap():BitmapData
 	{
 		return _entries[_curIndex].bitmap;
 	}

--- a/flixel/system/debug/log/Log.hx
+++ b/flixel/system/debug/log/Log.hx
@@ -11,18 +11,18 @@ import flixel.system.debug.FlxDebugger.GraphicLog;
 class Log extends Window
 {
 	public static inline var MAX_LOG_LINES:Int = 200;
-	private static inline var LINE_BREAK:String = #if js "\n" #else "<br>"#end; 
+	static inline var LINE_BREAK:String = #if js "\n" #else "<br>"#end;
 
-	private var _text:TextField;
-	private var _lines:Array<String>;
-	
+	var _text:TextField;
+	var _lines:Array<String>;
+
 	/**
 	 * Creates a log window object.
-	 */	
+	 */
 	public function new()
 	{
 		super("Log", new GraphicLog(0, 0));
-		
+
 		_text = new TextField();
 		_text.x = 2;
 		_text.y = 15;
@@ -32,10 +32,10 @@ class Log extends Window
 		_text.embedFonts = true;
 		_text.defaultTextFormat = new TextFormat(FlxAssets.FONT_DEBUGGER, 12, 0xffffff);
 		addChild(_text);
-		
+
 		_lines = new Array<String>();
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -46,11 +46,11 @@ class Log extends Window
 			removeChild(_text);
 			_text = null;
 		}
-		
+
 		_lines = null;
 		super.destroy();
 	}
-	
+
 	/**
 	 * Adds a new line to the log window.
 	 * @param 	Data		The data being logged.
@@ -59,29 +59,29 @@ class Log extends Window
 	 */
 	public function add(Data:Array<Dynamic>, Style:LogStyle, FireOnce:Bool = false):Bool
 	{
-		if (Data == null) 
+		if (Data == null)
 		{
 			return false;
 		}
-		
+
 		var texts:Array<String> = new Array<String>();
-		
+
 		// Format FlxPoints, Arrays, Maps or turn the Data entry into a String
-		for (i in 0...Data.length) 
+		for (i in 0...Data.length)
 		{
 			texts[i] = Std.string(Data[i]);
-			
+
 			// Make sure you can't insert html tags
 			texts[i] = StringTools.htmlEscape(texts[i]);
 		}
-		
+
 		var text:String = Style.prefix + texts.join(" ");
-		
+
 		// Apply text formatting
 		#if (!js && !lime_console)
 		text = flixel.util.FlxStringUtil.htmlFormat(text, Style.size, Style.color, Style.bold, Style.italic, Style.underlined);
 		#end
-		
+
 		// Check if the text has been added yet already
 		if (FireOnce)
 		{
@@ -93,20 +93,20 @@ class Log extends Window
 				}
 			}
 		}
-		
+
 		// Actually add it to the textfield
 		if (_lines.length <= 0)
 		{
 			_text.text = "";
 		}
-		
+
 		_lines.push(text);
-		
+
 		if (_lines.length > MAX_LOG_LINES)
 		{
 			_lines.shift();
 			var newText:String = "";
-			for (i in 0..._lines.length) 
+			for (i in 0..._lines.length)
 			{
 				newText += _lines[i] + LINE_BREAK;
 			}
@@ -126,11 +126,11 @@ class Log extends Window
 			_text.text += text + LINE_BREAK;
 			#end
 		}
-		
+
 		_text.scrollV = Std.int(_text.maxScrollV);
 		return true;
 	}
-	
+
 	public function clear():Void
 	{
 		_text.text = "";
@@ -139,14 +139,14 @@ class Log extends Window
 		_text.scrollV = 0;
 		#end
 	}
-	
+
 	/**
 	 * Adjusts the width and height of the text field accordingly.
 	 */
-	override private function updateSize():Void
+	override function updateSize():Void
 	{
 		super.updateSize();
-		
+
 		_text.width = _width - 10;
 		_text.height = _height - 15;
 	}

--- a/flixel/system/debug/stats/Stats.hx
+++ b/flixel/system/debug/stats/Stats.hx
@@ -20,7 +20,7 @@ private class GraphicMaximizeButton extends BitmapData {}
 
 /**
  * A simple performance monitor widget, for use in the debugger overlay.
- * 
+ *
  * @author Adam "Atomic" Saltsman
  * @author Anton Karlov
  */
@@ -30,73 +30,73 @@ class Stats extends Window
 	/**
 	 * How often to update the stats, in ms. The lower, the more performance-intense!
 	 */
-	private static inline var UPDATE_DELAY:Int = 250;
+	static inline var UPDATE_DELAY:Int = 250;
 	/**
 	 * The initial width of the stats window.
 	 */
-	private static inline var INITIAL_WIDTH:Int = 160;
+	static inline var INITIAL_WIDTH:Int = 160;
 	/**
 	 * The minimal height of the window.
 	 */
-	private static var MIN_HEIGHT:Int = 0;
-	
-	private static inline var FPS_COLOR:FlxColor = 0xff96ff00;
-	private static inline var MEMORY_COLOR:FlxColor = 0xff009cff;
-	private static inline var DRAW_TIME_COLOR:FlxColor = 0xffA60004;
-	private static inline var UPDATE_TIME_COLOR:FlxColor = 0xffdcd400;
-	
+	static var MIN_HEIGHT:Int = 0;
+
+	static inline var FPS_COLOR:FlxColor = 0xff96ff00;
+	static inline var MEMORY_COLOR:FlxColor = 0xff009cff;
+	static inline var DRAW_TIME_COLOR:FlxColor = 0xffA60004;
+	static inline var UPDATE_TIME_COLOR:FlxColor = 0xffdcd400;
+
 	public static inline var LABEL_COLOR:FlxColor = 0xaaffffff;
 	public static inline var TEXT_SIZE:Int = 11;
 	public static inline var DECIMALS:Int = 1;
-	
-	private var _leftTextField:TextField;
-	private var _rightTextField:TextField;
-	
-	private var _itvTime:Int = 0;
-	private var _frameCount:Int;
-	private var _currentTime:Int;
-	
-	private var fpsGraph:StatsGraph;
-	private var memoryGraph:StatsGraph;
-	private var drawTimeGraph:StatsGraph;
-	private var updateTimeGraph:StatsGraph;
-	
-	private var flashPlayerFramerate:Float = 0;
-	private var visibleCount:Int = 0;
-	private var activeCount:Int = 0;
-	private var updateTime:Int = 0;
-	private var drawTime:Int = 0;
-	private var drawCallsCount:Int = 0;
 
-	private var _lastTime:Int = 0;
-	private var _updateTimer:Int = 0;
-	
-	private var _update:Array<Int> = [];
-	private var _updateMarker:Int = 0;
-	
-	private var _draw:Array<Int> = [];
-	private var _drawMarker:Int = 0;
-	
-	private var _drawCalls:Array<Int> = [];
-	private var _drawCallsMarker:Int = 0;
-	
-	private var _visibleObject:Array<Int> = [];
-	private var _visibleObjectMarker:Int = 0;
-	
-	private var _activeObject:Array<Int> = [];
-	private var _activeObjectMarker:Int = 0;
-	
-	private var _paused:Bool = true;
-	
-	private var _toggleSizeButton:FlxSystemButton;
-	
+	var _leftTextField:TextField;
+	var _rightTextField:TextField;
+
+	var _itvTime:Int = 0;
+	var _frameCount:Int;
+	var _currentTime:Int;
+
+	var fpsGraph:StatsGraph;
+	var memoryGraph:StatsGraph;
+	var drawTimeGraph:StatsGraph;
+	var updateTimeGraph:StatsGraph;
+
+	var flashPlayerFramerate:Float = 0;
+	var visibleCount:Int = 0;
+	var activeCount:Int = 0;
+	var updateTime:Int = 0;
+	var drawTime:Int = 0;
+	var drawCallsCount:Int = 0;
+
+	var _lastTime:Int = 0;
+	var _updateTimer:Int = 0;
+
+	var _update:Array<Int> = [];
+	var _updateMarker:Int = 0;
+
+	var _draw:Array<Int> = [];
+	var _drawMarker:Int = 0;
+
+	var _drawCalls:Array<Int> = [];
+	var _drawCallsMarker:Int = 0;
+
+	var _visibleObject:Array<Int> = [];
+	var _visibleObjectMarker:Int = 0;
+
+	var _activeObject:Array<Int> = [];
+	var _activeObjectMarker:Int = 0;
+
+	var _paused:Bool = true;
+
+	var _toggleSizeButton:FlxSystemButton;
+
 	/**
 	 * Creates a new window with fps and memory graphs, as well as other useful stats for debugging.
 	 */
 	public function new()
 	{
 		super("Stats", new GraphicStats(0, 0), 0, 0, false);
-		
+
 		if (MIN_HEIGHT == 0)
 		{
 			if (!FlxG.renderTile)
@@ -104,67 +104,67 @@ class Stats extends Window
 			else
 				MIN_HEIGHT = 200;
 		}
-		
+
 		minSize.y = MIN_HEIGHT;
 		resize(INITIAL_WIDTH, MIN_HEIGHT);
-		
+
 		start();
-		
+
 		_update = [];
 		_draw = [];
 		_activeObject = [];
 		_visibleObject = [];
-		
+
 		if (FlxG.renderTile)
 		{
 			_drawCalls = [];
 		}
-		
+
 		var gutter:Int = 5;
 		var graphX:Int = gutter;
 		var graphY:Int = Std.int(_header.height) + gutter;
 		var graphHeight:Int = 40;
 		var graphWidth:Int = INITIAL_WIDTH - 20;
-		
+
 		fpsGraph = new StatsGraph(graphX, graphY, graphWidth, graphHeight, FPS_COLOR, "fps");
-		addChild(fpsGraph);	
+		addChild(fpsGraph);
 		fpsGraph.maxValue = FlxG.drawFramerate;
 		fpsGraph.minValue = 0;
-		
+
 		graphY = (Std.int(_header.height) +  graphHeight + 20);
-		
+
 		memoryGraph = new StatsGraph(graphX, graphY, graphWidth, graphHeight, MEMORY_COLOR, "MB");
 		addChild(memoryGraph);
-		
+
 		graphY = Std.int(_header.height) + gutter;
 		graphX += (gutter + graphWidth + 20);
 		graphWidth -= 10;
-		
+
 		updateTimeGraph = new StatsGraph(graphX, graphY, graphWidth, graphHeight, UPDATE_TIME_COLOR, "ms", 35, "Update");
 		updateTimeGraph.visible = false;
 		addChild(updateTimeGraph);
-		
+
 		graphY = Std.int(_header.height) +  graphHeight + 20;
-		
+
 		drawTimeGraph = new StatsGraph(graphX, graphY, graphWidth, graphHeight, DRAW_TIME_COLOR, "ms", 35, "Draw");
 		drawTimeGraph.visible = false;
 		addChild(drawTimeGraph);
-		
+
 		addChild(_leftTextField = DebuggerUtil.createTextField(gutter, (graphHeight * 2) + 45, LABEL_COLOR, TEXT_SIZE));
 		addChild(_rightTextField = DebuggerUtil.createTextField(gutter + 70, (graphHeight * 2) + 45, FlxColor.WHITE, TEXT_SIZE));
-		
+
 		_leftTextField.multiline = _rightTextField.multiline = true;
 		_leftTextField.wordWrap = _rightTextField.wordWrap = true;
-		
+
 		_leftTextField.text = "Update: \nDraw:" + (FlxG.renderTile ? "\nDrawTiles:" : "") + "\nQuadTrees: \nLists:";
-		
+
 		_toggleSizeButton = new FlxSystemButton(new GraphicMaximizeButton(0, 0), toggleSize);
 		_toggleSizeButton.alpha = Window.HEADER_ALPHA;
 		addChild(_toggleSizeButton);
-		
+
 		updateSize();
 	}
-	
+
 	/**
 	 * Starts Stats window update logic
 	 */
@@ -177,7 +177,7 @@ class Stats extends Window
 			_frameCount = 0;
 		}
 	}
-	
+
 	/**
 	 * Stops Stats window
 	 */
@@ -185,7 +185,7 @@ class Stats extends Window
 	{
 		_paused = true;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -197,91 +197,91 @@ class Stats extends Window
 			removeChild(fpsGraph);
 		}
 		fpsGraph = null;
-		
+
 		if (memoryGraph != null)
 		{
 			removeChild(memoryGraph);
 		}
 		memoryGraph = null;
-		
+
 		if (_leftTextField != null)
 		{
 			removeChild(_leftTextField);
 		}
 		_leftTextField = null;
-		
+
 		if (_rightTextField != null)
 		{
 			removeChild(_rightTextField);
 		}
 		_rightTextField = null;
-		
+
 		_update = null;
 		_draw = null;
 		_activeObject = null;
 		_visibleObject = null;
 		_drawCalls = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Called each frame, but really only updates once every second or so, to save on performance.
 	 * Takes all the data in the accumulators and parses it into useful performance data.
 	 */
 	override public function update():Void
 	{
-		if (_paused) 
+		if (_paused)
 		{
 			return;
 		}
 		var time:Int = _currentTime = FlxG.game.ticks;
-		
+
 		var elapsed:Int = time - _lastTime;
-		
+
 		if (elapsed > UPDATE_DELAY)
 		{
 			elapsed = UPDATE_DELAY;
 		}
 		_lastTime = time;
-		
+
 		_updateTimer += elapsed;
-		
+
 		_frameCount++;
-		
+
 		if (_updateTimer > UPDATE_DELAY)
 		{
 			fpsGraph.update(currentFps());
 			memoryGraph.update(currentMem());
 			updateTexts();
-			
+
 			_frameCount = 0;
 			_itvTime = _currentTime;
-			
+
 			updateTime = 0;
 			for (i in 0..._updateMarker)
 			{
 				updateTime += _update[i];
 			}
-			
+
 			for (i in 0..._activeObjectMarker)
 			{
 				activeCount += _activeObject[i];
 			}
 			activeCount = Std.int(divide(activeCount, _activeObjectMarker));
-			
+
 			drawTime = 0;
 			for (i in 0..._drawMarker)
 			{
 				drawTime += _draw[i];
 			}
-			
+
 			for (i in 0..._visibleObjectMarker)
 			{
 				visibleCount += _visibleObject[i];
 			}
 			visibleCount = Std.int(divide(visibleCount, _visibleObjectMarker));
-			
+
 			if (FlxG.renderTile)
 			{
 				for (i in 0..._drawCallsMarker)
@@ -290,7 +290,7 @@ class Stats extends Window
 				}
 				drawCallsCount = Std.int(divide(drawCallsCount, _drawCallsMarker));
 			}
-			
+
 			_updateMarker = 0;
 			_drawMarker = 0;
 			_activeObjectMarker = 0;
@@ -299,19 +299,19 @@ class Stats extends Window
 			{
 				_drawCallsMarker = 0;
 			}
-			
+
 			_updateTimer -= UPDATE_DELAY;
 		}
 	}
-	
-	private function updateTexts():Void
+
+	function updateTexts():Void
 	{
 		var updTime = FlxMath.roundDecimal(divide(updateTime, _updateMarker), DECIMALS);
 		var drwTime = FlxMath.roundDecimal(divide(drawTime, _drawMarker), DECIMALS);
-		
+
 		drawTimeGraph.update(drwTime);
 		updateTimeGraph.update(updTime);
-		
+
 		_rightTextField.text =
 			activeCount + " (" + updTime + "ms)\n" +
 			visibleCount + " (" + drwTime + "ms)\n" +
@@ -319,14 +319,14 @@ class Stats extends Window
 			FlxQuadTree._NUM_CACHED_QUAD_TREES + "\n" +
 			FlxLinkedList._NUM_CACHED_FLX_LIST;
 	}
-	
-	private function divide(f1:Float, f2:Float):Float
+
+	function divide(f1:Float, f2:Float):Float
 	{
 		if (f2 == 0)
 			return 0;
 		return f1 / f2;
 	}
-	
+
 	/**
 	 * Calculates current game fps.
 	 */
@@ -334,7 +334,7 @@ class Stats extends Window
 	{
 		return _frameCount / intervalTime();
 	}
-	
+
 	/**
 	 * Time since performance monitoring started.
 	 */
@@ -342,7 +342,7 @@ class Stats extends Window
 	{
 		return (_currentTime - _itvTime) / 1000;
 	}
-	
+
 	/**
 	 * Current RAM consumption.
 	 */
@@ -350,67 +350,67 @@ class Stats extends Window
 	{
 		return (System.totalMemory / 1024) / 1000;
 	}
-	
+
 	/**
 	 * How long updates took.
-	 * 
+	 *
 	 * @param 	Time	How long this update took.
 	 */
 	public function flixelUpdate(Time:Int):Void
 	{
-		if (_paused) 
+		if (_paused)
 			return;
 		_update[_updateMarker++] = Time;
 	}
-	
+
 	/**
 	 * How long rendering took.
-	 * 
+	 *
 	 * @param	Time	How long this render took.
 	 */
 	public function flixelDraw(Time:Int):Void
 	{
-		if (_paused) 
+		if (_paused)
 			return;
 		_draw[_drawMarker++] = Time;
 	}
-	
+
 	/**
 	 * How many objects were updated.
-	 * 
+	 *
 	 * @param 	Count	How many objects were updated.
 	 */
 	public function activeObjects(Count:Int):Void
 	{
-		if (_paused) 
+		if (_paused)
 			return;
 		_activeObject[_activeObjectMarker++] = Count;
 	}
-	
+
 	/**
 	 * How many objects were rendered.
-	 * 
+	 *
 	 * @param 	Count	How many objects were rendered.
 	 */
 	public function visibleObjects(Count:Int):Void
 	{
-		if (_paused) 
+		if (_paused)
 			return;
 		_visibleObject[_visibleObjectMarker++] = Count;
 	}
-	
+
 	/**
 	 * How many times drawTiles() method was called.
-	 * 
+	 *
 	 * @param 	Count	How many times drawTiles() method was called.
 	 */
 	public function drawCalls(Drawcalls:Int):Void
 	{
-		if (_paused) 
+		if (_paused)
 			return;
 		_drawCalls[_drawCallsMarker++] = Drawcalls;
 	}
-	
+
 	/**
 	 * Re-enables tracking of the stats.
 	 */
@@ -418,7 +418,7 @@ class Stats extends Window
 	{
 		_paused = false;
 	}
-	
+
 	/**
 	 * Pauses tracking of the stats.
 	 */
@@ -426,8 +426,8 @@ class Stats extends Window
 	{
 		_paused = true;
 	}
-	
-	private function toggleSize():Void
+
+	function toggleSize():Void
 	{
 		if (_width == INITIAL_WIDTH)
 		{
@@ -445,12 +445,12 @@ class Stats extends Window
 			updateTimeGraph.visible = false;
 			_toggleSizeButton.changeIcon(new GraphicMaximizeButton(0, 0));
 		}
-		
+
 		updateSize();
 		bound();
 	}
-	
-	override private function updateSize():Void
+
+	override function updateSize():Void
 	{
 		super.updateSize();
 		if (_toggleSizeButton != null)

--- a/flixel/system/debug/stats/StatsGraph.hx
+++ b/flixel/system/debug/stats/StatsGraph.hx
@@ -15,29 +15,29 @@ import flixel.util.FlxDestroyUtil;
 #if FLX_DEBUG
 class StatsGraph extends Sprite
 {
-	private static inline var AXIS_COLOR:FlxColor = 0xffffff;
-	private static inline var AXIS_ALPHA:Float = 0.5;
-	private static inline var HISTORY_MAX:Int = 30;
-	
+	static inline var AXIS_COLOR:FlxColor = 0xffffff;
+	static inline var AXIS_ALPHA:Float = 0.5;
+	static inline var HISTORY_MAX:Int = 30;
+
 	public var minLabel:TextField;
 	public var curLabel:TextField;
 	public var maxLabel:TextField;
 	public var avgLabel:TextField;
-	
+
 	public var minValue:Float = FlxMath.MAX_VALUE_FLOAT;
 	public var maxValue:Float = FlxMath.MIN_VALUE_FLOAT;
-	
+
 	public var graphColor:FlxColor;
-	
+
 	public var history:Array<Float> = [];
-	
-	private var _axis:Shape;
-	private var _width:Int;
-	private var _height:Int;
-	private var _unit:String;
-	private var _labelWidth:Int;
-	private var _label:String;
-	
+
+	var _axis:Shape;
+	var _width:Int;
+	var _height:Int;
+	var _unit:String;
+	var _labelWidth:Int;
+	var _label:String;
+
 	public function new(X:Int, Y:Int, Width:Int, Height:Int, GraphColor:FlxColor, Unit:String, LabelWidth:Int = 45, ?Label:String)
 	{
 		super();
@@ -49,94 +49,94 @@ class StatsGraph extends Sprite
 		_unit = Unit;
 		_labelWidth = LabelWidth;
 		_label = (Label == null) ? "" : Label;
-		
+
 		_axis = new Shape();
 		_axis.x = _labelWidth + 10;
-		
+
 		maxLabel = DebuggerUtil.createTextField(0, 0, Stats.LABEL_COLOR, Stats.TEXT_SIZE);
 		curLabel = DebuggerUtil.createTextField(0, (_height / 2) - (Stats.TEXT_SIZE / 2), graphColor, Stats.TEXT_SIZE);
 		minLabel = DebuggerUtil.createTextField(0, _height - Stats.TEXT_SIZE, Stats.LABEL_COLOR, Stats.TEXT_SIZE);
-		
+
 		avgLabel = DebuggerUtil.createTextField(_labelWidth + 20, (_height / 2) - (Stats.TEXT_SIZE / 2) - 10, Stats.LABEL_COLOR, Stats.TEXT_SIZE);
 		avgLabel.width = _width;
 		avgLabel.defaultTextFormat.align = TextFormatAlign.CENTER;
 		avgLabel.alpha = 0.5;
-		
+
 		addChild(_axis);
 		addChild(maxLabel);
 		addChild(curLabel);
 		addChild(minLabel);
 		addChild(avgLabel);
-		
+
 		drawAxes();
 	}
-	
+
 	/**
 	 * Redraws the axes of the graph.
 	 */
-	private function drawAxes():Void
+	function drawAxes():Void
 	{
 		var gfx = _axis.graphics;
 		gfx.clear();
-		gfx.lineStyle(1, AXIS_COLOR, AXIS_ALPHA); 
-		
+		gfx.lineStyle(1, AXIS_COLOR, AXIS_ALPHA);
+
 		// y-Axis
 		gfx.moveTo(0, 0);
 		gfx.lineTo(0, _height);
-		
+
 		// x-Axis
 		gfx.moveTo(0, _height);
 		gfx.lineTo(_width, _height);
 	}
-	
+
 	/**
 	 * Redraws the graph based on the values stored in the history.
 	 */
-	private function drawGraph():Void
+	function drawGraph():Void
 	{
 		var gfx:Graphics = graphics;
 		gfx.clear();
 		gfx.lineStyle(1, graphColor, 1);
-		
+
 		var inc:Float = _width / (HISTORY_MAX - 1);
 		var range:Float = Math.max(maxValue - minValue, maxValue * 0.1);
 		var graphX = _axis.x + 1;
-		
+
 		for (i in 0...history.length)
 		{
 			var value = (history[i] - minValue) / range;
-			
+
 			var pointY = (-value * _height - 1) + _height;
 			if (i == 0)
 				gfx.moveTo(graphX, _axis.y + pointY);
 			gfx.lineTo(graphX + (i * inc), pointY);
 		}
 	}
-	
+
 	public function update(Value:Float):Void
 	{
 		history.unshift(Value);
 		if (history.length > HISTORY_MAX)
 			history.pop();
-		
+
 		// Update range
 		maxValue = Math.max(maxValue, Value);
 		minValue = Math.min(minValue, Value);
-		
+
 		minLabel.text = formatValue(minValue);
 		curLabel.text = formatValue(Value);
 		maxLabel.text = formatValue(maxValue);
-		
+
 		avgLabel.text = _label + "\nAvg: " + formatValue(average());
-		
+
 		drawGraph();
 	}
-	
-	private function formatValue(value:Float):String
+
+	function formatValue(value:Float):String
 	{
 		return FlxMath.roundDecimal(value, Stats.DECIMALS) + " " + _unit;
 	}
-	
+
 	public function average():Float
 	{
 		var sum:Float = 0;
@@ -144,7 +144,7 @@ class StatsGraph extends Sprite
 			sum += value;
 		return sum / history.length;
 	}
-	
+
 	public function destroy():Void
 	{
 		_axis = FlxDestroyUtil.removeChild(this, _axis);

--- a/flixel/system/debug/watch/EditableTextField.hx
+++ b/flixel/system/debug/watch/EditableTextField.hx
@@ -15,13 +15,13 @@ class EditableTextField extends TextField implements IFlxDestroyable
 {
 	public var isEditing(default, null):Bool;
 
-	private var allowEditing:Bool;
-	private var submitValue:Dynamic->Void;
-	private var expectedType:ValueType;
+	var allowEditing:Bool;
+	var submitValue:Dynamic->Void;
+	var expectedType:ValueType;
 
-	private var defaultFormat:TextFormat;
-	private var editFormat:TextFormat;
-	
+	var defaultFormat:TextFormat;
+	var editFormat:TextFormat;
+
 	public function new(allowEditing:Bool, defaultFormat:TextFormat, submitValue:Dynamic->Void, expectedType:ValueType)
 	{
 		super();
@@ -29,11 +29,11 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		this.submitValue = submitValue;
 		this.defaultFormat = defaultFormat;
 		this.expectedType = expectedType;
-		
+
 		if (allowEditing)
 		{
 			editFormat = new TextFormat(defaultFormat.font, defaultFormat.size, 0x000000);
-			
+
 			addEventListener(KeyboardEvent.KEY_UP, onKeyUp);
 			addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
 			addEventListener(MouseEvent.MOUSE_UP, onMouseUp);
@@ -41,7 +41,7 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		}
 	}
 
-	public function destroy():Void 
+	public function destroy():Void
 	{
 		if (allowEditing)
 		{
@@ -51,13 +51,13 @@ class EditableTextField extends TextField implements IFlxDestroyable
 			removeEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		}
 	}
-	
-	private function onMouseUp(_):Void
+
+	function onMouseUp(_):Void
 	{
 		setIsEditing(true);
 	}
-	
-	private function onKeyUp(e:KeyboardEvent):Void
+
+	function onKeyUp(e:KeyboardEvent):Void
 	{
 		switch (e.keyCode)
 		{
@@ -68,7 +68,7 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		}
 	}
 
-	private function onKeyDown(e:KeyboardEvent):Void
+	function onKeyDown(e:KeyboardEvent):Void
 	{
 		var modifier = 1.0;
 		if (e.altKey)
@@ -83,7 +83,7 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		}
 	}
 
-	private function cycleValue(modifier:Float, selection:Int):Void
+	function cycleValue(modifier:Float, selection:Int):Void
 	{
 		switch (expectedType)
 		{
@@ -101,12 +101,12 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		}
 	}
 
-	private function selectEnd():Void
+	function selectEnd():Void
 	{
 		setSelection(text.length, text.length);
 	}
-	
-	private function cycleNumericValue(modifier:Float):Void
+
+	function cycleNumericValue(modifier:Float):Void
 	{
 		var value:Float = Std.parseFloat(text);
 		if (Math.isNaN(value))
@@ -117,7 +117,7 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		text = Std.string(value);
 	}
 
-	private function cycleEnumValue(e:Enum<Dynamic>, modifier:Int):Void
+	function cycleEnumValue(e:Enum<Dynamic>, modifier:Int):Void
 	{
 		var values = e.getConstructors();
 		var index = values.indexOf(text);
@@ -131,7 +131,7 @@ class EditableTextField extends TextField implements IFlxDestroyable
 		text = Std.string(values[index]);
 	}
 
-	private function onFocusLost(_)
+	function onFocusLost(_)
 	{
 		setIsEditing(false);
 	}
@@ -157,18 +157,18 @@ class EditableTextField extends TextField implements IFlxDestroyable
 			submitValue(value);
 		}
 		catch (e:Dynamic) {}
-		
+
 		setIsEditing(false);
 	}
-	
-	private function setIsEditing(isEditing:Bool)
+
+	function setIsEditing(isEditing:Bool)
 	{
 		this.isEditing = isEditing;
-		
+
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = !isEditing;
 		#end
-		
+
 		type = isEditing ? TextFieldType.INPUT : TextFieldType.DYNAMIC;
 		background = isEditing;
 		defaultTextFormat = isEditing ? editFormat : defaultFormat;

--- a/flixel/system/debug/watch/Tracker.hx
+++ b/flixel/system/debug/watch/Tracker.hx
@@ -38,19 +38,19 @@ class Tracker extends Watch
 {
 	#if FLX_DEBUG
 	/**
-	 * Order matters here, as the last profile is the most relevant - i.e., if the 
+	 * Order matters here, as the last profile is the most relevant - i.e., if the
 	 * FlxSprite profile were added before the one for FlxObject, it would never be selected.
 	 */
 	public static var profiles:Array<TrackerProfile>;
-	
+
 	/**
 	 * Stores a reference to all objects for a which a tracker window exists
 	 * to prevent the creation of two windows for the same object.
-	 */ 
+	 */
 	public static var objectsBeingTracked:Array<Dynamic> = [];
-	
-	private static var _numTrackerWindows:Int = 0;
-	
+
+	static var _numTrackerWindows:Int = 0;
+
 	public static inline function addProfile(Profile:TrackerProfile):Void
 	{
 		if (Profile != null)
@@ -59,11 +59,11 @@ class Tracker extends Watch
 			profiles.push(Profile);
 		}
 	}
-	
+
 	public static function findProfile(Object:Dynamic):TrackerProfile
 	{
 		initProfiles();
-		
+
 		var lastMatchingProfile:TrackerProfile = null;
 		for (profile in profiles)
 			if (Std.is(Object, profile.objectClass) || Object == profile.objectClass)
@@ -71,25 +71,25 @@ class Tracker extends Watch
 
 		return lastMatchingProfile;
 	}
-	
+
 	public static function onStateSwitch():Void
 	{
 		_numTrackerWindows = 0;
 	}
-	
-	private static function initProfiles():Void
+
+	static function initProfiles():Void
 	{
 		if (profiles == null)
 		{
 			profiles = [];
-			
+
 			addProfile(new TrackerProfile(FlxG,
-				["width", "height", "worldBounds.x", "worldBounds.y", "worldBounds.width", "worldBounds.height", 
+				["width", "height", "worldBounds.x", "worldBounds.y", "worldBounds.width", "worldBounds.height",
 					"worldDivisions", "updateFramerate", "drawFramerate", "elapsed", "maxElapsed", "autoPause", "fixedTimestep", "timeScale"]));
-			
+
 			addProfile(new TrackerProfile(FlxPoint, ["x", "y"]));
 			addProfile(new TrackerProfile(FlxRect, ["width", "height"], [FlxPoint]));
-			
+
 			addProfile(new TrackerProfile(FlxBasic, ["active", "visible", "alive", "exists"]));
 			addProfile(new TrackerProfile(FlxObject, ["velocity", "acceleration", "drag", "angle", "immovable"], [FlxRect, FlxBasic]));
 			addProfile(new TrackerProfile(FlxTilemap, ["auto", "widthInTiles", "heightInTiles", "totalTiles", "scale"], [FlxObject]));
@@ -98,24 +98,24 @@ class Tracker extends Watch
 			addProfile(new TrackerProfile(FlxBar, ["min", "max", "range", "pct", "pxPerPercent", "value"], [FlxSprite]));
 			addProfile(new TrackerProfile(FlxText,
 				["text", "size", "font", "embedded", "bold", "italic", "wordWrap", "borderSize",  "borderStyle"], [FlxSprite]));
-			
+
 			addProfile(new TrackerProfile(FlxTypedGroup, ["length", "members.length", "maxSize"], [FlxBasic]));
 			addProfile(new TrackerProfile(FlxSpriteGroup, null, [FlxSprite, FlxTypedGroup]));
 			addProfile(new TrackerProfile(FlxState, ["persistentUpdate", "persistentDraw", "destroySubStates", "bgColor"], [FlxTypedGroup]));
-			
+
 			addProfile(new TrackerProfile(FlxCamera,
 				["style", "followLerp", "followLead", "deadzone", "bounds", "zoom", "alpha", "angle"], [FlxBasic, FlxRect]));
-			
+
 			addProfile(new TrackerProfile(FlxTween,
 				["active", "duration", "type", "percent", "finished", "scale", "backward", "executions", "startDelay", "loopDelay"]));
-			
+
 			addProfile(new TrackerProfile(FlxPath, ["speed", "angle", "autoCenter", "nodeIndex", "active", "finished"]));
 			addProfile(new TrackerProfile(FlxTimer, ["time", "loops", "active", "finished", "timeLeft", "elapsedTime", "loopsLeft", "elapsedLoops", "progress"]));
-			
+
 			addProfile(new TrackerProfile(FlxAnimationController, ["frameIndex", "frameName", "name", "paused", "finished", "frames"]));
-			
+
 			addProfile(new TrackerProfile(FlxTypedEmitter, ["emitting", "frequency", "bounce"], [FlxTypedGroup, FlxRect]));
-			
+
 			// Inputs
 			#if FLX_MOUSE
 			addProfile(new TrackerProfile(FlxMouse,
@@ -123,49 +123,49 @@ class Tracker extends Watch
 					"justReleased" #if FLX_MOUSE_ADVANCED , "pressedMiddle", "justPressedMiddle",
 					"justReleasedMiddle", "pressedRight", "justPressedRight", "justReleasedRight" #end], [FlxPoint]));
 			#end
-			#if FLX_TOUCH 
+			#if FLX_TOUCH
 			addProfile(new TrackerProfile(FlxTouch, ["screenX", "screenY", "touchPointID", "pressed", "justPressed", "justReleased", "isActive"], [FlxPoint]));
 			#end
 			#if FLX_GAMEPAD
 			addProfile(new TrackerProfile(FlxGamepad, ["id", "deadZone", "hat", "ball", "dpadUp", "dpadDown", "dpadLeft", "dpadRight"]));
 			#end
-			
+
 			#if FLX_POINTER_INPUT
 			addProfile(new TrackerProfile(FlxSwipe, ["ID", "startPosition", "endPosition", "distance", "angle", "duration"]));
 			#end
-			
+
 			addProfile(new TrackerProfile(DisplayObject, ["z", "scaleX", "scaleY", "mouseX", "mouseY", "rotationX", "rotationY", "visible"], [FlxRect]));
 			addProfile(new TrackerProfile(Point, null, [FlxPoint]));
 			addProfile(new TrackerProfile(Rectangle, null, [FlxRect]));
 			addProfile(new TrackerProfile(Matrix, ["a", "b", "c", "d", "tx", "ty"]));
 		}
 	}
-	
-	private var _object:Dynamic;
-	
-	public function new(Profile:TrackerProfile, ObjectOrClass:Dynamic, ?WindowTitle:String) 
+
+	var _object:Dynamic;
+
+	public function new(Profile:TrackerProfile, ObjectOrClass:Dynamic, ?WindowTitle:String)
 	{
 		super(true);
-		
+
 		initProfiles();
 		_object = ObjectOrClass;
 		objectsBeingTracked.push(_object);
-		
+
 		initWatchEntries(Profile);
-		
+
 		_title.text = (WindowTitle == null) ? FlxStringUtil.getClassName(_object, true) : WindowTitle;
 		visible = true;
-		
+
 		resize(200, entriesContainer.height + 30);
-		
+
 		// Small x and y offset
 		x = _numTrackerWindows * 80;
 		y = _numTrackerWindows * 25 + 20;
 		_numTrackerWindows++;
-		
+
 		FlxG.signals.stateSwitched.add(close);
 	}
-	
+
 	override public function destroy():Void
 	{
 		FlxG.signals.stateSwitched.remove(close);
@@ -174,17 +174,17 @@ class Tracker extends Watch
 		_object = null;
 		super.destroy();
 	}
-	
-	private function findProfileByClass(ObjectClass:Class<Dynamic>):TrackerProfile
+
+	function findProfileByClass(ObjectClass:Class<Dynamic>):TrackerProfile
 	{
 		for (profile in profiles)
 			if (profile.objectClass == ObjectClass)
 				return profile;
-		
+
 		return null;
 	}
-	
-	private function initWatchEntries(Profile:TrackerProfile):Void
+
+	function initWatchEntries(Profile:TrackerProfile):Void
 	{
 		if (Profile != null)
 		{
@@ -192,31 +192,31 @@ class Tracker extends Watch
 			addVariables(Profile.variables);
 		}
 	}
-	
-	private function addExtensions(Profile:TrackerProfile):Void
+
+	function addExtensions(Profile:TrackerProfile):Void
 	{
 		if (Profile.extensions == null)
 			return;
-		
+
 		for (extension in Profile.extensions)
 		{
 			if (extension == null)
 				continue;
-			
+
 			var extensionProfile:TrackerProfile = findProfileByClass(extension);
 			if (extensionProfile != null)
 			{
 				addVariables(extensionProfile.variables);
 				addExtensions(extensionProfile); // recurse
-			}			
+			}
 		}
 	}
-	
-	private function addVariables(Variables:Array<String>):Void
+
+	function addVariables(Variables:Array<String>):Void
 	{
 		if (Variables == null)
 			return;
-		
+
 		for (variable in Variables)
 			add(variable, FIELD(_object, variable));
 	}
@@ -228,14 +228,14 @@ class TrackerProfile
 	public var objectClass:Class<Dynamic>;
 	public var variables:Array<String>;
 	public var extensions:Array<Class<Dynamic>>;
-	
+
 	public function new(ObjectClass:Class<Dynamic>, ?Variables:Array<String>, ?Extensions:Array<Class<Dynamic>>)
 	{
 		objectClass = ObjectClass;
 		variables = Variables;
 		extensions = Extensions;
 	}
-	
+
 	public function toString():String
 	{
 		return FlxStringUtil.getDebugString([

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -14,21 +14,21 @@ using flixel.util.FlxArrayUtil;
 class Watch extends Window
 {
 	#if FLX_DEBUG
-	private static inline var LINE_HEIGHT:Int = 15;
-	
-	private var entriesContainer:Sprite;
-	private var entriesContainerOffset:FlxPoint = FlxPoint.get(2, 15);
-	private var entries:Array<WatchEntry> = [];
+	static inline var LINE_HEIGHT:Int = 15;
+
+	var entriesContainer:Sprite;
+	var entriesContainerOffset:FlxPoint = FlxPoint.get(2, 15);
+	var entries:Array<WatchEntry> = [];
 
 	public function new(closable:Bool = false)
 	{
 		super("Watch", new GraphicWatch(0, 0), 0, 0, true, null, closable);
-		
+
 		entriesContainer = new Sprite();
 		entriesContainer.x = entriesContainerOffset.x;
 		entriesContainer.y = entriesContainerOffset.y;
 		addChild(entriesContainer);
-		
+
 		FlxG.signals.stateSwitched.add(removeAll);
 	}
 
@@ -36,7 +36,7 @@ class Watch extends Window
 	{
 		if (isInvalid(displayName, data))
 			return;
-		
+
 		var existing = getExistingEntry(displayName, data);
 		if (existing != null)
 		{
@@ -48,11 +48,11 @@ class Watch extends Window
 			}
 			return;
 		}
-		
+
 		addEntry(displayName, data);
 	}
-	
-	private function isInvalid(displayName:String, data:WatchEntryData):Bool
+
+	function isInvalid(displayName:String, data:WatchEntryData):Bool
 	{
 		return switch (data)
 		{
@@ -64,8 +64,8 @@ class Watch extends Window
 				expression.isNullOrEmpty();
 		}
 	}
-	
-	private function getExistingEntry(displayName:String, data:WatchEntryData):WatchEntry
+
+	function getExistingEntry(displayName:String, data:WatchEntryData):WatchEntry
 	{
 		for (entry in entries)
 		{
@@ -79,30 +79,30 @@ class Watch extends Window
 		}
 		return null;
 	}
-	
-	private function addEntry(displayName:String, data:WatchEntryData):Void
+
+	function addEntry(displayName:String, data:WatchEntryData):Void
 	{
 		var entry = new WatchEntry(displayName, data, removeEntry);
 		entries.push(entry);
 		entriesContainer.addChild(entry);
 		resetEntries();
 	}
-	
+
 	public function remove(displayName:String, data:WatchEntryData):Void
 	{
 		var existing = getExistingEntry(displayName, data);
 		if (existing != null)
 			removeEntry(existing);
 	}
-	
-	private function removeEntry(entry:WatchEntry):Void
+
+	function removeEntry(entry:WatchEntry):Void
 	{
 		entries.fastSplice(entry);
 		entriesContainer.removeChild(entry);
 		entry.destroy();
 		resetEntries();
 	}
-	
+
 	public function removeAll():Void
 	{
 		for (i in 0...entries.length)
@@ -120,8 +120,8 @@ class Watch extends Window
 		for (entry in entries)
 			entry.updateValue();
 	}
-	
-	override private function updateSize():Void
+
+	override function updateSize():Void
 	{
 		minSize.setTo(
 			getMaxMinWidth() + entriesContainerOffset.x,
@@ -129,8 +129,8 @@ class Watch extends Window
 		super.updateSize();
 		resetEntries();
 	}
-	
-	private function resetEntries():Void
+
+	function resetEntries():Void
 	{
 		for (i in 0...entries.length)
 		{
@@ -139,18 +139,18 @@ class Watch extends Window
 			entry.updateSize(getMaxNameWidth(), _width);
 		}
 	}
-	
-	private function getMaxNameWidth():Float
+
+	function getMaxNameWidth():Float
 	{
 		return getMax(function(entry) return entry.getNameWidth());
 	}
-	
-	private function getMaxMinWidth():Float
+
+	function getMaxMinWidth():Float
 	{
 		return getMax(function(entry) return entry.getMinWidth());
 	}
-	
-	private function getMax(getValue:WatchEntry->Float):Float
+
+	function getMax(getValue:WatchEntry->Float):Float
 	{
 		var max = 0.0;
 		for (entry in entries)

--- a/flixel/system/debug/watch/WatchEntry.hx
+++ b/flixel/system/debug/watch/WatchEntry.hx
@@ -19,22 +19,22 @@ import flixel.system.debug.console.ConsoleUtil;
 
 class WatchEntry extends Sprite implements IFlxDestroyable
 {
-	private static inline var GUTTER = 4;
-	private static inline var TEXT_HEIGHT = 20;
-	private static inline var MAX_NAME_WIDTH = 125;
-	
+	static inline var GUTTER = 4;
+	static inline var TEXT_HEIGHT = 20;
+	static inline var MAX_NAME_WIDTH = 125;
+
 	public var data:WatchEntryData;
 	public var displayName(default, null):String;
 
-	private var nameText:TextField;
-	private var valueText:EditableTextField;
-	private var removeButton:FlxSystemButton;
-	private var defaultFormat:TextFormat;
+	var nameText:TextField;
+	var valueText:EditableTextField;
+	var removeButton:FlxSystemButton;
+	var defaultFormat:TextFormat;
 
 	public function new(displayName:String, data:WatchEntryData, removeEntry:WatchEntry->Void)
 	{
 		super();
-		
+
 		this.displayName = displayName;
 		this.data = data;
 
@@ -45,13 +45,13 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 			new EditableTextField(data.match(FIELD(_, _)), defaultFormat, submitValue, expectedType)));
 
 		updateName();
-		
+
 		addChild(removeButton = new FlxSystemButton(new GraphicCloseButton(0, 0), removeEntry.bind(this)));
 		removeButton.y = (TEXT_HEIGHT - removeButton.height) / 2;
 		removeButton.alpha = 0.3;
 	}
-	
-	private function getTextColor():FlxColor
+
+	function getTextColor():FlxColor
 	{
 		return switch (data)
 		{
@@ -60,8 +60,8 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 			case EXPRESSION(_, _): 0xC4FE83;
 		}
 	}
-	
-	private function initTextField<T:TextField>(textField:T):T
+
+	function initTextField<T:TextField>(textField:T):T
 	{
 		textField.selectable = true;
 		textField.defaultTextFormat = defaultFormat;
@@ -74,21 +74,21 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 	public function updateSize(nameWidth:Float, windowWidth:Float):Void
 	{
 		var textWidth = windowWidth - removeButton.width - GUTTER;
-		
+
 		nameText.width = nameWidth;
 		valueText.x = nameWidth + GUTTER;
 		valueText.width = textWidth - nameWidth - GUTTER;
 		removeButton.x = textWidth;
 	}
-	
-	private function updateName()
+
+	function updateName()
 	{
 		if (displayName != null)
 		{
 			setNameText(displayName);
 			return;
 		}
-		
+
 		switch (data)
 		{
 			case FIELD(object, field):
@@ -98,15 +98,15 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 			case QUICK(_):
 		}
 	}
-	
-	private function setNameText(name:String)
+
+	function setNameText(name:String)
 	{
 		nameText.text = name;
 		var currentWidth = nameText.textWidth + 4;
 		nameText.width = Math.min(currentWidth, MAX_NAME_WIDTH);
 	}
-	
-	private function getValue():Dynamic
+
+	function getValue():Dynamic
 	{
 		return switch (data)
 		{
@@ -123,15 +123,15 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 		}
 	}
 
-	private function getFormattedValue():String
+	function getFormattedValue():String
 	{
 		var value:Dynamic = getValue();
 		if (Std.is(value, Float))
 			value = FlxMath.roundDecimal(cast value, FlxG.debugger.precision);
 		return Std.string(value);
 	}
-	
-	private function submitValue(value:Dynamic):Void
+
+	function submitValue(value:Dynamic):Void
 	{
 		switch (data)
 		{
@@ -140,23 +140,23 @@ class WatchEntry extends Sprite implements IFlxDestroyable
 			case _:
 		}
 	}
-	
+
 	public function updateValue()
 	{
 		if (!valueText.isEditing)
 			valueText.text = getFormattedValue();
 	}
-	
+
 	public function getNameWidth():Float
 	{
 		return nameText.width;
 	}
-	
+
 	public function getMinWidth():Float
 	{
-		return valueText.x + GUTTER * 2 + removeButton.width; 
+		return valueText.x + GUTTER * 2 + removeButton.width;
 	}
-	
+
 	public function destroy()
 	{
 		nameText = FlxDestroyUtil.removeChild(this, nameText);

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -32,18 +32,18 @@ class BitmapFrontEnd
 	public var whitePixel(get, never):FlxFrame;
 
 	@:allow(flixel.system.frontEnds.BitmapLogFrontEnd)
-	private var _cache:Map<String, FlxGraphic>;
-	
-	private var _whitePixel:FlxFrame;
+	var _cache:Map<String, FlxGraphic>;
 
-	private var _lastUniqueKeyIndex:Int = 0;
+	var _whitePixel:FlxFrame;
+
+	var _lastUniqueKeyIndex:Int = 0;
 
 	public function new()
 	{
 		reset();
 	}
-	
-	public function onAssetsReload(_):Void 
+
+	public function onAssetsReload(_):Void
 	{
 		for (key in _cache.keys())
 		{
@@ -54,7 +54,7 @@ class BitmapFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * New context handler.
 	 * Regenerates tilesheets for all dumped graphics objects in the cache.
@@ -70,7 +70,7 @@ class BitmapFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Dumps bits of all graphics in the cache. This frees some memory, but you can't read/write pixels on those graphics anymore.
 	 * You can call undump() method for each FlxGraphic (or undumpCache()) object which will restore it again.
@@ -88,7 +88,7 @@ class BitmapFrontEnd
 		}
 		#end
 	}
-	
+
 	/**
 	 * Restores graphics of all dumped objects in the cache.
 	 */
@@ -105,10 +105,10 @@ class BitmapFrontEnd
 		}
 		#end
 	}
-	
+
 	/**
 	 * Check the local bitmap cache to see if a bitmap with this key has been loaded already.
-	 * 
+	 *
 	 * @param	Key		The string key identifying the bitmap.
 	 * @return	Whether or not this file can be found in the cache.
 	 */
@@ -116,10 +116,10 @@ class BitmapFrontEnd
 	{
 		return get(Key) != null;
 	}
-	
+
 	/**
 	 * Generates a new BitmapData object (a colored rectangle) and caches it.
-	 * 
+	 *
 	 * @param	Width	How wide the rectangle should be.
 	 * @param	Height	How high the rectangle should be.
 	 * @param	Color	What color the rectangle should be (0xAARRGGBB)
@@ -131,7 +131,7 @@ class BitmapFrontEnd
 	{
 		return FlxGraphic.fromRectangle(Width, Height, Color, Unique, Key);
 	}
-	
+
 	/**
 	 * Loads a bitmap from a file, clones it if necessary and caches it.
 	 * @param	Graphic		Optional FlxGraphics object to create FlxGraphic from.
@@ -153,14 +153,14 @@ class BitmapFrontEnd
 		{
 			return FlxGraphic.fromBitmapData(cast Graphic, Unique, Key);
 		}
-		
+
 		// String case
 		return FlxGraphic.fromAssetKey(Std.string(Graphic), Unique, Key);
 	}
-	
+
 	/**
 	 * Caches specified FlxGraphic object.
-	 * 
+	 *
 	 * @param	graphic	FlxGraphic to store in the cache.
 	 * @return	cached FlxGraphic object.
 	 */
@@ -169,9 +169,9 @@ class BitmapFrontEnd
 		_cache.set(graphic.key, graphic);
 		return graphic;
 	}
-	
+
 	/**
-	 * Gets FlxGraphic object from this storage by specified key. 
+	 * Gets FlxGraphic object from this storage by specified key.
 	 * @param	key	Key for FlxGraphic object (its name)
 	 * @return	FlxGraphic with the key name, or null if there is no such object
 	 */
@@ -179,10 +179,10 @@ class BitmapFrontEnd
 	{
 		return _cache.get(key);
 	}
-	
+
 	/**
 	 * Gets key from bitmap cache for specified BitmapData
-	 * 
+	 *
 	 * @param	bmd	BitmapData to find in cache
 	 * @return	BitmapData's key or null if there isn't such BitmapData in cache
 	 */
@@ -195,21 +195,21 @@ class BitmapFrontEnd
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Helper method for getting cache key for FlxGraphic objects created from the class.
-	 * 
-	 * @param	source	BitmapData source class. 
+	 *
+	 * @param	source	BitmapData source class.
 	 * @return	Full name for provided class.
 	 */
 	public inline function getKeyForClass(source:Class<Dynamic>):String
 	{
 		return Type.getClassName(source);
 	}
-	
+
 	/**
 	 * Creates string key for further caching.
-	 * 
+	 *
 	 * @param	systemKey	The first string key to use as a base for a new key. It's usually a key from openfl.Assets ("assets/image.png").
 	 * @param	userKey		The second string key to use as a base for a new key. It's usually a key provided by the user
 	 * @param	unique		Whether generated key should be unique or not.
@@ -220,16 +220,16 @@ class BitmapFrontEnd
 		var key:String = userKey;
 		if (key == null)
 			key = systemKey;
-		
+
 		if (unique || key == null)
 			key = getUniqueKey(key);
-		
+
 		return key;
 	}
-	
+
 	/**
 	 * Gets unique key for bitmap cache
-	 * 
+	 *
 	 * @param	baseKey	key's prefix
 	 * @return	unique key
 	 */
@@ -237,10 +237,10 @@ class BitmapFrontEnd
 	{
 		if (baseKey == null)
 			baseKey = "pixels";
-		
+
 		if (!checkCache(baseKey))
 			return baseKey;
-		
+
 		var i:Int = _lastUniqueKeyIndex;
 		var uniqueKey:String;
 		do
@@ -249,16 +249,16 @@ class BitmapFrontEnd
 			uniqueKey = baseKey + i;
 		}
 		while (checkCache(uniqueKey));
-		
+
 		_lastUniqueKeyIndex = i;
 		return uniqueKey;
 	}
-	
+
 	/**
-	 * Generates key from provided base key and information about tile size and offsets in spritesheet 
+	 * Generates key from provided base key and information about tile size and offsets in spritesheet
 	 * and the region of image to use as spritesheet graphics source.
-	 * 
-	 * @param	baseKey			Beginning of the key. Usually it is the key for original spritesheet graphics (like "assets/tile.png") 
+	 *
+	 * @param	baseKey			Beginning of the key. Usually it is the key for original spritesheet graphics (like "assets/tile.png")
 	 * @param	frameSize		the size of tile in spritesheet
 	 * @param	frameSpacing	offsets between tiles in offsets
 	 * @param	region			region of image to use as spritesheet graphics source
@@ -267,22 +267,22 @@ class BitmapFrontEnd
 	public function getKeyWithSpacesAndBorders(baseKey:String, ?frameSize:FlxPoint, ?frameSpacing:FlxPoint, ?frameBorder:FlxPoint, ?region:FlxRect):String
 	{
 		var result:String = baseKey;
-		
+
 		if (region != null)
 			result += "_Region:" + region.x + "_" + region.y + "_" + region.width + "_" + region.height;
-		
+
 		if (frameSize != null)
 			result += "_FrameSize:" + frameSize.x + "_" + frameSize.y;
-		
+
 		if (frameSpacing != null)
 			result += "_Spaces:" + frameSpacing.x + "_" + frameSpacing.y;
-		
+
 		if (frameBorder != null)
 			result += "_Border:" + frameBorder.x + "_" + frameBorder.y;
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Totally removes specified FlxGraphic object.
 	 * @param	FlxGraphic object you want to remove and destroy.
@@ -295,7 +295,7 @@ class BitmapFrontEnd
 			graphic.destroy();
 		}
 	}
-	
+
 	/**
 	 * Totally removes FlxGraphic object with specified key.
 	 * @param	key	the key for cached FlxGraphic object.
@@ -306,18 +306,18 @@ class BitmapFrontEnd
 		{
 			var obj = get(key);
 			removeKey(key);
-			
+
 			if (obj != null)
 				obj.destroy();
 		}
 	}
-	
+
 	public function removeIfNoUse(graphic:FlxGraphic):Void
 	{
 		if (graphic != null && graphic.useCount == 0 && !graphic.persist)
 			remove(graphic);
 	}
-	
+
 	/**
 	 * Clears image cache (and destroys those images).
 	 * Graphics object will be removed and destroyed only if it shouldn't persist in the cache and its useCount is 0.
@@ -329,7 +329,7 @@ class BitmapFrontEnd
 			_cache = new Map();
 			return;
 		}
-		
+
 		for (key in _cache.keys())
 		{
 			var obj = get(key);
@@ -340,8 +340,8 @@ class BitmapFrontEnd
 			}
 		}
 	}
-	
-	private inline function removeKey(key:String):Void
+
+	inline function removeKey(key:String):Void
 	{
 		if (key != null)
 		{
@@ -349,7 +349,7 @@ class BitmapFrontEnd
 			_cache.remove(key);
 		}
 	}
-	
+
 	/**
 	 * Completely resets bitmap cache, which means destroying ALL of the cached FlxGraphic objects.
 	 */
@@ -360,17 +360,17 @@ class BitmapFrontEnd
 			_cache = new Map();
 			return;
 		}
-		
+
 		for (key in _cache.keys())
 		{
 			var obj = get(key);
 			removeKey(key);
-			
+
 			if (obj != null)
 				obj.destroy();
 		}
 	}
-	
+
 	/**
 	 * Removes all unused graphics from cache,
 	 * but skips graphics which should persist in cache and shouldn't be destroyed on no use.
@@ -386,15 +386,15 @@ class BitmapFrontEnd
 			}
 		}
 	}
-	
+
 	#if !flash
-	private function get_maxTextureSize():Int
+	function get_maxTextureSize():Int
 	{
 		return cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
 	}
 	#end
-	
-	private function get_whitePixel():FlxFrame
+
+	function get_whitePixel():FlxFrame
 	{
 		if (_whitePixel == null)
 		{
@@ -403,7 +403,7 @@ class BitmapFrontEnd
 			graphic.persist = true;
 			_whitePixel = graphic.imageFrame.frame;
 		}
-		
+
 		return _whitePixel;
 	}
 }

--- a/flixel/system/frontEnds/BitmapLogFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapLogFrontEnd.hx
@@ -11,7 +11,7 @@ class BitmapLogFrontEnd
 		FlxG.game.debugger.bitmapLog.add(Data, Name);
 		#end
 	}
-	
+
 	/**
 	 * Clears all bitmaps
 	 */
@@ -21,18 +21,18 @@ class BitmapLogFrontEnd
 		FlxG.game.debugger.bitmapLog.clear();
 		#end
 	}
-	
+
 	/**
-	 * Clear one bitmap object from the log -- the last one, by default 
+	 * Clear one bitmap object from the log -- the last one, by default
 	 * @param	Index
 	 */
-	public inline function clearAt(Index:Int = -1):Void 
+	public inline function clearAt(Index:Int = -1):Void
 	{
 		#if FLX_DEBUG
 		FlxG.game.debugger.bitmapLog.clearAt(Index);
 		#end
 	}
-	
+
 	/**
 	 * Clears the bitmapLog window and adds the entire cache to it.
 	 */
@@ -46,7 +46,7 @@ class BitmapLogFrontEnd
 		}
 		#end
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() {}
+	function new() {}
 }

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -14,21 +14,21 @@ class CameraFrontEnd
 	 * By default flixel creates one camera the size of the screen.
 	 */
 	public var list(default, null):Array<FlxCamera> = [];
-	
+
 	/**
 	 * The current (global, applies to all cameras) bgColor.
 	 */
 	public var bgColor(get, set):FlxColor;
-	
+
 	/** @since 4.2.0 */
 	public var cameraAdded(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();
-	
+
 	/** @since 4.2.0 */
 	public var cameraRemoved(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();
-	
+
 	/** @since 4.2.0 */
 	public var cameraResized(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();
-	
+
 	/**
 	 * Allows you to possibly slightly optimize the rendering process IF
 	 * you are not doing any pre-processing in your game state's draw() call.
@@ -37,12 +37,12 @@ class CameraFrontEnd
 	/**
 	 * Internal helper variable for clearing the cameras each frame.
 	 */
-	private var _cameraRect:Rectangle = new Rectangle();
-	
+	var _cameraRect:Rectangle = new Rectangle();
+
 	/**
 	 * Add a new camera object to the game.
 	 * Handy for PiP, split-screen, etc.
-	 * 
+	 *
 	 * @param	NewCamera	The camera you want to add.
 	 * @return	This FlxCamera instance.
 	 */
@@ -54,10 +54,10 @@ class CameraFrontEnd
 		cameraAdded.dispatch(NewCamera);
 		return NewCamera;
 	}
-	
+
 	/**
 	 * Remove a camera from the game.
-	 * 
+	 *
 	 * @param   Camera    The camera you want to remove.
 	 * @param   Destroy   Whether to call destroy() on the camera, default value is true.
 	 */
@@ -74,7 +74,7 @@ class CameraFrontEnd
 			FlxG.log.warn("FlxG.cameras.remove(): The camera you attempted to remove is not a part of the game.");
 			return;
 		}
-		
+
 		if (FlxG.renderTile)
 		{
 			for (i in 0...list.length)
@@ -82,17 +82,17 @@ class CameraFrontEnd
 				list[i].ID = i;
 			}
 		}
-		
+
 		if (Destroy)
 			Camera.destroy();
-		
+
 		cameraRemoved.dispatch(Camera);
 	}
-		
+
 	/**
 	 * Dumps all the current cameras and resets to just one camera.
 	 * Handy for doing split-screen especially.
-	 * 
+	 *
 	 * @param	NewCamera	Optional; specify a specific camera object to be the new main camera.
 	 */
 	public function reset(?NewCamera:FlxCamera):Void
@@ -102,16 +102,16 @@ class CameraFrontEnd
 
 		if (NewCamera == null)
 			NewCamera = new FlxCamera(0, 0, FlxG.width, FlxG.height);
-		
+
 		FlxG.camera = add(NewCamera);
 		NewCamera.ID = 0;
-		
+
 		FlxCamera.defaultCameras = list;
 	}
-	
+
 	/**
 	 * All screens are filled with this color and gradually return to normal.
-	 * 
+	 *
 	 * @param	Color		The color you want to use.
 	 * @param	Duration	How long it takes for the flash to fade.
 	 * @param	OnComplete	A function you want to run when the flash finishes.
@@ -124,10 +124,10 @@ class CameraFrontEnd
 			camera.flash(Color, Duration, OnComplete, Force);
 		}
 	}
-	
+
 	/**
 	 * The screen is gradually filled with this color.
-	 * 
+	 *
 	 * @param	Color		The color you want to use.
 	 * @param	Duration	How long it takes for the fade to finish.
 	 * @param 	FadeIn 		True fades from a color, false fades to it.
@@ -141,10 +141,10 @@ class CameraFrontEnd
 			camera.fade(Color, Duration, FadeIn, OnComplete, Force);
 		}
 	}
-	
+
 	/**
 	 * A simple screen-shake effect.
-	 * 
+	 *
 	 * @param	Intensity	Percentage of screen size representing the maximum distance that the screen can move while shaking.
 	 * @param	Duration	The length in seconds that the shaking effect should last.
 	 * @param	OnComplete	A function you want to run when the shake effect finishes.
@@ -158,18 +158,18 @@ class CameraFrontEnd
 			camera.shake(Intensity, Duration, OnComplete, Force, Axes);
 		}
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() 
+	function new()
 	{
 		FlxCamera.defaultCameras = list;
 	}
-	
+
 	/**
 	 * Called by the game object to lock all the camera buffers and clear them for the next draw pass.
 	 */
 	@:allow(flixel.FlxGame)
-	private inline function lock():Void
+	inline function lock():Void
 	{
 		for (camera in list)
 		{
@@ -177,17 +177,17 @@ class CameraFrontEnd
 			{
 				continue;
 			}
-			
+
 			if (FlxG.renderBlit)
 			{
 				camera.checkResize();
-				
+
 				if (useBufferLocking)
 				{
 					camera.buffer.lock();
 				}
 			}
-			
+
 			if (FlxG.renderTile)
 			{
 				camera.clearDrawStack();
@@ -197,7 +197,7 @@ class CameraFrontEnd
 				camera.debugLayer.graphics.clear();
 				#end
 			}
-			
+
 			if (FlxG.renderBlit)
 			{
 				camera.fill(camera.bgColor, camera.useBgAlphaBlending);
@@ -209,9 +209,9 @@ class CameraFrontEnd
 			}
 		}
 	}
-	
+
 	@:allow(flixel.FlxGame)
-	private inline function render():Void
+	inline function render():Void
 	{
 		if (FlxG.renderTile)
 		{
@@ -224,12 +224,12 @@ class CameraFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Called by the game object to draw the special FX and unlock all the camera buffers.
 	 */
 	@:allow(flixel.FlxGame)
-	private inline function unlock():Void
+	inline function unlock():Void
 	{
 		for (camera in list)
 		{
@@ -237,26 +237,26 @@ class CameraFrontEnd
 			{
 				continue;
 			}
-			
+
 			camera.drawFX();
-			
+
 			if (FlxG.renderBlit)
 			{
 				if (useBufferLocking)
 				{
 					camera.buffer.unlock();
 				}
-				
+
 				camera.screen.dirty = true;
 			}
 		}
 	}
-	
+
 	/**
 	 * Called by the game object to update the cameras and their tracking/special effects logic.
 	 */
 	@:allow(flixel.FlxGame)
-	private inline function update(elapsed:Float):Void
+	inline function update(elapsed:Float):Void
 	{
 		for (camera in list)
 		{
@@ -266,31 +266,31 @@ class CameraFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Resizes and moves cameras when the game resizes (onResize signal).
 	 */
 	@:allow(flixel.FlxGame)
-	private function resize():Void
+	function resize():Void
 	{
 		for (camera in list)
 		{
 			camera.onResize();
 		}
 	}
-	
-	private function get_bgColor():FlxColor
+
+	function get_bgColor():FlxColor
 	{
 		return (FlxG.camera == null) ? FlxColor.BLACK : FlxG.camera.bgColor;
-	} 
-	
-	private function set_bgColor(Color:FlxColor):FlxColor
+	}
+
+	function set_bgColor(Color:FlxColor):FlxColor
 	{
 		for (camera in list)
 		{
 			camera.bgColor = Color;
 		}
-		
+
 		return Color;
 	}
 }

--- a/flixel/system/frontEnds/ConsoleFrontEnd.hx
+++ b/flixel/system/frontEnds/ConsoleFrontEnd.hx
@@ -8,7 +8,7 @@ class ConsoleFrontEnd
 	 * Whether the console should auto-pause or not when it's focused.
 	 */
 	public var autoPause:Bool = true;
-	
+
 	/**
 	 * Whether the console should `step()` the game after a command is entered.
 	 * Setting this to `false` allows inputting multiple console commands within the same frame.
@@ -16,10 +16,10 @@ class ConsoleFrontEnd
 	 * @since 4.2.0
 	 */
 	public var stepAfterCommand:Bool = true;
-	
+
 	/**
 	 * Register a new function to use in any command.
-	 * 
+	 *
 	 * @param 	FunctionAlias		The name with which you want to access the function.
 	 * @param 	Function			The function to register.
 	 */
@@ -29,10 +29,10 @@ class ConsoleFrontEnd
 		FlxG.game.debugger.console.registerFunction(FunctionAlias, Function);
 		#end
 	}
-	
+
 	/**
 	 * Register a new object to use in any command.
-	 * 
+	 *
 	 * @param 	ObjectAlias		The name with which you want to access the object.
 	 * @param 	AnyObject		The object to register.
 	 */
@@ -42,10 +42,10 @@ class ConsoleFrontEnd
 		FlxG.game.debugger.console.registerObject(ObjectAlias, AnyObject);
 		#end
 	}
-	
+
 	/**
 	 * Register a new class to use in any command.
-	 * 
+	 *
 	 * @param	cl	The class to register.
 	 */
 	public inline function registerClass(cl:Class<Dynamic>):Void
@@ -54,10 +54,10 @@ class ConsoleFrontEnd
 		FlxG.game.debugger.console.registerClass(cl);
 		#end
 	}
-	
+
 	/**
 	 * Register a new enum to use in any command.
-	 * 
+	 *
 	 * @param	e	The enum to register.
 	 * @since 4.4.0
 	 */
@@ -69,5 +69,5 @@ class ConsoleFrontEnd
 	}
 
 	@:allow(flixel.FlxG)
-	private function new() {}
+	function new() {}
 }

--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -13,12 +13,12 @@ using flixel.util.FlxStringUtil;
 using flixel.util.FlxArrayUtil;
 
 class DebuggerFrontEnd
-{	
+{
 	/**
 	 * The amount of decimals Floats are rounded to in the debugger.
 	 */
-	public var precision:Int = 3; 
-	
+	public var precision:Int = 3;
+
 	#if FLX_KEYBOARD
 	/**
 	 * The key codes used to toggle the debugger (see FlxG.keys for the keys available).
@@ -26,7 +26,7 @@ class DebuggerFrontEnd
 	 */
 	public var toggleKeys:Array<FlxKey> = [F2, GRAVEACCENT, BACKSLASH];
 	#end
-	
+
 	/**
 	 * Whether to draw the hitboxes of FlxObjects.
 	 */
@@ -40,12 +40,12 @@ class DebuggerFrontEnd
 	 * @since 4.1.0
 	 */
 	public var visibilityChanged(default, null):FlxSignal = new FlxSignal();
-	
+
 	public var visible(default, set):Bool = false;
-	
+
 	/**
 	 * Change the way the debugger's windows are laid out.
-	 * 
+	 *
 	 * @param	Layout	The layout codes can be found in FlxDebugger, for example FlxDebugger.MICRO
 	 */
 	public inline function setLayout(Layout:FlxDebuggerLayout):Void
@@ -54,7 +54,7 @@ class DebuggerFrontEnd
 		FlxG.game.debugger.setLayout(Layout);
 		#end
 	}
-	
+
 	/**
 	 * Just resets the debugger windows to whatever the last selected layout was (STANDARD by default).
 	 */
@@ -64,10 +64,10 @@ class DebuggerFrontEnd
 		FlxG.game.debugger.resetLayout();
 		#end
 	}
-	
+
 	/**
 	 * Create and add a new debugger button.
-	 * 
+	 *
 	 * @param   Position       Either LEFT, CENTER or RIGHT.
 	 * @param   Icon           The icon to use for the button
 	 * @param   UpHandler      The function to be called when the button is pressed.
@@ -83,11 +83,11 @@ class DebuggerFrontEnd
 		return null;
 		#end
 	}
-	
+
 	/**
 	 * Creates a new tracker window if there exists a tracking profile for the class / class of the object.
 	 * By default, flixel classes like FlxBasic, FlxRect and FlxPoint are supported.
-	 * 
+	 *
 	 * @param	ObjectOrClass	The object or class to track
 	 * @param	WindowTitle	Title of the tracker window, uses the class name by default
 	 */
@@ -96,23 +96,23 @@ class DebuggerFrontEnd
 		#if FLX_DEBUG
 		if (Tracker.objectsBeingTracked.contains(ObjectOrClass))
 			return null;
-		
+
 		var profile = Tracker.findProfile(ObjectOrClass);
 		if (profile == null)
 		{
 			FlxG.log.error("Could not find a tracking profile for object of class '" +
-				ObjectOrClass.getClassName(true) + "'."); 
+				ObjectOrClass.getClassName(true) + "'.");
 			return null;
 		}
-		else 
+		else
 			return FlxG.game.debugger.addWindow(new Tracker(profile, ObjectOrClass, WindowTitle));
 		#end
 		return null;
 	}
-	
+
 	/**
 	 * Adds a new TrackerProfile for track(). This also overrides existing profiles.
-	 * 
+	 *
 	 * @param	Profile	The TrackerProfile
 	 */
 	public inline function addTrackerProfile(Profile:TrackerProfile):Void
@@ -121,10 +121,10 @@ class DebuggerFrontEnd
 		Tracker.addProfile(Profile);
 		#end
 	}
-	
+
 	/**
 	 * Removes and destroys a button from the debugger.
-	 * 
+	 *
 	 * @param	Button			The FlxSystemButton instance to remove.
 	 * @param	UpdateLayout	Whether to update the button layout.
 	 */
@@ -134,34 +134,34 @@ class DebuggerFrontEnd
 		FlxG.game.debugger.removeButton(Button, UpdateLayout);
 		#end
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() {}
-	
-	private function set_drawDebug(Value:Bool):Bool
+	function new() {}
+
+	function set_drawDebug(Value:Bool):Bool
 	{
 		if (drawDebug == Value)
 			return drawDebug;
-	
+
 		drawDebug = Value;
 		#if FLX_DEBUG
 		drawDebugChanged.dispatch();
 		#end
 		return drawDebug;
 	}
-	
+
 	@:access(flixel.FlxGame.onFocus)
-	private function set_visible(Value:Bool):Bool
+	function set_visible(Value:Bool):Bool
 	{
 		if (visible == Value)
 			return visible;
 
 		visible = Value;
-	
+
 		#if FLX_DEBUG
 		FlxG.game.debugger.visible = Value;
-		
-		// if the debugger is non-visible, then we need to focus on game sprite, 
+
+		// if the debugger is non-visible, then we need to focus on game sprite,
 		// so the game still will be able to capture key presses
 		if (!Value)
 		{
@@ -169,7 +169,7 @@ class DebuggerFrontEnd
 			// setting focus to null will trigger a focus lost event, let's undo that
 			FlxG.game.onFocus(null);
 		}
-		
+
 		visibilityChanged.dispatch();
 		#end
 

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -15,16 +15,16 @@ class HTML5FrontEnd
 	public var browserWidth(get, never):Int;
 	public var browserHeight(get, never):Int;
 	public var browserPosition(get, null):FlxPoint;
-	
+
 	@:allow(flixel.FlxG)
-	private function new()
+	function new()
 	{
 		browser = getBrowser();
 		platform = getPlatform();
 		onMobile = getOnMobile();
 	}
-	
-	private function getBrowser():FlxBrowser
+
+	function getBrowser():FlxBrowser
 	{
 		if (userAgentContains(" OPR/"))
 		{
@@ -48,8 +48,8 @@ class HTML5FrontEnd
 		}
 		return FlxBrowser.UNKNOWN;
 	}
-	
-	private function getPlatform():FlxPlatform
+
+	function getPlatform():FlxPlatform
 	{
 		if (userAgentContains("Win"))
 		{
@@ -89,8 +89,8 @@ class HTML5FrontEnd
 		}
 		else return FlxPlatform.UNKNOWN;
 	}
-	
-	private function getOnMobile():Bool 
+
+	function getOnMobile():Bool
 	{
 		return switch (platform)
 		{
@@ -100,16 +100,16 @@ class HTML5FrontEnd
 				false;
 		}
 	}
-	
-	private function userAgentContains(substring:String, toLowerCase:Bool = false)
+
+	function userAgentContains(substring:String, toLowerCase:Bool = false)
 	{
 		var userAgent = Browser.navigator.userAgent;
 		if (toLowerCase)
 			userAgent = userAgent.toLowerCase();
 		return userAgent.contains(substring);
 	}
-	
-	private function get_browserPosition():FlxPoint
+
+	function get_browserPosition():FlxPoint
 	{
 		if (browserPosition == null)
 		{
@@ -118,13 +118,13 @@ class HTML5FrontEnd
 		browserPosition.set(Browser.window.screenX, Browser.window.screenY);
 		return browserPosition;
 	}
-	
-	private inline function get_browserWidth():Int
+
+	inline function get_browserWidth():Int
 	{
 		return Browser.window.innerWidth;
 	}
-	
-	private inline function get_browserHeight():Int
+
+	inline function get_browserHeight():Int
 	{
 		return Browser.window.innerHeight;
 	}

--- a/flixel/system/frontEnds/InputFrontEnd.hx
+++ b/flixel/system/frontEnds/InputFrontEnd.hx
@@ -10,16 +10,16 @@ class InputFrontEnd
 	 * A read-only list of all inputs.
 	 */
 	public var list(default, null):Array<IFlxInputManager> = [];
-	
+
 	/**
 	 * Whether inputs are reset on state switches.
 	 * Disable if you need persistent input states across states.
 	 */
 	public var resetOnStateSwitch:Bool = true;
-	
+
 	/**
 	 * Add an input to the system
-	 * 
+	 *
 	 * @param	Input 	The input to add
 	 * @return	The input
 	 */
@@ -34,14 +34,14 @@ class InputFrontEnd
 				return Input;
 			}
 		}
-		
+
 		list.push(Input);
 		return Input;
 	}
-	
+
 	/**
 	 * Removes an input from the system
-	 * 
+	 *
 	 * @param	Input	The input to remove
 	 * @return	Bool indicating whether it was removed or not
 	 */
@@ -60,10 +60,10 @@ class InputFrontEnd
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Replace an existing input in the system with a new one
-	 * 
+	 *
 	 * @param	Old 	The old input to replace
 	 * @param	New 	The new input to put in its place
 	 * @return	If successful returns New. Otherwise returns null.
@@ -83,14 +83,14 @@ class InputFrontEnd
 			}
 			i++;
 		}
-		
+
 		if (success)
 		{
 			return New;
 		}
 		return null;
 	}
-	
+
 	public function reset():Void
 	{
 		for (input in list)
@@ -98,48 +98,48 @@ class InputFrontEnd
 			input.reset();
 		}
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() {}
-	
+	function new() {}
+
 	@:allow(flixel.FlxGame)
-	private inline function update():Void
+	inline function update():Void
 	{
 		for (input in list)
 		{
 			input.update();
 		}
 	}
-	
+
 	@:allow(flixel.FlxGame)
-	private inline function onFocus():Void
+	inline function onFocus():Void
 	{
 		for (input in list)
 		{
 			input.onFocus();
 		}
 	}
-	
+
 	@:allow(flixel.FlxGame)
-	private inline function onFocusLost():Void
+	inline function onFocusLost():Void
 	{
 		for (input in list)
 		{
 			input.onFocusLost();
 		}
 	}
-	
+
 	@:allow(flixel.FlxGame)
 	@:allow(flixel.FlxState.resetSubState)
-	private function onStateSwitch():Void
+	function onStateSwitch():Void
 	{
 		if (resetOnStateSwitch)
 		{
 			reset();
 		}
 	}
-	
-	private function destroy():Void
+
+	function destroy():Void
 	{
 		for (input in list)
 		{

--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -12,44 +12,44 @@ class LogFrontEnd
 	 * Whether everything you trace() is being redirected into the log window.
 	 */
 	public var redirectTraces(default, set):Bool = false;
-	
-	private var _standardTraceFunction:Dynamic;	
-	
+
+	var _standardTraceFunction:Dynamic;
+
 	public inline function add(Data:Dynamic):Void
 	{
 		#if FLX_DEBUG
-		advanced(Data, LogStyle.NORMAL); 
+		advanced(Data, LogStyle.NORMAL);
 		#end
 	}
-	
+
 	public inline function warn(Data:Dynamic):Void
 	{
 		#if FLX_DEBUG
-		advanced(Data, LogStyle.WARNING, true); 
+		advanced(Data, LogStyle.WARNING, true);
 		#end
 	}
-	
+
 	public inline function error(Data:Dynamic):Void
 	{
 		#if FLX_DEBUG
-		advanced(Data, LogStyle.ERROR, true); 
+		advanced(Data, LogStyle.ERROR, true);
 		#end
 	}
-	
+
 	public inline function notice(Data:Dynamic):Void
 	{
 		#if FLX_DEBUG
-		advanced(Data, LogStyle.NOTICE); 
+		advanced(Data, LogStyle.NOTICE);
 		#end
 	}
-	
+
 	/**
 	 * Add an advanced log message to the debugger by also specifying a LogStyle. Backend to FlxG.log.add(), FlxG.log.warn(), FlxG.log.error() and FlxG.log.notice().
-	 * 
+	 *
 	 * @param	Data  		Any Data to log.
 	 * @param  	Style   	The LogStyle to use, for example LogStyle.WARNING. You can also create your own by importing the LogStyle class.
 	 * @param  	FireOnce   	Whether you only want to log the Data in case it hasn't been added already
-	 */ 
+	 */
 	public function advanced(Data:Dynamic, ?Style:LogStyle, FireOnce:Bool = false):Void
 	{
 		#if FLX_DEBUG
@@ -58,35 +58,35 @@ class LogFrontEnd
 			_standardTraceFunction(Data);
 			return;
 		}
-		
+
 		if (Style == null)
 		{
 			Style = LogStyle.NORMAL;
 		}
-		
+
 		if (!Std.is(Data, Array))
 		{
-			Data = [Data]; 
+			Data = [Data];
 		}
-		
+
 		if (FlxG.game.debugger.log.add(Data, Style, FireOnce))
 		{
 			#if FLX_SOUND_SYSTEM
 			if (Style.errorSound != null)
 			{
-				var sound = FlxAssets.getSound(Style.errorSound); 
+				var sound = FlxAssets.getSound(Style.errorSound);
 				if (sound != null)
 				{
 					FlxG.sound.load(sound).play();
 				}
 			}
 			#end
-			
-			if (Style.openConsole) 
+
+			if (Style.openConsole)
 			{
 				FlxG.debugger.visible = true;
 			}
-			
+
 			if (Style.callbackFunction != null)
 			{
 				Style.callbackFunction();
@@ -94,7 +94,7 @@ class LogFrontEnd
 		}
 		#end
 	}
-	
+
 	/**
 	 * Clears the log output.
 	 */
@@ -104,37 +104,37 @@ class LogFrontEnd
 		FlxG.game.debugger.log.clear();
 		#end
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() 
-	{ 
+	function new()
+	{
 		_standardTraceFunction = haxe.Log.trace;
 	}
-	
-	private inline function set_redirectTraces(Redirect:Bool):Bool
+
+	inline function set_redirectTraces(Redirect:Bool):Bool
 	{
 		Log.trace = (Redirect) ?  processTraceData : _standardTraceFunction;
 		return redirectTraces = Redirect;
 	}
-	
+
 	/**
 	 * Internal function used as a interface between trace() and add().
-	 * 
+	 *
 	 * @param	Data	The data that has been traced
 	 * @param	Inf		Information about the position at which trace() was called
 	 */
-	private function processTraceData(Data:Dynamic, ?Info:PosInfos):Void
+	function processTraceData(Data:Dynamic, ?Info:PosInfos):Void
 	{
 		var paramArray:Array<Dynamic> = [Data];
-		
-		if (Info.customParams != null) 
+
+		if (Info.customParams != null)
 		{
 			for (i in Info.customParams)
 			{
 				paramArray.push(i);
 			}
 		}
-		
+
 		advanced(paramArray, LogStyle.NORMAL);
 	}
 }

--- a/flixel/system/frontEnds/PluginFrontEnd.hx
+++ b/flixel/system/frontEnds/PluginFrontEnd.hx
@@ -10,10 +10,10 @@ class PluginFrontEnd
 	 * An array container for plugins.
 	 */
 	public var list(default, null):Array<FlxBasic> = [];
-	
+
 	/**
 	 * Adds a new plugin to the global plugin array.
-	 * 
+	 *
 	 * @param	Plugin	Any object that extends FlxPlugin. Useful for managers and other things. See flixel.plugin for some examples!
 	 * @return	The same FlxPlugin-based plugin you passed in.
 	 */
@@ -28,15 +28,15 @@ class PluginFrontEnd
 				return Plugin;
 			}
 		}
-		
+
 		// No repeats! safe to add a new instance of this plugin
 		list.push(Plugin);
 		return Plugin;
 	}
-	
+
 	/**
 	 * Retrieves a plugin based on its class name from the global plugin array.
-	 * 
+	 *
 	 * @param	ClassType	The class name of the plugin you want to retrieve. See the FlxPath or FlxTimer constructors for example usage.
 	 * @return	The plugin object, or null if no matching plugin was found.
 	 */
@@ -49,13 +49,13 @@ class PluginFrontEnd
 				return plugin;
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Removes an instance of a plugin from the global plugin array.
-	 * 
+	 *
 	 * @param	Plugin	The plugin instance you want to remove.
 	 * @return	The same FlxPlugin-based plugin you passed in.
 	 */
@@ -63,7 +63,7 @@ class PluginFrontEnd
 	{
 		// Don't add repeats
 		var i:Int = list.length - 1;
-		
+
 		while (i >= 0)
 		{
 			if (list[i] == Plugin)
@@ -73,13 +73,13 @@ class PluginFrontEnd
 			}
 			i--;
 		}
-		
+
 		return Plugin;
 	}
-	
+
 	/**
 	 * Removes all instances of a plugin from the global plugin array.
-	 * 
+	 *
 	 * @param	ClassType	The class name of the plugin type you want removed from the array.
 	 * @return	Whether or not at least one instance of this plugin type was removed.
 	 */
@@ -88,7 +88,7 @@ class PluginFrontEnd
 		// Don't add repeats
 		var results:Bool = false;
 		var i:Int = list.length - 1;
-		
+
 		while (i >= 0)
 		{
 			if (Std.is(list[i], ClassType))
@@ -98,22 +98,22 @@ class PluginFrontEnd
 			}
 			i--;
 		}
-		
+
 		return results;
 	}
-	
+
 	@:allow(flixel.FlxG)
-	private function new() 
+	function new()
 	{
 		add(FlxTimer.globalManager = new FlxTimerManager());
 		add(FlxTween.globalManager = new FlxTweenManager());
 	}
-	
+
 	/**
 	 * Used by the game object to call update() on all the plugins.
 	 */
 	@:allow(flixel.FlxGame)
-	private inline function update(elapsed:Float):Void
+	inline function update(elapsed:Float):Void
 	{
 		for (plugin in list)
 		{
@@ -123,12 +123,12 @@ class PluginFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Used by the game object to call draw() on all the plugins.
 	 */
 	@:allow(flixel.FlxGame)
-	private inline function draw():Void
+	inline function draw():Void
 	{
 		for (plugin in list)
 		{

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -10,7 +10,7 @@ class SignalFrontEnd
 	public var stateSwitched(default, null):FlxSignal = new FlxSignal();
 	public var preStateCreate(default, null):FlxTypedSignal<FlxState->Void> = new FlxTypedSignal<FlxState->Void>();
 	/**
-	 * Gets dispatched when the game is resized. 
+	 * Gets dispatched when the game is resized.
 	 * Passes the new window width and height to callback functions.
 	 */
 	public var gameResized(default, null):FlxTypedSignal<Int->Int->Void> = new FlxTypedSignal<Int->Int->Void>();
@@ -26,7 +26,7 @@ class SignalFrontEnd
 	public var postDraw(default, null):FlxSignal = new FlxSignal();
 	public var focusGained(default, null):FlxSignal = new FlxSignal();
 	public var focusLost(default, null):FlxSignal = new FlxSignal();
-	
+
 	@:allow(flixel.FlxG)
-	private function new() {}
+	function new() {}
 }

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -27,7 +27,7 @@ class SoundFrontEnd
 	 * Function should take the form myVolumeHandler(volume:Float).
 	 */
 	public var volumeHandler:Float->Void;
-	
+
 	#if FLX_KEYBOARD
 	/**
 	 * The key codes used to increase volume (see FlxG.keys for the keys available).
@@ -43,15 +43,15 @@ class SoundFrontEnd
 	 * The keys used to mute / unmute the game (see FlxG.keys for the keys available).
 	 * Default keys: 0 (and numpad 0). Set to null to deactivate.
 	 */
-	public var muteKeys:Array<FlxKey> = [ZERO, NUMPADZERO]; 
+	public var muteKeys:Array<FlxKey> = [ZERO, NUMPADZERO];
 	#end
-	
+
 	/**
 	 * Whether or not the soundTray should be shown when any of the
 	 * volumeUp-, volumeDown- or muteKeys is pressed.
-	 */ 
+	 */
 	public var soundTrayEnabled:Bool = true;
-	
+
 	/**
 	 * The group sounds played via playMusic() are added to unless specified otherwise.
 	 */
@@ -60,7 +60,7 @@ class SoundFrontEnd
 	 * The group sounds in load() / play() / stream() are added to unless specified otherwise.
 	 */
 	public var defaultSoundGroup:FlxSoundGroup = new FlxSoundGroup();
-	
+
 	/**
 	 * A list of all the sounds being played in the game.
 	 */
@@ -69,10 +69,10 @@ class SoundFrontEnd
 	 * Set this to a number between 0 and 1 to change the global volume.
 	 */
 	public var volume(default, set):Float = 1;
-	
+
 	/**
 	 * Set up and play a looping background soundtrack.
-	 * 
+	 *
 	 * @param	Music		The sound file you want to loop in the background.
 	 * @param	Volume		How loud the sound should be, from 0 to 1.
 	 * @param	Looped		Whether to loop this music.
@@ -88,17 +88,17 @@ class SoundFrontEnd
 		{
 			music.stop();
 		}
-		
+
 		music.loadEmbedded(Music, Looped);
 		music.volume = Volume;
 		music.persist = true;
 		music.group = (Group == null) ? defaultMusicGroup : Group;
 		music.play();
 	}
-	
+
 	/**
-	 * Creates a new FlxSound object. 
-	 * 
+	 * Creates a new FlxSound object.
+	 *
 	 * @param	EmbeddedSound	The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
 	 * @param	Volume			How loud to play it (0 to 1).
 	 * @param	Looped			Whether to loop this sound.
@@ -116,9 +116,9 @@ class SoundFrontEnd
 			FlxG.log.warn("FlxG.loadSound() requires either\nan embedded sound or a URL to work.");
 			return null;
 		}
-		
+
 		var sound:FlxSound = list.recycle(FlxSound);
-		
+
 		if (EmbeddedSound != null)
 		{
 			sound.loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
@@ -127,22 +127,22 @@ class SoundFrontEnd
 		{
 			sound.loadStream(URL, Looped, AutoDestroy, OnComplete);
 		}
-		
+
 		sound.volume = Volume;
-		
+
 		if (AutoPlay)
 		{
 			sound.play();
 		}
-		
+
 		sound.group = (Group == null) ? defaultSoundGroup : Group;
 		return sound;
 	}
-	
+
 	/**
 	 * Method for sound caching (especially useful on mobile targets). The game may freeze
 	 * for some time the first time you try to play a sound if you don't use this method.
-	 * 
+	 *
 	 * @param	EmbeddedSound	Name of sound assets specified in your .xml project file
 	 * @return	Cached Sound object
 	 */
@@ -154,24 +154,24 @@ class SoundFrontEnd
 			return Assets.getSound(EmbeddedSound, true);
 		FlxG.log.error('Could not find a Sound asset with an ID of \'$EmbeddedSound\'.');
 		return null;
-		
+
 	}
-	
+
 	/**
 	 * Calls FlxG.sound.cache() on all sounds that are embedded.
 	 * WARNING: can lead to high memory usage.
 	 */
 	public function cacheAll():Void
 	{
-		for (id in Assets.list(AssetType.SOUND)) 
+		for (id in Assets.list(AssetType.SOUND))
 		{
 			cache(id);
 		}
 	}
-	
+
 	/**
 	 * Plays a sound from an embedded sound. Tries to recycle a cached sound first.
-	 * 
+	 *
 	 * @param	EmbeddedSound	The sound you want to play.
 	 * @param	Volume			How loud to play it (0 to 1).
 	 * @param	Looped			Whether to loop this sound.
@@ -191,11 +191,11 @@ class SoundFrontEnd
 		sound.group = (Group == null) ? defaultSoundGroup : Group;
 		return sound.play();
 	}
-	
+
 	/**
 	 * Creates a new sound object from a URL.
 	 * NOTE: Just calls FlxG.loadSound() with AutoPlay == true.
-	 * 
+	 *
 	 * @param	URL		The URL of the sound you want to play.
 	 * @param	Volume	How loud to play it (0 to 1).
 	 * @param	Looped	Whether or not to loop this sound.
@@ -208,7 +208,7 @@ class SoundFrontEnd
 	{
 		return load(null, Volume, Looped, AutoDestroy, true, URL, OnComplete);
 	}
-	
+
 	/**
 	 * Pause all sounds currently playing.
 	 */
@@ -218,7 +218,7 @@ class SoundFrontEnd
 		{
 			music.pause();
 		}
-		
+
 		for (sound in list.members)
 		{
 			if (sound != null && sound.exists && sound.active)
@@ -227,7 +227,7 @@ class SoundFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Resume playing existing sounds.
 	 */
@@ -237,7 +237,7 @@ class SoundFrontEnd
 		{
 			music.resume();
 		}
-		
+
 		for (sound in list.members)
 		{
 			if (sound != null && sound.exists)
@@ -246,10 +246,10 @@ class SoundFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Called by FlxGame on state changes to stop and destroy sounds.
-	 * 
+	 *
 	 * @param	ForceDestroy	Kill sounds even if persist is true.
 	 */
 	public function destroy(ForceDestroy:Bool = false):Void
@@ -259,7 +259,7 @@ class SoundFrontEnd
 			music.destroy();
 			music = null;
 		}
-		
+
 		for (sound in list.members)
 		{
 			if (sound != null && (ForceDestroy || !sound.persist))
@@ -268,32 +268,32 @@ class SoundFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Toggles muted, also activating the sound tray.
-	 */ 
+	 */
 	public function toggleMuted():Void
 	{
 		muted = !muted;
-		
+
 		if (volumeHandler != null)
 		{
 			volumeHandler(muted ? 0 : volume);
 		}
-		
+
 		showSoundTray();
 	}
-	
+
 	/**
 	 * Changes the volume by a certain amount, also activating the sound tray.
-	 */ 
+	 */
 	public function changeVolume(Amount:Float):Void
 	{
 		muted = false;
 		volume += Amount;
 		showSoundTray();
 	}
-	
+
 	/**
 	 * Shows the sound tray if it is enabled.
 	 */
@@ -306,24 +306,24 @@ class SoundFrontEnd
 		}
 		#end
 	}
-	
-	private function new()
+
+	function new()
 	{
 		loadSavedPrefs();
 	}
-	
+
 	/**
 	 * Called by the game loop to make sure the sounds get updated each frame.
 	 */
 	@:allow(flixel.FlxGame)
-	private function update(elapsed:Float):Void
+	function update(elapsed:Float):Void
 	{
 		if (music != null && music.active)
 			music.update(elapsed);
-		
+
 		if (list != null && list.active)
 			list.update(elapsed);
-		
+
 		#if FLX_KEYBOARD
 		if (FlxG.keys.anyJustReleased(muteKeys))
 			toggleMuted();
@@ -333,15 +333,15 @@ class SoundFrontEnd
 			changeVolume(-0.1);
 		#end
 	}
-	
+
 	@:allow(flixel.FlxGame)
-	private function onFocusLost():Void
+	function onFocusLost():Void
 	{
 		if (music != null)
 		{
 			music.onFocusLost();
 		}
-		
+
 		for (sound in list.members)
 		{
 			if (sound != null)
@@ -350,15 +350,15 @@ class SoundFrontEnd
 			}
 		}
 	}
-	
+
 	@:allow(flixel.FlxGame)
-	private function onFocus():Void
+	function onFocus():Void
 	{
 		if (music != null)
 		{
 			music.onFocus();
 		}
-		
+
 		for (sound in list.members)
 		{
 			if (sound != null)
@@ -367,27 +367,27 @@ class SoundFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Loads saved sound preferences if they exist.
 	 */
-	private function loadSavedPrefs():Void
+	function loadSavedPrefs():Void
 	{
 		if (FlxG.save.data.volume != null)
 		{
 			volume = FlxG.save.data.volume;
 		}
-		
+
 		if (FlxG.save.data.mute != null)
 		{
 			muted = FlxG.save.data.mute;
 		}
 	}
-	
-	private function set_volume(Volume:Float):Float
+
+	function set_volume(Volume:Float):Float
 	{
 		Volume = FlxMath.bound(Volume, 0, 1);
-		
+
 		if (volumeHandler != null)
 		{
 			var param:Float = muted ? 0 : Volume;

--- a/flixel/system/frontEnds/VCRFrontEnd.hx
+++ b/flixel/system/frontEnds/VCRFrontEnd.hx
@@ -20,9 +20,9 @@ class VCRFrontEnd
 {
 	#if FLX_RECORD
 	#if flash
-	private static var FILE_TYPES:Array<FileFilter> = [new FileFilter("Flixel Game Recording", "*.fgr")];
+	static var FILE_TYPES:Array<FileFilter> = [new FileFilter("Flixel Game Recording", "*.fgr")];
 
-	private static inline var DEFAULT_FILE_NAME:String = "replay.fgr";
+	static inline var DEFAULT_FILE_NAME:String = "replay.fgr";
 	#end
 	/**
 	 * This function, if set, is triggered when the callback stops playing.
@@ -39,7 +39,7 @@ class VCRFrontEnd
 	public var timeout:Float = 0;
 
 	#if flash
-	private var _file:FileReference;
+	var _file:FileReference;
 	#end
 	#end
 
@@ -63,9 +63,9 @@ class VCRFrontEnd
 			if (!FlxG.mouse.useSystemCursor)
 				Mouse.show();
 			#end
-			
+
 			paused = true;
-			
+
 			#if FLX_DEBUG
 			FlxG.game.debugger.vcr.onPause();
 			#end
@@ -83,9 +83,9 @@ class VCRFrontEnd
 			if (!FlxG.mouse.useSystemCursor)
 				Mouse.hide();
 			#end
-			
+
 			paused = false;
-			
+
 			#if FLX_DEBUG
 			FlxG.game.debugger.vcr.onResume();
 			#end
@@ -96,7 +96,7 @@ class VCRFrontEnd
 	/**
 	 * Called when the user presses the Rewind-looking button. If Alt is pressed, the entire game is reset.
 	 * If Alt is NOT pressed, only the current state is reset. The GUI is updated accordingly.
-	 * 
+	 *
 	 * @param	StandardMode	Whether to reset the current game (== true), or just the current state.  Just resetting the current state can be very handy for debugging.
 	 */
 	public function restartReplay(StandardMode:Bool = false):Void
@@ -107,7 +107,7 @@ class VCRFrontEnd
 
 	/**
 	 * Load replay data from a string and play it back.
-	 * 
+	 *
 	 * @param	Data		The replay that you want to load.
 	 * @param	State		Optional parameter: if you recorded a state-specific demo or cutscene, pass a new instance of that state here.
 	 * @param	CancelKeys	Optional parameter: an array of string names of keys (see FlxKeyboard) that can be pressed to cancel the playback, e.g. ["ESCAPE","ENTER"].  Also accepts 2 custom key names: "ANY" and "MOUSE" (fairly self-explanatory I hope!).
@@ -117,7 +117,7 @@ class VCRFrontEnd
 	public function loadReplay(Data:String, ?State:FlxState, ?CancelKeys:Array<FlxKey>, ?Timeout:Float = 0, ?Callback:Void->Void):Void
 	{
 		FlxG.game._replay.load(Data);
-		
+
 		if (State == null)
 		{
 			FlxG.resetGame();
@@ -126,20 +126,20 @@ class VCRFrontEnd
 		{
 			FlxG.switchState(State);
 		}
-		
+
 		cancelKeys = CancelKeys;
 		timeout = Std.int(Timeout * 1000);
 		replayCallback = Callback;
 		FlxG.game._replayRequested = true;
-		
+
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = false;
 		#end
-	
+
 		#if FLX_MOUSE
 		FlxG.mouse.enabled = false;
 		#end
-		
+
 		#if FLX_DEBUG
 		FlxG.game.debugger.vcr.runtime = 0;
 		FlxG.game.debugger.vcr.playingReplay();
@@ -148,7 +148,7 @@ class VCRFrontEnd
 
 	/**
 	 * Resets the game or state and replay requested flag.
-	 * 
+	 *
 	 * @param	StandardMode	If true, reload entire game, else just reload current game state.
 	 */
 	public function reloadReplay(StandardMode:Bool = true):Void
@@ -161,13 +161,13 @@ class VCRFrontEnd
 		{
 			FlxG.resetState();
 		}
-		
+
 		if (FlxG.game._replay.frameCount > 0)
 		{
 			FlxG.game._replayRequested = true;
 		}
 	}
-	
+
 	/**
 	 * Stops the current replay.
 	 */
@@ -175,20 +175,20 @@ class VCRFrontEnd
 	{
 		FlxG.game.replaying = false;
 		FlxG.inputs.reset();
-		
+
 		#if FLX_DEBUG
 		FlxG.game.debugger.vcr.stoppedReplay();
 		#end
-		
+
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = true;
 		#end
-	
+
 		#if FLX_MOUSE
 		FlxG.mouse.enabled = true;
 		#end
 	}
-	
+
 	public function cancelReplay():Void
 	{
 		if (replayCallback != null)
@@ -201,16 +201,16 @@ class VCRFrontEnd
 			stopReplay();
 		}
 	}
-	
+
 	/**
 	 * Resets the game or state and requests a new recording.
-	 * 
+	 *
 	 * @param	StandardMode	If true, reset the entire game, else just reset the current state.
 	 */
 	public function startRecording(StandardMode:Bool = true):Void
 	{
 		FlxRandom.updateRecordingSeed(StandardMode);
-		
+
 		if (StandardMode)
 		{
 			FlxG.resetGame();
@@ -219,31 +219,31 @@ class VCRFrontEnd
 		{
 			FlxG.resetState();
 		}
-		
+
 		FlxG.game._recordingRequested = true;
 		#if FLX_DEBUG
 		FlxG.game.debugger.vcr.recording();
 		#end
 	}
-	
+
 	/**
 	 * Stop recording the current replay and return the replay data.
-	 * 
+	 *
 	 * @param	OpenSaveDialog	If true, and targeting flash, open an OS-native save dialog for the user to choose where to save the data, and save it there.
-	 * 
+	 *
 	 * @return	The replay data in simple ASCII format (see FlxReplay.save()).
 	 */
 	public inline function stopRecording(OpenSaveDialog:Bool = true):String
 	{
 		FlxG.game.recording = false;
-		
+
 		#if FLX_DEBUG
 		FlxG.game.debugger.vcr.stoppedRecording();
 		FlxG.game.debugger.vcr.stoppedReplay();
 		#end
-		
+
 		var data:String = FlxG.game._replay.save();
-		
+
 		if (OpenSaveDialog && (data != null) && (data.length > 0))
 		{
 			#if flash
@@ -270,11 +270,11 @@ class VCRFrontEnd
 		_file.browse(FILE_TYPES);
 		#end
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
-	private function destroy():Void
+	function destroy():Void
 	{
 		#if FLX_RECORD
 		cancelKeys = null;
@@ -288,12 +288,12 @@ class VCRFrontEnd
 	 * Called when a file is picked from the file dialog.
 	 * Attempts to load the file and registers file loading event handlers.
 	 */
-	private function onOpenSelect(_):Void
+	function onOpenSelect(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.SELECT, onOpenSelect);
 		_file.removeEventListener(Event.CANCEL, onOpenCancel);
-		
+
 		_file.addEventListener(Event.COMPLETE, onOpenComplete);
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onOpenError);
 		_file.load();
@@ -304,12 +304,12 @@ class VCRFrontEnd
 	 * Called when a file is opened successfully.
 	 * If there's stuff inside, then the contents are loaded into a new replay.
 	 */
-	private function onOpenComplete(_):Void
+	function onOpenComplete(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.COMPLETE, onOpenComplete);
 		_file.removeEventListener(IOErrorEvent.IO_ERROR, onOpenError);
-		
+
 		//Turn the file into a giant string
 		var fileContents:String = null;
 		var data:ByteArray = _file.data;
@@ -323,7 +323,7 @@ class VCRFrontEnd
 			FlxG.log.error("Empty flixel gameplay record.");
 			return;
 		}
-		
+
 		FlxG.vcr.loadReplay(fileContents);
 		#end
 	}
@@ -331,7 +331,7 @@ class VCRFrontEnd
 	/**
 	 * Called if the open file dialog is canceled.
 	 */
-	private function onOpenCancel(_):Void
+	function onOpenCancel(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.SELECT, onOpenSelect);
@@ -343,7 +343,7 @@ class VCRFrontEnd
 	/**
 	 * Called if there is a file open error.
 	 */
-	private function onOpenError(_):Void
+	function onOpenError(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.COMPLETE, onOpenComplete);
@@ -356,7 +356,7 @@ class VCRFrontEnd
 	/**
 	 * Called when the file is saved successfully.
 	 */
-	private function onSaveComplete(_):Void
+	function onSaveComplete(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.COMPLETE, onSaveComplete);
@@ -370,7 +370,7 @@ class VCRFrontEnd
 	/**
 	 * Called when the save file dialog is cancelled.
 	 */
-	private function onSaveCancel(_):Void
+	function onSaveCancel(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.COMPLETE, onSaveComplete);
@@ -383,7 +383,7 @@ class VCRFrontEnd
 	/**
 	 * Called if there is an error while saving the gameplay recording.
 	 */
-	private function onSaveError(_):Void
+	function onSaveError(_):Void
 	{
 		#if flash
 		_file.removeEventListener(Event.COMPLETE, onSaveComplete);
@@ -394,7 +394,7 @@ class VCRFrontEnd
 		#end
 	}
 	#end
-	
+
 	@:allow(flixel.FlxG)
-	private function new() {}
+	function new() {}
 }

--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -7,17 +7,17 @@ import sys.FileSystem;
 using flixel.util.FlxArrayUtil;
 using StringTools;
 
-class FlxAssetPaths 
+class FlxAssetPaths
 {
 	public static function buildFileReferences(directory:String = "assets/", subDirectories:Bool = false, ?filterExtensions:Array<String>):Array<Field>
 	{
 		if (!directory.endsWith("/"))
 			directory += "/";
-			
+
 		var fileReferences:Array<FileReference> = getFileReferences(directory, subDirectories, filterExtensions);
-		
+
 		var fields:Array<Field> = Context.getBuildFields();
-			
+
 		for (fileRef in fileReferences)
 		{
 			// create new field based on file references!
@@ -31,8 +31,8 @@ class FlxAssetPaths
 		}
 		return fields;
 	}
-	
-	private static function getFileReferences(directory:String, subDirectories:Bool = false, ?filterExtensions:Array<String>):Array<FileReference>
+
+	static function getFileReferences(directory:String, subDirectories:Bool = false, ?filterExtensions:Array<String>):Array<FileReference>
 	{
 		var fileReferences:Array<FileReference> = [];
 		var resolvedPath = #if (ios || tvos) Context.resolvePath(directory) #else directory #end;
@@ -44,14 +44,14 @@ class FlxAssetPaths
 				// ignore invisible files
 				if (name.startsWith("."))
 					continue;
-				
+
 				if (filterExtensions != null)
 				{
 					var extension:String = name.split(".").last(); // get the last string with a dot before it
 					if (!filterExtensions.contains(extension))
 						continue;
 				}
-				
+
 				fileReferences.push(new FileReference(directory + name));
 			}
 			else if (subDirectories)
@@ -59,7 +59,7 @@ class FlxAssetPaths
 				fileReferences = fileReferences.concat(getFileReferences(directory + name + "/", true, filterExtensions));
 			}
 		}
-		
+
 		return fileReferences;
 	}
 }
@@ -69,16 +69,16 @@ private class FileReference
 	public var name:String;
 	public var value:String;
 	public var documentation:String;
-	
+
 	public function new(value:String)
 	{
 		this.value = value;
-		
+
 		// replace some forbidden names to underscores, since variables cannot have these symbols.
 		this.name = value.split("-").join("_").split(".").join("__");
 		var split:Array<String> = name.split("/");
 		this.name = split.last();
-		
+
 		// auto generate documentation
 		this.documentation = "\"" + value + "\" (auto generated).";
 	}

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -38,7 +38,7 @@ private enum HelperDefines
 	FLX_SOUND_SYSTEM;
 	FLX_FOCUS_LOST_SCREEN;
 	FLX_DEBUG;
-	
+
 	FLX_MOUSE_ADVANCED;
 	FLX_NATIVE_CURSOR;
 	FLX_SOUND_TRAY;
@@ -63,26 +63,26 @@ class FlxDefines
 		defineInversions();
 		defineHelperDefines();
 	}
-	
-	private static function checkDependencyCompatibility()
+
+	static function checkDependencyCompatibility()
 	{
 		#if (haxe_ver < "3.2")
 		abortMinVersion("Haxe", "3.2.0", (macro null).pos);
 		#end
-		
+
 		#if ((haxe_ver == "3.201") && flixel_ui)
 		if (defined("cpp"))
 			abort('flixel-ui is not compatible with Haxe 3.2.1 on the cpp target'
 				+' due to a compiler bug (#4343). Please use a different Haxe version.',
 				(macro null).pos);
 		#end
-		
+
 		#if !nme
 		checkOpenFLVersions();
 		#end
 	}
 
-	private static function checkOpenFLVersions()
+	static function checkOpenFLVersions()
 	{
 		#if (openfl < "3.5.0")
 		abortMinVersion("OpenFL", "3.5.0", (macro null).pos);
@@ -95,29 +95,29 @@ class FlxDefines
 		#if (openfl >= "4.0.0")
 		abortMaxVersion("OpenFL", "4.0.0", "3.6.1", (macro null).pos);
 		#end
-		
+
 		#if ((lime >= "3.0.0") || (tools >= "3.0.0"))
 		abortMaxVersion("Lime", "3.0.0", "2.9.1", (macro null).pos);
 		#end
 	}
 
-	private static function abortMinVersion(dependency:String, minimumRequired:String, pos:Position)
+	static function abortMinVersion(dependency:String, minimumRequired:String, pos:Position)
 	{
 		abort('The minimum required $dependency version for HaxeFlixel is $minimumRequired. '
 			+ 'Please install a newer version.', pos);
 	}
 
-	private static function abortMaxVersion(lib:String, firstIncompatible:String, lastCompatible:String, pos:Position)
+	static function abortMaxVersion(lib:String, firstIncompatible:String, lastCompatible:String, pos:Position)
 	{
 		abort('Please run \'haxelib set ${lib.toLowerCase()} $lastCompatible\'' +
 			' (Flixel is currently incompatible with $lib $firstIncompatible or newer).' , pos);
 	}
-	
-	private static function checkDefines()
+
+	static function checkDefines()
 	{
 		for (define in HelperDefines.getConstructors())
 			abortIfDefined(define);
-		
+
 		#if (haxe_ver >= "3.2")
 		var userDefinable = UserDefines.getConstructors();
 		for (define in Context.getDefines().keys())
@@ -129,14 +129,14 @@ class FlxDefines
 		}
 		#end
 	}
-	
-	private static function abortIfDefined(define:String)
+
+	static function abortIfDefined(define:String)
 	{
 		if (defined(define))
 			abort('$define can only be defined by flixel.', (macro null).pos);
 	}
 
-	private static function defineInversions()
+	static function defineInversions()
 	{
 		defineInversion(FLX_NO_GAMEPAD, FLX_GAMEPAD);
 		defineInversion(FLX_NO_MOUSE, FLX_MOUSE);
@@ -147,65 +147,65 @@ class FlxDefines
 		defineInversion(FLX_NO_DEBUG, FLX_DEBUG);
 	}
 
-	private static function defineHelperDefines()
+	static function defineHelperDefines()
 	{
 		if (!defined(FLX_NO_MOUSE) && !defined(FLX_NO_MOUSE_ADVANCED) && (!defined("flash") || defined("flash11_2")))
 			define(FLX_MOUSE_ADVANCED);
-		
+
 		if (!defined(FLX_NO_MOUSE) && !defined(FLX_NO_NATIVE_CURSOR) && defined("flash10_2"))
 			define(FLX_NATIVE_CURSOR);
-		
+
 		if (!defined(FLX_NO_SOUND_SYSTEM) && !defined(FLX_NO_SOUND_TRAY))
 			define(FLX_SOUND_TRAY);
-		
+
 		if ((defined("openfl_next") && !defined("flash")) || defined("flash11_8"))
 			define(FLX_GAMEINPUT_API);
 		else if (!defined("openfl_next") && (defined("cpp") || defined("neko")))
 			define(FLX_JOYSTICK_API);
-		
+
 		if (!defined(FLX_NO_TOUCH) || !defined(FLX_NO_MOUSE))
 			define(FLX_POINTER_INPUT);
-		
+
 		if (defined("cpp") || defined("neko"))
 			define(FLX_POST_PROCESS);
 	}
-	
-	private static function defineInversion(userDefine:UserDefines, invertedDefine:HelperDefines)
+
+	static function defineInversion(userDefine:UserDefines, invertedDefine:HelperDefines)
 	{
 		if (!defined(userDefine))
 			define(invertedDefine);
 	}
-	
-	private static function checkSwfVersion()
+
+	static function checkSwfVersion()
 	{
 		if (!defined("flash11"))
 			abort("The minimum required Flash Player version for HaxeFlixel is 11." +
 				" Please specify a newer version in your Project.xml file.", (macro null).pos);
-		
+
 		swfVersionError("Middle and right mouse button events are", "11.2", FLX_NO_MOUSE_ADVANCED);
 		swfVersionError("Gamepad input is", "11.8", FLX_NO_GAMEPAD);
 	}
-	
-	private static function swfVersionError(feature:String, version:String, define:UserDefines)
+
+	static function swfVersionError(feature:String, version:String, define:UserDefines)
 	{
 		var errorMessage = '$feature only supported in Flash Player version $version or higher. '
 			+ 'Define ${define.getName()} to disable this feature or add <set name="SWF_VERSION" value="$version" /> to your Project.xml.';
-		
+
 		if (!defined("flash" + version.replace(".", "_")) && !defined(define))
 			abort(errorMessage, (macro null).pos);
 	}
-	
-	private static inline function defined(define:Dynamic)
+
+	static inline function defined(define:Dynamic)
 	{
 		return Context.defined(Std.string(define));
 	}
-	
-	private static inline function define(define:Dynamic)
+
+	static inline function define(define:Dynamic)
 	{
 		Compiler.define(Std.string(define));
 	}
-	
-	private static function abort(message:String, pos:Position)
+
+	static function abort(message:String, pos:Position)
 	{
 		Context.fatalError(message, pos);
 	}

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -28,20 +28,20 @@ class FlxReplay
 	 * Whether the replay has finished playing or not.
 	 */
 	public var finished:Bool;
-	
+
 	/**
 	 * Internal container for all the frames in this replay.
 	 */
-	private var _frames:Array<FrameRecord>;
+	var _frames:Array<FrameRecord>;
 	/**
 	 * Internal tracker for max number of frames we can fit before growing the _frames again.
 	 */
-	private var _capacity:Int;
+	var _capacity:Int;
 	/**
 	 * Internal helper variable for keeping track of where we are in _frames during recording or replay.
 	 */
-	private var _marker:Int;
-	
+	var _marker:Int;
+
 	/**
 	 * Instantiate a new replay object.  Doesn't actually do much until you call create() or load().
 	 */
@@ -55,7 +55,7 @@ class FlxReplay
 		_capacity = 0;
 		_marker = 0;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -72,10 +72,10 @@ class FlxReplay
 		}
 		_frames = null;
 	}
-	
+
 	/**
 	 * Create a new gameplay recording.  Requires the current random number generator seed.
-	 * 
+	 *
 	 * @param	Seed	The current seed from the random number generator.
 	 */
 	public function create(Seed:Int):Void
@@ -85,21 +85,21 @@ class FlxReplay
 		seed = Seed;
 		rewind();
 	}
-	
+
 	/**
 	 * Load replay data from a String object.
 	 * Strings can come from embedded assets or external
-	 * files loaded through the debugger overlay. 
+	 * files loaded through the debugger overlay.
 	 * @param	FileContents	A String object containing a gameplay recording.
 	 */
 	public function load(FileContents:String):Void
 	{
 		init();
-		
+
 		var lines:Array<String> = FileContents.split("\n");
-		
+
 		seed = Std.parseInt(lines[0]);
-		
+
 		var line:String;
 		var i:Int = 1;
 		var l:Int = lines.length;
@@ -116,10 +116,10 @@ class FlxReplay
 				}
 			}
 		}
-		
+
 		rewind();
 	}
-	
+
 	/**
 	 * Save the current recording data off to a String object.
 	 * Basically goes through and calls FrameRecord.save() on each frame in the replay.
@@ -146,12 +146,12 @@ class FlxReplay
 	public function recordFrame():Void
 	{
 		var continueFrame = true;
-		
+
 		#if FLX_KEYBOARD
 		var keysRecord:Array<CodeValuePair> = FlxG.keys.record();
 		if (keysRecord != null) continueFrame = false;
 		#end
-		
+
 		#if FLX_MOUSE
 		var mouseRecord:MouseRecord = FlxG.mouse.record();
 		if (mouseRecord != null) continueFrame = false;
@@ -162,7 +162,7 @@ class FlxReplay
 			frame++;
 			return;
 		}
-		
+
 		var frameRecorded = new FrameRecord().create(frame++);
 		#if FLX_MOUSE
 		frameRecorded.mouse = mouseRecord;
@@ -170,23 +170,23 @@ class FlxReplay
 		#if FLX_KEYBOARD
 		frameRecorded.keys = keysRecord;
 		#end
-		
+
 		_frames[frameCount++] = frameRecorded;
-		
+
 		if (frameCount >= _capacity)
 		{
 			_capacity *= 2;
 			FlxArrayUtil.setLength(_frames, _capacity);
 		}
 	}
-	
+
 	/**
 	 * Get the current frame record data and load it into the input managers.
 	 */
 	public function playNextFrame():Void
 	{
 		FlxG.inputs.reset();
-		
+
 		if (_marker >= frameCount)
 		{
 			finished = true;
@@ -196,16 +196,16 @@ class FlxReplay
 		{
 			return;
 		}
-		
+
 		var fr:FrameRecord = _frames[_marker++];
-		
+
 		#if FLX_KEYBOARD
 		if (fr.keys != null)
 		{
 			FlxG.keys.playback(fr.keys);
 		}
 		#end
-		
+
 		#if FLX_MOUSE
 		if (fr.mouse != null)
 		{
@@ -213,7 +213,7 @@ class FlxReplay
 		}
 		#end
 	}
-	
+
 	/**
 	 * Reset the replay back to the first frame.
 	 */
@@ -223,11 +223,11 @@ class FlxReplay
 		frame = 0;
 		finished = false;
 	}
-	
+
 	/**
 	 * Common initialization terms used by both create() and load() to set up the replay object.
 	 */
-	private function init():Void
+	function init():Void
 	{
 		_capacity = 100;
 		_frames = new Array<FrameRecord>(/*_capacity*/);

--- a/flixel/system/scaleModes/BaseScaleMode.hx
+++ b/flixel/system/scaleModes/BaseScaleMode.hx
@@ -11,10 +11,10 @@ class BaseScaleMode
 	public var gameSize(default, null):FlxPoint;
 	public var scale(default, null):FlxPoint;
 	public var offset(default, null):FlxPoint;
-	
+
 	public var horizontalAlign(default, set):FlxHorizontalAlign = CENTER;
 	public var verticalAlign(default, set):FlxVerticalAlign = CENTER;
-	
+
 	public function new()
 	{
 		deviceSize = FlxPoint.get();
@@ -22,37 +22,37 @@ class BaseScaleMode
 		scale = FlxPoint.get();
 		offset = FlxPoint.get();
 	}
-	
+
 	public function onMeasure(Width:Int, Height:Int):Void
 	{
 		FlxG.width = FlxG.initialWidth;
 		FlxG.height = FlxG.initialHeight;
-		
+
 		updateGameSize(Width, Height);
 		updateDeviceSize(Width, Height);
 		updateScaleOffset();
 		updateGamePosition();
 	}
-	
-	private function updateGameSize(Width:Int, Height:Int):Void
+
+	function updateGameSize(Width:Int, Height:Int):Void
 	{
 		gameSize.set(Width, Height);
 	}
-	
-	private function updateDeviceSize(Width:Int, Height:Int):Void
+
+	function updateDeviceSize(Width:Int, Height:Int):Void
 	{
 		deviceSize.set(Width, Height);
 	}
-	
-	private function updateScaleOffset():Void
+
+	function updateScaleOffset():Void
 	{
 		scale.x = gameSize.x / (FlxG.width * FlxG.initialZoom);
 		scale.y = gameSize.y / (FlxG.height * FlxG.initialZoom);
 		updateOffsetX();
 		updateOffsetY();
 	}
-	
-	private function updateOffsetX():Void
+
+	function updateOffsetX():Void
 	{
 		offset.x = switch (horizontalAlign)
 		{
@@ -64,8 +64,8 @@ class BaseScaleMode
 				deviceSize.x - gameSize.x;
 		}
 	}
-	
-	private function updateOffsetY():Void
+
+	function updateOffsetY():Void
 	{
 		offset.y = switch (verticalAlign)
 		{
@@ -77,17 +77,17 @@ class BaseScaleMode
 				deviceSize.y - gameSize.y;
 		}
 	}
-	
-	private function updateGamePosition():Void
+
+	function updateGamePosition():Void
 	{
 		if (FlxG.game == null)
 			return;
-		
+
 		FlxG.game.x = offset.x;
 		FlxG.game.y = offset.y;
 	}
-	
-	private function set_horizontalAlign(value:FlxHorizontalAlign):FlxHorizontalAlign
+
+	function set_horizontalAlign(value:FlxHorizontalAlign):FlxHorizontalAlign
 	{
 		horizontalAlign = value;
 		if (offset != null)
@@ -97,8 +97,8 @@ class BaseScaleMode
 		}
 		return value;
 	}
-	
-	private function set_verticalAlign(value:FlxVerticalAlign):FlxVerticalAlign
+
+	function set_verticalAlign(value:FlxVerticalAlign):FlxVerticalAlign
 	{
 		verticalAlign = value;
 		if (offset != null)

--- a/flixel/system/scaleModes/FillScaleMode.hx
+++ b/flixel/system/scaleModes/FillScaleMode.hx
@@ -4,7 +4,7 @@ import flixel.FlxG;
 
 class FillScaleMode extends BaseScaleMode
 {
-	override private function updateGamePosition():Void 
+	override function updateGamePosition():Void
 	{
 		FlxG.game.x = FlxG.game.y = 0;
 	}

--- a/flixel/system/scaleModes/FixedScaleAdjustSizeScaleMode.hx
+++ b/flixel/system/scaleModes/FixedScaleAdjustSizeScaleMode.hx
@@ -4,39 +4,39 @@ import flixel.FlxG;
 
 class FixedScaleAdjustSizeScaleMode extends BaseScaleMode
 {
-	private var fixedWidth:Bool = false;
-	private var fixedHeight:Bool = false;
-	
+	var fixedWidth:Bool = false;
+	var fixedHeight:Bool = false;
+
 	public function new(fixedWidth:Bool = false, fixedHeight:Bool = false)
 	{
 		super();
 		this.fixedWidth = fixedWidth;
 		this.fixedHeight = fixedHeight;
-		
+
 		gameSize.set(FlxG.width * FlxG.initialZoom, FlxG.height * FlxG.initialZoom);
 	}
-	
+
 	override public function onMeasure(Width:Int, Height:Int):Void
 	{
 		FlxG.width = fixedWidth ? FlxG.initialWidth : Math.ceil(Width / FlxG.initialZoom);
 		FlxG.height = fixedHeight ? FlxG.initialHeight : Math.ceil(Height / FlxG.initialZoom);
-		
+
 		updateGameSize(Width, Height);
 		updateDeviceSize(Width, Height);
 		updateScaleOffset();
 		updateGamePosition();
 	}
-	
-	override private function updateGameSize(Width:Int, Height:Int):Void 
+
+	override function updateGameSize(Width:Int, Height:Int):Void
 	{
 		gameSize.x = FlxG.width * FlxG.initialZoom;
 		gameSize.y = FlxG.height * FlxG.initialZoom;
-		
+
 		if (FlxG.camera != null)
 		{
 			var oldWidth:Float = FlxG.camera.width;
 			var oldHeight:Float = FlxG.camera.height;
-			
+
 			FlxG.camera.setSize(FlxG.width, FlxG.height);
 			FlxG.camera.scroll.x += 0.5 * (oldWidth - FlxG.width);
 			FlxG.camera.scroll.y += 0.5 * (oldHeight - FlxG.height);

--- a/flixel/system/scaleModes/FixedScaleMode.hx
+++ b/flixel/system/scaleModes/FixedScaleMode.hx
@@ -4,7 +4,7 @@ import flixel.FlxG;
 
 class FixedScaleMode extends BaseScaleMode
 {
-	override private function updateGameSize(Width:Int, Height:Int):Void 
+	override function updateGameSize(Width:Int, Height:Int):Void
 	{
 		gameSize.x = FlxG.width;
 		gameSize.y = FlxG.height;

--- a/flixel/system/scaleModes/PixelPerfectScaleMode.hx
+++ b/flixel/system/scaleModes/PixelPerfectScaleMode.hx
@@ -6,18 +6,18 @@ import flixel.FlxG;
  * A scale mode which scales up the game to the highest integer factor it can,
  * maintains the aspect ratio, and windowboxes the game if necessary.
  */
-class PixelPerfectScaleMode extends BaseScaleMode 
+class PixelPerfectScaleMode extends BaseScaleMode
 {
-	override private function updateGameSize(Width:Int, Height:Int) 
+	override function updateGameSize(Width:Int, Height:Int)
 	{
 		var scaleFactorX:Float = Width / FlxG.width;
 		var scaleFactorY:Float = Height / FlxG.height;
 		var scaleFactor:Int = Math.floor(Math.min(scaleFactorX, scaleFactorY));
-		
+
 		// If the scale factor is less than zero, set it to one and crop
 		if (scaleFactor < 1)
 			scaleFactor = 1;
-		
+
 		gameSize.x = FlxG.width * scaleFactor;
 		gameSize.y = FlxG.height * scaleFactor;
 	}

--- a/flixel/system/scaleModes/RatioScaleMode.hx
+++ b/flixel/system/scaleModes/RatioScaleMode.hx
@@ -4,8 +4,8 @@ import flixel.FlxG;
 
 class RatioScaleMode extends BaseScaleMode
 {
-	private var fillScreen:Bool;
-	
+	var fillScreen:Bool;
+
 	/**
 	 * @param fillScreen Whether to cut the excess side to fill the
 	 * screen or always display everything.
@@ -15,18 +15,18 @@ class RatioScaleMode extends BaseScaleMode
 		super();
 		this.fillScreen = fillScreen;
 	}
-	
-	override private function updateGameSize(Width:Int, Height:Int):Void 
+
+	override function updateGameSize(Width:Int, Height:Int):Void
 	{
 		var ratio:Float = FlxG.width / FlxG.height;
 		var realRatio:Float = Width / Height;
-		
+
 		var scaleY:Bool = realRatio < ratio;
 		if (fillScreen)
 		{
 			scaleY = !scaleY;
 		}
-		
+
 		if (scaleY)
 		{
 			gameSize.x = Width;

--- a/flixel/system/scaleModes/RelativeScaleMode.hx
+++ b/flixel/system/scaleModes/RelativeScaleMode.hx
@@ -2,30 +2,30 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
-class RelativeScaleMode extends BaseScaleMode 
+class RelativeScaleMode extends BaseScaleMode
 {
-	private var _widthScale:Float;
-	private var _heightScale:Float;
-	
+	var _widthScale:Float;
+	var _heightScale:Float;
+
 	public function new(WidthScale:Float, HeightScale:Float)
 	{
 		super();
 		initScale(WidthScale, HeightScale);
 	}
-	
-	private inline function initScale(WidthScale:Float, HeightScale:Float):Void
+
+	inline function initScale(WidthScale:Float, HeightScale:Float):Void
 	{
 		_widthScale = WidthScale;
 		_heightScale = HeightScale;
 	}
-	
+
 	public function setScale(WidthScale:Float, HeightScale:Float):Void
 	{
 		initScale(WidthScale, HeightScale);
 		onMeasure(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
 	}
-	
-	override private function updateGameSize(Width:Int, Height:Int):Void 
+
+	override function updateGameSize(Width:Int, Height:Int):Void
 	{
 		gameSize.x = Std.int(Width * _widthScale);
 		gameSize.y = Std.int(Height * _heightScale);

--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -26,22 +26,22 @@ class FlxSoundTray extends Sprite
 	 * Because reading any data from DisplayObject is insanely expensive in hxcpp, keep track of whether we need to update it or not.
 	 */
 	public var active:Bool;
-	
+
 	/**
 	 * Helps us auto-hide the sound tray after a volume change.
 	 */
-	private var _timer:Float;
+	var _timer:Float;
 	/**
 	 * Helps display the volume bars on the sound tray.
 	 */
-	private var _bars:Array<Bitmap>;
+	var _bars:Array<Bitmap>;
 	/**
 	 * How wide the sound tray background is.
 	 */
-	private var _width:Int = 80;
-	
-	private var _defaultScale:Float = 2.0;
-	
+	var _width:Int = 80;
+
+	var _defaultScale:Float = 2.0;
+
 	/**
 	 * Sets up the "sound tray", the little volume meter that pops down sometimes.
 	 */
@@ -49,27 +49,27 @@ class FlxSoundTray extends Sprite
 	public function new()
 	{
 		super();
-		
+
 		visible = false;
 		scaleX = _defaultScale;
 		scaleY = _defaultScale;
 		var tmp:Bitmap = new Bitmap(new BitmapData(_width, 30, true, 0x7F000000));
 		screenCenter();
 		addChild(tmp);
-		
+
 		var text:TextField = new TextField();
 		text.width = tmp.width;
 		text.height = tmp.height;
 		text.multiline = true;
 		text.wordWrap = true;
 		text.selectable = false;
-		
+
 		#if flash
 		text.embedFonts = true;
 		text.antiAliasType = AntiAliasType.NORMAL;
 		text.gridFitType = GridFitType.PIXEL;
 		#else
-		
+
 		#end
 		var dtf:TextFormat = new TextFormat(FlxAssets.FONT_DEFAULT, 10, 0xffffff);
 		dtf.align = TextFormatAlign.CENTER;
@@ -77,11 +77,11 @@ class FlxSoundTray extends Sprite
 		addChild(text);
 		text.text = "VOLUME";
 		text.y = 16;
-		
+
 		var bx:Int = 10;
 		var by:Int = 14;
 		_bars = new Array();
-		
+
 		for (i in 0...10)
 		{
 			tmp = new Bitmap(new BitmapData(4, i + 1, false, FlxColor.WHITE));
@@ -92,11 +92,11 @@ class FlxSoundTray extends Sprite
 			bx += 6;
 			by--;
 		}
-		
+
 		y = -height;
 		visible = false;
 	}
-	
+
 	/**
 	 * This function just updates the soundtray object.
 	 */
@@ -110,23 +110,23 @@ class FlxSoundTray extends Sprite
 		else if (y > -height)
 		{
 			y -= (MS / 1000) * FlxG.height * 2;
-			
+
 			if (y <= -height)
 			{
 				visible = false;
 				active = false;
-				
+
 				// Save sound preferences
 				FlxG.save.data.mute = FlxG.sound.muted;
-				FlxG.save.data.volume = FlxG.sound.volume; 
-				FlxG.save.flush(); 
+				FlxG.save.data.volume = FlxG.sound.volume;
+				FlxG.save.flush();
 			}
 		}
 	}
-	
+
 	/**
 	 * Makes the little volume tray slide out.
-	 * 
+	 *
 	 * @param	Silent	Whether or not it should beep.
 	 */
 	public function show(Silent:Bool = false):Void
@@ -137,36 +137,36 @@ class FlxSoundTray extends Sprite
 			if (sound != null)
 				FlxG.sound.load(sound).play();
 		}
-		
+
 		_timer = 1;
 		y = 0;
 		visible = true;
 		active = true;
 		var globalVolume:Int = Math.round(FlxG.sound.volume * 10);
-		
+
 		if (FlxG.sound.muted)
 		{
 			globalVolume = 0;
 		}
-		
+
 		for (i in 0..._bars.length)
 		{
-			if (i < globalVolume) 
+			if (i < globalVolume)
 			{
 				_bars[i].alpha = 1;
 			}
-			else 
+			else
 			{
 				_bars[i].alpha = 0.5;
 			}
 		}
 	}
-	
+
 	public function screenCenter():Void
 	{
 		scaleX = _defaultScale;
 		scaleY = _defaultScale;
-		
+
 		x = (0.5 * (Lib.current.stage.stageWidth - _width * _defaultScale) - FlxG.game.x);
 	}
 }

--- a/flixel/system/ui/FlxSystemButton.hx
+++ b/flixel/system/ui/FlxSystemButton.hx
@@ -18,7 +18,7 @@ class FlxSystemButton extends Sprite implements IFlxDestroyable
 	 */
 	public var upHandler:Void->Void;
 	/**
-	 * Whether or not the downHandler function will be called when 
+	 * Whether or not the downHandler function will be called when
 	 * the button is clicked.
 	 */
 	public var enabled:Bool = true;
@@ -31,19 +31,19 @@ class FlxSystemButton extends Sprite implements IFlxDestroyable
 	 * Whether the button has been toggled in toggleMode.
 	 */
 	public var toggled(default, set):Bool = false;
-	
+
 	/**
 	 * The icon this button uses.
 	 */
-	private var _icon:Bitmap;
+	var _icon:Bitmap;
 	/**
 	 * Whether the mouse has been pressed while over this button.
 	 */
-	private var _mouseDown:Bool = false;
-	
+	var _mouseDown:Bool = false;
+
 	/**
 	 * Create a new FlxSystemButton
-	 * 
+	 *
 	 * @param	Icon		The icon to use for the button.
 	 * @param	UpHandler	The function to be called when the button is pressed.
 	 * @param	ToggleMode	Whether this is a toggle button or not.
@@ -51,17 +51,17 @@ class FlxSystemButton extends Sprite implements IFlxDestroyable
 	public function new(Icon:BitmapData, ?UpHandler:Void->Void, ToggleMode:Bool = false)
 	{
 		super();
-		
+
 		if (Icon != null)
 			changeIcon(Icon);
-		
+
 		#if flash
 		tabEnabled = false;
 		#end
-		
+
 		upHandler = UpHandler;
 		toggleMode = ToggleMode;
-		
+
 		addEventListener(MouseEvent.MOUSE_UP, onMouseUp);
 		addEventListener(MouseEvent.MOUSE_DOWN, onMouseDown);
 		addEventListener(MouseEvent.MOUSE_OUT, onMouseOut);
@@ -70,19 +70,19 @@ class FlxSystemButton extends Sprite implements IFlxDestroyable
 
 	/**
 	 * Change the Icon of the button
-	 * 
+	 *
 	 * @param	Icon	The new icon to use for the button.
 	 */
 	public function changeIcon(Icon:BitmapData):Void
 	{
 		if (_icon != null)
 			removeChild(_icon);
-		
+
 		DebuggerUtil.fixSize(Icon);
 		_icon = new Bitmap(Icon);
 		addChild(_icon);
 	}
-	
+
 	public function destroy():Void
 	{
 		removeEventListener(MouseEvent.MOUSE_UP, onMouseUp);
@@ -93,36 +93,36 @@ class FlxSystemButton extends Sprite implements IFlxDestroyable
 		upHandler = null;
 	}
 
-	private function onMouseUp(_):Void
+	function onMouseUp(_):Void
 	{
 		if (enabled && _mouseDown)
 		{
 			toggled = !toggled;
 			_mouseDown = false;
-			
+
 			if (upHandler != null)
 				upHandler();
 		}
 	}
-	
-	private function onMouseDown(_):Void
+
+	function onMouseDown(_):Void
 	{
 		_mouseDown = true;
 	}
 
-	private inline function onMouseOver(_):Void
+	inline function onMouseOver(_):Void
 	{
 		if (enabled)
 			alpha -= 0.2;
 	}
 
-	private inline function onMouseOut(_):Void
+	inline function onMouseOut(_):Void
 	{
 		if (enabled)
 			alpha += 0.2;
 	}
-	
-	private function set_toggled(Value:Bool):Bool
+
+	function set_toggled(Value:Bool):Bool
 	{
 		if (toggleMode)
 			alpha = Value ? 0.3 : 1;

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -28,186 +28,186 @@ class FlxBitmapText extends FlxSprite
 	 * Font for text rendering.
 	 */
 	public var font(default, set):FlxBitmapFont;
-	
+
 	/**
 	 * Text to display.
 	 */
 	public var text(default, set):String = "";
-	
+
 	/**
 	 * Helper object to avoid many ColorTransform allocations
 	 */
-	private var _colorParams:ColorTransform = new ColorTransform();
-	
+	var _colorParams:ColorTransform = new ColorTransform();
+
 	/**
 	 * Helper array which contains actual strings for rendering.
 	 */
 	// TODO: switch it to Array<Array<Int>> (for optimizations - i.e. less Utf8 usage)
-	private var _lines:Array<String> = [];
+	var _lines:Array<String> = [];
 	/**
 	 * Helper array which contains width of each displayed lines.
 	 */
-	private var _linesWidth:Array<Int> = [];
-	
+	var _linesWidth:Array<Int> = [];
+
 	/**
 	 * Specifies how the text field should align text.
 	 * JUSTIFY alignment isn't supported.
 	 * Note: 'autoSize' must be set to false or alignment won't show any visual differences.
 	 */
 	public var alignment(default, set):FlxTextAlign = FlxTextAlign.LEFT;
-	
+
 	/**
 	 * The distance to add between lines.
 	 */
 	public var lineSpacing(default, set):Int = 0;
-	
+
 	/**
 	 * The distance to add between letters.
 	 */
 	public var letterSpacing(default, set):Int = 0;
-	
+
 	/**
 	 * Whether to convert text to upper case or not.
 	 */
 	public var autoUpperCase(default, set):Bool = false;
-	
+
 	/**
 	 * A Boolean value that indicates whether the text field has word wrap.
 	 */
 	public var wordWrap(default, set):Bool = true;
-	
+
 	/**
 	 * Whether word wrapping algorithm should wrap lines by words or by single character.
 	 * Default value is true.
 	 */
 	public var wrapByWord(default, set):Bool = true;
-	
+
 	/**
 	 * Whether this text field have fixed width or not.
 	 * Default value if true.
 	 */
 	public var autoSize(default, set):Bool = true;
-	
+
 	/**
 	 * Number of pixels between text and text field border
 	 */
 	public var padding(default, set):Int = 0;
-	
+
 	/**
 	 * Width of the text in this text field.
 	 */
 	public var textWidth(get, null):Int;
-	
+
 	/**
 	 * Height of the text in this text field.
 	 */
 	public var textHeight(get, null):Int;
-	
+
 	/**
 	 * Height of the single line of text (without lineSpacing).
 	 */
 	public var lineHeight(get, null):Int;
-	
+
 	/**
 	 * Number of space characters in one tab.
 	 */
 	public var numSpacesInTab(default, set):Int = 4;
-	
+
 	/**
 	 * The color of the text in 0xAARRGGBB format.
 	 * Result color of text will be multiplication of textColor and color.
 	 */
 	public var textColor(default, set):FlxColor = FlxColor.WHITE;
-	
+
 	/**
 	 * Whether to use textColor while rendering or not.
 	 */
 	public var useTextColor(default, set):Bool = false;
-	
+
 	/**
 	 * Use a border style
-	 */	
+	 */
 	public var borderStyle(default, set):FlxTextBorderStyle = NONE;
-	
+
 	/**
 	 * The color of the border in 0xAARRGGBB format
-	 */	
+	 */
 	public var borderColor(default, set):FlxColor = FlxColor.BLACK;
-	
+
 	/**
 	 * The size of the border, in pixels.
 	 */
 	public var borderSize(default, set):Float = 1;
-	
+
 	/**
 	 * How many iterations do use when drawing the border. 0: only 1 iteration, 1: one iteration for every pixel in borderSize
-	 * A value of 1 will have the best quality for large border sizes, but might reduce performance when changing text. 
+	 * A value of 1 will have the best quality for large border sizes, but might reduce performance when changing text.
 	 * NOTE: If the borderSize is 1, borderQuality of 0 or 1 will have the exact same effect (and performance).
 	 */
 	public var borderQuality(default, set):Float = 0;
-	
+
 	/**
-	 * Offset that is applied to the shadow border style, if active. 
+	 * Offset that is applied to the shadow border style, if active.
 	 * x and y are multiplied by borderSize. Default is (1, 1), or lower-right corner.
 	 */
 	public var shadowOffset(default, null):FlxPoint;
-	
+
 	/**
 	 * Specifies whether the text should have background
 	 */
 	public var background(default, set):Bool = false;
-	
+
 	/**
 	 * Specifies the color of background
 	 */
 	public var backgroundColor(default, set):FlxColor = FlxColor.TRANSPARENT;
-	
+
 	/**
 	 * Specifies whether the text field will break into multiple lines or not on overflow.
 	 */
 	public var multiLine(default, set):Bool = true;
-	
+
 	/**
 	 * Reflects how many lines have this text field.
 	 */
 	public var numLines(get, null):Int = 0;
-	
+
 	/**
 	 * The width of the TextField object used for bitmap generation for this FlxText object.
 	 * Use it when you want to change the visible width of text. Enables autoSize if <= 0.
 	 */
 	public var fieldWidth(get, set):Int;
-	
-	private var _fieldWidth:Int;
-	
-	private var pendingTextChange:Bool = true;
-	private var pendingTextBitmapChange:Bool = true;
-	private var pendingPixelsChange:Bool = true;
-	
-	private var textData:Array<Float>;
-	private var textDrawData:Array<Float>;
-	private var borderDrawData:Array<Float>;
-	
+
+	var _fieldWidth:Int;
+
+	var pendingTextChange:Bool = true;
+	var pendingTextBitmapChange:Bool = true;
+	var pendingPixelsChange:Bool = true;
+
+	var textData:Array<Float>;
+	var textDrawData:Array<Float>;
+	var borderDrawData:Array<Float>;
+
 	/**
 	 * Helper bitmap buffer for text pixels but without any color transformations
 	 */
-	private var textBitmap:BitmapData;
-	
+	var textBitmap:BitmapData;
+
 	/**
 	 * Constructs a new text field component.
 	 * @param 	font	Optional parameter for component's font prop
 	 */
-	public function new(?font:FlxBitmapFont) 
+	public function new(?font:FlxBitmapFont)
 	{
 		super();
-		
+
 		width = fieldWidth = 2;
 		alpha = 1;
-		
+
 		this.font = (font == null) ? FlxBitmapFont.getDefaultFont() : font;
-		
+
 		shadowOffset = FlxPoint.get(1, 1);
-		
+
 		if (FlxG.renderBlit)
 		{
 			pixels = new BitmapData(1, 1, true, FlxColor.TRANSPARENT);
@@ -215,27 +215,27 @@ class FlxBitmapText extends FlxSprite
 		else
 		{
 			textData = [];
-			
+
 			textDrawData = [];
 			borderDrawData = [];
 		}
 	}
-	
+
 	/**
 	 * Clears all resources used.
 	 */
-	override public function destroy():Void 
+	override public function destroy():Void
 	{
 		font = null;
 		text = null;
 		_lines = null;
 		_linesWidth = null;
-		
+
 		shadowOffset = FlxDestroyUtil.put(shadowOffset);
 		textBitmap = FlxDestroyUtil.dispose(textBitmap);
-		
+
 		_colorParams = null;
-		
+
 		if (FlxG.renderTile)
 		{
 			textData = null;
@@ -244,11 +244,11 @@ class FlxBitmapText extends FlxSprite
 		}
 		super.destroy();
 	}
-	
+
 	/**
 	 * Forces graphic regeneration for this text field.
 	 */
-	override public function drawFrame(Force:Bool = false):Void 
+	override public function drawFrame(Force:Bool = false):Void
 	{
 		if (FlxG.renderTile)
 		{
@@ -261,33 +261,33 @@ class FlxBitmapText extends FlxSprite
 			super.drawFrame(Force);
 		}
 	}
-	
-	private inline function checkPendingChanges(useTiles:Bool = false):Void
+
+	inline function checkPendingChanges(useTiles:Bool = false):Void
 	{
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
-		
+
 		if (pendingTextChange)
 		{
 			updateText();
 			pendingTextBitmapChange = true;
 		}
-		
+
 		if (pendingTextBitmapChange)
 		{
 			updateTextBitmap(useTiles);
 			pendingPixelsChange = true;
 		}
-		
+
 		if (pendingPixelsChange)
 		{
 			updatePixels(useTiles);
 		}
 	}
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -297,26 +297,26 @@ class FlxBitmapText extends FlxSprite
 		else
 		{
 			checkPendingChanges(true);
-			
+
 			var textLength:Int = Std.int(textDrawData.length / 3);
 			var borderLength:Int = Std.int(borderDrawData.length / 3);
-			
+
 			var dataPos:Int;
-			
+
 			var cr:Float = color.redFloat;
 			var cg:Float = color.greenFloat;
 			var cb:Float = color.blueFloat;
-			
+
 			var borderRed:Float = borderColor.redFloat * cr;
 			var borderGreen:Float = borderColor.greenFloat * cg;
 			var borderBlue:Float = borderColor.blueFloat * cb;
 			var bAlpha:Float = borderColor.alphaFloat * alpha;
-			
+
 			var textRed:Float = cr;
 			var textGreen:Float = cg;
 			var textBlue:Float = cb;
 			var tAlpha:Float = alpha;
-			
+
 			if (useTextColor)
 			{
 				textRed *= textColor.redFloat;
@@ -324,12 +324,12 @@ class FlxBitmapText extends FlxSprite
 				textBlue *= textColor.blueFloat;
 				tAlpha *= textColor.alpha;
 			}
-			
+
 			var bgRed:Float = cr;
 			var bgGreen:Float = cg;
 			var bgBlue:Float = cb;
 			var bgAlpha:Float = alpha;
-			
+
 			if (background)
 			{
 				bgRed *= backgroundColor.redFloat;
@@ -337,17 +337,17 @@ class FlxBitmapText extends FlxSprite
 				bgBlue *= backgroundColor.blueFloat;
 				bgAlpha *= backgroundColor.alphaFloat;
 			}
-			
+
 			var drawItem;
 			var currFrame:FlxFrame = null;
 			var currTileX:Float = 0;
 			var currTileY:Float = 0;
 			var sx:Float = scale.x * _facingHorizontalMult;
 			var sy:Float = scale.y * _facingVerticalMult;
-			
+
 			var ox:Float = origin.x;
 			var oy:Float = origin.y;
-			
+
 			if (_facingHorizontalMult != 1)
 			{
 				ox = frameWidth - ox;
@@ -356,23 +356,23 @@ class FlxBitmapText extends FlxSprite
 			{
 				oy = frameHeight - oy;
 			}
-			
+
 			for (camera in cameras)
 			{
 				if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				{
 					continue;
 				}
-				
+
 				getScreenPosition(_point, camera).subtractPoint(offset);
-				
+
 				if (isPixelPerfectRender(camera))
 				{
 					_point.floor();
 				}
-				
+
 				updateTrig();
-				
+
 				if (background)
 				{
 					// backround tile transformations
@@ -381,30 +381,30 @@ class FlxBitmapText extends FlxSprite
 					_matrix.scale(0.1 * frameWidth, 0.1 * frameHeight);
 					_matrix.translate(-ox, -oy);
 					_matrix.scale(sx, sy);
-					
+
 					if (angle != 0)
 					{
 						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
-					
+
 					_matrix.translate(_point.x + ox, _point.y + oy);
 					_colorParams.setMultipliers(bgRed, bgGreen, bgBlue, bgAlpha);
 					camera.drawPixels(currFrame, null, _matrix, _colorParams, blend, antialiasing);
 				}
-				
+
 				var hasColorOffsets:Bool = (colorTransform != null && colorTransform.hasRGBAOffsets());
-				
+
 				drawItem = camera.startQuadBatch(font.parent, true, hasColorOffsets, blend, antialiasing, shader);
-				
+
 				for (j in 0...borderLength)
 				{
 					dataPos = j * 3;
-					
+
 					currFrame = font.getCharFrame(Std.int(borderDrawData[dataPos]));
-					
+
 					currTileX = borderDrawData[dataPos + 1];
 					currTileY = borderDrawData[dataPos + 2];
-					
+
 					currFrame.prepareMatrix(_matrix);
 					_matrix.translate(currTileX - ox, currTileY - oy);
 					_matrix.scale(sx, sy);
@@ -412,21 +412,21 @@ class FlxBitmapText extends FlxSprite
 					{
 						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
-					
+
 					_matrix.translate(_point.x + ox, _point.y + oy);
 					_colorParams.setMultipliers(borderRed, borderGreen, borderBlue, bAlpha);
 					drawItem.addQuad(currFrame, _matrix, _colorParams);
 				}
-				
+
 				for (j in 0...textLength)
 				{
 					dataPos = j * 3;
-					
+
 					currFrame = font.getCharFrame(Std.int(textDrawData[dataPos]));
-					
+
 					currTileX = textDrawData[dataPos + 1];
 					currTileY = textDrawData[dataPos + 2];
-					
+
 					currFrame.prepareMatrix(_matrix);
 					_matrix.translate(currTileX - ox, currTileY - oy);
 					_matrix.scale(sx, sy);
@@ -434,18 +434,18 @@ class FlxBitmapText extends FlxSprite
 					{
 						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
-					
+
 					_matrix.translate(_point.x + ox, _point.y + oy);
-					
+
 					_colorParams.setMultipliers(textRed, textGreen, textBlue, tAlpha);
 					drawItem.addQuad(currFrame, _matrix, _colorParams);
 				}
-				
+
 				#if FLX_DEBUG
 				FlxBasic.visibleCount++;
 				#end
 			}
-			
+
 			#if FLX_DEBUG
 			if (FlxG.debugger.drawDebug)
 			{
@@ -454,8 +454,8 @@ class FlxBitmapText extends FlxSprite
 			#end
 		}
 	}
-	
-	override private function set_color(Color:FlxColor):FlxColor
+
+	override function set_color(Color:FlxColor):FlxColor
 	{
 		super.set_color(Color);
 		if (FlxG.renderBlit)
@@ -464,8 +464,8 @@ class FlxBitmapText extends FlxSprite
 		}
 		return color;
 	}
-	
-	override private function set_alpha(value:Float):Float
+
+	override function set_alpha(value:Float):Float
 	{
 		super.set_alpha(value);
 		if (FlxG.renderBlit)
@@ -474,8 +474,8 @@ class FlxBitmapText extends FlxSprite
 		}
 		return value;
 	}
-	
-	private function set_textColor(value:FlxColor):FlxColor 
+
+	function set_textColor(value:FlxColor):FlxColor
 	{
 		if (textColor != value)
 		{
@@ -485,11 +485,11 @@ class FlxBitmapText extends FlxSprite
 				pendingPixelsChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function set_useTextColor(value:Bool):Bool 
+
+	function set_useTextColor(value:Bool):Bool
 	{
 		if (useTextColor != value)
 		{
@@ -499,11 +499,11 @@ class FlxBitmapText extends FlxSprite
 				pendingPixelsChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	override private function calcFrame(RunOnCpp:Bool = false):Void 
+
+	override function calcFrame(RunOnCpp:Bool = false):Void
 	{
 		if (FlxG.renderTile)
 		{
@@ -514,24 +514,24 @@ class FlxBitmapText extends FlxSprite
 			super.calcFrame(RunOnCpp);
 		}
 	}
-	
-	private function set_text(value:String):String 
+
+	function set_text(value:String):String
 	{
 		if (value != text)
 		{
 			text = value;
 			pendingTextChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function updateText():Void 
+
+	function updateText():Void
 	{
 		var tmp:String = (autoUpperCase) ? text.toUpperCase() : text;
-		
+
 		_lines = tmp.split("\n");
-		
+
 		if (!autoSize)
 		{
 			if (wordWrap)
@@ -543,30 +543,30 @@ class FlxBitmapText extends FlxSprite
 				cutLines();
 			}
 		}
-		
+
 		if (!multiLine)
 		{
 			_lines = [_lines[0]];
 		}
-		
+
 		var numLines:Int = _lines.length;
 		for (i in 0...numLines)
 		{
 			_lines[i] = StringTools.rtrim(_lines[i]);
 		}
-		
+
 		pendingTextChange = false;
 		pendingTextBitmapChange = true;
 	}
-	
+
 	/**
 	 * Calculates the size of text field.
 	 */
-	private function computeTextSize():Void 
+	function computeTextSize():Void
 	{
 		var txtWidth:Int = textWidth;
 		var txtHeight:Int = textHeight + 2 * padding;
-		
+
 		if (autoSize)
 		{
 			txtWidth += 2 * padding;
@@ -575,14 +575,14 @@ class FlxBitmapText extends FlxSprite
 		{
 			txtWidth = fieldWidth;
 		}
-		
+
 		frameWidth = (txtWidth == 0) ? 1 : txtWidth;
 		frameHeight = (txtHeight == 0) ? 1 : txtHeight;
 	}
-	
+
 	/**
 	 * Calculates width of the line with provided index
-	 * 
+	 *
 	 * @param	lineIndex	index of the line in _lines array
 	 * @return	The width of the line
 	 */
@@ -592,13 +592,13 @@ class FlxBitmapText extends FlxSprite
 		{
 			return 0;
 		}
-		
+
 		return getStringWidth(_lines[lineIndex]);
 	}
-	
+
 	/**
 	 * Calculates width of provided string (for current font).
-	 * 
+	 *
 	 * @param	str	String to calculate width for
 	 * @return	The width of result bitmap text.
 	 */
@@ -606,19 +606,19 @@ class FlxBitmapText extends FlxSprite
 	{
 		var spaceWidth:Int = font.spaceWidth;
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		
+
 		var lineLength:Int = Utf8.length(str);	// lenght of the current line
 		var lineWidth:Float = font.minOffsetX;
-		
+
 		var charCode:Int;						// current character in word
 		var charWidth:Float;					// the width of current character
 		var charFrame:FlxFrame;
-		
+
 		for (c in 0...lineLength)
 		{
 			charCode = Utf8.charCodeAt(str, c);
 			charWidth = 0;
-			
+
 			if (charCode == FlxBitmapFont.SPACE_CODE)
 			{
 				charWidth = spaceWidth;
@@ -630,57 +630,57 @@ class FlxBitmapText extends FlxSprite
 			else if (font.charExists(charCode))
 			{
 				charWidth = font.getCharAdvance(charCode);
-				
+
 				if (c == (lineLength - 1))
 				{
 					charFrame = font.getCharFrame(charCode);
 					charWidth = Std.int(charFrame.sourceSize.x);
 				}
 			}
-			
+
 			lineWidth += (charWidth + letterSpacing);
 		}
-		
+
 		if (lineLength > 0)
 		{
 			lineWidth -= letterSpacing;
 		}
-		
+
 		return Std.int(lineWidth);
 	}
-	
+
 	/**
 	 * Just cuts the lines which are too long to fit in the field.
 	 */
-	private function cutLines():Void 
+	function cutLines():Void
 	{
 		var newLines:Array<String> = [];
-		
+
 		var lineLength:Int;			// lenght of the current line
-		
+
 		var c:Int;					// char index
 		var charCode:Int;			// code for the current character in word
 		var charWidth:Float;		// the width of current character
-		
+
 		var subLine:Utf8;			// current subline to assemble
 		var subLineWidth:Float;		// the width of current subline
-		
+
 		var spaceWidth:Int = font.spaceWidth;
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		
+
 		var startX:Int = font.minOffsetX;
-		
+
 		for (line in _lines)
 		{
 			lineLength = Utf8.length(line);
 			subLine = new Utf8();
 			subLineWidth = startX;
-			
+
 			c = 0;
 			while (c < lineLength)
 			{
 				charCode = Utf8.charCodeAt(line, c);
-				
+
 				if (charCode == FlxBitmapFont.SPACE_CODE)
 				{
 					charWidth = spaceWidth;
@@ -694,7 +694,7 @@ class FlxBitmapText extends FlxSprite
 					charWidth = font.getCharAdvance(charCode);
 				}
 				charWidth += letterSpacing;
-				
+
 				if (subLineWidth + charWidth > _fieldWidth - 2 * padding)
 				{
 					subLine.addChar(charCode);
@@ -708,30 +708,30 @@ class FlxBitmapText extends FlxSprite
 					subLine.addChar(charCode);
 					subLineWidth += charWidth;
 				}
-				
+
 				c++;
 			}
 		}
-		
+
 		_lines = newLines;
 	}
-	
+
 	/**
 	 * Automatically wraps text by figuring out how many characters can fit on a
 	 * single line, and splitting the remainder onto a new line.
 	 */
-	private function wrap():Void
+	function wrap():Void
 	{
 		// subdivide lines
 		var newLines:Array<String> = [];
 		var words:Array<String>;			// the array of words in the current line
-		
+
 		for (line in _lines)
 		{
 			words = [];
 			// split this line into words
 			splitLineIntoWords(line, words);
-			
+
 			if (wrapByWord)
 			{
 				wrapLineByWord(words, newLines);
@@ -741,47 +741,47 @@ class FlxBitmapText extends FlxSprite
 				wrapLineByCharacter(words, newLines);
 			}
 		}
-		
+
 		_lines = newLines;
 	}
-	
+
 	/**
 	 * Helper function for splitting line of text into separate words.
-	 * 
+	 *
 	 * @param	line	line to split.
 	 * @param	words	result array to fill with words.
 	 */
-	private function splitLineIntoWords(line:String, words:Array<String>):Void
+	function splitLineIntoWords(line:String, words:Array<String>):Void
 	{
 		var word:String = "";				// current word to process
 		var wordUtf8:Utf8 = new Utf8();
 		var isSpaceWord:Bool = false; 		// whether current word consists of spaces or not
 		var lineLength:Int = Utf8.length(line);	// lenght of the current line
-		
+
 		var hyphenCode:Int = Utf8.charCodeAt('-', 0);
-		
+
 		var c:Int = 0;						// char index on the line
 		var charCode:Int; 					// code for the current character in word
 		var charUtf8:Utf8;
-		
+
 		while (c < lineLength)
 		{
 			charCode = Utf8.charCodeAt(line, c);
 			word = wordUtf8.toString();
-			
+
 			if (charCode == FlxBitmapFont.SPACE_CODE || charCode == FlxBitmapFont.TAB_CODE)
 			{
 				if (!isSpaceWord)
 				{
 					isSpaceWord = true;
-					
+
 					if (word != "")
 					{
 						words.push(word);
 						wordUtf8 = new Utf8();
 					}
 				}
-				
+
 				wordUtf8.addChar(charCode);
 			}
 			else if (charCode == hyphenCode)
@@ -798,7 +798,7 @@ class FlxBitmapText extends FlxSprite
 					charUtf8.addChar(charCode);
 					words.push(word + charUtf8.toString());
 				}
-				
+
 				wordUtf8 = new Utf8();
 			}
 			else
@@ -809,65 +809,65 @@ class FlxBitmapText extends FlxSprite
 					words.push(word);
 					wordUtf8 = new Utf8();
 				}
-				
+
 				wordUtf8.addChar(charCode);
 			}
-			
+
 			c++;
 		}
-		
+
 		word = wordUtf8.toString();
 		if (word != "") words.push(word);
 	}
-	
+
 	/**
 	 * Wraps provided line by words.
-	 * 
+	 *
 	 * @param	words		The array of words in the line to process.
 	 * @param	newLines	Array to fill with result lines.
 	 */
-	private function wrapLineByWord(words:Array<String>, newLines:Array<String>):Void
+	function wrapLineByWord(words:Array<String>, newLines:Array<String>):Void
 	{
 		var numWords:Int = words.length;	// number of words in the current line
 		var w:Int;							// word index in the current line
 		var word:String;					// current word to process
 		var wordWidth:Float;				// total width of current word
 		var wordLength:Int;					// number of letters in current word
-		
+
 		var isSpaceWord:Bool = false; 		// whether current word consists of spaces or not
-		
+
 		var charCode:Int;
 		var charWidth:Float = 0;			// the width of current character
-		
+
 		var subLines:Array<String> = [];	// helper array for subdividing lines
-		
+
 		var subLine:String;					// current subline to assemble
 		var subLineWidth:Float;				// the width of current subline
-		
+
 		var spaceWidth:Int = font.spaceWidth;
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		
+
 		var startX:Int = font.minOffsetX;
-		
+
 		if (numWords > 0)
 		{
 			w = 0;
 			subLineWidth = startX;
 			subLine = "";
-			
+
 			while (w < numWords)
 			{
 				wordWidth = 0;
 				word = words[w];
 				wordLength = Utf8.length(word);
-				
+
 				charCode = Utf8.charCodeAt(word, 0);
 				isSpaceWord = (charCode == FlxBitmapFont.SPACE_CODE || charCode == FlxBitmapFont.TAB_CODE);
-				
+
 				for (c in 0...wordLength)
 				{
 					charCode = Utf8.charCodeAt(word, c);
-					
+
 					if (charCode == FlxBitmapFont.SPACE_CODE)
 					{
 						charWidth = spaceWidth;
@@ -880,12 +880,12 @@ class FlxBitmapText extends FlxSprite
 					{
 						charWidth = font.getCharAdvance(charCode);
 					}
-					
+
 					wordWidth += charWidth;
 				}
-				
+
 				wordWidth += (wordLength - 1) * letterSpacing;
-				
+
 				if (subLineWidth + wordWidth > _fieldWidth - 2 * padding)
 				{
 					if (isSpaceWord)
@@ -911,72 +911,72 @@ class FlxBitmapText extends FlxSprite
 					subLine += word;
 					subLineWidth += wordWidth + letterSpacing;
 				}
-				
+
 				w++;
 			}
-			
+
 			if (subLine != "")
 			{
 				subLines.push(subLine);
 			}
 		}
-		
+
 		for (subline in subLines)
 		{
 			newLines.push(subline);
 		}
 	}
-	
+
 	/**
 	 * Wraps provided line by characters (as in standart flash text fields).
-	 * 
+	 *
 	 * @param	words		The array of words in the line to process.
 	 * @param	newLines	Array to fill with result lines.
 	 */
-	private function wrapLineByCharacter(words:Array<String>, newLines:Array<String>):Void
+	function wrapLineByCharacter(words:Array<String>, newLines:Array<String>):Void
 	{
 		var numWords:Int = words.length;	// number of words in the current line
 		var w:Int;							// word index in the current line
 		var word:String;					// current word to process
 		var wordLength:Int;					// number of letters in current word
-		
+
 		var isSpaceWord:Bool = false; 		// whether current word consists of spaces or not
-		
+
 		var charCode:Int;
 		var c:Int;							// char index
 		var charWidth:Float = 0;			// the width of current character
-		
+
 		var subLines:Array<String> = [];	// helper array for subdividing lines
-		
+
 		var subLine:String;					// current subline to assemble
 		var subLineUtf8:Utf8;
 		var subLineWidth:Float;				// the width of current subline
-		
+
 		var spaceWidth:Int = font.spaceWidth;
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		
+
 		var startX:Int = font.minOffsetX;
-		
+
 		if (numWords > 0)
 		{
 			w = 0;
 			subLineWidth = startX;
 			subLineUtf8 = new Utf8();
-			
+
 			while (w < numWords)
 			{
 				word = words[w];
 				wordLength = Utf8.length(word);
-				
+
 				charCode = Utf8.charCodeAt(word, 0);
 				isSpaceWord = (charCode == FlxBitmapFont.SPACE_CODE || charCode == FlxBitmapFont.TAB_CODE);
-				
+
 				c = 0;
-				
+
 				while (c < wordLength)
 				{
 					charCode = Utf8.charCodeAt(word, c);
-					
+
 					if (charCode == FlxBitmapFont.SPACE_CODE)
 					{
 						charWidth = spaceWidth;
@@ -989,11 +989,11 @@ class FlxBitmapText extends FlxSprite
 					{
 						charWidth = font.getCharAdvance(charCode);
 					}
-					
+
 					if (subLineWidth + charWidth > _fieldWidth - 2 * padding)
 					{
 						subLine = subLineUtf8.toString();
-						
+
 						if (isSpaceWord) // new line ends with space / tab char, so we push it to sublines array, skip all the rest spaces and start another line
 						{
 							subLines.push(subLine);
@@ -1020,43 +1020,43 @@ class FlxBitmapText extends FlxSprite
 						subLineUtf8.addChar(charCode);
 						subLineWidth += (charWidth + letterSpacing);
 					}
-					
+
 					c++;
 				}
-				
+
 				w++;
 			}
-			
+
 			subLine = subLineUtf8.toString();
-			
+
 			if (subLine != "")
 			{
 				subLines.push(subLine);
 			}
 		}
-		
+
 		for (subline in subLines)
 		{
 			newLines.push(subline);
 		}
 	}
-	
+
 	/**
 	 * Internal method for updating helper data for text rendering
 	 */
-	private function updateTextBitmap(useTiles:Bool = false):Void 
+	function updateTextBitmap(useTiles:Bool = false):Void
 	{
 		computeTextSize();
-		
+
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
-		
+
 		if (!useTiles)
 		{
 			textBitmap = FlxDestroyUtil.disposeIfNotEqual(textBitmap, frameWidth, frameHeight);
-			
+
 			if (textBitmap == null)
 			{
 				textBitmap = new BitmapData(frameWidth, frameHeight, true, FlxColor.TRANSPARENT);
@@ -1065,36 +1065,36 @@ class FlxBitmapText extends FlxSprite
 			{
 				textBitmap.fillRect(textBitmap.rect, FlxColor.TRANSPARENT);
 			}
-			
+
 			textBitmap.lock();
 		}
 		else if (FlxG.renderTile)
 		{
 			textData.splice(0, textData.length);
 		}
-		
+
 		_fieldWidth = frameWidth;
-		
+
 		var numLines:Int = _lines.length;
 		var line:String;
 		var lineWidth:Int;
-		
+
 		var ox:Int, oy:Int;
-		
+
 		for (i in 0...numLines)
 		{
 			line = _lines[i];
 			lineWidth = _linesWidth[i];
-			
+
 			// LEFT
 			ox = font.minOffsetX;
 			oy = i * (font.lineHeight + lineSpacing) + padding;
-			
-			if (alignment == FlxTextAlign.CENTER) 
+
+			if (alignment == FlxTextAlign.CENTER)
 			{
 				ox += Std.int((frameWidth - lineWidth) / 2);
 			}
-			else if (alignment == FlxTextAlign.RIGHT) 
+			else if (alignment == FlxTextAlign.RIGHT)
 			{
 				ox += (frameWidth - lineWidth) - padding;
 			}
@@ -1102,25 +1102,25 @@ class FlxBitmapText extends FlxSprite
 			{
 				ox += padding;
 			}
-			
+
 			drawLine(i, ox, oy, useTiles);
 		}
-		
+
 		if (!useTiles)
 		{
 			textBitmap.unlock();
 		}
-		
+
 		pendingTextBitmapChange = false;
 	}
-	
-	private function drawLine(lineIndex:Int, posX:Int, posY:Int, useTiles:Bool = false):Void
+
+	function drawLine(lineIndex:Int, posX:Int, posY:Int, useTiles:Bool = false):Void
 	{
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
-		
+
 		if (useTiles)
 		{
 			tileLine(lineIndex, posX, posY);
@@ -1130,27 +1130,27 @@ class FlxBitmapText extends FlxSprite
 			blitLine(lineIndex, posX, posY);
 		}
 	}
-	
-	private function blitLine(lineIndex:Int, startX:Int, startY:Int):Void
+
+	function blitLine(lineIndex:Int, startX:Int, startY:Int):Void
 	{
 		var charFrame:FlxFrame;
 		var charCode:Int;
 		var curX:Float = startX;
 		var curY:Int = startY;
-		
+
 		var line:String = _lines[lineIndex];
 		var spaceWidth:Int = font.spaceWidth;
 		var lineLength:Int = Utf8.length(line);
 		var textWidth:Int = this.textWidth;
-		
+
 		if (alignment == FlxTextAlign.JUSTIFY)
 		{
 			var numSpaces:Int = 0;
-			
+
 			for (i in 0...lineLength)
 			{
 				charCode = Utf8.charCodeAt(line, i);
-				
+
 				if (charCode == FlxBitmapFont.SPACE_CODE)
 				{
 					numSpaces++;
@@ -1160,18 +1160,18 @@ class FlxBitmapText extends FlxSprite
 					numSpaces += numSpacesInTab;
 				}
 			}
-			
+
 			var lineWidth:Int = getStringWidth(line);
 			var totalSpacesWidth:Int = numSpaces * font.spaceWidth;
 			spaceWidth = Std.int((textWidth - lineWidth + totalSpacesWidth) / numSpaces);
 		}
-		
+
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		
+
 		for (i in 0...lineLength)
 		{
 			charCode = Utf8.charCodeAt(line, i);
-			
+
 			if (charCode == FlxBitmapFont.SPACE_CODE)
 			{
 				curX += spaceWidth;
@@ -1192,35 +1192,35 @@ class FlxBitmapText extends FlxSprite
 					curX += font.getCharAdvance(charCode);
 				}
 			}
-			
+
 			curX += letterSpacing;
 		}
 	}
-	
-	private function tileLine(lineIndex:Int, startX:Int, startY:Int):Void
+
+	function tileLine(lineIndex:Int, startX:Int, startY:Int):Void
 	{
 		if (!FlxG.renderTile) return;
-		
+
 		var charFrame:FlxFrame;
 		var pos:Int = textData.length;
-		
+
 		var charCode:Int;
 		var curX:Float = startX;
 		var curY:Int = startY;
-		
+
 		var line:String = _lines[lineIndex];
 		var spaceWidth:Int = font.spaceWidth;
 		var lineLength:Int = Utf8.length(line);
 		var textWidth:Int = this.textWidth;
-		
+
 		if (alignment == FlxTextAlign.JUSTIFY)
 		{
 			var numSpaces:Int = 0;
-			
+
 			for (i in 0...lineLength)
 			{
 				charCode = Utf8.charCodeAt(line, i);
-				
+
 				if (charCode == FlxBitmapFont.SPACE_CODE)
 				{
 					numSpaces++;
@@ -1230,18 +1230,18 @@ class FlxBitmapText extends FlxSprite
 					numSpaces += numSpacesInTab;
 				}
 			}
-			
+
 			var lineWidth:Int = getStringWidth(line);
 			var totalSpacesWidth:Int = numSpaces * font.spaceWidth;
 			spaceWidth = Std.int((textWidth - lineWidth + totalSpacesWidth) / numSpaces);
 		}
-		
+
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		
+
 		for (i in 0...lineLength)
 		{
 			charCode = Utf8.charCodeAt(line, i);
-			
+
 			if (charCode == FlxBitmapFont.SPACE_CODE)
 			{
 				curX += spaceWidth;
@@ -1261,16 +1261,16 @@ class FlxBitmapText extends FlxSprite
 					curX += font.getCharAdvance(charCode);
 				}
 			}
-			
+
 			curX += letterSpacing;
 		}
 	}
-	
-	private function updatePixels(useTiles:Bool = false):Void
+
+	function updatePixels(useTiles:Bool = false):Void
 	{
 		var colorForFill:Int = background ? backgroundColor : FlxColor.TRANSPARENT;
 		var bitmap:BitmapData = null;
-		
+
 		if (FlxG.renderBlit)
 		{
 			if (pixels == null || (frameWidth != pixels.width || frameHeight != pixels.height))
@@ -1281,7 +1281,7 @@ class FlxBitmapText extends FlxSprite
 			{
 				pixels.fillRect(graphic.bitmap.rect, colorForFill);
 			}
-			
+
 			bitmap = pixels;
 		}
 		else
@@ -1297,7 +1297,7 @@ class FlxBitmapText extends FlxSprite
 				{
 					framePixels.fillRect(framePixels.rect, colorForFill);
 				}
-				
+
 				bitmap = framePixels;
 			}
 			else
@@ -1305,43 +1305,43 @@ class FlxBitmapText extends FlxSprite
 				textDrawData.splice(0, textDrawData.length);
 				borderDrawData.splice(0, borderDrawData.length);
 			}
-			
+
 			width = frameWidth;
 			height = frameHeight;
-			
+
 			origin.x = frameWidth * 0.5;
 			origin.y = frameHeight * 0.5;
 		}
-		
+
 		if (!useTiles)
 		{
 			bitmap.lock();
 		}
-		
+
 		var isFront:Bool = false;
-		
+
 		var iterations:Int = Std.int(borderSize * borderQuality);
-		iterations = (iterations <= 0) ? 1 : iterations; 
-		
+		iterations = (iterations <= 0) ? 1 : iterations;
+
 		var delta:Int = Std.int(borderSize / iterations);
-		
+
 		var iterationsX:Int = 1;
 		var iterationsY:Int = 1;
 		var deltaX:Int = 1;
 		var deltaY:Int = 1;
-		
+
 		if (borderStyle == FlxTextBorderStyle.SHADOW)
 		{
 			iterationsX = Math.round(Math.abs(shadowOffset.x) * borderQuality);
 			iterationsX = (iterationsX <= 0) ? 1 : iterationsX;
-			
+
 			iterationsY = Math.round(Math.abs(shadowOffset.y) * borderQuality);
 			iterationsY = (iterationsY <= 0) ? 1 : iterationsY;
-			
+
 			deltaX = Math.round(shadowOffset.x / iterationsX);
 			deltaY = Math.round(shadowOffset.y / iterationsY);
 		}
-		
+
 		// render border
 		switch (borderStyle)
 		{
@@ -1393,33 +1393,33 @@ class FlxBitmapText extends FlxSprite
 					drawText( -itd, itd, isFront, bitmap, useTiles);
 					//lower-right
 					drawText(itd, itd, isFront, bitmap, useTiles);
-				}	
+				}
 			case NONE:
 		}
-		
+
 		isFront = true;
 		drawText(0, 0, isFront, bitmap, useTiles);
-		
+
 		if (!useTiles)
 		{
 			bitmap.unlock();
 		}
-		
+
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 		}
-		
+
 		pendingPixelsChange = false;
 	}
-	
-	private function drawText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData, useTiles:Bool = false):Void
+
+	function drawText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData, useTiles:Bool = false):Void
 	{
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
-		
+
 		if (useTiles)
 		{
 			tileText(posX, posY, isFront);
@@ -1429,14 +1429,14 @@ class FlxBitmapText extends FlxSprite
 			blitText(posX, posY, isFront, bitmap);
 		}
 	}
-	
-	private function blitText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData):Void
+
+	function blitText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData):Void
 	{
 		_matrix.identity();
 		_matrix.translate(posX, posY);
-		
+
 		var colorToApply = FlxColor.WHITE;
-		
+
 		if (isFront && useTextColor)
 		{
 			colorToApply = textColor;
@@ -1445,11 +1445,11 @@ class FlxBitmapText extends FlxSprite
 		{
 			colorToApply = borderColor;
 		}
-		
+
 		_colorParams.setMultipliers(
 			colorToApply.redFloat, colorToApply.greenFloat,
 			colorToApply.blueFloat, colorToApply.alphaFloat);
-		
+
 		if (isFront && !useTextColor)
 		{
 			_flashRect.setTo(0, 0, textBitmap.width, textBitmap.height);
@@ -1460,17 +1460,17 @@ class FlxBitmapText extends FlxSprite
 			bitmap.draw(textBitmap, _matrix, _colorParams);
 		}
 	}
-	
-	private function tileText(posX:Int, posY:Int, isFront:Bool = true):Void
+
+	function tileText(posX:Int, posY:Int, isFront:Bool = true):Void
 	{
 		if (!FlxG.renderTile) return;
-		
+
 		var data:Array<Float> = isFront ? textDrawData : borderDrawData;
-		
+
 		var pos:Int = data.length;
 		var textPos:Int;
 		var textLen:Int = Std.int(textData.length / 3);
-		
+
 		for (i in 0...textLen)
 		{
 			textPos = 3 * i;
@@ -1479,16 +1479,16 @@ class FlxBitmapText extends FlxSprite
 			data[pos++] = textData[textPos + 2] + posY;
 		}
 	}
-	
+
 	/**
 	 * Set border's style (shadow, outline, etc), color, and size all in one go!
-	 * 
+	 *
 	 * @param	Style outline style
 	 * @param	Color outline color in flash 0xAARRGGBB format
 	 * @param	Size outline size in pixels
 	 * @param	Quality outline quality - # of iterations to use when drawing. 0:just 1, 1:equal number to BorderSize
 	 */
-	public inline function setBorderStyle(Style:FlxTextBorderStyle, Color:FlxColor = 0, Size:Float = 1, Quality:Float = 1):Void 
+	public inline function setBorderStyle(Style:FlxTextBorderStyle, Color:FlxColor = 0, Size:Float = 1, Quality:Float = 1):Void
 	{
 		borderStyle = Style;
 		borderColor = Color;
@@ -1500,19 +1500,19 @@ class FlxBitmapText extends FlxSprite
 		}
 		pendingTextBitmapChange = true;
 	}
-	
-	private function get_fieldWidth():Int
+
+	function get_fieldWidth():Int
 	{
 		return (autoSize) ? textWidth : _fieldWidth;
 	}
-	
+
 	/**
 	 * Sets the width of the text field. If the text does not fit, it will spread on multiple lines.
 	 */
-	private function set_fieldWidth(value:Int):Int
+	function set_fieldWidth(value:Int):Int
 	{
 		value = (value > 1) ? value : 1;
-		
+
 		if (value != _fieldWidth)
 		{
 			if (value <= 0)
@@ -1520,135 +1520,135 @@ class FlxBitmapText extends FlxSprite
 				autoSize = true;
 				wordWrap = false;
 			}
-			
+
 			pendingTextChange = true;
 		}
-		
+
 		return _fieldWidth = value;
 	}
-	
-	private function set_alignment(value:FlxTextAlign):FlxTextAlign 
+
+	function set_alignment(value:FlxTextAlign):FlxTextAlign
 	{
 		if (alignment != value && alignment != FlxTextAlign.JUSTIFY)
 		{
 			alignment = value;
 			pendingTextBitmapChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function set_multiLine(value:Bool):Bool 
+
+	function set_multiLine(value:Bool):Bool
 	{
 		if (multiLine != value)
 		{
 			multiLine = value;
 			pendingTextChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function set_font(value:FlxBitmapFont):FlxBitmapFont 
+
+	function set_font(value:FlxBitmapFont):FlxBitmapFont
 	{
 		if (font != value)
 		{
 			font = value;
 			pendingTextChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function set_lineSpacing(value:Int):Int
+
+	function set_lineSpacing(value:Int):Int
 	{
 		if (lineSpacing != value)
 		{
 			lineSpacing = value;
 			pendingTextBitmapChange = true;
 		}
-		
+
 		return lineSpacing;
 	}
-	
-	private function set_letterSpacing(value:Int):Int
+
+	function set_letterSpacing(value:Int):Int
 	{
 		if (value != letterSpacing)
 		{
 			letterSpacing = value;
 			pendingTextChange = true;
 		}
-		
+
 		return letterSpacing;
 	}
-	
-	private function set_autoUpperCase(value:Bool):Bool 
+
+	function set_autoUpperCase(value:Bool):Bool
 	{
 		if (autoUpperCase != value)
 		{
 			autoUpperCase = value;
 			pendingTextChange = true;
 		}
-		
+
 		return autoUpperCase;
 	}
-	
-	private function set_wordWrap(value:Bool):Bool 
+
+	function set_wordWrap(value:Bool):Bool
 	{
 		if (wordWrap != value)
 		{
 			wordWrap = value;
 			pendingTextChange = true;
 		}
-		
+
 		return wordWrap;
 	}
-	
-	private function set_wrapByWord(value:Bool):Bool
+
+	function set_wrapByWord(value:Bool):Bool
 	{
 		if (wrapByWord != value)
 		{
 			wrapByWord = value;
 			pendingTextChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function set_autoSize(value:Bool):Bool 
+
+	function set_autoSize(value:Bool):Bool
 	{
 		if (autoSize != value)
 		{
 			autoSize = value;
 			pendingTextChange = true;
 		}
-		
+
 		return autoSize;
 	}
-	
-	private function set_padding(value:Int):Int
+
+	function set_padding(value:Int):Int
 	{
 		if (value != padding)
 		{
 			padding = value;
 			pendingTextChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function set_numSpacesInTab(value:Int):Int 
+
+	function set_numSpacesInTab(value:Int):Int
 	{
 		if (numSpacesInTab != value && value > 0)
 		{
 			numSpacesInTab = value;
 			pendingTextChange = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function set_background(value:Bool):Bool
+
+	function set_background(value:Bool):Bool
 	{
 		if (background != value)
 		{
@@ -1658,11 +1658,11 @@ class FlxBitmapText extends FlxSprite
 				pendingPixelsChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function set_backgroundColor(value:Int):Int 
+
+	function set_backgroundColor(value:Int):Int
 	{
 		if (backgroundColor != value)
 		{
@@ -1672,22 +1672,22 @@ class FlxBitmapText extends FlxSprite
 				pendingPixelsChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function set_borderStyle(style:FlxTextBorderStyle):FlxTextBorderStyle
-	{		
+
+	function set_borderStyle(style:FlxTextBorderStyle):FlxTextBorderStyle
+	{
 		if (style != borderStyle)
 		{
 			borderStyle = style;
 			pendingTextBitmapChange = true;
 		}
-		
+
 		return borderStyle;
 	}
-	
-	private function set_borderColor(value:Int):Int 
+
+	function set_borderColor(value:Int):Int
 	{
 		if (borderColor != value)
 		{
@@ -1697,86 +1697,86 @@ class FlxBitmapText extends FlxSprite
 				pendingPixelsChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function set_borderSize(value:Float):Float
+
+	function set_borderSize(value:Float):Float
 	{
 		if (value != borderSize)
-		{			
+		{
 			borderSize = value;
-			
+
 			if (borderStyle != FlxTextBorderStyle.NONE)
 			{
 				pendingTextBitmapChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function set_borderQuality(value:Float):Float
+
+	function set_borderQuality(value:Float):Float
 	{
 		value = Math.min(1, Math.max(0, value));
-		
+
 		if (value != borderQuality)
 		{
 			borderQuality = value;
-			
+
 			if (borderStyle != FlxTextBorderStyle.NONE)
 			{
 				pendingTextBitmapChange = true;
 			}
 		}
-		
+
 		return value;
 	}
-	
-	private function get_numLines():Int
+
+	function get_numLines():Int
 	{
 		return _lines.length;
 	}
-	
+
 	/**
 	 * Calculates maximum width of the text.
-	 * 
+	 *
 	 * @return	text width.
 	 */
-	private function get_textWidth():Int
+	function get_textWidth():Int
 	{
 		var max:Int = 0;
 		var numLines:Int = _lines.length;
 		var lineWidth:Int;
 		_linesWidth = [];
-		
+
 		for (i in 0...numLines)
 		{
 			lineWidth = getLineWidth(i);
 			_linesWidth[i] = lineWidth;
 			max = (max > lineWidth) ? max : lineWidth;
 		}
-		
+
 		return max;
 	}
-	
-	private function get_textHeight():Int
+
+	function get_textHeight():Int
 	{
 		return (lineHeight + lineSpacing) * _lines.length - lineSpacing;
 	}
-	
-	private function get_lineHeight():Int
+
+	function get_lineHeight():Int
 	{
 		return font.lineHeight;
 	}
-	
-	override private function get_width():Float 
+
+	override function get_width():Float
 	{
 		checkPendingChanges(true);
 		return super.get_width();
 	}
-	
-	override private function get_height():Float 
+
+	override function get_height():Float
 	{
 		checkPendingChanges(true);
 		return super.get_height();

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -30,7 +30,7 @@ import openfl.geom.Rectangle;
 // TODO: think about filters and text
 
 /**
- * Extends FlxSprite to support rendering text. Can tint, fade, rotate and scale just like a sprite. Doesn't really animate 
+ * Extends FlxSprite to support rendering text. Can tint, fade, rotate and scale just like a sprite. Doesn't really animate
  * though. Also does nice pixel-perfect centering on pixel fonts as long as they are only one-liners.
  */
 class FlxText extends FlxSprite
@@ -38,130 +38,130 @@ class FlxText extends FlxSprite
 	/**
 	 * 2px gutter on both top and bottom
 	 */
-	private static inline var VERTICAL_GUTTER:Int = 4;
+	static inline var VERTICAL_GUTTER:Int = 4;
 
 	/**
 	 * The text being displayed.
 	 */
 	public var text(default, set):String = "";
-	
+
 	/**
 	 * The size of the text being displayed in pixels.
 	 */
 	public var size(get, set):Int;
-	
+
 	/**
 	 * The font used for this text (assuming that it's using embedded font).
 	 */
 	public var font(get, set):String;
-	
+
 	/**
-	 * Whether this text field uses an embedded font (by default) or not. 
+	 * Whether this text field uses an embedded font (by default) or not.
 	 * Read-only - use `systemFont` to specify a system font to use, which then automatically sets this to `false`.
 	 */
 	public var embedded(get, never):Bool;
-	
+
 	/**
 	 * The system font for this text (not embedded). Setting this sets `embedded` to `false`.
-	 * Passing an invalid font name (like `""` or `null`) causes a default font to be used. 
+	 * Passing an invalid font name (like `""` or `null`) causes a default font to be used.
 	 */
 	public var systemFont(get, set):String;
-	
+
 	/**
 	 * Whether to use bold text or not (`false` by default).
 	 */
 	public var bold(get, set):Bool;
-	
+
 	/**
 	 * Whether to use italic text or not (`false` by default). Only works on Flash.
 	 */
 	public var italic(get, set):Bool;
-	
+
 	/**
 	 * Whether to use word wrapping and multiline or not (`true` by default).
 	 */
 	public var wordWrap(get, set):Bool;
-	
+
 	/**
 	 * The alignment of the font. Note: `autoSize` must be set to
 	 * `false` or `alignment` won't show any visual differences.
 	 */
 	public var alignment(get, set):FlxTextAlign;
-	
+
 	/**
 	 * The border style to use
-	 */	
+	 */
 	public var borderStyle(default, set):FlxTextBorderStyle = NONE;
-	
+
 	/**
 	 * The color of the border in `0xAARRGGBB` format
-	 */	
+	 */
 	public var borderColor(default, set):FlxColor = FlxColor.TRANSPARENT;
-	
+
 	/**
 	 * The size of the border, in pixels.
 	 */
 	public var borderSize(default, set):Float = 1;
-	
+
 	/**
 	 * How many iterations do use when drawing the border. `0`: only 1 iteration, `1`: one iteration for every pixel in `borderSize`
-	 * A value of `1` will have the best quality for large border sizes, but might reduce performance when changing text. 
+	 * A value of `1` will have the best quality for large border sizes, but might reduce performance when changing text.
 	 * NOTE: If the `borderSize` is `1`, `borderQuality` of `0` or `1` will have the exact same effect (and performance).
 	 */
 	public var borderQuality(default, set):Float = 1;
-	
+
 	/**
 	 * Reference to a `TextField` object used internally for rendering -
 	 * be sure to know what you're doing if messing with its properties!
 	 */
 	public var textField(default, null):TextField;
-	
+
 	/**
 	 * The width of the `TextField` object used for bitmap generation for this `FlxText` object.
 	 * Use it when you want to change the visible width of text. Enables `autoSize` if `<= 0`.
 	 */
 	public var fieldWidth(get, set):Float;
-	
+
 	/**
 	 * Whether the `fieldWidth` should be determined automatically. Requires `wordWrap` to be `false`.
 	 */
 	public var autoSize(get, set):Bool;
-	
+
 	/**
-	 * Offset that is applied to the shadow border style, if active. 
+	 * Offset that is applied to the shadow border style, if active.
 	 * `x` and `y` are multiplied by `borderSize`. Default is `(1, 1)`, or lower-right corner.
 	 */
 	public var shadowOffset(default, null):FlxPoint;
-	
-	private var _defaultFormat:TextFormat;
-	private var _formatAdjusted:TextFormat;
-	private var _formatRanges:Array<FlxTextFormatRange> = [];
-	private var _font:String;
-	
+
+	var _defaultFormat:TextFormat;
+	var _formatAdjusted:TextFormat;
+	var _formatRanges:Array<FlxTextFormatRange> = [];
+	var _font:String;
+
 	/**
 	 * Helper boolean which tells whether to update graphic of this text object or not.
 	 */
-	private var _regen:Bool = true;
-	
+	var _regen:Bool = true;
+
 	/**
 	 * Helper vars to draw border styles with transparency.
 	 */
-	private var _borderPixels:BitmapData;
-	
-	private var _borderColorTransform:ColorTransform;
-	
-	private var _hasBorderAlpha = false;
-	
+	var _borderPixels:BitmapData;
+
+	var _borderColorTransform:ColorTransform;
+
+	var _hasBorderAlpha = false;
+
 	#if flash
 	/**
 	 * Helper to draw line by line used at `drawTextFieldTo()`.
 	 */
-	private var _textFieldRect:Rectangle = new Rectangle();
+	var _textFieldRect:Rectangle = new Rectangle();
 	#end
-	
+
 	/**
 	 * Creates a new `FlxText` object at the specified position.
-	 * 
+	 *
 	 * @param   X              The x position of the text.
 	 * @param   Y              The y position of the text.
 	 * @param   FieldWidth     The `width` of the text object. Enables `autoSize` if `<= 0`.
@@ -173,7 +173,7 @@ class FlxText extends FlxSprite
 	public function new(X:Float = 0, Y:Float = 0, FieldWidth:Float = 0, ?Text:String, Size:Int = 8, EmbeddedFont:Bool = true)
 	{
 		super(X, Y);
-		
+
 		if (Text == null || Text == "")
 		{
 			// empty texts have a textHeight of 0, need to
@@ -185,7 +185,7 @@ class FlxText extends FlxSprite
 		{
 			text = Text;
 		}
-		
+
 		textField = new TextField();
 		textField.selectable = false;
 		textField.multiline = true;
@@ -197,21 +197,21 @@ class FlxText extends FlxSprite
 		textField.text = Text;
 		fieldWidth = FieldWidth;
 		textField.embedFonts = EmbeddedFont;
-		
+
 		#if flash
 		textField.sharpness = 100;
 		#end
-		
+
 		textField.height = (Text.length <= 0) ? 1 : 10;
-		
+
 		allowCollisions = FlxObject.NONE;
 		moves = false;
-		
+
 		drawFrame();
-		
+
 		shadowOffset = FlxPoint.get(1, 1);
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -224,57 +224,57 @@ class FlxText extends FlxSprite
 		shadowOffset = FlxDestroyUtil.put(shadowOffset);
 		super.destroy();
 	}
-	
-	override public function drawFrame(Force:Bool = false):Void 
+
+	override public function drawFrame(Force:Bool = false):Void
 	{
 		_regen = _regen || Force;
 		super.drawFrame(_regen);
 	}
-	
+
 	/**
 	 * Stamps text onto specified atlas object and loads graphic from this atlas.
 	 * WARNING: Changing text after stamping it on the atlas will break the atlas, so do it only for
 	 * static texts and only after making all the text customizing (like `size`, `alignment`, `color`, etc.)
-	 * 
+	 *
 	 * @param	atlas	atlas to stamp graphic to.
 	 * @return	whether the graphic was stamped on the atlas successfully
 	 */
 	public function stampOnAtlas(atlas:FlxAtlas):Bool
 	{
 		regenGraphic();
-		
+
 		var node:FlxNode = atlas.addNode(graphic.bitmap, graphic.key);
 		var result:Bool = (node != null);
-		
+
 		if (node != null)
 		{
 			frames = node.getImageFrame();
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Applies formats to text between marker characters, then removes those markers.
 	 * NOTE: this will clear all `FlxTextFormat`s and return to the default format.
-	 * 
-	 * Usage: 
-	 * 
+	 *
+	 * Usage:
+	 *
 	 * ```haxe
 	 * text.applyMarkup(
 	 * 	"show $green text$ between dollar-signs",
 	 * 	[new FlxTextFormatMarkerPair(greenFormat, "$")]
 	 * );
 	 * ```
-	 * 
+	 *
 	 * Even works for complex nested formats like this:
-	 * 
+	 *
 	 * ```haxe
 	 * var yellow = new FlxTextFormatMarkerPair(yellowFormat, "@");
 	 * var green = new FlxTextFormatMarkerPair(greenFormat, "<g>");
 	 * text.applyMarkup("Hey @Buddy@, what <g>is<g> going @on<g>?<g>@", [yellow, green]);
 	 * ```
-	 * 
+	 *
 	 * @param   input   The text you want to format
 	 * @param   rules   `FlxTextFormat`s to selectively apply, paired with marker strings
 	 */
@@ -282,13 +282,13 @@ class FlxText extends FlxSprite
 	{
 		if (rules == null || rules.length == 0)
 			return this; // there's no point in running the big loop
-		
+
 		clearFormats(); // start with default formatting
-		
+
 		var rangeStarts:Array<Int> = [];
 		var rangeEnds:Array<Int> = [];
 		var rulesToApply:Array<FlxTextFormatMarkerPair> = [];
-		
+
 		var i:Int = 0;
 		for (rule in rules)
 		{
@@ -297,8 +297,8 @@ class FlxText extends FlxSprite
 
 			var start:Bool = false;
 			var markerLength:Int = Utf8.length(rule.marker);
-			
-			if (input.indexOf(rule.marker) == -1)  
+
+			if (input.indexOf(rule.marker) == -1)
 				continue; // marker not present
 
 			// inspect each character
@@ -307,7 +307,7 @@ class FlxText extends FlxSprite
 				if (Utf8.compare(Utf8.sub(input, charIndex, markerLength), rule.marker) != 0)
 					continue; // it's not one of the markers
 
-				if (start)   
+				if (start)
 				{
 					start = false;
 					rangeEnds.push(charIndex); //end a format block
@@ -328,18 +328,18 @@ class FlxText extends FlxSprite
 
 			i++;
 		}
-		
+
 		// Remove all of the markers in the string
 		for (rule in rules)
 			input = input.remove(rule.marker);
-		
+
 		// Adjust all the ranges to reflect the removed markers
 		for (i in 0...rangeStarts.length)
 		{
 			// Consider each range start
 			var delIndex:Int = rangeStarts[i];
 			var markerLength:Int = Utf8.length(rulesToApply[i].marker);
-			
+
 			// Any start or end index that is HIGHER than this must be subtracted by one markerLength
 			for (j in 0...rangeStarts.length)
 			{
@@ -352,10 +352,10 @@ class FlxText extends FlxSprite
 					rangeEnds[j] -= markerLength;
 				}
 			}
-			
+
 			// Consider each range end
 			delIndex = rangeEnds[i];
-			
+
 			// Any start or end index that is HIGHER than this must be subtracted by one markerLength
 			for (j in 0...rangeStarts.length)
 			{
@@ -369,20 +369,20 @@ class FlxText extends FlxSprite
 				}
 			}
 		}
-		
+
 		// Apply the new text
 		text = input;
-		
+
 		// Apply each format selectively to the given range
 		for (i in 0...rangeStarts.length)
 			addFormat(rulesToApply[i].format, rangeStarts[i], rangeEnds[i]);
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Adds another format to this `FlxText`
-	 * 
+	 *
 	 * @param	Format	The format to be added.
 	 * @param	Start	The start index of the string where the format will be applied.
 	 * @param	End		The end index of the string where the format will be applied.
@@ -392,14 +392,14 @@ class FlxText extends FlxSprite
 		_formatRanges.push(new FlxTextFormatRange(Format, Start, End));
 		// sort the array using the start value of the format so we can skip formats that can't be applied to the textField
 		_formatRanges.sort(function(left, right)
-		{ 
+		{
 			return left.range.start < right.range.start ? -1 : 1;
 		});
 		_regen = true;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Removes a specific `FlxTextFormat` from this text.
 	 * If a range is specified, this only removes the format when it touches that range.
@@ -410,18 +410,18 @@ class FlxText extends FlxSprite
 		{
 			if (formatRange.format != Format)
 				continue;
-			
+
 			if (Start != null && End != null &&
 				(Start > formatRange.range.end || End < formatRange.range.start))
 				continue;
-			
+
 			_formatRanges.remove(formatRange);
 		}
 		_regen = true;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Clears all the formats applied.
 	 */
@@ -429,13 +429,13 @@ class FlxText extends FlxSprite
 	{
 		_formatRanges = [];
 		updateDefaultFormat();
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * You can use this if you have a lot of text parameters to set instead of the individual properties.
-	 * 
+	 *
 	 * @param	Font			The name of the font face for the text display.
 	 * @param	Size			The size of the font (in pixels essentially).
 	 * @param	Color			The color of the text in `0xRRGGBB` format.
@@ -445,11 +445,11 @@ class FlxText extends FlxSprite
 	 * @param	EmbeddedFont	Whether this text field uses embedded fonts or not
 	 * @return	This `FlxText` instance (nice for chaining stuff together, if you're into that).
 	 */
-	public function setFormat(?Font:String, Size:Int = 8, Color:FlxColor = FlxColor.WHITE, ?Alignment:FlxTextAlign, 
+	public function setFormat(?Font:String, Size:Int = 8, Color:FlxColor = FlxColor.WHITE, ?Alignment:FlxTextAlign,
 		?BorderStyle:FlxTextBorderStyle, BorderColor:FlxColor = FlxColor.TRANSPARENT, EmbeddedFont:Bool = true):FlxText
 	{
 		BorderStyle = (BorderStyle == null) ? NONE : BorderStyle;
-		
+
 		if (EmbeddedFont)
 		{
 			font = Font;
@@ -458,41 +458,41 @@ class FlxText extends FlxSprite
 		{
 			systemFont = Font;
 		}
-		
+
 		size = Size;
 		color = Color;
 		if (Alignment != null)
 			alignment = Alignment;
 		setBorderStyle(BorderStyle, BorderColor);
-		
+
 		updateDefaultFormat();
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Set border's style (shadow, outline, etc), color, and size all in one go!
-	 * 
+	 *
 	 * @param	Style outline style
 	 * @param	Color outline color in `0xAARRGGBB` format
 	 * @param	Size outline size in pixels
 	 * @param	Quality outline quality - # of iterations to use when drawing. `0`: just 1, `1`: equal number to `Size`
 	 */
-	public inline function setBorderStyle(Style:FlxTextBorderStyle, Color:FlxColor = 0, Size:Float = 1, Quality:Float = 1):FlxText 
+	public inline function setBorderStyle(Style:FlxTextBorderStyle, Color:FlxColor = 0, Size:Float = 1, Quality:Float = 1):FlxText
 	{
 		borderStyle = Style;
 		borderColor = Color;
 		borderSize = Size;
 		borderQuality = Quality;
-		
+
 		return this;
 	}
-	
-	private function set_fieldWidth(value:Float):Float
+
+	function set_fieldWidth(value:Float):Float
 	{
 		if (textField == null)
 			return value;
-		
+
 		if (value <= 0)
 		{
 			wordWrap = false;
@@ -504,33 +504,33 @@ class FlxText extends FlxSprite
 			wordWrap = true;
 			textField.width = value;
 		}
-		
+
 		_regen = true;
 		return value;
 	}
-	
-	private function get_fieldWidth():Float
+
+	function get_fieldWidth():Float
 	{
 		return (textField != null) ? textField.width : 0;
 	}
-	
-	private function set_autoSize(value:Bool):Bool
+
+	function set_autoSize(value:Bool):Bool
 	{
 		if (textField != null)
 		{
 			textField.autoSize = value ? TextFieldAutoSize.LEFT : TextFieldAutoSize.NONE;
 			_regen = true;
 		}
-		
+
 		return value;
 	}
-	
-	private function get_autoSize():Bool
+
+	function get_autoSize():Bool
 	{
 		return (textField != null) ? (textField.autoSize != TextFieldAutoSize.NONE) : false;
 	}
-	
-	private function set_text(Text:String):String
+
+	function set_text(Text:String):String
 	{
 		text = Text;
 		if (textField != null)
@@ -541,20 +541,20 @@ class FlxText extends FlxSprite
 		}
 		return Text;
 	}
-	
-	private inline function get_size():Int
+
+	inline function get_size():Int
 	{
 		return Std.int(_defaultFormat.size);
 	}
-	
-	private function set_size(Size:Int):Int
+
+	function set_size(Size:Int):Int
 	{
 		_defaultFormat.size = Size;
 		updateDefaultFormat();
 		return Size;
 	}
-	
-	override private function set_color(Color:FlxColor):Int
+
+	override function set_color(Color:FlxColor):Int
 	{
 		if (_defaultFormat.color == Color.to24Bit())
 		{
@@ -565,16 +565,16 @@ class FlxText extends FlxSprite
 		updateDefaultFormat();
 		return Color;
 	}
-	
-	private inline function get_font():String
+
+	inline function get_font():String
 	{
 		return _font;
 	}
-	
-	private function set_font(Font:String):String
+
+	function set_font(Font:String):String
 	{
 		textField.embedFonts = true;
-		
+
 		if (Font != null)
 		{
 			var newFontName:String = Font;
@@ -582,42 +582,42 @@ class FlxText extends FlxSprite
 			{
 				newFontName = Assets.getFont(Font).fontName;
 			}
-			
+
 			_defaultFormat.font = newFontName;
 		}
 		else
 		{
 			_defaultFormat.font = FlxAssets.FONT_DEFAULT;
 		}
-		
+
 		updateDefaultFormat();
 		return _font = _defaultFormat.font;
 	}
-	
-	private inline function get_embedded():Bool
+
+	inline function get_embedded():Bool
 	{
 		return textField.embedFonts = true;
 	}
-	
-	private inline function get_systemFont():String
+
+	inline function get_systemFont():String
 	{
 		return _defaultFormat.font;
 	}
-	
-	private function set_systemFont(Font:String):String
+
+	function set_systemFont(Font:String):String
 	{
 		textField.embedFonts = false;
 		_defaultFormat.font = Font;
 		updateDefaultFormat();
 		return Font;
 	}
-	
-	private inline function get_bold():Bool 
-	{ 
-		return _defaultFormat.bold; 
+
+	inline function get_bold():Bool
+	{
+		return _defaultFormat.bold;
 	}
-	
-	private function set_bold(value:Bool):Bool
+
+	function set_bold(value:Bool):Bool
 	{
 		if (_defaultFormat.bold != value)
 		{
@@ -626,13 +626,13 @@ class FlxText extends FlxSprite
 		}
 		return value;
 	}
-	
-	private inline function get_italic():Bool 
-	{ 
-		return _defaultFormat.italic; 
+
+	inline function get_italic():Bool
+	{
+		return _defaultFormat.italic;
 	}
-	
-	private function set_italic(value:Bool):Bool
+
+	function set_italic(value:Bool):Bool
 	{
 		if (_defaultFormat.italic != value)
 		{
@@ -641,13 +641,13 @@ class FlxText extends FlxSprite
 		}
 		return value;
 	}
-	
-	private inline function get_wordWrap():Bool 
-	{ 
-		return textField.wordWrap; 
+
+	inline function get_wordWrap():Bool
+	{
+		return textField.wordWrap;
 	}
-	
-	private function set_wordWrap(value:Bool):Bool
+
+	function set_wordWrap(value:Bool):Bool
 	{
 		if (textField.wordWrap != value)
 		{
@@ -656,77 +656,77 @@ class FlxText extends FlxSprite
 		}
 		return value;
 	}
-	
-	private inline function get_alignment():FlxTextAlign
+
+	inline function get_alignment():FlxTextAlign
 	{
 		return FlxTextAlign.fromOpenFL(_defaultFormat.align);
 	}
-	
-	private function set_alignment(Alignment:FlxTextAlign):FlxTextAlign
+
+	function set_alignment(Alignment:FlxTextAlign):FlxTextAlign
 	{
 		_defaultFormat.align = FlxTextAlign.toOpenFL(Alignment);
 		updateDefaultFormat();
 		return Alignment;
 	}
-	
-	private function set_borderStyle(style:FlxTextBorderStyle):FlxTextBorderStyle
+
+	function set_borderStyle(style:FlxTextBorderStyle):FlxTextBorderStyle
 	{
 		if (style != borderStyle)
 			_regen = true;
-		
+
 		return borderStyle = style;
 	}
-	
-	private function set_borderColor(Color:FlxColor):FlxColor
+
+	function set_borderColor(Color:FlxColor):FlxColor
 	{
 		if (borderColor != Color && borderStyle != NONE)
 			_regen = true;
 		_hasBorderAlpha = Color.alphaFloat < 1;
 		return borderColor = Color;
 	}
-	
-	private function set_borderSize(Value:Float):Float
+
+	function set_borderSize(Value:Float):Float
 	{
 		if (Value != borderSize && borderStyle != NONE)
 			_regen = true;
-		
+
 		return borderSize = Value;
 	}
-	
-	private function set_borderQuality(Value:Float):Float
+
+	function set_borderQuality(Value:Float):Float
 	{
 		Value = FlxMath.bound(Value, 0, 1);
 		if (Value != borderQuality && borderStyle != NONE)
 			_regen = true;
-		
+
 		return borderQuality = Value;
 	}
-	
-	override private function set_graphic(Value:FlxGraphic):FlxGraphic 
+
+	override function set_graphic(Value:FlxGraphic):FlxGraphic
 	{
 		var oldGraphic:FlxGraphic = graphic;
 		var graph:FlxGraphic = super.set_graphic(Value);
 		FlxG.bitmap.removeIfNoUse(oldGraphic);
 		return graph;
 	}
-	
-	override private function get_width():Float 
+
+	override function get_width():Float
 	{
 		regenGraphic();
 		return super.get_width();
 	}
-	
-	override private function get_height():Float 
+
+	override function get_height():Float
 	{
 		regenGraphic();
 		return super.get_height();
 	}
-	
-	override private function updateColorTransform():Void
+
+	override function updateColorTransform():Void
 	{
 		if (colorTransform == null)
 			colorTransform = new ColorTransform();
-		
+
 		if (alpha != 1)
 		{
 			colorTransform.alphaMultiplier = alpha;
@@ -737,47 +737,47 @@ class FlxText extends FlxSprite
 			colorTransform.alphaMultiplier = 1;
 			useColorTransform = false;
 		}
-		
+
 		dirty = true;
 	}
-	
-	private function regenGraphic():Void
+
+	function regenGraphic():Void
 	{
 		if (textField == null || !_regen)
 			return;
-		
+
 		var oldWidth:Int = 0;
 		var oldHeight:Int = VERTICAL_GUTTER;
-		
+
 		if (graphic != null)
 		{
 			oldWidth = graphic.width;
 			oldHeight = graphic.height;
 		}
-		
+
 		var newWidth:Float = textField.width;
 		// Account for gutter
 		var newHeight:Float = textField.textHeight + VERTICAL_GUTTER;
-		
+
 		// prevent text height from shrinking on flash if text == ""
-		if (textField.textHeight == 0) 
+		if (textField.textHeight == 0)
 		{
 			newHeight = oldHeight;
 		}
-		
+
 		if (oldWidth != newWidth || oldHeight != newHeight)
 		{
 			// Need to generate a new buffer to store the text graphic
 			height = newHeight;
 			var key:String = FlxG.bitmap.getUniqueKey("text");
-			
+
 			// retain the clipRect through text changes
 			var tempRect = clipRect;
-			
+
 			makeGraphic(Std.int(newWidth), Std.int(newHeight), FlxColor.TRANSPARENT, false, key);
-			
+
 			clipRect = tempRect;
-			
+
 			if (_hasBorderAlpha)
 				_borderPixels = graphic.bitmap.clone();
 			frameHeight = Std.int(height);
@@ -798,39 +798,39 @@ class FlxText extends FlxSprite
 					_borderPixels.fillRect(_flashRect, FlxColor.TRANSPARENT);
 			}
 		}
-		
+
 		if (textField != null && textField.text != null && textField.text.length > 0)
 		{
 			// Now that we've cleared a buffer, we need to actually render the text to it
 			copyTextFormat(_defaultFormat, _formatAdjusted);
-			
+
 			_matrix.identity();
-			
+
 			applyBorderStyle();
 			applyBorderTransparency();
 			applyFormats(_formatAdjusted, false);
-			
+
 			drawTextFieldTo(graphic.bitmap);
 		}
-		
+
 		_regen = false;
 		resetFrame();
 	}
-	
+
 	/**
 	 * Internal function to draw textField to a BitmapData, if flash it calculates every line x to avoid blurry lines.
 	 */
-	private function drawTextFieldTo(graphic:BitmapData):Void
+	function drawTextFieldTo(graphic:BitmapData):Void
 	{
 		#if flash
 		if (alignment == FlxTextAlign.CENTER && isTextBlurry())
 		{
 			var h:Int = 0;
 			var tx:Float = _matrix.tx;
-			for (i in 0...textField.numLines) 
+			for (i in 0...textField.numLines)
 			{
 				var lineMetrics = textField.getLineMetrics(i);
-				
+
 				// Workaround for blurry lines caused by non-integer x positions on flash
 				var diff:Float = lineMetrics.x - Std.int(lineMetrics.x);
 				if (diff != 0)
@@ -838,27 +838,27 @@ class FlxText extends FlxSprite
 					_matrix.tx = tx + diff;
 				}
 				_textFieldRect.setTo(0, h, textField.width, lineMetrics.height + lineMetrics.descent);
-				
+
 				graphic.draw(textField, _matrix, null, null, _textFieldRect, false);
-				
+
 				_matrix.tx = tx;
 				h += Std.int(lineMetrics.height);
 			}
-			
+
 			return;
 		}
 		#end
-		
+
 		graphic.draw(textField, _matrix);
 	}
-	
+
 	#if flash
 	/**
 	 * Helper function for `drawTextFieldTo()`, this checks if thw workaround is needed to prevent blurry lines.
 	 */
-	private function isTextBlurry():Bool
+	function isTextBlurry():Bool
 	{
-		for (i in 0...textField.numLines) 
+		for (i in 0...textField.numLines)
 		{
 			var lineMetricsX = textField.getLineMetrics(i).x;
 			if (lineMetricsX - Std.int(lineMetricsX) != 0)
@@ -869,58 +869,58 @@ class FlxText extends FlxSprite
 		return false;
 	}
 	#end
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		regenGraphic();
 		super.draw();
 	}
-	
+
 	/**
 	 * Internal function to update the current animation frame.
-	 * 
+	 *
 	 * @param	RunOnCpp	Whether the frame should also be recalculated if we're on a non-flash target
 	 */
-	override private function calcFrame(RunOnCpp:Bool = false):Void
+	override function calcFrame(RunOnCpp:Bool = false):Void
 	{
 		if (textField == null)
 			return;
-		
+
 		if (FlxG.renderTile && !RunOnCpp)
 			return;
-		
+
 		regenGraphic();
 		super.calcFrame(RunOnCpp);
 	}
-	
-	private function applyBorderStyle():Void
+
+	function applyBorderStyle():Void
 	{
 		var iterations:Int = Std.int(borderSize * borderQuality);
-		if (iterations <= 0) 
-		{ 
+		if (iterations <= 0)
+		{
 			iterations = 1;
 		}
 		var delta:Float = borderSize / iterations;
-		
+
 		switch (borderStyle)
 		{
 			case SHADOW:
 				//Render a shadow beneath the text
 				//(do one lower-right offset draw call)
 				applyFormats(_formatAdjusted, true);
-				
+
 				for (i in 0...iterations)
 				{
 					copyTextWithOffset(delta, delta);
 				}
-				
+
 				_matrix.translate( -shadowOffset.x * borderSize, -shadowOffset.y * borderSize);
-				
+
 			case OUTLINE:
 				//Render an outline around the text
 				//(do 8 offset draw calls)
 				applyFormats(_formatAdjusted, true);
-				
+
 				var curDelta:Float = delta;
 				for (i in 0...iterations)
 				{
@@ -932,17 +932,17 @@ class FlxText extends FlxSprite
 					copyTextWithOffset( -curDelta, 0);         //lower-middle
 					copyTextWithOffset( -curDelta, 0);         //lower-left
 					copyTextWithOffset(0, -curDelta);          //lower-left
-					
+
 					_matrix.translate(curDelta, 0);            //return to center
 					curDelta += delta;
 				}
-				
+
 			case OUTLINE_FAST:
 				//Render an outline around the text
 				//(do 4 diagonal offset draw calls)
 				//(this method might not work with certain narrow fonts)
 				applyFormats(_formatAdjusted, true);
-				
+
 				var curDelta:Float = delta;
 				for (i in 0...iterations)
 				{
@@ -950,66 +950,66 @@ class FlxText extends FlxSprite
 					copyTextWithOffset(curDelta * 2, 0);       //upper-right
 					copyTextWithOffset(0, curDelta * 2);       //lower-right
 					copyTextWithOffset( -curDelta * 2, 0);     //lower-left
-					
+
 					_matrix.translate(curDelta, -curDelta);    //return to center
 					curDelta += delta;
 				}
-				
+
 			case NONE:
 		}
 	}
-	
-	private inline function applyBorderTransparency()
+
+	inline function applyBorderTransparency()
 	{
 		if (!_hasBorderAlpha)
 			return;
-		
+
 		if (_borderColorTransform == null)
 			_borderColorTransform = new ColorTransform();
-			
+
 		_borderColorTransform.alphaMultiplier = borderColor.alphaFloat;
 		_borderPixels.colorTransform(_borderPixels.rect, _borderColorTransform);
 		graphic.bitmap.draw(_borderPixels);
 	}
-	
+
 	/**
 	 * Helper function for `applyBorderStyle()`
 	 */
-	private inline function copyTextWithOffset(x:Float, y:Float)
+	inline function copyTextWithOffset(x:Float, y:Float)
 	{
 		var graphic:BitmapData = _hasBorderAlpha ? _borderPixels : graphic.bitmap;
 		_matrix.translate(x, y);
 		drawTextFieldTo(graphic);
 	}
-	
-	private function applyFormats(FormatAdjusted:TextFormat, UseBorderColor:Bool = false):Void
+
+	function applyFormats(FormatAdjusted:TextFormat, UseBorderColor:Bool = false):Void
 	{
 		// Apply the default format
 		copyTextFormat(_defaultFormat, FormatAdjusted, false);
 		FormatAdjusted.color = UseBorderColor ? borderColor.to24Bit() : _defaultFormat.color;
 		textField.setTextFormat(FormatAdjusted);
-		
+
 		// Apply other formats
 		for (formatRange in _formatRanges)
 		{
-			if (textField.text.length - 1 < formatRange.range.start) 
+			if (textField.text.length - 1 < formatRange.range.start)
 			{
 				// we can break safely because the array is ordered by the format start value
 				break;
 			}
-			else 
+			else
 			{
 				var textFormat:TextFormat = formatRange.format.format;
 				copyTextFormat(textFormat, FormatAdjusted, false);
 				FormatAdjusted.color = UseBorderColor ? formatRange.format.borderColor.to24Bit() : textFormat.color;
 			}
-			
+
 			textField.setTextFormat(FormatAdjusted, formatRange.range.start,
 				Std.int(Math.min(formatRange.range.end, textField.text.length)));
 		}
 	}
-	
-	private function copyTextFormat(from:TextFormat, to:TextFormat, withAlign:Bool = true):Void
+
+	function copyTextFormat(from:TextFormat, to:TextFormat, withAlign:Bool = true):Void
 	{
 		to.font = from.font;
 		to.bold = from.bold;
@@ -1019,26 +1019,26 @@ class FlxText extends FlxSprite
 		if (withAlign)
 			to.align = from.align;
 	}
-	
+
 	/**
 	 * A helper function for updating the TextField that we use for rendering.
-	 * 
+	 *
 	 * @return	A writable copy of `TextField.defaultTextFormat`.
 	 */
-	private function dtfCopy():TextFormat
+	function dtfCopy():TextFormat
 	{
 		var dtf:TextFormat = textField.defaultTextFormat;
 		return new TextFormat(dtf.font, dtf.size, dtf.color, dtf.bold, dtf.italic, dtf.underline, dtf.url, dtf.target, dtf.align);
 	}
-	
-	private inline function updateDefaultFormat():Void
+
+	inline function updateDefaultFormat():Void
 	{
 		textField.defaultTextFormat = _defaultFormat;
 		textField.setTextFormat(_defaultFormat);
 		_regen = true;
 	}
-	
-	override function set_frames(Frames:FlxFramesCollection):FlxFramesCollection 
+
+	override function set_frames(Frames:FlxFramesCollection):FlxFramesCollection
 	{
 		super.set_frames(Frames);
 		_regen = false;
@@ -1052,13 +1052,13 @@ class FlxTextFormat
 	/**
 	 * The border color if the text has a shadow or a border
 	 */
-	private var borderColor:FlxColor;
-	private var format(default, null):TextFormat;
-	
+	var borderColor:FlxColor;
+	var format(default, null):TextFormat;
+
 	/**
 	 * @param   FontColor     Font color, in `0xRRGGBB` format. Inherits from the default format by default.
 	 * @param   Bold          Whether the text should be bold (must be supported by the font). `false` by default.
-	 * @param   Italic        Whether the text should be in italics (must be supported by the font). Only works on Flash. `false` by default.  
+	 * @param   Italic        Whether the text should be in italics (must be supported by the font). Only works on Flash. `false` by default.
 	 * @param   BorderColor   Border color, in `0xAARRGGBB` format. By default, no border (`null` / transparent).
 	 */
 	public function new(?FontColor:FlxColor, ?Bold:Bool, ?Italic:Bool, ?BorderColor:FlxColor)
@@ -1068,11 +1068,11 @@ class FlxTextFormat
 	}
 }
 
-private class FlxTextFormatRange
+class FlxTextFormatRange
 {
 	public var range(default, null):FlxRange<Int>;
 	public var format(default, null):FlxTextFormat;
-	
+
 	public function new(format:FlxTextFormat, start:Int, end:Int)
 	{
 		range = new FlxRange<Int>(start, end);
@@ -1084,7 +1084,7 @@ class FlxTextFormatMarkerPair
 {
 	public var format:FlxTextFormat;
 	public var marker:String;
-	
+
 	public function new(format:FlxTextFormat, marker:String)
 	{
 		this.format = format;
@@ -1114,18 +1114,18 @@ enum FlxTextBorderStyle
 abstract FlxTextAlign(String) from String
 {
 	var LEFT = "left";
-	
+
 	/**
 	 * Warning: on Flash, this can have a negative impact on performance
 	 * of multiline texts that are frequently regenerated (especially with
 	 * `borderStyle == OUTLINE`) due to a workaround for blurry rendering.
 	 */
 	var CENTER = "center";
-	
+
 	var RIGHT = "right";
-	
+
 	var JUSTIFY = "justify";
-	
+
 	public static function fromOpenFL(align:AlignType):FlxTextAlign
 	{
 		return switch (align)
@@ -1137,7 +1137,7 @@ abstract FlxTextAlign(String) from String
 			default: LEFT;
 		}
 	}
-	
+
 	public static function toOpenFL(align:FlxTextAlign):AlignType
 	{
 		return switch (align)
@@ -1151,4 +1151,4 @@ abstract FlxTextAlign(String) from String
 	}
 }
 
-private typedef AlignType = #if openfl_legacy String #else TextFormatAlign #end ;
+typedef AlignType = #if openfl_legacy String #else TextFormatAlign #end ;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -20,21 +20,21 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * Set this flag to use one of the 16-tile binary auto-tile algorithms (OFF, AUTO, or ALT).
 	 */
 	public var auto:FlxTilemapAutoTiling = OFF;
-	
+
 	public var widthInTiles(default, null):Int = 0;
-	
+
 	public var heightInTiles(default, null):Int = 0;
-	
+
 	public var totalTiles(default, null):Int = 0;
-	
+
 	/**
 	 * Set this to create your own image index remapper, so you can create your own tile layouts.
 	 * Mostly useful in combination with the auto-tilers.
-	 * 
-	 * Normally, each tile's value in _data corresponds to the index of a 
+	 *
+	 * Normally, each tile's value in _data corresponds to the index of a
 	 * tile frame in the tilesheet. With this active, each value in _data
 	 * is a lookup value to that index in customTileRemap.
-	 * 
+	 *
 	 * Example:
 	 *  customTileRemap = [10,9,8,7,6]
 	 *  means: 0=10, 1=9, 2=8, 3=7, 4=6
@@ -42,111 +42,111 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	public var customTileRemap:Array<Int>;
 
 	/**
-	 * If these next two arrays are not null, you're telling FlxTilemap to 
-	 * draw random tiles in certain places. 
-	 * 
+	 * If these next two arrays are not null, you're telling FlxTilemap to
+	 * draw random tiles in certain places.
+	 *
 	 * _randomIndices is a list of tilemap values that should be replaced
 	 * by a randomly selected value. The available values are chosen from
 	 * the corresponding array in randomize_choices
-	 * 
+	 *
 	 * So if you have:
 	 *   randomIndices = [12,14]
 	 *   randomChoices = [[0,1,2],[3,4,5,6,7]]
-	 * 
+	 *
 	 * Everywhere the tilemap has a value of 12 it will be replaced by 0, 1, or, 2
 	 * Everywhere the tilemap has a value of 14 it will be replaced by 3, 4, 5, 6, 7
 	 */
-	private var _randomIndices:Array<Int>;
-	private var _randomChoices:Array<Array<Int>>;
+	var _randomIndices:Array<Int>;
+	var _randomChoices:Array<Array<Int>>;
 	/**
 	 * Setting this function allows you to control which choice will be selected for each element within _randomIndices array.
 	 * Must return a 0-1 value that gets multiplied by _randomChoices[randIndex].length;
 	 */
-	private var _randomLambda:Void->Float;
+	var _randomLambda:Void->Float;
 	/**
 	 * Internal collection of tile objects, one for each type of tile in the map (NOT one for every single tile in the whole map).
 	 */
-	private var _tileObjects:Array<Tile> = [];
+	var _tileObjects:Array<Tile> = [];
 
 	/**
 	 * Internal, used to sort of insert blank tiles in front of the tiles in the provided graphic.
 	 */
-	private var _startingIndex:Int = 0;
+	var _startingIndex:Int = 0;
 	/**
 	 * Internal representation of the actual tile data, as a large 1D array of integers.
 	 */
-	private var _data:Array<Int>;
-	
-	private var _drawIndex:Int = 0;
-	private var _collideIndex:Int = 0;
-	
+	var _data:Array<Int>;
+
+	var _drawIndex:Int = 0;
+	var _collideIndex:Int = 0;
+
 	/**
 	 * Virtual methods, must be implemented in each renderers
 	 */
-	private function updateTile(Index:Int):Void 
+	function updateTile(Index:Int):Void
 	{
 		throw "updateTile must be implemented";
 	}
-	
-	private function cacheGraphics(TileWidth:Int, TileHeight:Int, TileGraphic:FlxTilemapGraphicAsset):Void
+
+	function cacheGraphics(TileWidth:Int, TileHeight:Int, TileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		throw "cacheGraphics must be implemented";
 	}
-	
-	private function initTileObjects():Void 
+
+	function initTileObjects():Void
 	{
 		throw "initTileObjects must be implemented";
 	}
-	
-	private function updateMap():Void
+
+	function updateMap():Void
 	{
 		throw "updateMap must be implemented";
 	}
-	
-	private function computeDimensions():Void
+
+	function computeDimensions():Void
 	{
 		throw "computeDimensions must be implemented";
 	}
-	
+
 	public function getTileIndexByCoords(Coord:FlxPoint):Int
 	{
 		throw "getTileIndexByCoords must be implemented";
 		return 0;
 	}
-	
+
 	public function getTileCoordsByIndex(Index:Int, Midpoint:Bool = true):FlxPoint
-	{ 
+	{
 		throw "getTileCoordsByIndex must be implemented";
 		return null;
 	}
-	
+
 	public function ray(Start:FlxPoint, End:FlxPoint, ?Result:FlxPoint, Resolution:Float = 1):Bool
-	{ 
+	{
 		throw "ray must be implemented";
 		return false;
 	}
-	
+
 	public function overlapsWithCallback(Object:FlxObject, ?Callback:FlxObject->FlxObject->Bool, FlipCallbackParams:Bool = false, ?Position:FlxPoint):Bool
-	{ 
+	{
 		throw "overlapsWithCallback must be implemented";
 		return false;
 	}
-	
+
 	public function setDirty(Dirty:Bool = true):Void
 	{
 		throw "setDirty must be implemented";
 	}
 
-	private function new()
+	function new()
 	{
 		super();
-		
+
 		flixelType = TILEMAP;
 		immovable = true;
 		moves = false;
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		_data = null;
 		super.destroy();
@@ -154,7 +154,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Load the tilemap with string data and a tile graphic.
-	 * 
+	 *
 	 * @param   MapData         A csv-formatted string indicating what order the tiles should go in (or the path to that file)
 	 * @param   TileGraphic     All the tiles you want to use, arranged in a strip corresponding to the numbers in MapData.
 	 * @param   TileWidth       The width of your tiles (e.g. 8) - defaults to height of the tile graphic if unspecified.
@@ -166,11 +166,11 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   DrawIndex       Initializes all tile objects equal to and after this index as visible.
 	 *                          Default value is 1. Ignored if AutoTile is set.
 	 * @param   CollideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
-	 *                          Default value is 1.  Ignored if AutoTile is set.  
+	 *                          Default value is 1.  Ignored if AutoTile is set.
 	 *                          Can override and customize per-tile-type collision behavior using setTileProperties().
 	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
 	 */
-	public function loadMapFromCSV(MapData:String, TileGraphic:FlxTilemapGraphicAsset, TileWidth:Int = 0, TileHeight:Int = 0, 
+	public function loadMapFromCSV(MapData:String, TileGraphic:FlxTilemapGraphicAsset, TileWidth:Int = 0, TileHeight:Int = 0,
 		?AutoTile:FlxTilemapAutoTiling, StartingIndex:Int = 0, DrawIndex:Int = 1, CollideIndex:Int = 1)
 	{
 		// path to map data file?
@@ -178,18 +178,18 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			MapData = Assets.getText(MapData);
 		}
-		
+
 		// Figure out the map dimensions based on the data string
 		_data = new Array<Int>();
 		var columns:Array<String>;
-		
+
 		var regex:EReg = new EReg("[ \t]*((\r\n)|\r|\n)[ \t]*", "g");
 		var lines:Array<String> = regex.split(MapData);
 		var rows:Array<String> = lines.filter(function(line) return line != "");
-		
+
 		heightInTiles = rows.length;
 		widthInTiles = 0;
-		
+
 		var row:Int = 0;
 		while (row < heightInTiles)
 		{
@@ -197,7 +197,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			if (rowString.endsWith(","))
 				rowString = rowString.substr(0, rowString.length - 1);
 			columns = rowString.split(",");
-			
+
 			if (columns.length == 0)
 			{
 				heightInTiles--;
@@ -207,35 +207,35 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			{
 				widthInTiles = columns.length;
 			}
-			
+
 			var column = 0;
 			while (column < widthInTiles)
 			{
 				//the current tile to be added:
 				var columnString = columns[column];
 				var curTile = Std.parseInt(columnString);
-				
+
 				if (curTile == null)
 					throw 'String in row $row, column $column is not a valid integer: "$columnString"';
-				
+
 				// anything < 0 should be treated as 0 for compatibility with certain map formats (ogmo)
 				if (curTile < 0)
 					curTile = 0;
-				
+
 				_data.push(curTile);
 				column++;
 			}
-			
+
 			row++;
 		}
-		
+
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;
 	}
-	
+
 	/**
 	 * Load the tilemap with string data and a tile graphic.
-	 * 
+	 *
 	 * @param   MapData         An array containing the tile indices
 	 * @param   WidthInTiles    The width of the tilemap in tiles
 	 * @param   HeightInTiles   The height of the tilemap in tiles
@@ -249,7 +249,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   DrawIndex       Initializes all tile objects equal to and after this index as visible.
 	 *                          Default value is 1. Ignored if AutoTile is set.
 	 * @param   CollideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
-	 *                          Default value is 1.  Ignored if AutoTile is set.  
+	 *                          Default value is 1.  Ignored if AutoTile is set.
 	 *                          Can override and customize per-tile-type collision behavior using setTileProperties().
 	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
 	 */
@@ -259,14 +259,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		widthInTiles = WidthInTiles;
 		heightInTiles = HeightInTiles;
 		_data = MapData.copy(); // make a copy to make sure we don't mess with the original array, which might be used for something!
-		
+
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;
 	}
-	
+
 	/**
 	 * Load the tilemap with string data and a tile graphic.
-	 * 
+	 *
 	 * @param   MapData         A 2D array containing the tile indices. The length of the inner arrays should be consistent.
 	 * @param   TileGraphic     All the tiles you want to use, arranged in a strip corresponding to the numbers in MapData.
 	 * @param   TileWidth       The width of your tiles (e.g. 8) - defaults to height of the tile graphic if unspecified.
@@ -278,7 +278,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   DrawIndex       Initializes all tile objects equal to and after this index as visible.
 	 *                          Default value is 1. Ignored if AutoTile is set.
 	 * @param   CollideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
-	 *                          Default value is 1.  Ignored if AutoTile is set.  
+	 *                          Default value is 1.  Ignored if AutoTile is set.
 	 *                          Can override and customize per-tile-type collision behavior using setTileProperties().
 	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
 	 */
@@ -288,13 +288,13 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		widthInTiles = MapData[0].length;
 		heightInTiles = MapData.length;
 		_data = FlxArrayUtil.flatten2DArray(MapData);
-		
+
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;
 	}
-	
+
 	/**
-	 * Load the tilemap with image data and a tile graphic. 
+	 * Load the tilemap with image data and a tile graphic.
 	 * Black pixels are flagged as 'solid' by default, non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
 	 * @param   MapGraphic      The image you want to use as a source of map data, where each pixel is a tile (or more than one tile if you change Scale's default value). Preferably black and white.
 	 * @param   Invert          Load white pixels as solid instead.
@@ -310,7 +310,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   DrawIndex       Initializes all tile objects equal to and after this index as visible.
 	 *                          Default value is 1. Ignored if AutoTile is set.
 	 * @param   CollideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
-	 *                          Default value is 1.  Ignored if AutoTile is set.  
+	 *                          Default value is 1.  Ignored if AutoTile is set.
 	 *                          Can override and customize per-tile-type collision behavior using setTileProperties().
 	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
 	 * @since   4.1.0
@@ -323,8 +323,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var mapData:String = FlxStringUtil.bitmapToCSV(mapBitmap, Invert, Scale, ColorMap);
 		return loadMapFromCSV(mapData, TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 	}
-	
-	private function loadMapHelper(TileGraphic:FlxTilemapGraphicAsset, TileWidth:Int = 0, TileHeight:Int = 0, ?AutoTile:FlxTilemapAutoTiling,
+
+	function loadMapHelper(TileGraphic:FlxTilemapGraphicAsset, TileWidth:Int = 0, TileHeight:Int = 0, ?AutoTile:FlxTilemapAutoTiling,
 		StartingIndex:Int = 0, DrawIndex:Int = 1, CollideIndex:Int = 1)
 	{
 		totalTiles = _data.length;
@@ -337,10 +337,10 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			DrawIndex = 1;
 			CollideIndex = 1;
 		}
-		
+
 		_drawIndex = DrawIndex;
 		_collideIndex = CollideIndex;
-		
+
 		applyAutoTile();
 		applyCustomRemap();
 		randomizeIndices();
@@ -348,14 +348,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		postGraphicLoad();
 	}
 
-	private function postGraphicLoad()
+	function postGraphicLoad()
 	{
 		initTileObjects();
 		computeDimensions();
 		updateMap();
 	}
-	
-	private function applyAutoTile():Void	
+
+	function applyAutoTile():Void
 	{
 		// Pre-process the map data if it's auto-tiled
 		if (auto != OFF)
@@ -367,14 +367,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			}
 		}
 	}
-	
-	private function applyCustomRemap():Void
+
+	function applyCustomRemap():Void
 	{
 		var i:Int = 0;
 
-		if (customTileRemap != null) 
+		if (customTileRemap != null)
 		{
-			while (i < totalTiles) 
+			while (i < totalTiles)
 			{
 				var oldIndex = _data[i];
 				var newIndex = oldIndex;
@@ -387,8 +387,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			}
 		}
 	}
-	
-	private function randomizeIndices():Void
+
+	function randomizeIndices():Void
 	{
 		var i:Int = 0;
 
@@ -398,15 +398,15 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			{
 				return FlxG.random.float();
 			};
-			
+
 			while (i < totalTiles)
 			{
 				var oldIndex = _data[i];
 				var j = 0;
 				var newIndex = oldIndex;
-				for (rand in _randomIndices) 
+				for (rand in _randomIndices)
 				{
-					if (oldIndex == rand) 
+					if (oldIndex == rand)
 					{
 						var k:Int = Std.int(randLambda() * _randomChoices[j].length);
 						newIndex = _randomChoices[j][k];
@@ -421,18 +421,18 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * An internal function used by the binary auto-tilers.
-	 * 
+	 *
 	 * @param	Index		The index of the tile you want to analyze.
 	 */
-	private function autoTile(Index:Int):Void
+	function autoTile(Index:Int):Void
 	{
 		if (_data[Index] == 0)
 		{
 			return;
 		}
-		
+
 		_data[Index] = 0;
-		
+
 		// UP
 		if ((Index - widthInTiles < 0) || (_data[Index - widthInTiles] > 0))
 		{
@@ -444,7 +444,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			_data[Index] += 2;
 		}
 		// DOWN
-		if ((Std.int(Index + widthInTiles) >= totalTiles) || (_data[Index + widthInTiles] > 0)) 
+		if ((Std.int(Index + widthInTiles) >= totalTiles) || (_data[Index + widthInTiles] > 0))
 		{
 			_data[Index] += 4;
 		}
@@ -453,7 +453,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			_data[Index] += 8;
 		}
-		
+
 		// The alternate algo checks for interior corners
 		if ((auto == ALT) && (_data[Index] == 15))
 		{
@@ -478,14 +478,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 				_data[Index] = 8;
 			}
 		}
-		
+
 		_data[Index] += 1;
 	}
 
 	/**
 	 * Set custom tile mapping and/or randomization rules prior to loading. This MUST be called BEFORE loadMap().
 	 * WARNING: Using this will cause your maps to take longer to load. Be careful using this in very large tilemaps.
-	 * 
+	 *
 	 * @param	mappings		Array of ints for remapping tiles. Ex: [7,4,12] means "0-->7, 1-->4, 2-->12"
 	 * @param	randomIndices	Array of ints indicating which tile indices should be randomized. Ex: [7,4,12] means "replace tile index of 7, 4, or 12 with a randomized value"
 	 * @param	randomChoices	A list of int-arrays that serve as the corresponding choices to randomly choose from. Ex: indices = [7,4], choices = [[1,2],[3,4,5]], 7 will be replaced by either 1 or 2, 4 will be replaced by 3, 4, or 5.
@@ -497,17 +497,17 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		_randomIndices = randomIndices;
 		_randomChoices = randomChoices;
 		_randomLambda = randomLambda;
-		
+
 		// make sure users provide all that data required if they wish to randomize tile mappings.
 		if (_randomIndices != null && (_randomChoices == null || _randomChoices.length == 0))
 		{
 			throw "You must provide valid 'randomChoices' if you wish to randomize tilemap indices, please read documentation of 'setCustomTileMappings' function.";
 		}
 	}
-	
+
 	/**
 	 * Check the value of a particular tile.
-	 * 
+	 *
 	 * @param	X		The X coordinate of the tile (in tiles, not pixels).
 	 * @param	Y		The Y coordinate of the tile (in tiles, not pixels).
 	 * @return	An integer containing the value of the tile at this spot in the array.
@@ -519,7 +519,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Get the value of a tile in the tilemap by index.
-	 * 
+	 *
 	 * @param	Index	The slot in the data array (Y * widthInTiles + X) where this tile is stored.
 	 * @return	An integer containing the value of the tile at this spot in the array.
 	 */
@@ -530,7 +530,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Gets the collision flags of tile by index.
-	 * 
+	 *
 	 * @param	Index	Tile index returned by getTile or getTileByIndex
 	 * @return	The internal collision flag for the requested tile.
 	 */
@@ -541,7 +541,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Returns a new array full of every map index of the requested tile type.
-	 * 
+	 *
 	 * @param	Index	The requested tile type.
 	 * @return	An Array with a list of all map indices of that tile type.
 	 */
@@ -550,7 +550,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var array:Array<Int> = null;
 		var i:Int = 0;
 		var l:Int = widthInTiles * heightInTiles;
-		
+
 		while (i < l)
 		{
 			if (_data[i] == Index)
@@ -563,32 +563,32 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			}
 			i++;
 		}
-		
+
 		return array;
 	}
 
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
-	 * 
+	 *
 	 * @param	X				The X coordinate of the tile (in tiles, not pixels).
 	 * @param	Y				The Y coordinate of the tile (in tiles, not pixels).
 	 * @param	Tile			The new integer data you wish to inject.
 	 * @param	UpdateGraphics	Whether the graphical representation of this tile should change.
 	 * @return	Whether or not the tile was actually changed.
-	 */ 
+	 */
 	public function setTile(X:Int, Y:Int, Tile:Int, UpdateGraphics:Bool = true):Bool
 	{
 		if ((X >= widthInTiles) || (Y >= heightInTiles))
 		{
 			return false;
 		}
-		
+
 		return setTileByIndex(Y * widthInTiles + X, Tile, UpdateGraphics);
 	}
 
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
-	 * 
+	 *
 	 * @param	Index			The slot in the data array (Y * widthInTiles + X) where this tile is stored.
 	 * @param	Tile			The new integer data you wish to inject.
 	 * @param	UpdateGraphics	Whether the graphical representation of this tile should change.
@@ -600,34 +600,34 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			return false;
 		}
-		
+
 		var ok:Bool = true;
 		_data[Index] = Tile;
-		
+
 		if (!UpdateGraphics)
 		{
 			return ok;
 		}
-		
+
 		setDirty();
-		
+
 		if (auto == OFF)
 		{
 			updateTile(_data[Index]);
 			return ok;
 		}
-		
+
 		// If this map is auto-tiled and it changes, locally update the arrangement
 		var i:Int;
 		var row:Int = Std.int(Index / widthInTiles) - 1;
 		var rowLength:Int = row + 3;
 		var column:Int = Index % widthInTiles - 1;
 		var columnHeight:Int = column + 3;
-		
+
 		while (row < rowLength)
 		{
 			column = columnHeight - 3;
-			
+
 			while (column < columnHeight)
 			{
 				if ((row >= 0) && (row < heightInTiles) && (column >= 0) && (column < widthInTiles))
@@ -640,14 +640,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			}
 			row++;
 		}
-		
+
 		return ok;
 	}
 
 	/**
 	 * Adjust collision settings and/or bind a callback function to a range of tiles.
 	 * This callback function, if present, is triggered by calls to overlap() or overlapsWithCallback().
-	 * 
+	 *
 	 * @param	Tile				The tile or tiles you want to adjust.
 	 * @param	AllowCollisions		Modify the tile or tiles to only allow collisions from certain directions, use FlxObject constants NONE, ANY, LEFT, RIGHT, etc. Default is "ANY".
 	 * @param	Callback			The function to trigger, e.g. lavaCallback(Tile:FlxObject, Object:FlxObject).
@@ -660,17 +660,17 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			Range = 1;
 		}
-		
+
 		var tile:Tile;
 		var i:Int = Tile;
 		var l:Int = Tile + Range;
-		
+
 		var maxIndex = _tileObjects.length;
-		if (l > maxIndex) 
+		if (l > maxIndex)
 		{
 			throw 'Index $l exceeds the maximum tile index of $maxIndex. Please verify the Tile ($Tile) and Range ($Range) parameters.';
 		}
-		
+
 		while (i < l)
 		{
 			tile = _tileObjects[i++];
@@ -682,7 +682,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Fetches the tilemap data array.
-	 * 
+	 *
 	 * @param   Simple   If true, returns the data as copy, as a series of 1s and 0s (useful for auto-tiling stuff).
 	 *                   Default value is false, meaning it will return the actual data array (NOT a copy).
 	 * @return  An array the size of the tilemap full of integers indicating tile placement.
@@ -693,25 +693,25 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			return _data;
 		}
-		
+
 		var i:Int = 0;
 		var l:Int = _data.length;
 		var data:Array<Int> = new Array();
 		FlxArrayUtil.setLength(data, l);
-		
+
 		while (i < l)
 		{
 			data[i] = (_tileObjects[_data[i]].allowCollisions > 0) ? 1 : 0;
 			i++;
 		}
-		
+
 		return data;
 	}
 
 	/**
 	 * Find a path through the tilemap.  Any tile with any collision flags set is treated as impassable.
 	 * If no path is discovered then a null reference is returned.
-	 * 
+	 *
 	 * @param	Start		The start point in world coordinates.
 	 * @param	End			The end point in world coordinates.
 	 * @param	Simplify	Whether to run a basic simplification algorithm over the path data, removing extra points that are on the same line.  Default value is true.
@@ -724,7 +724,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		// Figure out what tile we are starting and ending on.
 		var startIndex:Int = getTileIndexByCoords(Start);
 		var endIndex:Int = getTileIndexByCoords(End);
-		
+
 		// Check if any point given is outside the tilemap
 		if ((startIndex < 0) || (endIndex < 0))
 			return null;
@@ -734,10 +734,10 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			return null;
 		}
-		
+
 		// Figure out how far each of the tiles is from the starting tile
 		var distances:Array<Int> = computePathDistance(startIndex, endIndex, DiagonalPolicy);
-		
+
 		if (distances == null)
 		{
 			return null;
@@ -746,7 +746,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		// Then count backward to find the shortest path.
 		var points:Array<FlxPoint> = new Array<FlxPoint>();
 		walkPath(distances, endIndex, points);
-		
+
 		// Reset the start and end points to be exact
 		var node:FlxPoint;
 		node = points[points.length - 1];
@@ -763,28 +763,28 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			raySimplifyPath(points);
 		}
-		
+
 		// Finally load the remaining points into a new path object and return it
 		var path:Array<FlxPoint> = [];
 		var i:Int = points.length - 1;
-		
+
 		while (i >= 0)
 		{
 			node = points[i--];
-			
+
 			if (node != null)
 			{
 				path.push(node);
 			}
 		}
-		
+
 		return path;
 	}
-	
+
 	/**
 	 * Pathfinding helper function, floods a grid with distance information until it finds the end point.
 	 * NOTE: Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
-	 * 
+	 *
 	 * @param	StartIndex		The starting tile's map index.
 	 * @param	EndIndex		The ending tile's map index.
 	 * @param	DiagonalPolicy	How to treat diagonal movement.
@@ -799,7 +799,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var distances:Array<Int> = new Array<Int>(/*mapSize*/);
 		FlxArrayUtil.setLength(distances, mapSize);
 		var i:Int = 0;
-		
+
 		while (i < mapSize)
 		{
 			if (_tileObjects[_data[i]].allowCollisions != FlxObject.NONE)
@@ -812,7 +812,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			}
 			i++;
 		}
-		
+
 		distances[StartIndex] = 0;
 		var distance:Int = 1;
 		var neighbors:Array<Int> = [StartIndex];
@@ -824,18 +824,18 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var down:Bool;
 		var currentLength:Int;
 		var foundEnd:Bool = false;
-		
+
 		while (neighbors.length > 0)
 		{
 			current = neighbors;
 			neighbors = new Array<Int>();
-			
+
 			i = 0;
 			currentLength = current.length;
 			while (i < currentLength)
 			{
 				currentIndex = current[i++];
-				
+
 				if (currentIndex == Std.int(EndIndex))
 				{
 					foundEnd = true;
@@ -845,19 +845,19 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 						break;
 					}
 				}
-				
+
 				// Basic map bounds
 				left = currentIndex % widthInTiles > 0;
 				right = currentIndex % widthInTiles < widthInTiles - 1;
 				up = currentIndex / widthInTiles > 0;
 				down = currentIndex / widthInTiles < heightInTiles - 1;
-				
+
 				var index:Int;
-				
+
 				if (up)
 				{
 					index = currentIndex - widthInTiles;
-					
+
 					if (distances[index] == -1)
 					{
 						distances[index] = distance;
@@ -867,7 +867,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 				if (right)
 				{
 					index = currentIndex + 1;
-					
+
 					if (distances[index] == -1)
 					{
 						distances[index] = distance;
@@ -877,7 +877,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 				if (down)
 				{
 					index = currentIndex + widthInTiles;
-					
+
 					if (distances[index] == -1)
 					{
 						distances[index] = distance;
@@ -887,21 +887,21 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 				if (left)
 				{
 					index = currentIndex - 1;
-					
+
 					if (distances[index] == -1)
 					{
 						distances[index] = distance;
 						neighbors.push(index);
 					}
 				}
-				
+
 				if (DiagonalPolicy != NONE)
 				{
 					var wideDiagonal = DiagonalPolicy == WIDE;
 					if (up && right)
 					{
 						index = currentIndex - widthInTiles + 1;
-						
+
 						if (wideDiagonal && (distances[index] == -1) &&
 							(distances[currentIndex - widthInTiles] >= -1) &&
 							(distances[currentIndex + 1] >= -1))
@@ -918,7 +918,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 					if (right && down)
 					{
 						index = currentIndex + widthInTiles + 1;
-						
+
 						if (wideDiagonal && (distances[index] == -1) &&
 							(distances[currentIndex + widthInTiles] >= -1) &&
 							(distances[currentIndex + 1] >= -1))
@@ -935,7 +935,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 					if (left && down)
 					{
 						index = currentIndex + widthInTiles - 1;
-						
+
 						if (wideDiagonal && (distances[index] == -1) &&
 							(distances[currentIndex + widthInTiles] >= -1) &&
 							(distances[currentIndex - 1] >= -1))
@@ -952,7 +952,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 					if (up && left)
 					{
 						index = currentIndex - widthInTiles - 1;
-						
+
 						if (wideDiagonal && (distances[index] == -1) &&
 							(distances[currentIndex - widthInTiles] >= -1) &&
 							(distances[currentIndex - 1] >= -1))
@@ -968,46 +968,46 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 					}
 				}
 			}
-			
+
 			distance++;
 		}
 		if (!foundEnd)
 		{
 			distances = null;
 		}
-		
+
 		return distances;
 	}
 
 	/**
 	 * Pathfinding helper function, recursively walks the grid and finds a shortest path back to the start.
-	 * 
+	 *
 	 * @param	Data	An array of distance information.
 	 * @param	Start	The tile we're on in our walk backward.
 	 * @param	Points	An array of FlxPoint nodes composing the path from the start to the end, compiled in reverse order.
 	 */
-	private function walkPath(Data:Array<Int>, Start:Int, Points:Array<FlxPoint>):Void
+	function walkPath(Data:Array<Int>, Start:Int, Points:Array<FlxPoint>):Void
 	{
 		Points.push(getTileCoordsByIndex(Start));
-		
+
 		if (Data[Start] == 0)
 		{
 			return;
 		}
-		
+
 		// Basic map bounds
 		var left:Bool = (Start % widthInTiles) > 0;
 		var right:Bool = (Start % widthInTiles) < (widthInTiles - 1);
 		var up:Bool = (Start / widthInTiles) > 0;
 		var down:Bool = (Start / widthInTiles) < (heightInTiles - 1);
-		
+
 		var current:Int = Data[Start];
 		var i:Int;
-		
+
 		if (up)
 		{
 			i = Start - widthInTiles;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1016,7 +1016,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (right)
 		{
 			i = Start + 1;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1025,7 +1025,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (down)
 		{
 			i = Start + widthInTiles;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1034,7 +1034,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (left)
 		{
 			i = Start - 1;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1043,7 +1043,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (up && right)
 		{
 			i = Start - widthInTiles + 1;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1052,7 +1052,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (right && down)
 		{
 			i = Start + widthInTiles + 1;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1061,7 +1061,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (left && down)
 		{
 			i = Start + widthInTiles - 1;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
@@ -1070,22 +1070,22 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (up && left)
 		{
 			i = Start - widthInTiles - 1;
-			
+
 			if (i >= 0 && (Data[i] >= 0) && (Data[i] < current))
 			{
 				return walkPath(Data, i, Points);
 			}
 		}
-		
+
 		return;
 	}
 
 	/**
 	 * Pathfinding helper function, strips out extra points on the same line.
-	 * 
+	 *
 	 * @param	Points		An array of FlxPoint nodes.
 	 */
-	private function simplifyPath(Points:Array<FlxPoint>):Void
+	function simplifyPath(Points:Array<FlxPoint>):Void
 	{
 		var deltaPrevious:Float;
 		var deltaNext:Float;
@@ -1093,13 +1093,13 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var node:FlxPoint;
 		var i:Int = 1;
 		var l:Int = Points.length - 1;
-		
+
 		while (i < l)
 		{
 			node = Points[i];
 			deltaPrevious = (node.x - last.x) / (node.y - last.y);
 			deltaNext = (node.x - Points[i + 1].x) / (node.y - Points[i + 1].y);
-			
+
 			if ((last.x == Points[i + 1].x) || (last.y == Points[i + 1].y) || (deltaPrevious == deltaNext))
 			{
 				Points[i] = null;
@@ -1108,33 +1108,33 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			{
 				last = node;
 			}
-			
+
 			i++;
 		}
 	}
 
 	/**
 	 * Pathfinding helper function, strips out even more points by raycasting from one point to the next and dropping unnecessary points.
-	 * 
+	 *
 	 * @param	Points		An array of FlxPoint nodes.
 	 */
-	private function raySimplifyPath(Points:Array<FlxPoint>):Void
+	function raySimplifyPath(Points:Array<FlxPoint>):Void
 	{
 		var source:FlxPoint = Points[0];
 		var lastIndex:Int = -1;
 		var node:FlxPoint;
 		var i:Int = 1;
 		var l:Int = Points.length;
-		
+
 		while (i < l)
 		{
 			node = Points[i++];
-			
+
 			if (node == null)
 			{
 				continue;
 			}
-			
+
 			if (ray(source, node, _point))
 			{
 				if (lastIndex >= 0)
@@ -1146,16 +1146,16 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			{
 				source = Points[lastIndex];
 			}
-			
+
 			lastIndex = i - 1;
 		}
 	}
-	
+
 	/**
 	 * Checks to see if some FlxObject overlaps this FlxObject object in world space.
 	 * If the group has a LOT of things in it, it might be faster to use FlxG.overlaps().
 	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
-	 * 
+	 *
 	 * @param	Object			The object being tested.
 	 * @param	InScreenSpace	Whether to take scroll factors into account when checking for overlap.
 	 * @param	Camera			Specify which game camera you want. If null, getScreenPosition() will just grab the first global camera.
@@ -1175,14 +1175,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		}
 		return false;
 	}
-	
-	private inline function tilemapOverlapsCallback(ObjectOrGroup:FlxBasic, X:Float = 0, Y:Float = 0, InScreenSpace:Bool = false, ?Camera:FlxCamera):Bool
+
+	inline function tilemapOverlapsCallback(ObjectOrGroup:FlxBasic, X:Float = 0, Y:Float = 0, InScreenSpace:Bool = false, ?Camera:FlxCamera):Bool
 	{
 		if (ObjectOrGroup.flixelType == OBJECT || ObjectOrGroup.flixelType == TILEMAP)
 		{
 			return overlapsWithCallback(cast ObjectOrGroup);
 		}
-		else 
+		else
 		{
 			return overlaps(ObjectOrGroup, InScreenSpace, Camera);
 		}
@@ -1191,8 +1191,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Checks to see if this FlxObject were located at the given position, would it overlap the FlxObject or FlxGroup?
 	 * This is distinct from overlapsPoint(), which just checks that point, rather than taking the object's size into account.
-	 * WARNING: Currently tilemaps do NOT support screen space overlap checks! 
-	 * 
+	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
+	 *
 	 * @param	X				The X position you want to check.  Pretends this object (the caller, not the parameter) is located here.
 	 * @param	Y				The Y position you want to check.  Pretends this object (the caller, not the parameter) is located here.
 	 * @param	ObjectOrGroup	The object or group being tested.
@@ -1215,14 +1215,14 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 		return false;
 	}
-	
-	private inline function tilemapOverlapsAtCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool, Camera:FlxCamera):Bool
+
+	inline function tilemapOverlapsAtCallback(ObjectOrGroup:FlxBasic, X:Float, Y:Float, InScreenSpace:Bool, Camera:FlxCamera):Bool
 	{
 		if (ObjectOrGroup.flixelType == OBJECT || ObjectOrGroup.flixelType == TILEMAP)
 		{
 			return overlapsWithCallback(cast ObjectOrGroup, null, false, _point.set(X, Y));
 		}
-		else 
+		else
 		{
 			return overlapsAt(X, Y, ObjectOrGroup, InScreenSpace, Camera);
 		}
@@ -1230,7 +1230,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Checks to see if a point in 2D world space overlaps this FlxObject object.
-	 * 
+	 *
 	 * @param	WorldPoint		The point in world space you want to check.
 	 * @param	InScreenSpace	Whether to take scroll factors into account when checking for overlap.
 	 * @param	Camera			Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
@@ -1242,15 +1242,15 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			if (Camera == null)
 				Camera = FlxG.camera;
-			
+
 			WorldPoint.subtractPoint(Camera.scroll);
 			WorldPoint.putWeak();
 		}
-		
+
 		return tileAtPointAllowsCollisions(WorldPoint);
 	}
-	
-	private function tileAtPointAllowsCollisions(point:FlxPoint):Bool
+
+	function tileAtPointAllowsCollisions(point:FlxPoint):Bool
 	{
 		var tileIndex = getTileIndexByCoords(point);
 		if (tileIndex < 0 || tileIndex >= _data.length)
@@ -1260,7 +1260,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Get the world coordinates and size of the entire tilemap as a FlxRect.
-	 * 
+	 *
 	 * @param	Bounds		Optional, pass in a pre-existing FlxRect to prevent instantiation of a new object.
 	 * @return	A FlxRect containing the world coordinates and size of the entire tilemap.
 	 */
@@ -1268,7 +1268,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		if (Bounds == null)
 			Bounds = FlxRect.get();
-		
+
 		return Bounds.set(x, y, width, height);
 	}
 }

--- a/flixel/tile/FlxTileblock.hx
+++ b/flixel/tile/FlxTileblock.hx
@@ -16,11 +16,11 @@ import flixel.util.FlxSpriteUtil;
  */
 class FlxTileblock extends FlxSprite
 {
-	private var tileSprite:FlxSprite;
-	
+	var tileSprite:FlxSprite;
+
 	/**
 	 * Creates a new FlxBlock object with the specified position and size.
-	 * 
+	 *
 	 * @param	X			The X position of the block.
 	 * @param	Y			The Y position of the block.
 	 * @param	Width		The width of the block.
@@ -34,16 +34,16 @@ class FlxTileblock extends FlxSprite
 		immovable = true;
 		moves = false;
 	}
-	
+
 	override public function destroy():Void
 	{
 		tileSprite = FlxDestroyUtil.destroy(tileSprite);
 		super.destroy();
 	}
-	
+
 	/**
 	 * Fills the block with a randomly arranged selection of frames.
-	 * 
+	 *
 	 * @param	TileFrames		The frames that should fill this block.
 	 * @param	Empties			The number of "empty" tiles to add to the auto-fill algorithm (e.g. 8 tiles + 4 empties = 1/3 of block will be open holes).
 	 * @return	This tile block.
@@ -54,29 +54,29 @@ class FlxTileblock extends FlxSprite
 		{
 			return this;
 		}
-		
+
 		// First create a tile brush
 		tileSprite = (tileSprite == null) ? new FlxSprite() : tileSprite;
 		tileSprite.frames = tileFrames;
 		var spriteWidth:Int = Std.int(tileSprite.width);
 		var spriteHeight:Int = Std.int(tileSprite.height);
 		var total:Int = tileSprite.numFrames + empties;
-		
+
 		// Then prep the "canvas" as it were (just double checking that the size is on tile boundaries)
 		var regen:Bool = false;
-		
+
 		if (width % tileSprite.width != 0)
 		{
 			width = Std.int((width / spriteWidth + 1)) * spriteWidth;
 			regen = true;
 		}
-		
+
 		if (height % tileSprite.height != 0)
 		{
 			height = Std.int((height / spriteHeight + 1)) * spriteHeight;
 			regen = true;
 		}
-		
+
 		if (regen)
 		{
 			makeGraphic(Std.int(width), Std.int(height), 0, true);
@@ -85,7 +85,7 @@ class FlxTileblock extends FlxSprite
 		{
 			FlxSpriteUtil.fill(this, 0);
 		}
-		
+
 		// Stamp random tiles onto the canvas
 		var row:Int = 0;
 		var column:Int;
@@ -93,12 +93,12 @@ class FlxTileblock extends FlxSprite
 		var destinationY:Int = 0;
 		var widthInTiles:Int = Std.int(width / spriteWidth);
 		var heightInTiles:Int = Std.int(height / spriteHeight);
-		
+
 		while (row < heightInTiles)
 		{
 			destinationX = 0;
 			column = 0;
-			
+
 			while (column < widthInTiles)
 			{
 				if (FlxG.random.float() * total > empties)
@@ -107,22 +107,22 @@ class FlxTileblock extends FlxSprite
 					tileSprite.drawFrame();
 					stamp(tileSprite, destinationX, destinationY);
 				}
-				
+
 				destinationX += spriteWidth;
 				column++;
 			}
-			
+
 			destinationY += spriteHeight;
 			row++;
 		}
-		
+
 		dirty = true;
 		return this;
 	}
-	
+
 	/**
 	 * Fills the block with a randomly arranged selection of graphics from the image provided.
-	 * 
+	 *
 	 * @param	TileGraphic 	The graphic class that contains the tiles that should fill this block.
 	 * @param	TileWidth		The width of a single tile in the graphic.
 	 * @param	TileHeight		The height of a single tile in the graphic.
@@ -135,30 +135,30 @@ class FlxTileblock extends FlxSprite
 		{
 			return this;
 		}
-		
+
 		var graph:FlxGraphic = FlxG.bitmap.add(TileGraphic);
 		if (graph == null)
 		{
 			return this;
 		}
-		
+
 		if (TileWidth == 0)
 		{
 			TileWidth = graph.height;
 			TileWidth = (TileWidth > graph.width) ? graph.width : TileWidth;
 		}
-		
+
 		if (TileHeight == 0)
 		{
 			TileHeight = TileWidth;
 			TileHeight = (TileHeight > graph.height) ? graph.height : TileHeight;
 		}
-		
+
 		var tileFrames:FlxTileFrames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(TileWidth, TileHeight));
 		return this.loadFrames(tileFrames, Empties);
 	}
-	
-	public function setTile(x:Int, y:Int, index:Int):Void 
+
+	public function setTile(x:Int, y:Int, index:Int):Void
 	{
 		tileSprite.animation.frameIndex = index;
 		stamp(tileSprite, x * Std.int(tileSprite.width), y * Std.int(tileSprite.height));

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -44,13 +44,13 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 {
 	// TODO: remove this hack and add docs about how to avoid tearing problem by preparing assets and some code...
 	/**
-	 * Try to eliminate 1 px gap between tiles in tile render mode by increasing tile scale, 
+	 * Try to eliminate 1 px gap between tiles in tile render mode by increasing tile scale,
 	 * so the tile will look one pixel wider than it is.
 	 */
 	public var useScaleHack:Bool = true;
-	
+
 	/**
-	 * Changes the size of this tilemap. Default is (1, 1). 
+	 * Changes the size of this tilemap. Default is (1, 1).
 	 * Anything other than the default is very slow with blitting!
 	 */
 	public var scale(default, null):FlxPoint;
@@ -60,37 +60,37 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @since 4.1.0
 	 */
 	public var antialiasing(default, set):Bool = false;
-	
+
 	/**
 	 * Use to offset the drawing position of the tilemap,
 	 * just like FlxSprite.
 	 */
 	public var offset(default, null):FlxPoint = FlxPoint.get();
-	
+
 	/**
 	 * Rendering variables.
 	 */
 	public var frames(default, set):FlxFramesCollection;
 	public var graphic(default, set):FlxGraphic;
-	
+
 	/**
 	 * Tints the whole sprite to a color (0xRRGGBB format) - similar to OpenGL vertex colors. You can use
-	 * 0xAARRGGBB colors, but the alpha value will simply be ignored. To change the opacity use alpha. 
+	 * 0xAARRGGBB colors, but the alpha value will simply be ignored. To change the opacity use alpha.
 	 */
 	public var color(default, set):FlxColor = 0xffffff;
-	
+
 	/**
 	 * Set alpha to a number between 0 and 1 to change the opacity of the sprite.
 	 */
 	public var alpha(default, set):Float = 1.0;
-	
+
 	public var colorTransform(default, null):ColorTransform = new ColorTransform();
-	
+
 	/**
 	 * Blending modes, just like Photoshop or whatever, e.g. "multiply", "screen", etc.
 	 */
 	public var blend(default, set):BlendMode = null;
-	
+
 	/**
 	 * GLSL shader for this tilemap. Only works with OpenFL Next or WebGL.
 	 * Avoid changing it frequently as this is a costly operation.
@@ -98,53 +98,53 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 */
 	#if openfl_legacy @:noCompletion #end
 	public var shader:FlxShader;
-	
+
 	/**
 	 * Rendering helper, minimize new object instantiation on repetitive methods.
 	 */
-	private var _flashPoint:Point = new Point();
+	var _flashPoint:Point = new Point();
 	/**
 	 * Rendering helper, minimize new object instantiation on repetitive methods.
 	 */
-	private var _flashRect:Rectangle = new Rectangle();
+	var _flashRect:Rectangle = new Rectangle();
 	/**
 	 * Internal list of buffers, one for each camera, used for drawing the tilemaps.
 	 */
-	private var _buffers:Array<FlxTilemapBuffer> = [];
+	var _buffers:Array<FlxTilemapBuffer> = [];
 	/**
 	 * Internal, the width of a single tile.
 	 */
-	private var _tileWidth:Int = 0;
+	var _tileWidth:Int = 0;
 	/**
 	 * Internal, the height of a single tile.
 	 */
-	private var _tileHeight:Int = 0;
-	
-	private var _scaledTileWidth:Float = 0;
-	private var _scaledTileHeight:Float = 0;
-	
+	var _tileHeight:Int = 0;
+
+	var _scaledTileWidth:Float = 0;
+	var _scaledTileHeight:Float = 0;
+
 	#if FLX_DEBUG
-	private var _debugTileNotSolid:BitmapData;
-	private var _debugTilePartial:BitmapData;
-	private var _debugTileSolid:BitmapData;
-	private var _debugRect:Rectangle;
+	var _debugTileNotSolid:BitmapData;
+	var _debugTilePartial:BitmapData;
+	var _debugTileSolid:BitmapData;
+	var _debugRect:Rectangle;
 	#end
-	
+
 	/**
 	 * Rendering helper, minimize new object instantiation on repetitive methods. Used only in tile rendering mode
 	 */
-	private var _helperPoint:Point;
-	
+	var _helperPoint:Point;
+
 	/**
 	 * Rendering helper, used for tile's frame transformations (only in tile rendering mode).
 	 */
-	private var _matrix:FlxMatrix;
-	
+	var _matrix:FlxMatrix;
+
 	/**
 	 * Whether buffers need to be checked again next draw().
 	 */
-	private var _checkBufferChanges:Bool = false;
-	
+	var _checkBufferChanges:Bool = false;
+
 	public function new()
 	{
 		super();
@@ -154,15 +154,15 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			_helperPoint = new Point();
 			_matrix = new FlxMatrix();
 		}
-		
+
 		scale = new FlxCallbackPoint(setScaleXCallback, setScaleYCallback, setScaleXYCallback);
 		scale.set(1, 1);
-		
+
 		FlxG.signals.gameResized.add(onGameResized);
 		FlxG.cameras.cameraAdded.add(onCameraChanged);
 		FlxG.cameras.cameraRemoved.add(onCameraChanged);
 		FlxG.cameras.cameraResized.add(onCameraChanged);
-		
+
 		#if FLX_DEBUG
 		debugBoundingBoxColorSolid = FlxColor.GREEN;
 		debugBoundingBoxColorPartial = FlxColor.PINK;
@@ -172,7 +172,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			FlxG.debugger.drawDebugChanged.add(onDrawDebugChanged);
 		#end
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -180,10 +180,10 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	{
 		_flashPoint = null;
 		_flashRect = null;
-		
+
 		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
 		_buffers = FlxDestroyUtil.destroyArray(_buffers);
-		
+
 		if (FlxG.renderBlit)
 		{
 			#if FLX_DEBUG
@@ -198,35 +198,35 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			_helperPoint = null;
 			_matrix = null;
 		}
-		
+
 		frames = null;
 		graphic = null;
-		
+
 		// need to destroy FlxCallbackPoints
 		scale = FlxDestroyUtil.destroy(scale);
 		offset = FlxDestroyUtil.put(offset);
-		
+
 		colorTransform = null;
-		
+
 		FlxG.signals.gameResized.remove(onGameResized);
 		FlxG.cameras.cameraAdded.remove(onCameraChanged);
 		FlxG.cameras.cameraRemoved.remove(onCameraChanged);
 		FlxG.cameras.cameraResized.remove(onCameraChanged);
-		
+
 		#if FLX_DEBUG
 		if (FlxG.renderBlit)
 			FlxG.debugger.drawDebugChanged.remove(onDrawDebugChanged);
 		#end
-		
+
 		shader = null;
-		
+
 		super.destroy();
 	}
-	
-	private function set_frames(value:FlxFramesCollection):FlxFramesCollection
+
+	function set_frames(value:FlxFramesCollection):FlxFramesCollection
 	{
 		frames = value;
-		
+
 		if (value != null)
 		{
 			_tileWidth = Std.int(value.frames[0].sourceSize.x);
@@ -235,28 +235,28 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			graphic = value.parent;
 			postGraphicLoad();
 		}
-		
+
 		return value;
 	}
-	
-	private function onGameResized(_, _):Void
+
+	function onGameResized(_, _):Void
 	{
 		_checkBufferChanges = true;
 	}
-	
-	private function onCameraChanged(_):Void
+
+	function onCameraChanged(_):Void
 	{
 		_checkBufferChanges = true;
 	}
-	
-	override private function cacheGraphics(TileWidth:Int, TileHeight:Int, TileGraphic:FlxTilemapGraphicAsset):Void 
+
+	override function cacheGraphics(TileWidth:Int, TileHeight:Int, TileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		if (Std.is(TileGraphic, FlxFramesCollection))
 		{
 			frames = cast TileGraphic;
 			return;
 		}
-		
+
 		var graph:FlxGraphic = FlxG.bitmap.add(cast TileGraphic);
 		if (graph == null)
 			return;
@@ -265,29 +265,29 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_tileWidth = TileWidth;
 		if (_tileWidth <= 0)
 			_tileWidth = graph.height;
-		
+
 		_tileHeight = TileHeight;
 		if (_tileHeight <= 0)
 			_tileHeight = _tileWidth;
-		
+
 		frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(_tileWidth, _tileHeight));
 	}
-	
-	override private function initTileObjects():Void 
+
+	override function initTileObjects():Void
 	{
 		if (frames == null)
 			return;
-		
+
 		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
 		// Create some tile objects that we'll use for overlap checks (one for each tile)
 		_tileObjects = new Array<FlxTile>();
-		
+
 		var length:Int = frames.numFrames;
 		length += _startingIndex;
-		
+
 		for (i in 0...length)
 			_tileObjects[i] = new FlxTile(this, i, _tileWidth, _tileHeight, (i >= _drawIndex), (i >= _collideIndex) ? allowCollisions : FlxObject.NONE);
-		
+
 		// Create debug tiles for rendering bounding boxes on demand
 		#if FLX_DEBUG
 		updateDebugTileBoundingBoxSolid();
@@ -295,24 +295,24 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		updateDebugTileBoundingBoxPartial();
 		#end
 	}
-	
+
 	#if FLX_DEBUG
-	private function updateDebugTileBoundingBoxSolid():Void 
+	function updateDebugTileBoundingBoxSolid():Void
 	{
 		_debugTileSolid = updateDebugTile(_debugTileSolid, debugBoundingBoxColorSolid);
 	}
-	
-	private function updateDebugTileBoundingBoxNotSolid():Void 
+
+	function updateDebugTileBoundingBoxNotSolid():Void
 	{
 		_debugTileNotSolid = updateDebugTile(_debugTileNotSolid, debugBoundingBoxColorNotSolid);
 	}
-	
-	private function updateDebugTileBoundingBoxPartial():Void 
+
+	function updateDebugTileBoundingBoxPartial():Void
 	{
 		_debugTilePartial = updateDebugTile(_debugTilePartial, debugBoundingBoxColorPartial);
 	}
-	
-	private function updateDebugTile(tileBitmap:BitmapData, color:FlxColor):BitmapData
+
+	function updateDebugTile(tileBitmap:BitmapData, color:FlxColor):BitmapData
 	{
 		if (FlxG.renderTile)
 			return null;
@@ -335,38 +335,38 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		return tileBitmap;
 	}
 	#end
-	
-	override private function computeDimensions():Void 
+
+	override function computeDimensions():Void
 	{
 		_scaledTileWidth = _tileWidth * scale.x;
 		_scaledTileHeight = _tileHeight * scale.y;
-		
+
 		// Then go through and create the actual map
 		width = widthInTiles * _scaledTileWidth;
 		height = heightInTiles * _scaledTileHeight;
 	}
-	
-	override private function updateMap():Void 
+
+	override function updateMap():Void
 	{
 		#if FLX_DEBUG
 		if (FlxG.renderBlit)
 			_debugRect = new Rectangle(0, 0, _tileWidth, _tileHeight);
 		#end
-		
+
 		var numTiles:Int = _tileObjects.length;
 		for (i in 0...numTiles)
 			updateTile(i);
 	}
-	
+
 	#if FLX_DEBUG
 	override public function drawDebugOnCamera(Camera:FlxCamera):Void
 	{
 		if (!FlxG.renderTile)
 			return;
-		
+
 		var buffer:FlxTilemapBuffer = null;
 		var l:Int = FlxG.cameras.list.length;
-		
+
 		for (i in 0...l)
 		{
 			if (FlxG.cameras.list[i] == Camera)
@@ -375,43 +375,43 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				break;
 			}
 		}
-		
+
 		if (buffer == null)
 			return;
-		
+
 		// Copied from getScreenPosition()
 		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x;
 		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y;
-		
+
 		var rectWidth:Float = _scaledTileWidth;
 		var rectHeight:Float = _scaledTileHeight;
 		var rect = FlxRect.get(0, 0, rectWidth, rectHeight);
-		
+
 		// Copy tile images into the tile buffer
 		// Modified from getScreenPosition()
-		_point.x = (Camera.scroll.x * scrollFactor.x) - x; 
+		_point.x = (Camera.scroll.x * scrollFactor.x) - x;
 		_point.y = (Camera.scroll.y * scrollFactor.y) - y;
 		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
 		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);
 		var screenRows:Int = buffer.rows;
 		var screenColumns:Int = buffer.columns;
-		
+
 		// Bound the upper left corner
 		screenXInTiles = Std.int(FlxMath.bound(screenXInTiles, 0, widthInTiles - screenColumns));
 		screenYInTiles = Std.int(FlxMath.bound(screenYInTiles, 0, heightInTiles - screenRows));
-		
+
 		var rowIndex:Int = screenYInTiles * widthInTiles + screenXInTiles;
 		var columnIndex:Int;
 		var tile:FlxTile;
-		
+
 		for (row in 0...screenRows)
 		{
 			columnIndex = rowIndex;
-			
+
 			for (column in 0...screenColumns)
 			{
 				tile = _tileObjects[_data[columnIndex]];
-				
+
 				if (tile != null && tile.visible)
 				{
 					rect.x = _helperPoint.x + (columnIndex % widthInTiles) * rectWidth;
@@ -419,21 +419,21 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					drawDebugBoundingBox(Camera.debugLayer.graphics, rect,
 						tile.allowCollisions, tile.allowCollisions != FlxObject.ANY);
 				}
-				
+
 				columnIndex++;
 			}
-			
+
 			rowIndex += widthInTiles;
 		}
-		
+
 		rect.put();
 	}
 	#end
-	
+
 	/**
 	 * Check and see if this object is currently on screen. Differs from `FlxObject`'s implementation
 	 * in that it takes the actual graphic into account, not just the hitbox or bounding box or whatever.
-	 * 
+	 *
 	 * @param   Camera  Specify which game camera you want. If `null`, it will just grab the first global camera.
 	 * @return  Whether the object is on screen or not.
 	 */
@@ -441,14 +441,14 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;
-			
+
 		var minX:Float = x - offset.x - Camera.scroll.x * scrollFactor.x;
 		var minY:Float = y - offset.y - Camera.scroll.y * scrollFactor.y;
-		
+
 		_point.set(minX, minY);
 		return Camera.containsPoint(_point, _scaledTileWidth * widthInTiles, _scaledTileHeight * heightInTiles);
 	}
-	
+
 	/**
 	 * Draws the tilemap buffers to the cameras.
 	 */
@@ -457,34 +457,34 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		// don't try to render a tilemap that isn't loaded yet
 		if (graphic == null)
 			return;
-		
+
 		if (_checkBufferChanges)
 		{
 			refreshBuffers();
 			_checkBufferChanges = false;
 		}
-		
+
 		var camera:FlxCamera;
 		var buffer:FlxTilemapBuffer;
 		var l:Int = cameras.length;
-		
+
 		for (i in 0...l)
 		{
 			camera = cameras[i];
-			
+
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;
-			
+
 			if (_buffers[i] == null)
 				_buffers[i] = createBuffer(camera);
-			
+
 			buffer = _buffers[i];
-			
+
 			if (FlxG.renderBlit)
 			{
 				if (buffer.isDirty(this, camera))
 					drawTilemap(buffer, camera);
-				
+
 				getScreenPosition(_point, camera).subtractPoint(offset).add(buffer.x, buffer.y).copyToFlash(_flashPoint);
 				buffer.draw(camera, _flashPoint, scale.x, scale.y);
 			}
@@ -492,25 +492,25 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			{
 				drawTilemap(buffer, camera);
 			}
-			
+
 			#if FLX_DEBUG
 			FlxBasic.visibleCount++;
 			#end
 		}
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.drawDebug)
 			drawDebug();
 		#end
 	}
-	
-	private function refreshBuffers():Void
+
+	function refreshBuffers():Void
 	{
 		for (i in 0...cameras.length)
 		{
 			var camera = cameras[i];
 			var buffer = _buffers[i];
-			
+
 			// Create a new buffer if the number of columns and rows differs
 			if (buffer == null)
 				_buffers[i] = createBuffer(camera);
@@ -518,11 +518,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				buffer.resize(_tileWidth, _tileHeight, widthInTiles, heightInTiles, camera, scale.x, scale.y);
 		}
 	}
-	
+
 	/**
 	 * Set the dirty flag on all the tilemap buffers.
 	 * Basically forces a reset of the drawn tilemaps, even if it wasn't necessary.
-	 * 
+	 *
 	 * @param	Dirty		Whether to flag the tilemap buffers as dirty or not.
 	 */
 	override public function setDirty(Dirty:Bool = true):Void
@@ -539,7 +539,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * Checks if the Object overlaps any tiles with any collision flags set,
 	 * and calls the specified callback function (if there is one).
 	 * Also calls the tile's registered callback if the filter matches.
-	 * 
+	 *
 	 * @param	Object				The FlxObject you are checking for overlaps against.
 	 * @param	Callback			An optional function that takes the form "myCallback(Object1:FlxObject,Object2:FlxObject)", where Object1 is a FlxTile object, and Object2 is the object passed in in the first parameter of this method.
 	 * @param	FlipCallbackParams	Used to preserve A-B list ordering from FlxObject.separate() - returns the FlxTile object as the second parameter instead.
@@ -549,28 +549,28 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	override public function overlapsWithCallback(Object:FlxObject, ?Callback:FlxObject->FlxObject->Bool, FlipCallbackParams:Bool = false, ?Position:FlxPoint):Bool
 	{
 		var results:Bool = false;
-		
+
 		var xPos:Float = x;
 		var yPos:Float = y;
-		
+
 		if (Position != null)
 		{
 			xPos = Position.x;
 			yPos = Position.y;
 		}
-		
+
 		// Figure out what tiles we need to check against
 		var selectionX:Int = Math.floor((Object.x - xPos) / _scaledTileWidth);
 		var selectionY:Int = Math.floor((Object.y - yPos) / _scaledTileHeight);
 		var selectionWidth:Int = selectionX + Math.ceil(Object.width / _scaledTileWidth) + 1;
 		var selectionHeight:Int = selectionY + Math.ceil(Object.height / _scaledTileHeight) + 1;
-		
+
 		// Then bound these coordinates by the map edges
 		selectionX = Std.int(FlxMath.bound(selectionX, 0, widthInTiles));
 		selectionY = Std.int(FlxMath.bound(selectionY, 0, heightInTiles));
 		selectionWidth = Std.int(FlxMath.bound(selectionWidth, 0, widthInTiles));
 		selectionHeight = Std.int(FlxMath.bound(selectionHeight, 0, heightInTiles));
-		
+
 		// Then loop through this selection of tiles
 		var rowStart:Int = selectionY * widthInTiles;
 		var column:Int;
@@ -578,11 +578,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		var overlapFound:Bool;
 		var deltaX:Float = xPos - last.x;
 		var deltaY:Float = yPos - last.y;
-		
+
 		for (row in selectionY...selectionHeight)
 		{
 			column = selectionX;
-			
+
 			while (column < selectionWidth)
 			{
 				var index:Int = rowStart + column;
@@ -591,14 +591,14 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					column++;
 					continue;
 				}
-				
+
 				var dataIndex:Int = _data[index];
 				if (dataIndex < 0)
 				{
 					column++;
 					continue;
 				}
-				
+
 				tile = _tileObjects[dataIndex];
 				tile.width = _scaledTileWidth;
 				tile.height = _scaledTileHeight;
@@ -606,11 +606,11 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				tile.y = yPos + row * tile.height;
 				tile.last.x = tile.x - deltaX;
 				tile.last.y = tile.y - deltaY;
-				
+
 				overlapFound =
-					((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) && 
+					((Object.x + Object.width) > tile.x)  && (Object.x < (tile.x + tile.width)) &&
 					((Object.y + Object.height) > tile.y) && (Object.y < (tile.y + tile.height));
-				
+
 				if (tile.allowCollisions != FlxObject.NONE)
 				{
 					if (Callback != null)
@@ -625,7 +625,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 						}
 					}
 				}
-				
+
 				if (overlapFound)
 				{
 					if (tile.callbackFunction != null && (tile.filter == null || Std.is(Object, tile.filter)))
@@ -633,17 +633,17 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 						tile.mapIndex = rowStart + column;
 						tile.callbackFunction(tile, Object);
 					}
-					
+
 					if (tile.allowCollisions != FlxObject.NONE)
 						results = true;
 				}
-				
+
 				column++;
 			}
-			
+
 			rowStart += widthInTiles;
 		}
-		
+
 		return results;
 	}
 
@@ -652,13 +652,13 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		var localX = Coord.x - x;
 		var localY = Coord.y - y;
 		Coord.putWeak();
-		
+
 		if ((localX < 0) || (localY < 0) || (localX >= width) || (localY >= height))
 			return -1;
-		
+
 		return Std.int(localY / _scaledTileHeight) * widthInTiles + Std.int(localX / _scaledTileWidth);
 	}
-	
+
 	override public function getTileCoordsByIndex(Index:Int, Midpoint:Bool = true):FlxPoint
 	{
 		var point = FlxPoint.get(x + (Index % widthInTiles) * _scaledTileWidth, y + Std.int(Index / widthInTiles) * _scaledTileHeight);
@@ -669,10 +669,10 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		}
 		return point;
 	}
-	
+
 	/**
 	 * Returns a new array full of every coordinate of the requested tile type.
-	 * 
+	 *
 	 * @param	Index		The requested tile type.
 	 * @param	Midpoint	Whether to return the coordinates of the tile midpoint, or upper left corner. Default is true, return midpoint.
 	 * @return	An Array with a list of all the coordinates of that tile type.
@@ -680,22 +680,22 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	public function getTileCoords(Index:Int, Midpoint:Bool = true):Array<FlxPoint>
 	{
 		var array:Array<FlxPoint> = null;
-		
+
 		var point:FlxPoint;
 		var l:Int = widthInTiles * heightInTiles;
-		
+
 		for (i in 0...l)
 		{
 			if (_data[i] == Index)
 			{
 				point = FlxPoint.get(x + (i % widthInTiles) * _scaledTileWidth, y + Std.int(i / widthInTiles) * _scaledTileHeight);
-				
+
 				if (Midpoint)
 				{
 					point.x += _scaledTileWidth * 0.5;
 					point.y += _scaledTileHeight * 0.5;
 				}
-				
+
 				if (array == null)
 				{
 					array = new Array<FlxPoint>();
@@ -703,13 +703,13 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				array.push(point);
 			}
 		}
-		
+
 		return array;
 	}
-	
+
 	/**
 	 * Call this function to lock the automatic camera to the map's edges.
-	 * 
+	 *
 	 * @param	Camera			Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
 	 * @param	Border			Adjusts the camera follow boundary by whatever number of tiles you specify here.  Handy for blocking off deadends that are offscreen, etc.  Use a negative number to add padding instead of hiding the edges.
 	 * @param	UpdateWorld		Whether to update the collision system's world size, default value is true.
@@ -718,14 +718,14 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		Camera.setScrollBoundsRect(x + Border * _scaledTileWidth, y + Border * _scaledTileHeight, width - Border * _scaledTileWidth * 2, height - Border * _scaledTileHeight * 2, UpdateWorld);
 	}
-	
+
 	/**
 	 * Shoots a ray from the start point to the end point.
 	 * If/when it passes through a tile, it stores that point and returns false.
-	 * 
+	 *
 	 * @param	Start		The world coordinates of the start of the ray.
 	 * @param	End			The world coordinates of the end of the ray.
 	 * @param	Result		An optional point containing the first wall impact if there was one. Null otherwise.
@@ -735,10 +735,10 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	override public function ray(Start:FlxPoint, End:FlxPoint, ?Result:FlxPoint, Resolution:Float = 1):Bool
 	{
 		var step:Float = _scaledTileWidth;
-		
+
 		if (_scaledTileHeight < _scaledTileWidth)
 			step = _scaledTileHeight;
-		
+
 		step /= Resolution;
 		var deltaX:Float = End.x - Start.x;
 		var deltaY:Float = End.y - Start.y;
@@ -751,24 +751,24 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		var tileX:Int;
 		var tileY:Int;
 		var i:Int = 0;
-		
+
 		Start.putWeak();
 		End.putWeak();
-		
+
 		while (i < steps)
 		{
 			curX += stepX;
 			curY += stepY;
-			
+
 			if ((curX < 0) || (curX > width) || (curY < 0) || (curY > height))
 			{
 				i++;
 				continue;
 			}
-			
+
 			tileX = Math.floor(curX / _scaledTileWidth);
 			tileY = Math.floor(curY / _scaledTileHeight);
-			
+
 			if (_tileObjects[_data[tileY * widthInTiles + tileX]].allowCollisions != FlxObject.NONE)
 			{
 				// Some basic helper stuff
@@ -779,62 +779,62 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				var q:Float;
 				var lx:Float = curX - stepX;
 				var ly:Float = curY - stepY;
-				
+
 				// Figure out if it crosses the X boundary
 				q = tileX;
-				
+
 				if (deltaX < 0)
 				{
 					q += _scaledTileWidth;
 				}
-				
+
 				rx = q;
 				ry = ly + stepY * ((q - lx) / stepX);
-				
+
 				if ((ry >= tileY) && (ry <= tileY + _scaledTileHeight))
 				{
 					if (Result == null)
 					{
 						Result = FlxPoint.get();
 					}
-					
+
 					Result.set(rx, ry);
 					return false;
 				}
-				
+
 				// Else, figure out if it crosses the Y boundary
 				q = tileY;
-				
+
 				if (deltaY < 0)
 				{
 					q += _scaledTileHeight;
 				}
-				
+
 				rx = lx + stepX * ((q - ly) / stepY);
 				ry = q;
-				
+
 				if ((rx >= tileX) && (rx <= tileX + _scaledTileWidth))
 				{
 					if (Result == null)
 					{
 						Result = FlxPoint.get();
 					}
-					
+
 					Result.set(rx, ry);
 					return false;
 				}
-				
+
 				return true;
 			}
 			i++;
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Change a particular tile to FlxSprite. Or just copy the graphic if you dont want any changes to map data itself.
-	 * 
+	 *
 	 * @link http://forums.flixel.org/index.php/topic,5398.0.html
 	 * @param	X				The X coordinate of the tile (in tiles, not pixels).
 	 * @param	Y				The Y coordinate of the tile (in tiles, not pixels).
@@ -846,26 +846,26 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	{
 		if (SpriteFactory == null)
 			SpriteFactory = defaultTileToSprite;
-		
+
 		var rowIndex:Int = X + (Y * widthInTiles);
 		var tile:FlxTile = _tileObjects[_data[rowIndex]];
 		var image:FlxImageFrame = null;
-		
+
 		if (tile != null && tile.visible)
 			image = FlxImageFrame.fromFrame(tile.frame);
 		else
 			image = FlxImageFrame.fromEmptyFrame(graphic, FlxRect.get(0, 0, _tileWidth, _tileHeight));
-		
+
 		var tileX:Float = X * _tileWidth * scale.x + x;
 		var tileY:Float = Y * _tileHeight * scale.y + y;
 		var tileSprite:FlxSprite = SpriteFactory({graphic: image, x: tileX, y: tileY, scale: FlxPoint.get().copyFrom(scale), alpha: alpha, blend: blend});
-		
-		if (NewTile >= 0) 
+
+		if (NewTile >= 0)
 			setTile(X, Y, NewTile);
-		
+
 		return tileSprite;
 	}
-	
+
 	/**
 	 * Use this method so the tilemap buffers are updated, e.g. when resizing your game
 	 */
@@ -874,25 +874,25 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		FlxDestroyUtil.destroyArray(_buffers);
 		_buffers = [];
 	}
-	
+
 	/**
 	 * Internal function that actually renders the tilemap to the tilemap buffer. Called by draw().
-	 * 
+	 *
 	 * @param	Buffer		The FlxTilemapBuffer you are rendering to.
 	 * @param	Camera		The related FlxCamera, mainly for scroll values.
 	 */
 	@:access(flixel.FlxCamera)
-	private function drawTilemap(Buffer:FlxTilemapBuffer, Camera:FlxCamera):Void
+	function drawTilemap(Buffer:FlxTilemapBuffer, Camera:FlxCamera):Void
 	{
 		var isColored:Bool = (alpha != 1) || (color != 0xffffff);
-		
+
 		//only used for renderTile
 		var drawX:Float = 0;
 		var drawY:Float = 0;
 		var scaledWidth:Float = 0;
 		var scaledHeight:Float = 0;
 		var drawItem = null;
-		
+
 		if (FlxG.renderBlit)
 		{
 			Buffer.fill();
@@ -900,73 +900,73 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		else
 		{
 			getScreenPosition(_point, Camera).subtractPoint(offset).copyToFlash(_helperPoint);
-			
+
 			_helperPoint.x = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
 			_helperPoint.y = isPixelPerfectRender(Camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;
-			
+
 			scaledWidth  = _scaledTileWidth;
 			scaledHeight = _scaledTileHeight;
-			
+
 			var hasColorOffsets:Bool = (colorTransform != null && colorTransform.hasRGBAOffsets());
 			drawItem = Camera.startQuadBatch(graphic, isColored, hasColorOffsets, blend, antialiasing, shader);
 		}
-		
+
 		// Copy tile images into the tile buffer
 		_point.x = (Camera.scroll.x * scrollFactor.x) - x - offset.x + Camera.viewOffsetX; //modified from getScreenPosition()
 		_point.y = (Camera.scroll.y * scrollFactor.y) - y - offset.y + Camera.viewOffsetY;
-		
+
 		var screenXInTiles:Int = Math.floor(_point.x / _scaledTileWidth);
 		var screenYInTiles:Int = Math.floor(_point.y / _scaledTileHeight);
 		var screenRows:Int = Buffer.rows;
 		var screenColumns:Int = Buffer.columns;
-		
+
 		// Bound the upper left corner
 		screenXInTiles = Std.int(FlxMath.bound(screenXInTiles, 0, widthInTiles - screenColumns));
 		screenYInTiles =  Std.int(FlxMath.bound(screenYInTiles, 0, heightInTiles - screenRows));
-		
+
 		var rowIndex:Int = screenYInTiles * widthInTiles + screenXInTiles;
 		_flashPoint.y = 0;
 		var columnIndex:Int;
 		var tile:FlxTile;
 		var frame:FlxFrame;
-		
+
 		#if FLX_DEBUG
 		var debugTile:BitmapData;
 		#end
-		
+
 		for (row in 0...screenRows)
 		{
 			columnIndex = rowIndex;
 			_flashPoint.x = 0;
-			
+
 			for (column in 0...screenColumns)
 			{
 				tile = _tileObjects[_data[columnIndex]];
-				
+
 				if (tile != null && tile.visible && tile.frame.type != FlxFrameType.EMPTY)
 				{
 					frame = tile.frame;
-					
+
 					if (FlxG.renderBlit)
 					{
 						frame.paint(Buffer.pixels, _flashPoint, true);
-						
+
 						#if FLX_DEBUG
-						if (FlxG.debugger.drawDebug && !ignoreDrawDebug) 
+						if (FlxG.debugger.drawDebug && !ignoreDrawDebug)
 						{
 							if (tile.allowCollisions <= FlxObject.NONE)
 							{
-								debugTile = _debugTileNotSolid; 
+								debugTile = _debugTileNotSolid;
 							}
 							else if (tile.allowCollisions != FlxObject.ANY)
 							{
-								debugTile = _debugTilePartial; 
+								debugTile = _debugTilePartial;
 							}
 							else
 							{
-								debugTile = _debugTileSolid; 
+								debugTile = _debugTileSolid;
 							}
-							
+
 							offset.addToFlash(_flashPoint);
 							Buffer.pixels.copyPixels(debugTile, _debugRect, _flashPoint, null, null, true);
 							offset.subtractFromFlash(_flashPoint);
@@ -977,60 +977,60 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					{
 						drawX = _helperPoint.x + (columnIndex % widthInTiles) * scaledWidth;
 						drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * scaledHeight;
-						
+
 						_matrix.identity();
-						
+
 						if (frame.angle != FlxFrameAngle.ANGLE_0)
 						{
 							frame.prepareMatrix(_matrix);
 						}
-						
+
 						var scaleX:Float = scale.x;
 						var scaleY:Float = scale.y;
-						
+
 						if (useScaleHack)
 						{
 							scaleX += 1 / (frame.sourceSize.x * Camera.totalScaleX);
 							scaleY += 1 / (frame.sourceSize.y * Camera.totalScaleY);
 						}
-						
+
 						_matrix.scale(scaleX, scaleY);
 						_matrix.translate(drawX, drawY);
-						
+
 						drawItem.addQuad(frame, _matrix, colorTransform);
 					}
 				}
-				
+
 				if (FlxG.renderBlit)
 					_flashPoint.x += _tileWidth;
-				
+
 				columnIndex++;
 			}
-			
+
 			if (FlxG.renderBlit)
 				_flashPoint.y += _tileHeight;
 			rowIndex += widthInTiles;
 		}
-		
+
 		Buffer.x = screenXInTiles * _scaledTileWidth;
 		Buffer.y = screenYInTiles * _scaledTileHeight;
-		
+
 		if (FlxG.renderBlit)
 		{
 			if (isColored)
 				Buffer.colorTransform(colorTransform);
 			Buffer.blend = blend;
 		}
-		
+
 		Buffer.dirty = false;
 	}
-	
+
 	/**
 	 * Internal function to clean up the map loading code.
 	 * Just generates a wireframe box the size of a tile with the specified color.
 	 */
 	#if FLX_DEBUG
-	private function makeDebugTile(color:FlxColor):BitmapData
+	function makeDebugTile(color:FlxColor):BitmapData
 	{
 		if (FlxG.renderTile)
 			return null;
@@ -1039,8 +1039,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		drawDebugTile(debugTile, color);
 		return debugTile;
 	}
-	
-	private function drawDebugTile(debugTile:BitmapData, color:FlxColor):Void
+
+	function drawDebugTile(debugTile:BitmapData, color:FlxColor):Void
 	{
 		if (color != FlxColor.TRANSPARENT)
 		{
@@ -1052,12 +1052,12 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			gfx.lineTo(_tileWidth - 1, _tileHeight - 1);
 			gfx.lineTo(0, _tileHeight - 1);
 			gfx.lineTo(0, 0);
-			
+
 			debugTile.draw(FlxSpriteUtil.flashGfxSprite);
 		}
 	}
 
-	private function onDrawDebugChanged():Void
+	function onDrawDebugChanged():Void
 	{
 		setDirty();
 	}
@@ -1065,10 +1065,10 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 
 	/**
 	 * Internal function used in setTileByIndex() and the constructor to update the map.
-	 * 
+	 *
 	 * @param	Index		The index of the tile object in _tileObjects internal array you want to update.
 	 */
-	override private function updateTile(Index:Int):Void
+	override function updateTile(Index:Int):Void
 	{
 		var tile:FlxTile = _tileObjects[Index];
 		if (tile == null || !tile.visible)
@@ -1076,27 +1076,27 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 
 		tile.frame = frames.frames[Index - _startingIndex];
 	}
-	
-	private inline function createBuffer(camera:FlxCamera):FlxTilemapBuffer
+
+	inline function createBuffer(camera:FlxCamera):FlxTilemapBuffer
 	{
 		var buffer = new FlxTilemapBuffer(_tileWidth, _tileHeight, widthInTiles, heightInTiles, camera, scale.x, scale.y);
 		buffer.pixelPerfectRender = pixelPerfectRender;
 		buffer.antialiasing = antialiasing;
 		return buffer;
 	}
-	
-	private function set_antialiasing(value:Bool):Bool
+
+	function set_antialiasing(value:Bool):Bool
 	{
 		for (buffer in _buffers)
 			buffer.antialiasing = value;
 		return antialiasing = value;
 	}
-	
+
 	/**
-	 * Internal function for setting graphic property for this object. 
+	 * Internal function for setting graphic property for this object.
 	 * It changes graphic' useCount also for better memory tracking.
 	 */
-	private function set_graphic(Value:FlxGraphic):FlxGraphic
+	function set_graphic(Value:FlxGraphic):FlxGraphic
 	{
 		//If graphics are changing
 		if (graphic != Value)
@@ -1109,27 +1109,27 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			if (graphic != null)
 				graphic.useCount--;
 		}
-		
+
 		return graphic = Value;
 	}
-	
-	override private function set_pixelPerfectRender(Value:Bool):Bool 
+
+	override function set_pixelPerfectRender(Value:Bool):Bool
 	{
 		if (_buffers != null)
 			for (buffer in _buffers)
 				buffer.pixelPerfectRender = Value;
-		
+
 		return pixelPerfectRender = Value;
 	}
-	
-	private function set_alpha(Alpha:Float):Float
+
+	function set_alpha(Alpha:Float):Float
 	{
 		alpha = FlxMath.bound(Alpha, 0, 1);
 		updateColorTransform();
 		return alpha;
 	}
-	
-	private function set_color(Color:FlxColor):Int
+
+	function set_color(Color:FlxColor):Int
 	{
 		if (color == Color)
 			return Color;
@@ -1138,37 +1138,37 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		updateColorTransform();
 		return color;
 	}
-	
-	private function updateColorTransform():Void
+
+	function updateColorTransform():Void
 	{
 		if (colorTransform == null)
 			colorTransform = new ColorTransform();
-		
+
 		if (alpha != 1 || color != 0xffffff)
 			colorTransform.setMultipliers(color.redFloat, color.greenFloat, color.blueFloat, alpha);
 		else
 			colorTransform.setMultipliers(1, 1, 1, 1);
-		
+
 		setDirty();
 	}
-	
-	private function set_blend(Value:BlendMode):BlendMode 
+
+	function set_blend(Value:BlendMode):BlendMode
 	{
 		setDirty();
 		return blend = Value;
 	}
-	
-	private function setScaleXYCallback(Scale:FlxPoint):Void
+
+	function setScaleXYCallback(Scale:FlxPoint):Void
 	{
 		setScaleXCallback(Scale);
 		setScaleYCallback(Scale);
 	}
-	
-	private function setScaleXCallback(Scale:FlxPoint):Void
+
+	function setScaleXCallback(Scale:FlxPoint):Void
 	{
 		_scaledTileWidth = _tileWidth * scale.x;
 		width = widthInTiles * _scaledTileWidth;
-		
+
 		if (cameras == null)
 			return;
 
@@ -1176,12 +1176,12 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			if (_buffers[i] != null)
 				_buffers[i].updateColumns(_tileWidth, widthInTiles, scale.x, cameras[i]);
 	}
-	
-	private function setScaleYCallback(Scale:FlxPoint):Void
+
+	function setScaleYCallback(Scale:FlxPoint):Void
 	{
 		_scaledTileHeight = _tileHeight * scale.y;
 		height = heightInTiles * _scaledTileHeight;
-		
+
 		if (cameras == null)
 			return;
 
@@ -1189,14 +1189,14 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			if (_buffers[i] != null)
 				_buffers[i].updateRows(_tileHeight, heightInTiles, scale.y, cameras[i]);
 	}
-	
+
 	/**
 	 * Default method for generating FlxSprite from FlxTile
-	 * 
+	 *
 	 * @param	TileProperties	properties for new sprite
 	 * @return	New FlxSprite with specified graphic
 	 */
-	private function defaultTileToSprite(TileProperties:FlxTileProperties):FlxSprite
+	function defaultTileToSprite(TileProperties:FlxTileProperties):FlxSprite
 	{
 		var tileSprite = new FlxSprite(TileProperties.x, TileProperties.y);
 		tileSprite.frames = TileProperties.graphic;
@@ -1206,8 +1206,8 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		tileSprite.blend = TileProperties.blend;
 		return tileSprite;
 	}
-	
-	override function set_allowCollisions(Value:Int):Int 
+
+	override function set_allowCollisions(Value:Int):Int
 	{
 		for (tile in _tileObjects)
 			if (tile.index >= _collideIndex)
@@ -1217,21 +1217,21 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	}
 
 	#if FLX_DEBUG
-	override private function set_debugBoundingBoxColorSolid(color:FlxColor)
+	override function set_debugBoundingBoxColorSolid(color:FlxColor)
 	{
 		super.set_debugBoundingBoxColorSolid(color);
 		updateDebugTileBoundingBoxSolid();
 		return color;
 	}
-	
-	override private function set_debugBoundingBoxColorNotSolid(color:FlxColor)
+
+	override function set_debugBoundingBoxColorNotSolid(color:FlxColor)
 	{
 		super.set_debugBoundingBoxColorNotSolid(color);
 		updateDebugTileBoundingBoxNotSolid();
 		return color;
 	}
-	
-	override private function set_debugBoundingBoxColorPartial(color:FlxColor)
+
+	override function set_debugBoundingBoxColorPartial(color:FlxColor)
 	{
 		super.set_debugBoundingBoxColorPartial(color);
 		updateDebugTileBoundingBoxPartial();

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -47,42 +47,42 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public var columns:Int = 0;
 	/**
-	 * Whether or not the coordinates should be rounded during draw(), true by default (recommended for pixel art). 
+	 * Whether or not the coordinates should be rounded during draw(), true by default (recommended for pixel art).
 	 * Only affects tilesheet rendering and rendering using BitmapData.draw() in blitting.
 	 * (copyPixels() only renders on whole pixels by nature). Causes draw() to be used if false, which is more expensive.
 	 */
 	public var pixelPerfectRender:Null<Bool>;
-	
+
 	/**
 	 * The actual buffer BitmapData. (Only used if FlxG.renderBlit == true)
-	 */ 
+	 */
 	public var pixels(default, null):BitmapData;
-	
+
 	public var blend:BlendMode;
 	public var antialiasing:Bool = false;
-	
-	private var _flashRect:Rectangle;
-	private var _matrix:FlxMatrix;
-	
+
+	var _flashRect:Rectangle;
+	var _matrix:FlxMatrix;
+
 	/**
 	 * Variables related to calculation of dirty value
 	 */
-	private var _prevTilemapX:Float;
-	private var _prevTilemapY:Float;
-	private var _prevTilemapScaleX:Float;
-	private var _prevTilemapScaleY:Float;
-	private var _prevTilemapScrollX:Float;
-	private var _prevTilemapScrollY:Float;
-	private var _prevCameraScrollX:Float;
-	private var _prevCameraScrollY:Float;
-	private var _prevCameraScaleX:Float;
-	private var _prevCameraScaleY:Float;
-	private var _prevCameraWidth:Int;
-	private var _prevCameraHeight:Int;
-	
+	var _prevTilemapX:Float;
+	var _prevTilemapY:Float;
+	var _prevTilemapScaleX:Float;
+	var _prevTilemapScaleY:Float;
+	var _prevTilemapScrollX:Float;
+	var _prevTilemapScrollY:Float;
+	var _prevCameraScrollX:Float;
+	var _prevCameraScrollY:Float;
+	var _prevCameraScaleX:Float;
+	var _prevCameraScaleY:Float;
+	var _prevCameraWidth:Int;
+	var _prevCameraHeight:Int;
+
 	/**
 	 * Instantiates a new camera-specific buffer for storing the visual tilemap data.
-	 * 
+	 *
 	 * @param   TileWidth       The width of the tiles in this tilemap.
 	 * @param   TileHeight      The height of the tiles in this tilemap.
 	 * @param   WidthInTiles    How many tiles wide the tilemap is.
@@ -94,18 +94,18 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	{
 		resize(TileWidth, TileHeight, WidthInTiles, HeightInTiles, Camera, ScaleX, ScaleY);
 	}
-	
+
 	public function resize(TileWidth:Int, TileHeight:Int, WidthInTiles:Int, HeightInTiles:Int,
 		?Camera:FlxCamera, ScaleX:Float = 1.0, ScaleY:Float = 1.0):Void
 	{
 		updateColumns(TileWidth, WidthInTiles, ScaleX, Camera);
 		updateRows(TileHeight, HeightInTiles, ScaleY, Camera);
-		
+
 		if (FlxG.renderBlit)
 		{
 			var newWidth:Int = Std.int(columns * TileWidth);
 			var newHeight:Int = Std.int(rows * TileHeight);
-			
+
 			if (pixels == null)
 			{
 				pixels = new BitmapData(newWidth, newHeight, true, 0);
@@ -122,7 +122,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			}
 		}
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -136,11 +136,11 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			_flashRect = null;
 		}
 	}
-	
+
 	/**
 	 * Fill the buffer with the specified color.
 	 * Default value is transparent.
-	 * 
+	 *
 	 * @param	Color	What color to fill with, in 0xAARRGGBB hex format.
 	 */
 	public function fill(Color:FlxColor = FlxColor.TRANSPARENT):Void
@@ -150,10 +150,10 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			pixels.fillRect(_flashRect, Color);
 		}
 	}
-	
+
 	/**
 	 * Just stamps this buffer onto the specified camera at the specified location.
-	 * 
+	 *
 	 * @param	Camera		Which camera to draw the buffer onto.
 	 * @param	FlashPoint	Where to draw the buffer at in camera coordinates.
 	 */
@@ -164,7 +164,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			FlashPoint.x = Math.floor(FlashPoint.x);
 			FlashPoint.y = Math.floor(FlashPoint.y);
 		}
-		
+
 		if (isPixelPerfectRender(Camera) && (ScaleX == 1.0 && ScaleY == 1.0) && blend == null)
 		{
 			Camera.copyPixels(pixels, _flashRect, FlashPoint, null, null, true);
@@ -177,47 +177,47 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			Camera.drawPixels(pixels, _matrix, null, blend, antialiasing);
 		}
 	}
-	
+
 	public function colorTransform(Transform:ColorTransform):Void
 	{
 		pixels.colorTransform(_flashRect, Transform);
 	}
-	
+
 	@:access(flixel.FlxCamera.viewWidth)
 	public function updateColumns(TileWidth:Int, WidthInTiles:Int, ScaleX:Float = 1.0, ?Camera:FlxCamera):Void
 	{
-		if (WidthInTiles < 0) 
+		if (WidthInTiles < 0)
 			WidthInTiles = 0;
-		
+
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		columns = Math.ceil(Camera.viewWidth / (TileWidth * ScaleX)) + 1;
-		
+
 		if (columns > WidthInTiles)
 			columns = WidthInTiles;
-		
+
 		width = Std.int(columns * TileWidth * ScaleX);
-		
+
 		dirty = true;
 	}
-	
+
 	@:access(flixel.FlxCamera.viewHeight)
 	public function updateRows(TileHeight:Int, HeightInTiles:Int, ScaleY:Float = 1.0, ?Camera:FlxCamera):Void
 	{
-		if (HeightInTiles < 0) 
+		if (HeightInTiles < 0)
 			HeightInTiles = 0;
-		
+
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		rows = Math.ceil(Camera.viewHeight / (TileHeight * ScaleY)) + 1;
-		
+
 		if (rows > HeightInTiles)
 			rows = HeightInTiles;
-		
+
 		height = Std.int(rows * TileHeight * ScaleY);
-		
+
 		dirty = true;
 	}
 
@@ -228,10 +228,10 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	{
 		if (Camera == null)
 			Camera = FlxG.camera;
-		
+
 		return pixelPerfectRender == null ? Camera.pixelPerfectRender : pixelPerfectRender;
 	}
-	
+
 	/**
 	 * Check if tilemap or camera has changed (scrolled, moved, resized or scaled) since the previous frame.
 	 * If so, then it means that we need to redraw this buffer.
@@ -241,13 +241,13 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public function isDirty(Tilemap:FlxTilemap, Camera:FlxCamera):Bool
 	{
-		dirty = dirty || (Tilemap.x != _prevTilemapX) || (Tilemap.y != _prevTilemapY) 
-				|| (Tilemap.scale.x != _prevTilemapScaleX) || (Tilemap.scale.y != _prevTilemapScaleY) 
-				|| (Tilemap.scrollFactor.x != _prevTilemapScrollX) || (Tilemap.scrollFactor.y != _prevTilemapScrollY) 
-				|| (Camera.scroll.x != _prevCameraScrollX) || (Camera.scroll.y != _prevCameraScrollY) 
+		dirty = dirty || (Tilemap.x != _prevTilemapX) || (Tilemap.y != _prevTilemapY)
+				|| (Tilemap.scale.x != _prevTilemapScaleX) || (Tilemap.scale.y != _prevTilemapScaleY)
+				|| (Tilemap.scrollFactor.x != _prevTilemapScrollX) || (Tilemap.scrollFactor.y != _prevTilemapScrollY)
+				|| (Camera.scroll.x != _prevCameraScrollX) || (Camera.scroll.y != _prevCameraScrollY)
 				|| (Camera.scaleX != _prevCameraScaleX) || (Camera.scaleY != _prevCameraScaleY)
 				|| (Camera.width != _prevCameraWidth) || (Camera.height != _prevCameraHeight);
-		
+
 		if (dirty)
 		{
 			_prevTilemapX = Tilemap.x;
@@ -263,7 +263,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			_prevCameraWidth = Camera.width;
 			_prevCameraHeight = Camera.height;
 		}
-		
+
 		return dirty;
 	}
 }

--- a/flixel/tweens/FlxEase.hx
+++ b/flixel/tweens/FlxEase.hx
@@ -2,9 +2,9 @@ package flixel.tweens;
 
 /**
  * Static class with useful easer functions that can be used by Tweens.
- * 
+ *
  * Operation of in/out easers:
- * 
+ *
  * in(t)
  * 	return t;
  * out(t)
@@ -12,22 +12,22 @@ package flixel.tweens;
  * inOut(t)
  * 		return (t <= .5) ? in(t * 2) / 2 : out(t * 2 - 1) / 2 + .5;
  */
-class FlxEase 
+class FlxEase
 {
 	/**
 	 * Easing constants.
-	 */ 
-	private static var PI2:Float = Math.PI / 2;
-	private static var EL:Float = 2 * Math.PI / .45;
-	private static var B1:Float = 1 / 2.75;
-	private static var B2:Float = 2 / 2.75;
-	private static var B3:Float = 1.5 / 2.75;
-	private static var B4:Float = 2.5 / 2.75;
-	private static var B5:Float = 2.25 / 2.75;
-	private static var B6:Float = 2.625 / 2.75;
-	private static var ELASTIC_AMPLITUDE:Float = 1;
-	private static var ELASTIC_PERIOD:Float = 0.4;
-	
+	 */
+	static var PI2:Float = Math.PI / 2;
+	static var EL:Float = 2 * Math.PI / .45;
+	static var B1:Float = 1 / 2.75;
+	static var B2:Float = 2 / 2.75;
+	static var B3:Float = 1.5 / 2.75;
+	static var B4:Float = 2.5 / 2.75;
+	static var B5:Float = 2.25 / 2.75;
+	static var B6:Float = 2.625 / 2.75;
+	static var ELASTIC_AMPLITUDE:Float = 1;
+	static var ELASTIC_PERIOD:Float = 0.4;
+
 	/** @since 4.3.0 */
 	public static inline function linear(t:Float):Float
 	{
@@ -38,27 +38,27 @@ class FlxEase
 	{
 		return t * t;
 	}
-	
+
 	public static inline function quadOut(t:Float):Float
 	{
 		return -t * (t - 2);
 	}
-	
+
 	public static inline function quadInOut(t:Float):Float
 	{
 		return t <= .5 ? t * t * 2 : 1 - (--t) * t * 2;
 	}
-	
+
 	public static inline function cubeIn(t:Float):Float
 	{
 		return t * t * t;
 	}
-	
+
 	public static inline function cubeOut(t:Float):Float
 	{
 		return 1 + (--t) * t * t;
 	}
-	
+
 	public static inline function cubeInOut(t:Float):Float
 	{
 		return t <= .5 ? t * t * t * 4 : 1 + (--t) * t * t * 4;
@@ -68,83 +68,83 @@ class FlxEase
 	{
 		return t * t * t * t;
 	}
-	
+
 	public static inline function quartOut(t:Float):Float
 	{
 		return 1 - (t -= 1) * t * t * t;
 	}
-	
+
 	public static inline function quartInOut(t:Float):Float
 	{
 		return t <= .5 ? t * t * t * t * 8 : (1 - (t = t * 2 - 2) * t * t * t) / 2 + .5;
 	}
-	
+
 	public static inline function quintIn(t:Float):Float
 	{
 		return t * t * t * t * t;
 	}
-	
+
 	public static inline function quintOut(t:Float):Float
 	{
 		return (t = t - 1) * t * t * t * t + 1;
 	}
-	
+
 	public static inline function quintInOut(t:Float):Float
 	{
 		return ((t *= 2) < 1) ? (t * t * t * t * t) / 2 : ((t -= 2) * t * t * t * t + 2) / 2;
 	}
-	
+
 	/** @since 4.3.0 */
 	public static inline function smoothStepIn(t:Float):Float
 	{
 		return 2 * smoothStepInOut(t / 2);
 	}
-	
+
 	/** @since 4.3.0 */
 	public static inline function smoothStepOut(t:Float):Float
 	{
 		return 2 * smoothStepInOut(t / 2 + 0.5) - 1;
 	}
-	
+
 	/** @since 4.3.0 */
 	public static inline function smoothStepInOut(t:Float):Float
 	{
 		return t * t * (t * -2 + 3);
 	}
-	
+
 	/** @since 4.3.0 */
 	public static inline function smootherStepIn(t:Float):Float
 	{
 		return 2 * smootherStepInOut(t / 2);
 	}
-	
+
 	/** @since 4.3.0 */
 	public static inline function smootherStepOut(t:Float):Float
 	{
 		return 2 * smootherStepInOut(t / 2 + 0.5) - 1;
 	}
-	
+
 	/** @since 4.3.0 */
 	public static inline function smootherStepInOut(t:Float):Float
 	{
 		return t * t * t * (t * (t * 6 - 15) + 10);
 	}
-	
+
 	public static inline function sineIn(t:Float):Float
 	{
 		return -Math.cos(PI2 * t) + 1;
 	}
-	
+
 	public static inline function sineOut(t:Float):Float
 	{
 		return Math.sin(PI2 * t);
 	}
-	
+
 	public static inline function sineInOut(t:Float):Float
 	{
 		return -Math.cos(Math.PI * t) / 2 + .5;
 	}
-	
+
 	public static function bounceIn(t:Float):Float
 	{
 		t = 1 - t;
@@ -153,7 +153,7 @@ class FlxEase
 		if (t < B4) return 1 - (7.5625 * (t - B5) * (t - B5) + .9375);
 		return 1 - (7.5625 * (t - B6) * (t - B6) + .984375);
 	}
-	
+
 	public static function bounceOut(t:Float):Float
 	{
 		if (t < B1) return 7.5625 * t * t;
@@ -161,7 +161,7 @@ class FlxEase
 		if (t < B4) return 7.5625 * (t - B5) * (t - B5) + .9375;
 		return 7.5625 * (t - B6) * (t - B6) + .984375;
 	}
-	
+
 	public static function bounceInOut(t:Float):Float
 	{
 		if (t < .5)
@@ -178,47 +178,47 @@ class FlxEase
 		if (t < B4) return (7.5625 * (t - B5) * (t - B5) + .9375) / 2 + .5;
 		return (7.5625 * (t - B6) * (t - B6) + .984375) / 2 + .5;
 	}
-	
+
 	public static inline function circIn(t:Float):Float
 	{
 		return -(Math.sqrt(1 - t * t) - 1);
 	}
-	
+
 	public static inline function circOut(t:Float):Float
 	{
 		return Math.sqrt(1 - (t - 1) * (t - 1));
 	}
-	
+
 	public static function circInOut(t:Float):Float
 	{
 		return t <= .5 ? (Math.sqrt(1 - t * t * 4) - 1) / -2 : (Math.sqrt(1 - (t * 2 - 2) * (t * 2 - 2)) + 1) / 2;
 	}
-	
+
 	public static inline function expoIn(t:Float):Float
 	{
 		return Math.pow(2, 10 * (t - 1));
 	}
-	
+
 	public static inline function expoOut(t:Float):Float
 	{
 		return -Math.pow(2, -10 * t) + 1;
 	}
-	
+
 	public static function expoInOut(t:Float):Float
 	{
 		return t < .5 ? Math.pow(2, 10 * (t * 2 - 1)) / 2 : (-Math.pow(2, -10 * (t * 2 - 1)) + 2) / 2;
 	}
-	
+
 	public static inline function backIn(t:Float):Float
 	{
 		return t * t * (2.70158 * t - 1.70158);
 	}
-	
+
 	public static inline function backOut(t:Float):Float
 	{
 		return 1 - (--t) * (t) * (-2.70158 * t - 1.70158);
 	}
-	
+
 	public static function backInOut(t:Float):Float
 	{
 		t *= 2;
@@ -226,17 +226,17 @@ class FlxEase
 		t--;
 		return (1 - (--t) * (t) * (-2.70158 * t - 1.70158)) / 2 + .5;
 	}
-	
+
 	public static inline function elasticIn(t:Float):Float
 	{
 		return -(ELASTIC_AMPLITUDE * Math.pow(2, 10 * (t -= 1)) * Math.sin( (t - (ELASTIC_PERIOD / (2 * Math.PI) * Math.asin(1 / ELASTIC_AMPLITUDE))) * (2 * Math.PI) / ELASTIC_PERIOD));
 	}
-	
+
 	public static inline  function elasticOut(t:Float):Float
 	{
 		return (ELASTIC_AMPLITUDE * Math.pow(2, -10 * t) * Math.sin((t - (ELASTIC_PERIOD / (2 * Math.PI) * Math.asin(1 / ELASTIC_AMPLITUDE))) * (2 * Math.PI) / ELASTIC_PERIOD) + 1);
 	}
-	
+
 	public static function elasticInOut(t:Float):Float
 	{
 		if (t < 0.5)

--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -47,14 +47,14 @@ class FlxTween implements IFlxDestroyable
 	 * @since 4.2.0
 	 */
 	public static var globalManager:FlxTweenManager;
-	
+
 	/**
 	 * Tweens numeric public properties of an Object. Shorthand for creating a VarTween, starting it and adding it to the TweenManager.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.tween(Object, { x: 500, y: 350 }, 2.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object		The object containing the properties to tween.
 	 * @param	Values		An object containing key/value pairs of properties and target values.
 	 * @param	Duration	Duration of the tween in seconds.
@@ -65,24 +65,24 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.tween(Object, Values, Duration, Options);
 	}
-	
+
 	/**
-	 * Tweens some numeric value. Shorthand for creating a NumTween, starting it and adding it to the TweenManager. Using it in 
+	 * Tweens some numeric value. Shorthand for creating a NumTween, starting it and adding it to the TweenManager. Using it in
 	 * conjunction with a TweenFunction requires more setup, but is faster than VarTween because it doesn't use Reflection.
-	 * 
+	 *
 	 * ```haxe
 	 * private function tweenFunction(s:FlxSprite, v:Float) { s.alpha = v; }
 	 * FlxTween.num(1, 0, 2.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT }, tweenFunction.bind(mySprite));
 	 * ```
-	 * 
+	 *
 	 * Trivia: For historical reasons, you can use either onUpdate or TweenFunction to accomplish the same thing, but TweenFunction
 	 * gives you the updated Float as a direct argument.
-	 * 
+	 *
 	 * @param	FromValue	Start value.
 	 * @param	ToValue		End value.
 	 * @param	Duration	Duration of the tween.
 	 * @param	Options		A structure with tween options.
-	 * @param	TweenFunction	A function to be called when the tweened value updates.  It is recommended not to use an anonymous 
+	 * @param	TweenFunction	A function to be called when the tweened value updates.  It is recommended not to use an anonymous
 	 *							function if you are maximizing performance, as those will be compiled to Dynamics on cpp.
 	 * @return	The added NumTween object.
 	 */
@@ -90,14 +90,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.num(FromValue, ToValue, Duration, Options, TweenFunction);
 	}
-	
+
 	/**
 	 * Tweens numeric value which represents angle. Shorthand for creating a AngleTween object, starting it and adding it to the TweenManager.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.angle(Sprite, -90, 90, 2.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Sprite		Optional Sprite whose angle should be tweened.
 	 * @param	FromAngle	Start angle.
 	 * @param	ToAngle		End angle.
@@ -109,14 +109,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.angle(Sprite, FromAngle, ToAngle, Duration, Options);
 	}
-	
+
 	/**
 	 * Tweens numeric value which represents color. Shorthand for creating a ColorTween object, starting it and adding it to a TweenPlugin.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.color(Sprite, 2.0, 0x000000, 0xffffff, 0.0, 1.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Sprite		Optional Sprite whose color should be tweened.
 	 * @param	Duration	Duration of the tween in seconds.
 	 * @param	FromColor	Start color.
@@ -128,14 +128,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.color(Sprite, Duration, FromColor, ToColor, Options);
 	}
-	
+
 	/**
 	 * Create a new LinearMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.linearMotion(Object, 0, 0, 500, 20, 5, false, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	FromX			X start.
 	 * @param	FromY			Y start.
@@ -150,14 +150,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.linearMotion(Object, FromX, FromY, ToX, ToY, DurationOrSpeed, UseDuration, Options);
 	}
-	
+
 	/**
 	 * Create a new QuadMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.quadMotion(Object, 0, 100, 300, 500, 100, 2, 5, false, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	FromX			X start.
 	 * @param	FromY			Y start.
@@ -174,14 +174,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.quadMotion(Object, FromX, FromY, ControlX, ControlY, ToX, ToY, DurationOrSpeed, UseDuration, Options);
 	}
-	
+
 	/**
 	 * Create a new CubicMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.cubicMotion(_sprite, 0, 0, 500, 100, 400, 200, 100, 100, 2, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object 		The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	FromX		X start.
 	 * @param	FromY		Y start.
@@ -199,14 +199,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.cubicMotion(Object, FromX, FromY, aX, aY, bX, bY, ToX, ToY, Duration, Options);
 	}
-	
+
 	/**
 	 * Create a new CircularMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.circularMotion(Object, 250, 250, 50, 0, true, 2, true, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	CenterX			X position of the circle's center.
 	 * @param	CenterY			Y position of the circle's center.
@@ -223,14 +223,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.circularMotion(Object, CenterX, CenterY, Radius, Angle, Clockwise, DurationOrSpeed, UseDuration, Options);
 	}
-	
+
 	/**
 	 * Create a new LinearPath tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.linearPath(Object, [FlxPoint.get(0, 0), FlxPoint.get(100, 100)], 2, true, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object 			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	Points			An array of at least 2 FlxPoints defining the path
 	 * @param	DurationOrSpeed	Duration (in seconds) or speed of the movement.
@@ -242,14 +242,14 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.linearPath(Object, Points, DurationOrSpeed, UseDuration, Options);
 	}
-	
+
 	/**
 	 * Create a new QuadPath tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.quadPath(Object, [FlxPoint.get(0, 0), FlxPoint.get(200, 200), FlxPoint.get(400, 0)], 2, true, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	Points			An array of at least 3 FlxPoints defining the path
 	 * @param	DurationOrSpeed	Duration (in seconds) or speed of the movement.
@@ -261,7 +261,7 @@ class FlxTween implements IFlxDestroyable
 	{
 		return globalManager.quadPath(Object, Points, DurationOrSpeed, UseDuration, Options);
 	}
-	
+
 	/**
 	 * The manager to which this tween belongs
 	 * @since 4.2.0
@@ -273,9 +273,9 @@ class FlxTween implements IFlxDestroyable
 	public var onStart:TweenCallback;
 	public var onUpdate:TweenCallback;
 	public var onComplete:TweenCallback;
-	
+
 	public var type(default, set):Int;
-	
+
 	/**
 	 * Value between `0` and `1` that indicates how far along this tween is in its completion.
 	 * A value of `0.33` means that the tween is `33%` complete.
@@ -284,37 +284,37 @@ class FlxTween implements IFlxDestroyable
 	public var finished(default, null):Bool;
 	public var scale(default, null):Float = 0;
 	public var backward(default, null):Bool;
-	
+
 	/**
-	 * How many times this tween has been executed / has finished so far - useful to 
+	 * How many times this tween has been executed / has finished so far - useful to
 	 * stop the `LOOPING` and `PINGPONG` types after a certain amount of time
 	 */
 	public var executions(default, null):Int = 0;
-	
+
 	/**
 	 * Seconds to wait until starting this tween, 0 by default
 	 */
 	public var startDelay(default, set):Float = 0;
-	
+
 	/**
 	 * Seconds to wait between loops of this tween, 0 by default
 	 */
 	public var loopDelay(default, set):Float = 0;
-	
-	private var _secondsSinceStart:Float = 0;
-	private var _delayToUse:Float = 0;
-	private var _running:Bool = false;
-	private var _waitingForRestart:Bool = false;
-	private var _chainedTweens:Array<FlxTween>;
-	private var _nextTweenInChain:FlxTween;
-	
+
+	var _secondsSinceStart:Float = 0;
+	var _delayToUse:Float = 0;
+	var _running:Bool = false;
+	var _waitingForRestart:Bool = false;
+	var _chainedTweens:Array<FlxTween>;
+	var _nextTweenInChain:FlxTween;
+
 	/**
 	 * This function is called when tween is created, or recycled.
 	 */
-	private function new(Options:TweenOptions, ?manager:FlxTweenManager):Void
+	function new(Options:TweenOptions, ?manager:FlxTweenManager):Void
 	{
 		Options = resolveTweenOptions(Options);
-		
+
 		type = Options.type;
 		onStart = Options.onStart;
 		onUpdate = Options.onUpdate;
@@ -323,18 +323,18 @@ class FlxTween implements IFlxDestroyable
 		setDelays(Options.startDelay, Options.loopDelay);
 		this.manager = manager != null ? manager : globalManager;
 	}
-	
-	private function resolveTweenOptions(Options:TweenOptions):TweenOptions
+
+	function resolveTweenOptions(Options:TweenOptions):TweenOptions
 	{
 		if (Options == null)
 			Options = { type : ONESHOT };
-		
+
 		if (Options.type == null)
 			Options.type = ONESHOT;
-		
+
 		return Options;
 	}
-	
+
 	public function destroy():Void
 	{
 		onStart = null;
@@ -345,7 +345,7 @@ class FlxTween implements IFlxDestroyable
 		_chainedTweens = null;
 		_nextTweenInChain = null;
 	}
-	
+
 	/**
 	 * Specify a tween to be executed when this one has finished
 	 * (useful for creating "tween chains").
@@ -354,7 +354,7 @@ class FlxTween implements IFlxDestroyable
 	{
 		return addChainedTween(tween);
 	}
-	
+
 	/**
 	 * How many seconds to delay the execution of the next tween in a tween chain.
 	 */
@@ -362,20 +362,20 @@ class FlxTween implements IFlxDestroyable
 	{
 		return addChainedTween(FlxTween.num(0, 0, delay));
 	}
-	
-	private function addChainedTween(tween:FlxTween):FlxTween
+
+	function addChainedTween(tween:FlxTween):FlxTween
 	{
 		tween.setVarsOnEnd();
 		tween.manager.remove(tween, false);
-		
+
 		if (_chainedTweens == null)
 			_chainedTweens = [];
-		
+
 		_chainedTweens.push(tween);
 		return this;
 	}
-	
-	private function update(elapsed:Float):Void
+
+	function update(elapsed:Float):Void
 	{
 		_secondsSinceStart += elapsed;
 		var delay:Float = (executions > 0) ? loopDelay : startDelay;
@@ -395,7 +395,7 @@ class FlxTween implements IFlxDestroyable
 		if (_secondsSinceStart > delay && !_running)
 		{
 			_running = true;
-			if (onStart != null) 
+			if (onStart != null)
 				onStart(this);
 		}
 		if (_secondsSinceStart >= duration + delay)
@@ -403,7 +403,7 @@ class FlxTween implements IFlxDestroyable
 			scale = (backward) ? 0 : 1;
 			finished = true;
 		}
-		else 
+		else
 		{
 			if (onUpdate != null)
 				onUpdate(this);
@@ -428,9 +428,9 @@ class FlxTween implements IFlxDestroyable
 		finished = false;
 		return this;
 	}
-	
+
 	/**
-	 * Immediately stops the Tween and removes it from its 
+	 * Immediately stops the Tween and removes it from its
 	 * `manager` without calling the `onComplete` callback.
 	 *
 	 * Yields control to the next chained Tween if one exists.
@@ -438,7 +438,7 @@ class FlxTween implements IFlxDestroyable
 	public function cancel():Void
 	{
 		onEnd();
-		
+
 		if (manager != null)
 			manager.remove(this);
 	}
@@ -462,40 +462,40 @@ class FlxTween implements IFlxDestroyable
 		// Prevent yielding control to any chained tweens.
 		if (_chainedTweens != null)
 			_chainedTweens = null;
-			
+
 		cancel();
 	}
-	
-	private function finish():Void
+
+	function finish():Void
 	{
 		executions++;
-		
-		if (onComplete != null) 
+
+		if (onComplete != null)
 			onComplete(this);
-		
+
 		var type = type & ~FlxTween.BACKWARD;
-		
+
 		if (type == FlxTween.PERSIST || type == FlxTween.ONESHOT)
 		{
 			onEnd();
 			_secondsSinceStart = duration + startDelay;
-			
+
 			if (type == FlxTween.ONESHOT && manager != null)
 			{
 				manager.remove(this);
 			}
 		}
-		
+
 		if (type == FlxTween.LOOPING || type == FlxTween.PINGPONG)
 		{
 			_secondsSinceStart = (_secondsSinceStart - _delayToUse) % duration + _delayToUse;
 			scale = Math.max((_secondsSinceStart - _delayToUse), 0) / duration;
-			
+
 			if (ease != null && scale > 0 && scale < 1)
 			{
 				scale = ease(scale);
 			}
-			
+
 			if (type == FlxTween.PINGPONG)
 			{
 				backward = !backward;
@@ -504,66 +504,66 @@ class FlxTween implements IFlxDestroyable
 					scale = 1 - scale;
 				}
 			}
-			
+
 			restart();
 		}
 	}
-	
+
 	/**
 	 * Called when the tween ends, either via finish() or cancel().
 	 */
-	private function onEnd():Void
+	function onEnd():Void
 	{
 		setVarsOnEnd();
 		processTweenChain();
 	}
-	
-	private function setVarsOnEnd():Void
+
+	function setVarsOnEnd():Void
 	{
 		active = false;
 		_running = false;
 		finished = true;
 	}
-	
-	private function processTweenChain():Void
+
+	function processTweenChain():Void
 	{
 		if (_chainedTweens == null || _chainedTweens.length <= 0)
 			return;
-		
+
 		// Remember next tween to enable cancellation of the chain.
 		_nextTweenInChain = _chainedTweens.shift();
 
 		doNextTween(_nextTweenInChain);
 		_chainedTweens = null;
 	}
-	
-	private function doNextTween(tween:FlxTween):Void
+
+	function doNextTween(tween:FlxTween):Void
 	{
 		if (!tween.active)
 		{
 			tween.start();
 			manager.add(tween);
 		}
-		
+
 		tween.setChain(_chainedTweens);
 	}
-	
-	private function setChain(previousChain:Array<FlxTween>):Void
+
+	function setChain(previousChain:Array<FlxTween>):Void
 	{
 		if (previousChain == null)
 			return;
-		
+
 		if (_chainedTweens == null)
 			_chainedTweens = previousChain;
 		else
 			_chainedTweens = _chainedTweens.concat(previousChain);
 	}
-	
+
 	/**
 	 * In case the tween.active was set to false in onComplete(),
 	 * the tween should not be restarted yet.
 	 */
-	private function restart():Void
+	function restart():Void
 	{
 		if (active)
 		{
@@ -574,21 +574,21 @@ class FlxTween implements IFlxDestroyable
 			_waitingForRestart = true;
 		}
 	}
-	
+
 	/**
 	 * Set both type of delays for this tween.
-	 * 
+	 *
 	 * @param	startDelay	Seconds to wait until starting this tween, 0 by default.
 	 * @param	loopDelay	Seconds to wait between loops of this tween, 0 by default.
 	 */
-	private function setDelays(?StartDelay:Null<Float>, ?LoopDelay:Null<Float>):FlxTween
+	function setDelays(?StartDelay:Null<Float>, ?LoopDelay:Null<Float>):FlxTween
 	{
 		startDelay = (StartDelay != null) ? StartDelay : 0;
 		loopDelay = (LoopDelay != null) ? LoopDelay : 0;
 		return this;
 	}
-	
-	private function set_startDelay(value:Float):Float
+
+	function set_startDelay(value:Float):Float
 	{
 		var dly:Float = Math.abs(value);
 		if (executions == 0)
@@ -598,8 +598,8 @@ class FlxTween implements IFlxDestroyable
 		}
 		return startDelay = dly;
 	}
-	
-	private function set_loopDelay(value:Null<Float>):Float
+
+	function set_loopDelay(value:Null<Float>):Float
 	{
 		var dly:Float = Math.abs(value);
 		if (executions > 0)
@@ -609,20 +609,20 @@ class FlxTween implements IFlxDestroyable
 		}
 		return loopDelay = dly;
 	}
-	
-	private inline function get_percent():Float 
-	{ 
-		return Math.max((_secondsSinceStart - _delayToUse), 0) / duration; 
+
+	inline function get_percent():Float
+	{
+		return Math.max((_secondsSinceStart - _delayToUse), 0) / duration;
 	}
-	
-	private function set_percent(value:Float):Float
-	{ 
+
+	function set_percent(value:Float):Float
+	{
 		return _secondsSinceStart = duration * value + _delayToUse;
 	}
-	
-	private function set_type(value:Int):Int
+
+	function set_type(value:Int):Int
 	{
-		if (value == 0) 
+		if (value == 0)
 		{
 			value = FlxTween.ONESHOT;
 		}
@@ -630,18 +630,18 @@ class FlxTween implements IFlxDestroyable
 		{
 			value = FlxTween.PERSIST | FlxTween.BACKWARD;
 		}
-		
+
 		backward = (value & FlxTween.BACKWARD) > 0;
 		return type = value;
 	}
-	
-	private function set_active(active:Bool):Bool
+
+	function set_active(active:Bool):Bool
 	{
 		this.active = active;
-		
+
 		if (_waitingForRestart)
 			restart();
-		
+
 		return active;
 	}
 }
@@ -690,22 +690,22 @@ class FlxTweenManager extends FlxBasic
 	/**
 	 * A list of all FlxTween objects.
 	 */
-	private var _tweens(default, null):Array<FlxTween> = [];
-	
+	var _tweens(default, null):Array<FlxTween> = [];
+
 	public function new():Void
 	{
 		super();
 		visible = false; // No draw-calls needed
 		FlxG.signals.stateSwitched.add(clear);
 	}
-	
+
 	/**
 	 * Tweens numeric public properties of an Object. Shorthand for creating a VarTween, starting it and adding it to the TweenManager.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.tween(Object, { x: 500, y: 350 }, 2.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object		The object containing the properties to tween.
 	 * @param	Values		An object containing key/value pairs of properties and target values.
 	 * @param	Duration	Duration of the tween in seconds.
@@ -719,24 +719,24 @@ class FlxTweenManager extends FlxBasic
 		tween.tween(Object, Values, Duration);
 		return add(tween);
 	}
-	
+
 	/**
-	 * Tweens some numeric value. Shorthand for creating a NumTween, starting it and adding it to the TweenManager. Using it in 
+	 * Tweens some numeric value. Shorthand for creating a NumTween, starting it and adding it to the TweenManager. Using it in
 	 * conjunction with a TweenFunction requires more setup, but is faster than VarTween because it doesn't use Reflection.
-	 * 
+	 *
 	 * ```haxe
 	 * private function tweenFunction(s:FlxSprite, v:Float) { s.alpha = v; }
 	 * FlxTween.num(1, 0, 2.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT }, tweenFunction.bind(mySprite));
 	 * ```
-	 * 
+	 *
 	 * Trivia: For historical reasons, you can use either onUpdate or TweenFunction to accomplish the same thing, but TweenFunction
 	 * gives you the updated Float as a direct argument.
-	 * 
+	 *
 	 * @param	FromValue	Start value.
 	 * @param	ToValue		End value.
 	 * @param	Duration	Duration of the tween.
 	 * @param	Options		A structure with tween options.
-	 * @param	TweenFunction	A function to be called when the tweened value updates.  It is recommended not to use an anonymous 
+	 * @param	TweenFunction	A function to be called when the tweened value updates.  It is recommended not to use an anonymous
 	 *							function if you are maximizing performance, as those will be compiled to Dynamics on cpp.
 	 * @return	The added NumTween object.
 	 * @since   4.2.0
@@ -747,14 +747,14 @@ class FlxTweenManager extends FlxBasic
 		tween.tween(FromValue, ToValue, Duration, TweenFunction);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Tweens numeric value which represents angle. Shorthand for creating a AngleTween object, starting it and adding it to the TweenManager.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.angle(Sprite, -90, 90, 2.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Sprite		Optional Sprite whose angle should be tweened.
 	 * @param	FromAngle	Start angle.
 	 * @param	ToAngle		End angle.
@@ -769,14 +769,14 @@ class FlxTweenManager extends FlxBasic
 		tween.tween(FromAngle, ToAngle, Duration, Sprite);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Tweens numeric value which represents color. Shorthand for creating a ColorTween object, starting it and adding it to a TweenPlugin.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.color(Sprite, 2.0, 0x000000, 0xffffff, 0.0, 1.0, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Sprite		Optional Sprite whose color should be tweened.
 	 * @param	Duration	Duration of the tween in seconds.
 	 * @param	FromColor	Start color.
@@ -791,14 +791,14 @@ class FlxTweenManager extends FlxBasic
 		tween.tween(Duration, FromColor, ToColor, Sprite);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Create a new LinearMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.linearMotion(Object, 0, 0, 500, 20, 5, false, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	FromX			X start.
 	 * @param	FromY			Y start.
@@ -817,14 +817,14 @@ class FlxTweenManager extends FlxBasic
 		tween.setMotion(FromX, FromY, ToX, ToY, DurationOrSpeed, UseDuration);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Create a new QuadMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.quadMotion(Object, 0, 100, 300, 500, 100, 2, 5, false, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	FromX			X start.
 	 * @param	FromY			Y start.
@@ -845,14 +845,14 @@ class FlxTweenManager extends FlxBasic
 		tween.setMotion(FromX, FromY, ControlX, ControlY, ToX, ToY, DurationOrSpeed, UseDuration);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Create a new CubicMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.cubicMotion(_sprite, 0, 0, 500, 100, 400, 200, 100, 100, 2, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object 		The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	FromX		X start.
 	 * @param	FromY		Y start.
@@ -874,14 +874,14 @@ class FlxTweenManager extends FlxBasic
 		tween.setMotion(FromX, FromY, aX, aY, bX, bY, ToX, ToY, Duration);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Create a new CircularMotion tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.circularMotion(Object, 250, 250, 50, 0, true, 2, true, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	CenterX			X position of the circle's center.
 	 * @param	CenterY			Y position of the circle's center.
@@ -902,14 +902,14 @@ class FlxTweenManager extends FlxBasic
 		tween.setMotion(CenterX, CenterY, Radius, Angle, Clockwise, DurationOrSpeed, UseDuration);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Create a new LinearPath tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.linearPath(Object, [FlxPoint.get(0, 0), FlxPoint.get(100, 100)], 2, true, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object 			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	Points			An array of at least 2 FlxPoints defining the path
 	 * @param	DurationOrSpeed	Duration (in seconds) or speed of the movement.
@@ -921,7 +921,7 @@ class FlxTweenManager extends FlxBasic
 	public function linearPath(Object:FlxObject, Points:Array<FlxPoint>, DurationOrSpeed:Float = 1, UseDuration:Bool = true, ?Options:TweenOptions):LinearPath
 	{
 		var tween = new LinearPath(Options, this);
-		
+
 		if (Points != null)
 		{
 			for (point in Points)
@@ -929,19 +929,19 @@ class FlxTweenManager extends FlxBasic
 				tween.addPoint(point.x, point.y);
 			}
 		}
-		
+
 		tween.setObject(Object);
 		tween.setMotion(DurationOrSpeed, UseDuration);
 		return add(tween);
 	}
-	
+
 	/**
 	 * Create a new QuadPath tween.
-	 * 
+	 *
 	 * ```haxe
 	 * FlxTween.quadPath(Object, [FlxPoint.get(0, 0), FlxPoint.get(200, 200), FlxPoint.get(400, 0)], 2, true, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: FlxTween.ONESHOT });
 	 * ```
-	 * 
+	 *
 	 * @param	Object			The object to move (FlxObject or FlxSpriteGroup)
 	 * @param	Points			An array of at least 3 FlxPoints defining the path
 	 * @param	DurationOrSpeed	Duration (in seconds) or speed of the movement.
@@ -953,7 +953,7 @@ class FlxTweenManager extends FlxBasic
 	public function quadPath(Object:FlxObject, Points:Array<FlxPoint>, DurationOrSpeed:Float = 1, UseDuration:Bool = true, ?Options:TweenOptions):QuadPath
 	{
 		var tween = new QuadPath(Options, this);
-		
+
 		if (Points != null)
 		{
 			for (point in Points)
@@ -961,23 +961,23 @@ class FlxTweenManager extends FlxBasic
 				tween.addPoint(point.x, point.y);
 			}
 		}
-		
+
 		tween.setObject(Object);
 		tween.setMotion(DurationOrSpeed, UseDuration);
 		return add(tween);
 	}
-	
+
 	override public function destroy():Void
 	{
 		super.destroy();
 		FlxG.signals.stateSwitched.remove(clear);
 	}
-	
+
 	override public function update(elapsed:Float):Void
 	{
 		// process finished tweens after iterating through main list, since finish() can manipulate FlxTween.list
 		var finishedTweens:Array<FlxTween> = null;
-		
+
 		for (tween in _tweens)
 		{
 			if (!tween.active)
@@ -991,7 +991,7 @@ class FlxTweenManager extends FlxBasic
 				finishedTweens.push(tween);
 			}
 		}
-		
+
 		if (finishedTweens != null)
 		{
 			while (finishedTweens.length > 0)
@@ -1000,49 +1000,49 @@ class FlxTweenManager extends FlxBasic
 			}
 		}
 	}
-	
+
 	/**
 	 * Add a FlxTween.
-	 * 
+	 *
 	 * @param	Tween	The FlxTween to add.
 	 * @param	Start	Whether you want it to start right away.
 	 * @return	The added FlxTween object.
 	 */
 	@:generic
 	@:allow(flixel.tweens.FlxTween)
-	private function add<T:FlxTween>(Tween:T, Start:Bool = false):T
+	function add<T:FlxTween>(Tween:T, Start:Bool = false):T
 	{
 		// Don't add a null object
 		if (Tween == null)
 			return null;
-		
+
 		_tweens.push(Tween);
-		
-		if (Start) 
+
+		if (Start)
 			Tween.start();
 		return Tween;
 	}
 
 	/**
 	 * Remove a FlxTween.
-	 * 
+	 *
 	 * @param	Tween		The FlxTween to remove.
 	 * @param	Destroy		Whether you want to destroy the FlxTween
 	 * @return	The removed FlxTween object.
 	 */
 	@:allow(flixel.tweens.FlxTween)
-	private function remove(Tween:FlxTween, Destroy:Bool = true):FlxTween
+	function remove(Tween:FlxTween, Destroy:Bool = true):FlxTween
 	{
 		if (Tween == null)
 			return null;
-			
+
 		Tween.active = false;
-		
+
 		if (Destroy)
 			Tween.destroy();
-		
+
 		FlxArrayUtil.fastSplice(_tweens, Tween);
-		
+
 		return Tween;
 	}
 
@@ -1059,21 +1059,21 @@ class FlxTweenManager extends FlxBasic
 				tween.destroy();
 			}
 		}
-		
+
 		_tweens.splice(0, _tweens.length);
 	}
 
 	/**
 	 * Immediately updates all tweens that are not looping (type `FlxTween.LOOPING` or `FlxTween.PINGPONG`)
 	 * and `active` through their endings, triggering their `onComplete` callbacks.
-	 * 
+	 *
 	 * Note: if they haven't yet begun, this will first trigger their `onStart` callback.
-	 * 
-	 * Note: their `onComplete` callbacks are triggered in the next frame. 
+	 *
+	 * Note: their `onComplete` callbacks are triggered in the next frame.
 	 * To trigger them immediately, call `FlxTween.manager.update(0);` after this function.
-	 * 
+	 *
 	 * In no case should it trigger an `onUpdate` callback.
-	 * 
+	 *
 	 * @since 4.2.0
 	 */
 	public function completeAll():Void
@@ -1085,7 +1085,7 @@ class FlxTweenManager extends FlxBasic
 
 	/**
 	 * Applies a function to all tweens
-	 * 
+	 *
 	 * @param   Function   A function that modifies one tween at a time
 	 * @since   4.2.0
 	 */

--- a/flixel/tweens/misc/AngleTween.hx
+++ b/flixel/tweens/misc/AngleTween.hx
@@ -9,15 +9,15 @@ import flixel.tweens.FlxTween;
 class AngleTween extends FlxTween
 {
 	public var angle(default, null):Float;
-	
+
 	/**
 	 * Optional sprite object whose angle to tween
 	 */
 	public var sprite(default, null):FlxSprite;
-	
-	private var _start:Float;
-	private var _range:Float;
-	
+
+	var _start:Float;
+	var _range:Float;
+
 	/**
 	 * Clean up references
 	 */
@@ -26,10 +26,10 @@ class AngleTween extends FlxTween
 		super.destroy();
 		sprite = null;
 	}
-	
+
 	/**
 	 * Tweens the value from one angle to another.
-	 * 
+	 *
 	 * @param	FromAngle		Start angle.
 	 * @param	ToAngle			End angle.
 	 * @param	Duration		Duration of the tween.
@@ -47,12 +47,12 @@ class AngleTween extends FlxTween
 		start();
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		angle = _start + _range * scale;
-		
+
 		if (sprite != null)
 		{
 			var spriteAngle:Float = angle % 360;

--- a/flixel/tweens/misc/ColorTween.hx
+++ b/flixel/tweens/misc/ColorTween.hx
@@ -11,9 +11,9 @@ import flixel.util.FlxColor;
 class ColorTween extends FlxTween
 {
 	public var color(default, null):FlxColor;
-	private var startColor:FlxColor;
-	private var endColor:FlxColor;
-	
+	var startColor:FlxColor;
+	var endColor:FlxColor;
+
 	/**
 	 * Optional sprite object whose color to tween
 	 */
@@ -22,7 +22,7 @@ class ColorTween extends FlxTween
 	/**
 	 * Clean up references
 	 */
-	override public function destroy() 
+	override public function destroy()
 	{
 		super.destroy();
 		sprite = null;
@@ -30,7 +30,7 @@ class ColorTween extends FlxTween
 
 	/**
 	 * Tweens the color to a new color and an alpha to a new alpha.
-	 * 
+	 *
 	 * @param	Duration		Duration of the tween.
 	 * @param	FromColor		Start color.
 	 * @param	ToColor			End color.
@@ -46,12 +46,12 @@ class ColorTween extends FlxTween
 		start();
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		color = FlxColor.interpolate(startColor, endColor, scale);
-		
+
 		if (sprite != null)
 		{
 			sprite.color = color;

--- a/flixel/tweens/misc/NumTween.hx
+++ b/flixel/tweens/misc/NumTween.hx
@@ -11,31 +11,31 @@ class NumTween extends FlxTween
 	 * The current value.
 	 */
 	public var value(default, null):Float;
-	
+
 	// Tween information.
-	private var _tweenFunction:Float->Void;
-	private var _start:Float;
-	private var _range:Float;
-	
+	var _tweenFunction:Float->Void;
+	var _start:Float;
+	var _range:Float;
+
 	/**
 	 * Clean up references
 	 */
-	override public function destroy():Void 
+	override public function destroy():Void
 	{
 		super.destroy();
 		_tweenFunction = null;
 	}
-	
+
 	/**
 	 * Tweens the value from one value to another.
-	 * 
+	 *
 	 * @param	fromValue		Start value.
 	 * @param	toValue			End value.
 	 * @param	duration		Duration of the tween.
 	 * @param	tweenFunction	Optional tween function. See FlxTween.num()
 	 */
 	public function tween(fromValue:Float, toValue:Float, duration:Float, ?tweenFunction:Float->Void):NumTween
-	{	
+	{
 		_tweenFunction = tweenFunction;
 		_start = value = fromValue;
 		_range = toValue - value;
@@ -43,12 +43,12 @@ class NumTween extends FlxTween
 		start();
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		value = _start + _range * scale;
-		
+
 		if (_tweenFunction != null)
 			_tweenFunction(value);
 	}

--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -7,28 +7,28 @@ import flixel.tweens.FlxTween;
  */
 class VarTween extends FlxTween
 {
-	private var _object:Dynamic;
-	private var _properties:Dynamic;
-	private var _propertyInfos:Array<VarTweenProperty> = [];
-	
+	var _object:Dynamic;
+	var _properties:Dynamic;
+	var _propertyInfos:Array<VarTweenProperty> = [];
+
 	/**
 	 * Clean up references
 	 */
-	override public function destroy():Void 
+	override public function destroy():Void
 	{
 		super.destroy();
 		_object = null;
 		_properties = null;
 	}
-	
-	private function new(Options:TweenOptions, ?manager:FlxTweenManager)
+
+	function new(Options:TweenOptions, ?manager:FlxTweenManager)
 	{
 		super(Options, manager);
 	}
-	
+
 	/**
 	 * Tweens multiple numeric public properties.
-	 * 
+	 *
 	 * @param	object		The object containing the properties.
 	 * @param	properties	An object containing key/value pairs of properties and target values.
 	 * @param	duration	Duration of the tween.
@@ -45,18 +45,18 @@ class VarTween extends FlxTween
 			throw "Cannot tween null properties.";
 		}
 		#end
-		
+
 		_object = object;
 		_properties = properties;
 		this.duration = duration;
 		start();
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		var delay:Float = (executions > 0) ? loopDelay : startDelay;
-		
+
 		if (_secondsSinceStart < delay)
 		{
 			// Leave properties alone until delay is over
@@ -66,24 +66,24 @@ class VarTween extends FlxTween
 		{
 			if (_propertyInfos.length == 0)
 			{
-				// We don't initialize() in tween() because otherwise the start values 
+				// We don't initialize() in tween() because otherwise the start values
 				// will be inaccurate with delays
 				initializeVars();
 			}
-			
+
 			super.update(elapsed);
-			
+
 			for (info in _propertyInfos)
 			{
 				Reflect.setProperty(_object, info.name, (info.startValue + info.range * scale));
 			}
 		}
 	}
-	
-	private function initializeVars():Void
+
+	function initializeVars():Void
 	{
 		var fields:Array<String>;
-		
+
 		if (Reflect.isObject(_properties))
 		{
 			fields = Reflect.fields(_properties);
@@ -92,21 +92,21 @@ class VarTween extends FlxTween
 		{
 			throw "Unsupported properties container - use an object containing key/value pairs.";
 		}
-		
+
 		for (p in fields)
 		{
 			if (Reflect.getProperty(_object, p) == null)
 			{
 				throw 'The Object does not have the property "$p"';
 			}
-			
+
 			var a:Dynamic = Reflect.getProperty(_object, p);
-			
-			if (Math.isNaN(a)) 
+
+			if (Math.isNaN(a))
 			{
 				throw "The property \"" + p + "\" is not numeric.";
 			}
-			
+
 			_propertyInfos.push({ name: p, startValue: a, range: Reflect.getProperty(_properties, p) - a });
 		}
 	}

--- a/flixel/tweens/motion/CircularMotion.hx
+++ b/flixel/tweens/motion/CircularMotion.hx
@@ -14,17 +14,17 @@ class CircularMotion extends Motion
 	 * The circumference of the current circle motion.
 	 */
 	public var circumference(get, never):Float;
-	
+
 	// Circle information.
-	private var _centerX:Float = 0;
-	private var _centerY:Float = 0;
-	private var _radius:Float = 0;
-	private var _angleStart:Float = 0;
-	private var _angleFinish:Float = 0;
+	var _centerX:Float = 0;
+	var _centerY:Float = 0;
+	var _radius:Float = 0;
+	var _angleStart:Float = 0;
+	var _angleFinish:Float = 0;
 
 	/**
 	 * Starts moving along a circle.
-	 * 
+	 *
 	 * @param	CenterX			X position of the circle's center.
 	 * @param	CenterY			Y position of the circle's center.
 	 * @param	Radius			Radius of the circle.
@@ -40,7 +40,7 @@ class CircularMotion extends Motion
 		_radius = Radius;
 		this.angle = _angleStart = Angle * Math.PI / ( -180);
 		_angleFinish = (Math.PI * 2) * (Clockwise ? 1 : -1);
-		
+
 		if (UseDuration)
 		{
 			duration = DurationOrSpeed;
@@ -49,12 +49,12 @@ class CircularMotion extends Motion
 		{
 			duration = (_radius * (Math.PI * 2)) / DurationOrSpeed;
 		}
-		
+
 		start();
 		return this;
 	}
 
-	override private function update(elapsed:Float):Void
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		angle = _angleStart + _angleFinish * scale;
@@ -66,8 +66,8 @@ class CircularMotion extends Motion
 		}
 	}
 
-	private function get_circumference():Float 
-	{ 
-		return _radius * (Math.PI * 2); 
+	function get_circumference():Float
+	{
+		return _radius * (Math.PI * 2);
 	}
 }

--- a/flixel/tweens/motion/CubicMotion.hx
+++ b/flixel/tweens/motion/CubicMotion.hx
@@ -6,20 +6,20 @@ package flixel.tweens.motion;
 class CubicMotion extends Motion
 {
 	// Curve information.
-	private var _fromX:Float = 0;
-	private var _fromY:Float = 0;
-	private var _toX:Float = 0;
-	private var _toY:Float = 0;
-	private var _aX:Float = 0;
-	private var _aY:Float = 0;
-	private var _bX:Float = 0;
-	private var _bY:Float = 0;
-	private var _ttt:Float = 0;
-	private var _tt:Float = 0;
-	
+	var _fromX:Float = 0;
+	var _fromY:Float = 0;
+	var _toX:Float = 0;
+	var _toY:Float = 0;
+	var _aX:Float = 0;
+	var _aY:Float = 0;
+	var _bX:Float = 0;
+	var _bY:Float = 0;
+	var _ttt:Float = 0;
+	var _tt:Float = 0;
+
 	/**
 	 * Starts moving along the curve.
-	 * 
+	 *
 	 * @param	fromX		X start.
 	 * @param	fromY		Y start.
 	 * @param	aX			First control x.
@@ -44,8 +44,8 @@ class CubicMotion extends Motion
 		start();
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		x = scale * scale * scale * (_toX + 3 * (_aX - _bX) - _fromX) + 3 * scale * scale * (_fromX - 2 * _aX + _bX) + 3 * scale * (_aX - _fromX) + _fromX;

--- a/flixel/tweens/motion/LinearMotion.hx
+++ b/flixel/tweens/motion/LinearMotion.hx
@@ -9,17 +9,17 @@ class LinearMotion extends Motion
 	 * Length of the current line of movement.
 	 */
 	public var distance(get, never):Float;
-	
+
 	// Line information.
-	private var _fromX:Float = 0;
-	private var _fromY:Float = 0;
-	private var _moveX:Float = 0;
-	private var _moveY:Float = 0;
-	private var _distance:Float = -1;
+	var _fromX:Float = 0;
+	var _fromY:Float = 0;
+	var _moveX:Float = 0;
+	var _moveY:Float = 0;
+	var _distance:Float = -1;
 
 	/**
 	 * Starts moving along a line.
-	 * 
+	 *
 	 * @param	FromX			X start.
 	 * @param	FromY			Y start.
 	 * @param	ToX				X finish.
@@ -34,7 +34,7 @@ class LinearMotion extends Motion
 		y = _fromY = FromY;
 		_moveX = ToX - FromX;
 		_moveY = ToY - FromY;
-		
+
 		if (UseDuration)
 		{
 			duration = DurationOrSpeed;
@@ -43,19 +43,19 @@ class LinearMotion extends Motion
 		{
 			duration = distance / DurationOrSpeed;
 		}
-		
+
 		start();
-		
+
 		return this;
 	}
 
-	override private function update(elapsed:Float):Void
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		x = _fromX + _moveX * scale;
 		y = _fromY + _moveY * scale;
-		
-		if ((x == (_fromX + _moveX)) && (y == (_fromY + _moveY)) 
+
+		if ((x == (_fromX + _moveX)) && (y == (_fromY + _moveY))
 			&& active && (_secondsSinceStart >= duration))
 		{
 			finished = true;
@@ -66,7 +66,7 @@ class LinearMotion extends Motion
 		}
 	}
 
-	private function get_distance():Float
+	function get_distance():Float
 	{
 		if (_distance >= 0)
 			return _distance;

--- a/flixel/tweens/motion/LinearPath.hx
+++ b/flixel/tweens/motion/LinearPath.hx
@@ -16,28 +16,28 @@ class LinearPath extends Motion
 	public var distance(default, null):Float = 0;
 
 	public var points:Array<FlxPoint>;
-	
+
 	// Path information.
-	private var _pointD:Array<Float>;
-	private var _pointT:Array<Float>;
-	private var _speed:Float = 0;
-	private var _index:Int = 0;
+	var _pointD:Array<Float>;
+	var _pointT:Array<Float>;
+	var _speed:Float = 0;
+	var _index:Int = 0;
 
 	// Line information.
-	private var _last:FlxPoint;
-	private var _prevPoint:FlxPoint;
-	private var _nextPoint:FlxPoint;
-	
-	private function new(Options:TweenOptions, ?manager:FlxTweenManager)
+	var _last:FlxPoint;
+	var _prevPoint:FlxPoint;
+	var _nextPoint:FlxPoint;
+
+	function new(Options:TweenOptions, ?manager:FlxTweenManager)
 	{
 		super(Options, manager);
-		
+
 		points = [];
 		_pointD = [0];
 		_pointT = [0];
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		// recycle FlxPoints
@@ -52,14 +52,14 @@ class LinearPath extends Motion
 
 	/**
 	 * Starts moving along the path.
-	 * 
+	 *
 	 * @param	DurationOrSpeed		Duration or speed of the movement.
 	 * @param	UseDuration			Whether to use the previous param as duration or speed.
 	 */
 	public function setMotion(DurationOrSpeed:Float, UseDuration:Bool = true):LinearPath
 	{
 		updatePath();
-		
+
 		if (UseDuration)
 		{
 			duration = DurationOrSpeed;
@@ -70,7 +70,7 @@ class LinearPath extends Motion
 			duration = distance / DurationOrSpeed;
 			_speed = DurationOrSpeed;
 		}
-		
+
 		start();
 		return this;
 	}
@@ -85,10 +85,10 @@ class LinearPath extends Motion
 		points[points.length] = _last = FlxPoint.get(x, y);
 		return this;
 	}
-	
+
 	public function getPoint(index:Int = 0):FlxPoint
 	{
-		if (points.length == 0) 
+		if (points.length == 0)
 		{
 			throw "No points have been added to the path yet.";
 		}
@@ -102,20 +102,20 @@ class LinearPath extends Motion
 		return this;
 	}
 
-	override private function update(elapsed:Float):Void
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		var td:Float;
 		var	tt:Float;
-		
+
 		if (points == null)
 			return;
-		
+
 		if (!backward)
 		{
 			if (_index < points.length - 1)
 			{
-				while (scale > _pointT[_index + 1]) 
+				while (scale > _pointT[_index + 1])
 				{
 					_index++;
 					if (_index == points.length - 1)
@@ -125,7 +125,7 @@ class LinearPath extends Motion
 					}
 				}
 			}
-			
+
 			td = _pointT[_index];
 			tt = _pointT[_index + 1] - td;
 			td = (scale - td) / tt;
@@ -136,7 +136,7 @@ class LinearPath extends Motion
 		}
 		else
 		{
-			if (_index > 0) 
+			if (_index > 0)
 			{
 				while (scale < _pointT[_index - 1])
 				{
@@ -148,7 +148,7 @@ class LinearPath extends Motion
 					}
 				}
 			}
-			
+
 			td = _pointT[_index];
 			tt = _pointT[_index - 1] - td;
 			td = (scale - td) / tt;
@@ -157,20 +157,20 @@ class LinearPath extends Motion
 			x = _prevPoint.x + (_nextPoint.x - _prevPoint.x) * td;
 			y = _prevPoint.y + (_nextPoint.y - _prevPoint.y) * td;
 		}
-		
+
 		super.postUpdate();
 	}
 
 	/**
-	 * Updates the path, preparing it for motion. 
+	 * Updates the path, preparing it for motion.
 	 */
-	private function updatePath():Void
+	function updatePath():Void
 	{
 		if (points.length < 2)	throw "A LinearPath must have at least 2 points to operate.";
 		if (_pointD.length == _pointT.length) return;
 		// evaluate t for each point
 		var i:Int = 0;
-		while (i < points.length) 
+		while (i < points.length)
 		{
 			_pointT[i] = _pointD[i++] / distance;
 		}

--- a/flixel/tweens/motion/Motion.hx
+++ b/flixel/tweens/motion/Motion.hx
@@ -16,16 +16,16 @@ class Motion extends FlxTween
 	 * Current y position of the Tween.
 	 */
 	public var y:Float = 0;
-	
-	private var _object:FlxObject;
-	private var _wasObjectImmovable:Bool;
-	
-	override public function destroy():Void 
+
+	var _object:FlxObject;
+	var _wasObjectImmovable:Bool;
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		_object = null;
 	}
-	
+
 	public function setObject(object:FlxObject):Motion
 	{
 		_object = object;
@@ -33,20 +33,20 @@ class Motion extends FlxTween
 		_object.immovable = true;
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void 
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		postUpdate();
 	}
-	
-	override private function onEnd():Void
+
+	override function onEnd():Void
 	{
 		_object.immovable = _wasObjectImmovable;
 		super.onEnd();
 	}
-	
-	private function postUpdate():Void
+
+	function postUpdate():Void
 	{
 		if (_object != null)
 		{

--- a/flixel/tweens/motion/QuadMotion.hx
+++ b/flixel/tweens/motion/QuadMotion.hx
@@ -11,19 +11,19 @@ class QuadMotion extends Motion
 	 * The distance of the entire curve.
 	 */
 	public var distance(get, never):Float;
-	
+
 	// Curve information.
-	private var _distance:Float = -1;
-	private var _fromX:Float = 0;
-	private var _fromY:Float = 0;
-	private var _toX:Float = 0;
-	private var _toY:Float = 0;
-	private var _controlX:Float = 0;
-	private var _controlY:Float = 0;
-	
+	var _distance:Float = -1;
+	var _fromX:Float = 0;
+	var _fromY:Float = 0;
+	var _toX:Float = 0;
+	var _toY:Float = 0;
+	var _controlX:Float = 0;
+	var _controlY:Float = 0;
+
 	/**
 	 * Starts moving along the curve.
-	 * 
+	 *
 	 * @param	FromX			X start.
 	 * @param	FromY			Y start.
 	 * @param	ControlX		X control, used to determine the curve.
@@ -42,7 +42,7 @@ class QuadMotion extends Motion
 		_controlY = ControlY;
 		_toX = ToX;
 		_toY = ToY;
-		
+
 		if (UseDuration)
 		{
 			duration = DurationOrSpeed;
@@ -51,13 +51,13 @@ class QuadMotion extends Motion
 		{
 			duration = distance / DurationOrSpeed;
 		}
-		
+
 		start();
-		
+
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		x = _fromX * (1 - scale) * (1 - scale) + _controlX * 2 * (1 - scale) * scale + _toX * scale * scale;
@@ -67,12 +67,12 @@ class QuadMotion extends Motion
 			postUpdate();
 		}
 	}
-	
-	private function get_distance():Float
+
+	function get_distance():Float
 	{
 		if (_distance >= 0)
 			return _distance;
-		
+
 		var p1 = FlxPoint.get();
 		var p2 = FlxPoint.get();
 		p1.x = x - 2 * _controlX + _toX;
@@ -87,10 +87,10 @@ class QuadMotion extends Motion
 			a32:Float = 2 * a * a2,
 			c2:Float = 2 * Math.sqrt(c),
 			ba:Float = b / a2;
-			
+
 		p1.put();
 		p2.put();
-		
+
 		return (a32 * abc + a2 * b * (abc - c2) + (4 * c * a - b * b) *
 			Math.log((2 * a2 + ba + abc) / (ba + c2))) / (4 * a32);
 	}

--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -12,32 +12,32 @@ import flixel.util.FlxDestroyUtil;
 class QuadPath extends Motion
 {
 	// Path information.
-	private var _points:Array<FlxPoint>;
-	private var _distance:Float = 0;
-	private var _speed:Float = 0;
-	private var _index:Int = 0;
-	private var _numSegs:Int = 0;
-	
+	var _points:Array<FlxPoint>;
+	var _distance:Float = 0;
+	var _speed:Float = 0;
+	var _index:Int = 0;
+	var _numSegs:Int = 0;
+
 	// Curve information.
-	private var _updateCurve:Bool = true;
-	private var _curveT:Array<Float>;
-	private var _curveD:Array<Float>;
-	
+	var _updateCurve:Bool = true;
+	var _curveT:Array<Float>;
+	var _curveD:Array<Float>;
+
 	// Curve points.
-	private var _a:FlxPoint;
-	private var _b:FlxPoint;
-	private var _c:FlxPoint;
-	
-	private function new(Options:TweenOptions, ?manager:FlxTweenManager)
+	var _a:FlxPoint;
+	var _b:FlxPoint;
+	var _c:FlxPoint;
+
+	function new(Options:TweenOptions, ?manager:FlxTweenManager)
 	{
 		super(Options, manager);
-		
+
 		_points = [];
 		_curveT = [];
 		_curveD = [];
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
 		// recycle FlxPoints
@@ -49,17 +49,17 @@ class QuadPath extends Motion
 		_b = FlxDestroyUtil.put(_b);
 		_c = FlxDestroyUtil.put(_c);
 	}
-	
+
 	/**
 	 * Starts moving along the path.
-	 * 
+	 *
 	 * @param	DurationOrSpeed		Duration or speed of the movement.
 	 * @param	UseDuration			Whether to use the previous param as duration or speed.
 	 */
 	public function setMotion(DurationOrSpeed:Float, UseDuration:Bool = true):QuadPath
 	{
 		updatePath();
-		
+
 		if (UseDuration)
 		{
 			duration = DurationOrSpeed;
@@ -70,11 +70,11 @@ class QuadPath extends Motion
 			duration = _distance / DurationOrSpeed;
 			_speed = DurationOrSpeed;
 		}
-		
+
 		start();
 		return this;
 	}
-	
+
 	/**
 	 * Adds the point to the path.
 	 */
@@ -84,37 +84,37 @@ class QuadPath extends Motion
 		_points.push(FlxPoint.get(x, y));
 		return this;
 	}
-	
+
 	/**
 	 * Gets the point on the path.
 	 */
 	public function getPoint(index:Int = 0):FlxPoint
 	{
-		if (_points.length == 0) 
+		if (_points.length == 0)
 		{
 			throw "No points have been added to the path yet.";
 		}
 		return _points[index % _points.length];
 	}
-	
+
 	override public function start():QuadPath
 	{
-		_index = (backward) ? (_numSegs - 1) : 0; 
+		_index = (backward) ? (_numSegs - 1) : 0;
 		super.start();
 		return this;
 	}
-	
-	override private function update(elapsed:Float):Void
+
+	override function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
 		var td:Float;
 		var tt:Float;
-		
+
 		if (!backward && (_points != null))
 		{
 			if (_index < _numSegs - 1)
 			{
-				while (scale > _curveT[_index + 1]) 
+				while (scale > _curveT[_index + 1])
 				{
 					_index++;
 					if (_index == _numSegs - 1)
@@ -129,7 +129,7 @@ class QuadPath extends Motion
 			_a = _points[_index * 2];
 			_b = _points[_index * 2 + 1];
 			_c = _points[_index * 2 + 2];
-			
+
 			x = _a.x * (1 - td) * (1 - td) + _b.x * 2 * (1 - td) * td + _c.x * td * td;
 			y = _a.y * (1 - td) * (1 - td) + _b.y * 2 * (1 - td) * td + _c.y * td * td;
 		}
@@ -146,33 +146,33 @@ class QuadPath extends Motion
 					}
 				}
 			}
-			
+
 			td = _curveT[_index + 1];
 			tt = _curveT[_index] - td;
 			td = (scale - td) / tt;
 			_a = _points[_index * 2 + 2];
 			_b = _points[_index * 2 + 1];
 			_c = _points[_index * 2];
-			
+
 			x = _a.x * (1 - td) * (1 - td) + _b.x * 2 * (1 - td) * td + _c.x * td * td;
 			y = _a.y * (1 - td) * (1 - td) + _b.y * 2 * (1 - td) * td + _c.y * td * td;
 		}
 		super.postUpdate();
 	}
-	
+
 	// [from, control, to, control, to, control, to, control, to ...]
-	private function updatePath():Void
+	function updatePath():Void
 	{
-		if ((_points.length - 1) % 2 != 0 || _points.length < 3)	
+		if ((_points.length - 1) % 2 != 0 || _points.length < 3)
 		{
 			throw "A QuadPath must have at least 3 points to operate and number of points must be a odd.";
-		} 
-		if (!_updateCurve) 
+		}
+		if (!_updateCurve)
 		{
 			return;
 		}
 		_updateCurve = false;
-		
+
 		// find the total distance of the path
 		var i:Int = 0;
 		var j:Int = 0;
@@ -184,7 +184,7 @@ class QuadPath extends Motion
 			_curveD[i] = getCurveLength(_points[j], _points[j + 1], _points[j + 2]);
 			_distance += _curveD[i++];
 		}
-		
+
 		// find t for each point on the curve
 		i = 0;
 		var d:Float = 0;
@@ -196,12 +196,12 @@ class QuadPath extends Motion
 		_curveT[_numSegs - 1] = 1;
 		_curveT.unshift(0);
 	}
-	
-	private function getCurveLength(start:FlxPoint, control:FlxPoint, finish:FlxPoint):Float
+
+	function getCurveLength(start:FlxPoint, control:FlxPoint, finish:FlxPoint):Float
 	{
 		var p1 = FlxPoint.get();
 		var p2 = FlxPoint.get();
-		
+
 		p1.x = start.x - 2 * control.x + finish.x;
 		p1.y = start.y - 2 * control.y + finish.y;
 		p2.x = 2 * control.x - 2 * start.x;
@@ -214,10 +214,10 @@ class QuadPath extends Motion
 			a32:Float = 2 * a * a2,
 			c2:Float = 2 * Math.sqrt(c),
 			ba:Float = b / a2;
-			
+
 		p1.put();
 		p2.put();
-			
+
 		return (a32 * abc + a2 * b * (abc - c2) + (4 * c * a - b * b) *
 			Math.log((2 * a2 + ba + abc) / (ba + c2))) / (4 * a32);
 	}

--- a/flixel/ui/FlxAnalog.hx
+++ b/flixel/ui/FlxAnalog.hx
@@ -13,81 +13,81 @@ import flixel.util.FlxDestroyUtil;
 
 /**
  * A virtual thumbstick - useful for input on mobile devices.
- * 
+ *
  * @author Ka Wing Chin
  */
 class FlxAnalog extends FlxSpriteGroup
 {
 	/**
 	 * Shows the current state of the button.
-	 */ 
+	 */
 	public var status:Int = NORMAL;
 	public var thumb:FlxSprite;
 	/**
 	 * The background of the joystick, also known as the base.
-	 */ 
+	 */
 	public var base:FlxSprite;
 	/**
 	 * This function is called when the button is released.
-	 */ 
+	 */
 	public var onUp:Void->Void;
 	/**
 	 * This function is called when the button is pressed down.
-	 */ 
+	 */
 	public var onDown:Void->Void;
 	/**
 	 * This function is called when the mouse goes over the button.
-	 */ 
+	 */
 	public var onOver:Void->Void;
 	/**
 	 * This function is called when the button is hold down.
-	 */ 
+	 */
 	public var onPressed:Void->Void;
 	/**
 	 * Used with public variable status, means not highlighted or pressed.
-	 */ 
-	private static inline var NORMAL:Int = 0;
+	 */
+	static inline var NORMAL:Int = 0;
 	/**
 	 * Used with public variable status, means highlighted (usually from mouse over).
-	 */ 
-	private static inline var HIGHLIGHT:Int = 1;
+	 */
+	static inline var HIGHLIGHT:Int = 1;
 	/**
 	 * Used with public variable status, means pressed (usually from mouse click).
-	 */ 
-	private static inline var PRESSED:Int = 2;
-	
+	 */
+	static inline var PRESSED:Int = 2;
+
 	/**
 	 * A list of analogs that are currently active.
-	 */ 
-	private static var _analogs:Array<FlxAnalog> = [];
-	
+	 */
+	static var _analogs:Array<FlxAnalog> = [];
+
 	#if FLX_TOUCH
 	/**
 	 * The current pointer that's active on the analog.
 	 */
-	private var _currentTouch:FlxTouch;
+	var _currentTouch:FlxTouch;
 	/**
 	 * Helper array for checking touches
-	 */ 
-	private var _tempTouches:Array<FlxTouch> = [];
+	 */
+	var _tempTouches:Array<FlxTouch> = [];
 	#end
-	
+
 	/**
 	 * The area which the joystick will react.
 	 */
-	private var _zone:FlxRect = FlxRect.get();
-	
+	var _zone:FlxRect = FlxRect.get();
+
 	/**
 	 * The radius in which the stick can move.
-	 */ 
-	private var _radius:Float = 0;
-	private var _direction:Float = 0;
-	private var _amount:Float = 0;
+	 */
+	var _radius:Float = 0;
+	var _direction:Float = 0;
+	var _amount:Float = 0;
 	/**
 	 * The speed of easing when the thumb is released.
-	 */ 
-	private var _ease:Float;
-	
+	 */
+	var _ease:Float;
+
 	/**
 	 * Create a virtual thumbstick - useful for input on mobile devices.
 	 *
@@ -101,28 +101,28 @@ class FlxAnalog extends FlxSpriteGroup
 	public function new(X:Float = 0, Y:Float = 0, Radius:Float = 0, Ease:Float = 0.25, ?BaseGraphic:FlxGraphicAsset, ?ThumbGraphic:FlxGraphicAsset)
 	{
 		super();
-		
+
 		_radius = Radius;
 		_ease = FlxMath.bound(Ease, 0, 60 / FlxG.updateFramerate);
-		
+
 		_analogs.push(this);
-		
+
 		_point = FlxPoint.get();
-		
+
 		createBase(BaseGraphic);
 		createThumb(ThumbGraphic);
-		
+
 		x = X;
 		y = Y;
-		
+
 		scrollFactor.set();
 		moves = false;
 	}
-	
+
 	/**
 	 * Creates the background of the analog stick.
 	 */
-	private function createBase(?Graphic:FlxGraphicAsset):Void
+	function createBase(?Graphic:FlxGraphicAsset):Void
 	{
 		base = new FlxSprite(0, 0, Graphic);
 		if (Graphic == null)
@@ -135,18 +135,18 @@ class FlxAnalog extends FlxSpriteGroup
 		base.y += -base.height * 0.5;
 		base.scrollFactor.set();
 		base.solid = false;
-		
+
 		#if FLX_DEBUG
 		base.ignoreDrawDebug = true;
 		#end
-		
-		add(base);	
+
+		add(base);
 	}
-	
+
 	/**
 	 * Creates the thumb of the analog stick.
 	 */
-	private function createThumb(?Graphic:FlxGraphicAsset):Void 
+	function createThumb(?Graphic:FlxGraphicAsset):Void
 	{
 		thumb = new FlxSprite(0, 0, Graphic);
 		if (Graphic == null)
@@ -157,35 +157,35 @@ class FlxAnalog extends FlxSpriteGroup
 		}
 		thumb.scrollFactor.set();
 		thumb.solid = false;
-		
+
 		#if FLX_DEBUG
 		thumb.ignoreDrawDebug = true;
 		#end
-		
+
 		add(thumb);
 	}
-	
+
 	/**
 	 * Creates the touch zone. It's based on the size of the background.
 	 * The thumb will react when the mouse is in the zone.
 	 */
-	private function createZone():Void
+	function createZone():Void
 	{
 		if (base != null && _radius == 0)
 			_radius = base.width * 0.5;
-		
+
 		_zone.set(x - _radius, y - _radius, 2 * _radius, 2 * _radius);
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
 	override public function destroy():Void
 	{
 		super.destroy();
-		
+
 		_zone = FlxDestroyUtil.put(_zone);
-		
+
 		_analogs.remove(this);
 		onUp = null;
 		onDown = null;
@@ -193,29 +193,29 @@ class FlxAnalog extends FlxSpriteGroup
 		onPressed = null;
 		thumb = null;
 		base = null;
-		
+
 		#if FLX_TOUCH
 		_currentTouch = null;
 		_tempTouches = null;
 		#end
 	}
-	
+
 	/**
 	 * Update the behavior.
 	 */
-	override public function update(elapsed:Float):Void 
+	override public function update(elapsed:Float):Void
 	{
 		var offAll:Bool = true;
-		
+
 		#if FLX_MOUSE
 		_point.set(FlxG.mouse.screenX, FlxG.mouse.screenY);
-		
+
 		if (!updateAnalog(_point, FlxG.mouse.pressed, FlxG.mouse.justPressed, FlxG.mouse.justReleased))
 		{
 			offAll = false;
 		}
 		#end
-		
+
 		// There is no reason to get into the loop if their is already a pointer on the analog
 		#if FLX_TOUCH
 		if (_currentTouch != null)
@@ -227,24 +227,24 @@ class FlxAnalog extends FlxSpriteGroup
 			for (touch in FlxG.touches.list)
 			{
 				var touchInserted:Bool = false;
-				
+
 				for (analog in _analogs)
 				{
 					// Check whether the pointer is already taken by another analog.
 					// TODO: check this place. This line was 'if (analog != this && analog._currentTouch != touch && touchInserted == false)'
-					if (analog == this && analog._currentTouch != touch && !touchInserted) 
-					{		
+					if (analog == this && analog._currentTouch != touch && !touchInserted)
+					{
 						_tempTouches.push(touch);
 						touchInserted = true;
 					}
 				}
 			}
 		}
-			
+
 		for (touch in _tempTouches)
 		{
 			_point = touch.getWorldPosition(FlxG.camera, _point);
-				
+
 			if (!updateAnalog(_point, touch.pressed, touch.justPressed, touch.justReleased, touch))
 			{
 				offAll = false;
@@ -252,39 +252,39 @@ class FlxAnalog extends FlxSpriteGroup
 			}
 		}
 		#end
-		
+
 		if ((status == HIGHLIGHT || status == NORMAL) && _amount != 0)
 		{
 			_amount -= _amount * _ease * FlxG.updateFramerate / 60;
-			
-			if (Math.abs(_amount) < 0.1) 
+
+			if (Math.abs(_amount) < 0.1)
 			{
 				_amount = 0;
 				_direction = 0;
 			}
 		}
-		
+
 		thumb.x = x + Math.cos(_direction) * _amount * _radius - (thumb.width * 0.5);
 		thumb.y = y + Math.sin(_direction) * _amount * _radius - (thumb.height * 0.5);
-		
+
 		if (offAll)
 		{
 			status = NORMAL;
 		}
-		
+
 		#if FLX_TOUCH
 		_tempTouches.splice(0, _tempTouches.length);
 		#end
-		
+
 		super.update(elapsed);
 	}
-	
-	private function updateAnalog(TouchPoint:FlxPoint, Pressed:Bool, JustPressed:Bool, JustReleased:Bool, ?Touch:FlxTouch):Bool
+
+	function updateAnalog(TouchPoint:FlxPoint, Pressed:Bool, JustPressed:Bool, JustReleased:Bool, ?Touch:FlxTouch):Bool
 	{
 		var offAll:Bool = true;
-		
+
 		#if FLX_TOUCH
-		// Use the touch to figure out the world position if it's passed in, as 
+		// Use the touch to figure out the world position if it's passed in, as
 		// the screen coordinates passed in touchPoint are wrong
 		// if the control is used in a group, for example.
 		if (Touch != null)
@@ -292,11 +292,11 @@ class FlxAnalog extends FlxSpriteGroup
 			TouchPoint.set(Touch.screenX, Touch.screenY);
 		}
 		#end
-		
+
 		if (_zone.containsPoint(TouchPoint) || (status == PRESSED))
 		{
 			offAll = false;
-			
+
 			if (Pressed)
 			{
 				#if FLX_TOUCH
@@ -306,7 +306,7 @@ class FlxAnalog extends FlxSpriteGroup
 				}
 				#end
 				status = PRESSED;
-				
+
 				if (JustPressed)
 				{
 					if (onDown != null)
@@ -314,27 +314,27 @@ class FlxAnalog extends FlxSpriteGroup
 						onDown();
 					}
 				}
-				
+
 				if (status == PRESSED)
 				{
 					if (onPressed != null)
 					{
 						onPressed();
 					}
-					
+
 					var dx:Float = TouchPoint.x - x;
 					var dy:Float = TouchPoint.y - y;
-					
+
 					var dist:Float = Math.sqrt(dx * dx + dy * dy);
-					
-					if (dist < 1) 
+
+					if (dist < 1)
 					{
 						dist = 0;
 					}
-					
+
 					_direction = Math.atan2(dy, dx);
 					_amount = Math.min(_radius, dist) / _radius;
-					
+
 					acceleration.x = Math.cos(_direction) * _amount;
 					acceleration.y = Math.sin(_direction) * _amount;
 				}
@@ -344,31 +344,31 @@ class FlxAnalog extends FlxSpriteGroup
 				#if FLX_TOUCH
 				_currentTouch = null;
 				#end
-				
+
 				status = HIGHLIGHT;
-				
+
 				if (onUp != null)
 				{
 					onUp();
 				}
-				
+
 				acceleration.set();
 			}
-			
+
 			if (status == NORMAL)
 			{
 				status = HIGHLIGHT;
-				
+
 				if (onOver != null)
 				{
 					onOver();
 				}
 			}
 		}
-		
+
 		return offAll;
 	}
-	
+
 	/**
 	 * Returns the angle in degrees.
 	 */
@@ -376,23 +376,23 @@ class FlxAnalog extends FlxSpriteGroup
 	{
 		return _direction * FlxAngle.TO_DEG;
 	}
-	
+
 	/**
 	 * Whether the thumb is pressed or not.
 	 */
 	public var pressed(get, never):Bool;
-	
-	private inline function get_pressed():Bool
+
+	inline function get_pressed():Bool
 	{
 		return status == PRESSED;
 	}
-	
+
 	/**
 	 * Whether the thumb is just pressed or not.
 	 */
 	public var justPressed(get, never):Bool;
-	
-	private function get_justPressed():Bool
+
+	function get_justPressed():Bool
 	{
 		#if FLX_MOUSE
 		return FlxG.mouse.justPressed && status == PRESSED;
@@ -404,16 +404,16 @@ class FlxAnalog extends FlxSpriteGroup
 			return _currentTouch.justPressed && status == PRESSED;
 		}
 		#end
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Whether the thumb is just released or not.
 	 */
 	public var justReleased(get, never):Bool;
-	
-	private function get_justReleased():Bool
+
+	function get_justReleased():Bool
 	{
 		#if FLX_MOUSE
 		return FlxG.mouse.justReleased && status == HIGHLIGHT;
@@ -428,20 +428,20 @@ class FlxAnalog extends FlxSpriteGroup
 
 		return false;
 	}
-	
-	override private function set_x(X:Float):Float
+
+	override function set_x(X:Float):Float
 	{
 		super.set_x(X);
 		createZone();
-		
+
 		return X;
 	}
-	
-	override private function set_y(Y:Float):Float
+
+	override function set_y(Y:Float):Float
 	{
 		super.set_y(Y);
 		createZone();
-		
+
 		return Y;
 	}
 }

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -20,9 +20,9 @@ import flixel.util.FlxStringUtil;
 
 /**
  * FlxBar is a quick and easy way to create a graphical bar which can
- * be used as part of your UI/HUD, or positioned next to a sprite. 
+ * be used as part of your UI/HUD, or positioned next to a sprite.
  * It could represent a loader, progress or health bar.
- * 
+ *
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
  */
@@ -92,10 +92,10 @@ class FlxBar extends FlxSprite
 	 * Property of parent object to track.
 	 */
 	public var parentVariable:String;
-	
+
 	public var barWidth(default, null):Int;
 	public var barHeight(default, null):Int;
-	
+
 	/**
 	 * BarFrames which will be used for filled bar rendering.
 	 * It is recommended to use this property in tile render mode
@@ -103,36 +103,36 @@ class FlxBar extends FlxSprite
 	 */
 	@:isVar
 	public var frontFrames(get, set):FlxImageFrame;
-	
+
 	public var backFrames(get, set):FlxImageFrame;
-	
+
 	/**
 	 * The direction from which the health bar will fill-up. Default is from left to right. Change takes effect immediately.
 	 */
-	public var fillDirection(default, set):FlxBarFillDirection;	
-	private var _fillHorizontal:Bool;
-	
+	public var fillDirection(default, set):FlxBarFillDirection;
+	var _fillHorizontal:Bool;
+
 	/**
 	 * FlxSprite which is used for rendering front graphics of bar (showing value) in tile render mode.
 	 */
-	private var _frontFrame:FlxFrame;
-	private var _filledFlxRect:FlxRect;
-	
-	private var _emptyBar:BitmapData;
-	private var _emptyBarRect:Rectangle;
-	
-	private var _filledBar:BitmapData;
-	
-	private var _zeroOffset:Point;
-	
-	private var _filledBarRect:Rectangle;
-	private var _filledBarPoint:Point;
-	
-	private var _maxPercent:Int = 100;
-	
+	var _frontFrame:FlxFrame;
+	var _filledFlxRect:FlxRect;
+
+	var _emptyBar:BitmapData;
+	var _emptyBarRect:Rectangle;
+
+	var _filledBar:BitmapData;
+
+	var _zeroOffset:Point;
+
+	var _filledBarRect:Rectangle;
+	var _filledBarPoint:Point;
+
+	var _maxPercent:Int = 100;
+
 	/**
 	 * Create a new FlxBar Object
-	 * 
+	 *
 	 * @param	x			The x coordinate location of the resulting bar (in world pixels)
 	 * @param	y			The y coordinate location of the resulting bar (in world pixels)
 	 * @param	direction 	The fill direction, LEFT_TO_RIGHT by default
@@ -147,12 +147,12 @@ class FlxBar extends FlxSprite
 	public function new(x:Float = 0, y:Float = 0, ?direction:FlxBarFillDirection, width:Int = 100, height:Int = 10, ?parentRef:Dynamic, variable:String = "", min:Float = 0, max:Float = 100, showBorder:Bool = false)
 	{
 		super(x, y);
-		
+
 		direction = (direction == null) ? FlxBarFillDirection.LEFT_TO_RIGHT : direction;
-		
+
 		barWidth = width;
 		barHeight = height;
-		
+
 		_filledBarPoint = new Point();
 		_filledBarRect = new Rectangle();
 		if (FlxG.renderBlit)
@@ -165,22 +165,22 @@ class FlxBar extends FlxSprite
 		{
 			_filledFlxRect = FlxRect.get();
 		}
-		
+
 		if (parentRef != null)
 		{
 			parent = parentRef;
 			parentVariable = variable;
 		}
-		
+
 		fillDirection = direction;
 		createFilledBar(0xff005100, 0xff00F400, showBorder);
 		setRange(min, max);
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		positionOffset = FlxDestroyUtil.put(positionOffset);
-		
+
 		if (FlxG.renderBlit)
 		{
 			_frontFrame = null;
@@ -195,20 +195,20 @@ class FlxBar extends FlxSprite
 		}
 		_filledBarRect = null;
 		_filledBarPoint = null;
-		
+
 		parent = null;
 		positionOffset = null;
 		emptyCallback = null;
 		filledCallback = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Track the parent FlxSprites x/y coordinates. For example if you wanted your sprite to have a floating health-bar above their head.
 	 * If your health bar is 10px tall and you wanted it to appear above your sprite, then set offsetY to be -10
 	 * If you wanted it to appear below your sprite, and your sprite was 32px tall, then set offsetY to be 32. Same applies to offsetX.
-	 * 
+	 *
 	 * @param	offsetX		The offset on X in relation to the origin x/y of the parent
 	 * @param	offsetY		The offset on Y in relation to the origin x/y of the parent
 	 * @see		stopTrackingParent
@@ -217,17 +217,17 @@ class FlxBar extends FlxSprite
 	{
 		fixedPosition = false;
 		positionOffset = FlxPoint.get(offsetX, offsetY);
-		
+
 		if (Reflect.hasField(parent, "scrollFactor"))
 		{
 			scrollFactor.x = parent.scrollFactor.x;
 			scrollFactor.y = parent.scrollFactor.y;
 		}
 	}
-	
+
 	/**
 	 * Sets a parent for this FlxBar. Instantly replaces any previously set parent and refreshes the bar.
-	 * 
+	 *
 	 * @param	parentRef	A reference to an object in your game that you wish the bar to track
 	 * @param	variable	The variable of the object that is used to determine the bar position. For example if the parent was an FlxSprite this could be "health" to track the health value
 	 * @param	track		If you wish the FlxBar to track the x/y coordinates of parent set to true (default false)
@@ -238,18 +238,18 @@ class FlxBar extends FlxSprite
 	{
 		parent = parentRef;
 		parentVariable = variable;
-		
+
 		if (track)
 		{
 			trackParent(offsetX, offsetY);
 		}
-		
+
 		updateValueFromParent();
 	}
-	
+
 	/**
 	 * Tells the health bar to stop following the parent sprite. The given posX and posY values are where it will remain on-screen.
-	 * 
+	 *
 	 * @param	posX	X coordinate of the health bar now it's no longer tracking the parent sprite
 	 * @param	posY	Y coordinate of the health bar now it's no longer tracking the parent sprite
 	 */
@@ -259,12 +259,12 @@ class FlxBar extends FlxSprite
 		x = posX;
 		y = posY;
 	}
-	
+
 	/**
 	 * Sets callbacks which will be triggered when the value of this FlxBar reaches min or max.
 	 * Functions will only be called once and not again until the value changes.
 	 * Optionally the FlxBar can be killed if it reaches min, but if will fire the empty callback first (if set)
-	 * 
+	 *
 	 * @param	onEmpty			The function that is called if the value of this FlxBar reaches min
 	 * @param	onFilled		The function that is called if the value of this FlxBar reaches max
 	 * @param	killOnEmpty		If set it will call FlxBar.kill() if the value reaches min
@@ -275,10 +275,10 @@ class FlxBar extends FlxSprite
 		filledCallback = (onFilled != null) ? onFilled : filledCallback;
 		this.killOnEmpty = killOnEmpty;
 	}
-	
+
 	/**
 	 * Set the minimum and maximum allowed values for the FlxBar
-	 * 
+	 *
 	 * @param	min			The minimum value. I.e. for a progress bar this would be zero (nothing loaded yet)
 	 * @param	max			The maximum value the bar can reach. I.e. for a progress bar this would typically be 100.
 	 */
@@ -289,14 +289,14 @@ class FlxBar extends FlxSprite
 			throw "FlxBar: max cannot be less than or equal to min";
 			return;
 		}
-		
+
 		this.min = min;
 		this.max = max;
 		this.range = max - min;
 		this.pct = range / _maxPercent;
-		
+
 		pxPerPercent = (_fillHorizontal) ? (barWidth / _maxPercent) : (barHeight / _maxPercent);
-		
+
 		if (!Math.isNaN(value))
 		{
 			value = Math.max(min, Math.min(value, max));
@@ -306,11 +306,11 @@ class FlxBar extends FlxSprite
 			value = min;
 		}
 	}
-	
+
 	/**
 	 * Creates a solid-colour filled health bar in the given colours, with optional 1px thick border.
 	 * All colour values are in 0xAARRGGBB format, so if you want a slightly transparent health bar give it lower AA values.
-	 * 
+	 *
 	 * @param	empty		The color of the bar when empty in 0xAARRGGBB format (the background colour)
 	 * @param	fill		The color of the bar when full in 0xAARRGGBB format (the foreground colour)
 	 * @param	showBorder	Should the bar be outlined with a 1px solid border?
@@ -323,10 +323,10 @@ class FlxBar extends FlxSprite
 		createColoredFilledBar(fill, showBorder, border);
 		return this;
 	}
-	
+
 	/**
 	 * Creates a solid-colour filled background for health bar in the given colour, with optional 1px thick border.
-	 * 
+	 *
 	 * @param	empty			The color of the bar when empty in 0xAARRGGBB format (the background colour)
 	 * @param	showBorder		Should the bar be outlined with a 1px solid border?
 	 * @param	border			The border colour in 0xAARRGGBB format
@@ -339,11 +339,11 @@ class FlxBar extends FlxSprite
 			var emptyKey:String = "empty: " + barWidth + "x" + barHeight + ":" + empty.toHexString();
 			if (showBorder)
 				emptyKey += ",border: " + border.toHexString();
-			
+
 			if (!FlxG.bitmap.checkCache(emptyKey))
 			{
 				var emptyBar:BitmapData = null;
-				
+
 				if (showBorder)
 				{
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
@@ -353,10 +353,10 @@ class FlxBar extends FlxSprite
 				{
 					emptyBar = new BitmapData(barWidth, barHeight, true, empty);
 				}
-				
+
 				FlxG.bitmap.add(emptyBar, false, emptyKey);
 			}
-			
+
 			frames = FlxG.bitmap.get(emptyKey).imageFrame;
 		}
 		else
@@ -370,14 +370,14 @@ class FlxBar extends FlxSprite
 			{
 				_emptyBar = new BitmapData(barWidth, barHeight, true, empty);
 			}
-			
+
 			_emptyBarRect.setTo(0, 0, barWidth, barHeight);
 			updateEmptyBar();
 		}
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Creates a solid-colour filled foreground for health bar in the given colour, with optional 1px thick border.
 	 * @param	fill		The color of the bar when full in 0xAARRGGBB format (the foreground colour)
@@ -392,11 +392,11 @@ class FlxBar extends FlxSprite
 			var filledKey:String = "filled: " + barWidth + "x" + barHeight + ":" + fill.toHexString();
 			if (showBorder)
 				filledKey += ",border: " + border.toHexString();
-			
+
 			if (!FlxG.bitmap.checkCache(filledKey))
 			{
 				var filledBar:BitmapData = null;
-				
+
 				if (showBorder)
 				{
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
@@ -406,10 +406,10 @@ class FlxBar extends FlxSprite
 				{
 					filledBar = new BitmapData(barWidth, barHeight, true, fill);
 				}
-				
+
 				FlxG.bitmap.add(filledBar, false, filledKey);
 			}
-			
+
 			frontFrames = FlxG.bitmap.get(filledKey).imageFrame;
 		}
 		else
@@ -423,17 +423,17 @@ class FlxBar extends FlxSprite
 			{
 				_filledBar = new BitmapData(barWidth, barHeight, true, fill);
 			}
-			
+
 			_filledBarRect.setTo(0, 0, barWidth, barHeight);
 			updateFilledBar();
 		}
 		return this;
 	}
-	
+
 	/**
 	 * Creates a gradient filled health bar using the given colour ranges, with optional 1px thick border.
 	 * All colour values are in 0xAARRGGBB format, so if you want a slightly transparent health bar give it lower AA values.
-	 * 
+	 *
 	 * @param	empty		Array of colour values used to create the gradient of the health bar when empty, each colour must be in 0xAARRGGBB format (the background colour)
 	 * @param	fill		Array of colour values used to create the gradient of the health bar when full, each colour must be in 0xAARRGGBB format (the foreground colour)
 	 * @param	chunkSize	If you want a more old-skool looking chunky gradient, increase this value!
@@ -448,10 +448,10 @@ class FlxBar extends FlxSprite
 		createGradientFilledBar(fill, chunkSize, rotation, showBorder, border);
 		return this;
 	}
-	
+
 	/**
 	 * Creates a gradient filled background for health bar using the given colour range, with optional 1px thick border.
-	 * 
+	 *
 	 * @param	empty			Array of colour values used to create the gradient of the health bar when empty, each colour must be in 0xAARRGGBB format (the background colour)
 	 * @param	chunkSize		If you want a more old-skool looking chunky gradient, increase this value!
 	 * @param	rotation		Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
@@ -469,16 +469,16 @@ class FlxBar extends FlxSprite
 				emptyKey += col.toHexString() + ",";
 			}
 			emptyKey += "],chunkSize: " + chunkSize + ",rotation: " + rotation;
-			
+
 			if (showBorder)
 			{
 				emptyKey += ",border: " + border.toHexString();
 			}
-			
+
 			if (!FlxG.bitmap.checkCache(emptyKey))
 			{
 				var emptyBar:BitmapData = null;
-				
+
 				if (showBorder)
 				{
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
@@ -488,10 +488,10 @@ class FlxBar extends FlxSprite
 				{
 					emptyBar = FlxGradient.createGradientBitmapData(barWidth, barHeight, empty, chunkSize, rotation);
 				}
-				
+
 				FlxG.bitmap.add(emptyBar, false, emptyKey);
 			}
-			
+
 			frames = FlxG.bitmap.get(emptyKey).imageFrame;
 		}
 		else
@@ -505,17 +505,17 @@ class FlxBar extends FlxSprite
 			{
 				_emptyBar = FlxGradient.createGradientBitmapData(barWidth, barHeight, empty, chunkSize, rotation);
 			}
-			
+
 			_emptyBarRect.setTo(0, 0, barWidth, barHeight);
 			updateEmptyBar();
 		}
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Creates a gradient filled foreground for health bar using the given colour range, with optional 1px thick border.
-	 * 
+	 *
 	 * @param	fill		Array of colour values used to create the gradient of the health bar when full, each colour must be in 0xAARRGGBB format (the foreground colour)
 	 * @param	chunkSize	If you want a more old-skool looking chunky gradient, increase this value!
 	 * @param	rotation	Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
@@ -533,16 +533,16 @@ class FlxBar extends FlxSprite
 				filledKey += col.toHexString() + ",";
 			}
 			filledKey += "],chunkSize: " + chunkSize + ",rotation: " + rotation;
-			
+
 			if (showBorder)
 			{
 				filledKey += ",border: " + border.toHexString();
 			}
-			
+
 			if (!FlxG.bitmap.checkCache(filledKey))
 			{
 				var filledBar:BitmapData = null;
-				
+
 				if (showBorder)
 				{
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
@@ -552,10 +552,10 @@ class FlxBar extends FlxSprite
 				{
 					filledBar = FlxGradient.createGradientBitmapData(barWidth, barHeight, fill, chunkSize, rotation);
 				}
-				
+
 				FlxG.bitmap.add(filledBar, false, filledKey);
 			}
-			
+
 			frontFrames = FlxG.bitmap.get(filledKey).imageFrame;
 		}
 		else
@@ -563,26 +563,26 @@ class FlxBar extends FlxSprite
 			if (showBorder)
 			{
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_filledBar, barWidth - 2, barHeight - 2, fill, 1, 1, chunkSize, rotation);	
+				FlxGradient.overlayGradientOnBitmapData(_filledBar, barWidth - 2, barHeight - 2, fill, 1, 1, chunkSize, rotation);
 			}
 			else
 			{
 				_filledBar = FlxGradient.createGradientBitmapData(barWidth, barHeight, fill, chunkSize, rotation);
 			}
-			
+
 			_filledBarRect.setTo(0, 0, barWidth, barHeight);
 			updateFilledBar();
 		}
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Creates a health bar filled using the given bitmap images.
-	 * You can provide "empty" (background) and "fill" (foreground) images. either one or both images (empty / fill), and use the optional empty/fill colour values 
+	 * You can provide "empty" (background) and "fill" (foreground) images. either one or both images (empty / fill), and use the optional empty/fill colour values
 	 * All colour values are in 0xAARRGGBB format, so if you want a slightly transparent health bar give it lower AA values.
 	 * NOTE: This method doesn't check if the empty image doesn't have the same size as fill image.
-	 * 
+	 *
 	 * @param	empty				Bitmap image used as the background (empty part) of the health bar, if null the emptyBackground colour is used
 	 * @param	fill				Bitmap image used as the foreground (filled part) of the health bar, if null the fillBackground colour is used
 	 * @param	emptyBackground		If no background (empty) image is given, use this colour value instead. 0xAARRGGBB format
@@ -595,10 +595,10 @@ class FlxBar extends FlxSprite
 		createImageFilledBar(fill, fillBackground);
 		return this;
 	}
-	
+
 	/**
 	 * Loads given bitmap image for health bar background.
-	 * 
+	 *
 	 * @param	empty				Bitmap image used as the background (empty part) of the health bar, if null the emptyBackground colour is used
 	 * @param	emptyBackground		If no background (empty) image is given, use this colour value instead. 0xAARRGGBB format
 	 * @return	This FlxBar object with generated image for background rendering.
@@ -608,7 +608,7 @@ class FlxBar extends FlxSprite
 		if (empty != null)
 		{
 			var emptyGraphic:FlxGraphic = FlxG.bitmap.add(empty);
-		
+
 			if (FlxG.renderTile)
 			{
 				frames = emptyGraphic.imageFrame;
@@ -616,17 +616,17 @@ class FlxBar extends FlxSprite
 			else
 			{
 				_emptyBar = emptyGraphic.bitmap.clone();
-				
+
 				barWidth = _emptyBar.width;
 				barHeight = _emptyBar.height;
-				
+
 				_emptyBarRect.setTo(0, 0, barWidth, barHeight);
-				
+
 				if (graphic == null || (frame.sourceSize.x != barWidth || frame.sourceSize.y != barHeight))
 				{
 					makeGraphic(barWidth, barHeight, FlxColor.TRANSPARENT, true);
 				}
-				
+
 				updateEmptyBar();
 			}
 		}
@@ -634,13 +634,13 @@ class FlxBar extends FlxSprite
 		{
 			createColoredEmptyBar(emptyBackground);
 		}
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Loads given bitmap image for health bar foreground.
-	 * 
+	 *
 	 * @param	fill				Bitmap image used as the foreground (filled part) of the health bar, if null the fillBackground colour is used
 	 * @param	fillBackground		If no foreground (fill) image is given, use this colour value instead. 0xAARRGGBB format
 	 * @return	This FlxBar object with generated image for rendering actual values.
@@ -650,7 +650,7 @@ class FlxBar extends FlxSprite
 		if (fill != null)
 		{
 			var filledGraphic:FlxGraphic = FlxG.bitmap.add(fill);
-		
+
 			if (FlxG.renderTile)
 			{
 				frontFrames = filledGraphic.imageFrame;
@@ -658,14 +658,14 @@ class FlxBar extends FlxSprite
 			else
 			{
 				_filledBar = filledGraphic.bitmap.clone();
-				
+
 				_filledBarRect.setTo(0, 0, barWidth, barHeight);
-				
+
 				if (graphic == null || (frame.sourceSize.x != barWidth || frame.sourceSize.y != barHeight))
 				{
 					makeGraphic(barWidth, barHeight, FlxColor.TRANSPARENT, true);
 				}
-				
+
 				pxPerPercent = (_fillHorizontal) ? (barWidth / _maxPercent) : (barHeight / _maxPercent);
 				updateFilledBar();
 			}
@@ -674,31 +674,31 @@ class FlxBar extends FlxSprite
 		{
 			createColoredFilledBar(fillBackground);
 		}
-		
+
 		return this;
 	}
-	
-	private function set_fillDirection(direction:FlxBarFillDirection):FlxBarFillDirection
+
+	function set_fillDirection(direction:FlxBarFillDirection):FlxBarFillDirection
 	{
 		fillDirection = direction;
-		
+
 		switch (direction)
 		{
 			case LEFT_TO_RIGHT, RIGHT_TO_LEFT, HORIZONTAL_INSIDE_OUT, HORIZONTAL_OUTSIDE_IN:
 				_fillHorizontal = true;
-				
+
 			case TOP_TO_BOTTOM, BOTTOM_TO_TOP, VERTICAL_INSIDE_OUT, VERTICAL_OUTSIDE_IN:
 				_fillHorizontal = false;
 		}
-		
+
 		return fillDirection;
 	}
-	
-	private function updateValueFromParent():Void
+
+	function updateValueFromParent():Void
 	{
 		value = Reflect.getProperty(parent, parentVariable);
 	}
-	
+
 	/**
 	 * Updates health bar view according its current value.
 	 * Called when the health bar detects a change in the health of the parent.
@@ -708,7 +708,7 @@ class FlxBar extends FlxSprite
 		updateEmptyBar();
 		updateFilledBar();
 	}
-	
+
 	/**
 	 * Stamps health bar background on its pixels
 	 */
@@ -720,7 +720,7 @@ class FlxBar extends FlxSprite
 			dirty = true;
 		}
 	}
-	
+
 	/**
 	 * Stamps health bar foreground on its pixels
 	 */
@@ -728,13 +728,13 @@ class FlxBar extends FlxSprite
 	{
 		_filledBarRect.width = barWidth;
 		_filledBarRect.height = barHeight;
-		
+
 		var fraction:Float = (value - min) / range;
 		var percent:Float = fraction * _maxPercent;
 		var maxScale:Float = (_fillHorizontal) ? barWidth : barHeight;
 		var scaleInterval:Float = maxScale / numDivisions;
 		var interval:Float = Std.int(fraction * maxScale / scaleInterval) * scaleInterval;
-		
+
 		if (_fillHorizontal)
 		{
 			_filledBarRect.width = Std.int(interval);
@@ -743,39 +743,39 @@ class FlxBar extends FlxSprite
 		{
 			_filledBarRect.height = Std.int(interval);
 		}
-		
+
 		if (percent > 0)
 		{
 			switch (fillDirection)
 			{
 				case LEFT_TO_RIGHT, TOP_TO_BOTTOM:
 					//	Already handled above
-				
+
 				case BOTTOM_TO_TOP:
 					_filledBarRect.y = barHeight - _filledBarRect.height;
 					_filledBarPoint.y = barHeight - _filledBarRect.height;
-					
+
 				case RIGHT_TO_LEFT:
 					_filledBarRect.x = barWidth - _filledBarRect.width;
 					_filledBarPoint.x = barWidth - _filledBarRect.width;
-					
+
 				case HORIZONTAL_INSIDE_OUT:
 					_filledBarRect.x = Std.int((barWidth / 2) - (_filledBarRect.width / 2));
 					_filledBarPoint.x = Std.int((barWidth / 2) - (_filledBarRect.width / 2));
-				
+
 				case HORIZONTAL_OUTSIDE_IN:
 					_filledBarRect.width = Std.int(maxScale - interval);
 					_filledBarPoint.x = Std.int((barWidth - _filledBarRect.width) / 2);
-				
+
 				case VERTICAL_INSIDE_OUT:
 					_filledBarRect.y = Std.int((barHeight / 2) - (_filledBarRect.height / 2));
 					_filledBarPoint.y = Std.int((barHeight / 2) - (_filledBarRect.height / 2));
-					
+
 				case VERTICAL_OUTSIDE_IN:
 					_filledBarRect.height = Std.int(maxScale - interval);
 					_filledBarPoint.y = Std.int((barHeight - _filledBarRect.height) / 2);
 			}
-			
+
 			if (FlxG.renderBlit)
 			{
 				pixels.copyPixels(_filledBar, _filledBarRect, _filledBarPoint, null, null, true);
@@ -792,13 +792,13 @@ class FlxBar extends FlxSprite
 				}
 			}
 		}
-		
+
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 		}
 	}
-	
+
 	override public function update(elapsed:Float):Void
 	{
 		if (parent != null)
@@ -807,27 +807,27 @@ class FlxBar extends FlxSprite
 			{
 				updateValueFromParent();
 			}
-			
+
 			if (!fixedPosition)
 			{
 				x = parent.x + positionOffset.x;
 				y = parent.y + positionOffset.y;
 			}
 		}
-		
+
 		super.update(elapsed);
 	}
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		super.draw();
-		
+
 		if (!FlxG.renderTile)
 			return;
-		
+
 		if (alpha == 0)
 			return;
-		
+
 		if (percent > 0 && _frontFrame.type != FlxFrameType.EMPTY)
 		{
 			for (camera in cameras)
@@ -836,32 +836,32 @@ class FlxBar extends FlxSprite
 				{
 					continue;
 				}
-				
+
 				getScreenPosition(_point, camera).subtractPoint(offset);
-				
+
 				_frontFrame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, flipX, flipY);
 				_matrix.translate( -origin.x, -origin.y);
 				_matrix.scale(scale.x, scale.y);
-				
+
 				// rotate matrix if sprite's graphic isn't prerotated
 				if (angle != 0)
 				{
 					_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 				}
-				
+
 				_point.add(origin.x, origin.y);
 				if (isPixelPerfectRender(camera))
 				{
 					_point.floor();
 				}
-				
+
 				_matrix.translate(_point.x, _point.y);
 				camera.drawPixels(_frontFrame, _matrix, colorTransform, blend, antialiasing, shader);
 			}
 		}
 	}
-	
-	override private function set_pixels(Pixels:BitmapData):BitmapData
+
+	override function set_pixels(Pixels:BitmapData):BitmapData
 	{
 		if (FlxG.renderTile)
 		{
@@ -872,10 +872,10 @@ class FlxBar extends FlxSprite
 			return super.set_pixels(Pixels);
 		}
 	}
-	
+
 	override public function toString():String
 	{
-		return FlxStringUtil.getDebugString([ 
+		return FlxStringUtil.getDebugString([
 			LabelValuePair.weak("min", min),
 			LabelValuePair.weak("max", max),
 			LabelValuePair.weak("range", range),
@@ -883,18 +883,18 @@ class FlxBar extends FlxSprite
 			LabelValuePair.weak("px/%", pxPerPercent),
 			LabelValuePair.weak("value", value)]);
 	}
-	
-	private function get_percent():Float
+
+	function get_percent():Float
 	{
 		if (value > max)
 		{
 			return _maxPercent;
 		}
-		
+
 		return Math.floor(((value - min) / range) * _maxPercent);
 	}
 
-	private function set_percent(newPct:Float):Float
+	function set_percent(newPct:Float):Float
 	{
 		if (newPct >= 0 && newPct <= _maxPercent)
 		{
@@ -902,50 +902,50 @@ class FlxBar extends FlxSprite
 		}
 		return newPct;
 	}
-	
-	private function set_value(newValue:Float):Float
+
+	function set_value(newValue:Float):Float
 	{
 		value = Math.max(min, Math.min(newValue, max));
-		
+
 		if (value == min && emptyCallback != null)
 		{
 			emptyCallback();
 		}
-		
+
 		if (value == max && filledCallback != null)
 		{
 			filledCallback();
 		}
-		
+
 		if (value == min && killOnEmpty)
 		{
 			kill();
 		}
-		
+
 		updateBar();
 		return newValue;
 	}
-	
-	private function get_value():Float
+
+	function get_value():Float
 	{
 		#if neko
-		if (value == null) 
+		if (value == null)
 		{
 			value = min;
 		}
 		#end
-		
+
 		return value;
 	}
-	
-	private function set_numDivisions(newValue:Int):Int
+
+	function set_numDivisions(newValue:Int):Int
 	{
 		numDivisions = (newValue > 0) ? newValue : 100;
 		updateFilledBar();
 		return newValue;
 	}
-	
-	private function get_frontFrames():FlxImageFrame
+
+	function get_frontFrames():FlxImageFrame
 	{
 		if (FlxG.renderTile)
 		{
@@ -953,8 +953,8 @@ class FlxBar extends FlxSprite
 		}
 		return null;
 	}
-	
-	private function set_frontFrames(value:FlxImageFrame):FlxImageFrame
+
+	function set_frontFrames(value:FlxImageFrame):FlxImageFrame
 	{
 		if (FlxG.renderTile)
 		{
@@ -967,8 +967,8 @@ class FlxBar extends FlxSprite
 		}
 		return value;
 	}
-	
-	private function get_backFrames():FlxImageFrame
+
+	function get_backFrames():FlxImageFrame
 	{
 		if (FlxG.renderTile)
 		{
@@ -976,8 +976,8 @@ class FlxBar extends FlxSprite
 		}
 		return null;
 	}
-	
-	private function set_backFrames(value:FlxImageFrame):FlxImageFrame
+
+	function set_backFrames(value:FlxImageFrame):FlxImageFrame
 	{
 		if (FlxG.renderTile)
 		{

--- a/flixel/ui/FlxBitmapTextButton.hx
+++ b/flixel/ui/FlxBitmapTextButton.hx
@@ -12,7 +12,7 @@ class FlxBitmapTextButton extends FlxTypedButton<FlxBitmapText>
 	public function new(X:Float = 0, Y:Float = 0, ?Label:String, ?OnClick:Void->Void)
 	{
 		super(X, Y, OnClick);
-		
+
 		if (Label != null)
 		{
 			label = new FlxBitmapText();
@@ -21,34 +21,34 @@ class FlxBitmapTextButton extends FlxTypedButton<FlxBitmapText>
 			label.color = 0xFF333333;
 			label.useTextColor = true;
 			label.alignment = FlxTextAlign.CENTER;
-			
+
 			for (offset in labelOffsets)
 			{
 				offset.set(0, 5);
 			}
-			
+
 			label.x = X + labelOffsets[status].x;
 			label.y = Y + labelOffsets[status].y;
 		}
 	}
-	
+
 	/**
 	 * Updates the size of the text field to match the button.
 	 */
-	override private function resetHelpers():Void
+	override function resetHelpers():Void
 	{
 		super.resetHelpers();
-		
+
 		if (label != null)
 		{
 			label.width = width;
 		}
 	}
-	
+
 	override public function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
-		
+
 		if (label != null)
 		{
 			label.update(elapsed);

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -36,16 +36,16 @@ class FlxButton extends FlxTypedButton<FlxText>
 	 * Used with public variable status, means pressed (usually from mouse click).
 	 */
 	public static inline var PRESSED:Int = 2;
-	
+
 	/**
 	 * Shortcut to setting label.text
 	 */
 	public var text(get, set):String;
-	
+
 	/**
 	 * Creates a new `FlxButton` object with a gray background
 	 * and a callback function on the UI thread.
-	 * 
+	 *
 	 * @param   X         The x position of the button.
 	 * @param   Y         The y position of the button.
 	 * @param   Text      The text that you want to appear on the button.
@@ -54,28 +54,28 @@ class FlxButton extends FlxTypedButton<FlxText>
 	public function new(X:Float = 0, Y:Float = 0, ?Text:String, ?OnClick:Void->Void)
 	{
 		super(X, Y, OnClick);
-		
+
 		for (point in labelOffsets)
 			point.set(point.x - 1, point.y + 3);
-		
+
 		initLabel(Text);
 	}
-	
+
 	/**
 	 * Updates the size of the text field to match the button.
 	 */
-	override private function resetHelpers():Void
+	override function resetHelpers():Void
 	{
 		super.resetHelpers();
-		
+
 		if (label != null)
 		{
 			label.fieldWidth = label.frameWidth = Std.int(width);
 			label.size = label.size; // Calls set_size(), don't remove!
 		}
 	}
-	
-	private inline function initLabel(Text:String):Void 
+
+	inline function initLabel(Text:String):Void
 	{
 		if (Text != null)
 		{
@@ -85,13 +85,13 @@ class FlxButton extends FlxTypedButton<FlxText>
 			label.drawFrame(true);
 		}
 	}
-	
-	private inline function get_text():String 
+
+	inline function get_text():String
 	{
 		return (label != null) ? label.text : null;
 	}
-	
-	private inline function set_text(Text:String):String 
+
+	inline function set_text(Text:String):String
 	{
 		if (label == null)
 		{
@@ -169,32 +169,32 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 * The properties of this button's `onOut` event (callback function, sound).
 	 */
 	public var onOut(default, null):FlxButtonEvent;
-	
+
 	public var justReleased(get, never):Bool;
 	public var released(get, never):Bool;
 	public var pressed(get, never):Bool;
 	public var justPressed(get, never):Bool;
-	
+
 	/**
 	 * We cast label to a `FlxSprite` for internal operations to avoid Dynamic casts in C++
 	 */
-	private var _spriteLabel:FlxSprite;
-	
-	/** 
+	var _spriteLabel:FlxSprite;
+
+	/**
 	 * We don't need an ID here, so let's just use `Int` as the type.
 	 */
-	private var input:FlxInput<Int>;
-	
+	var input:FlxInput<Int>;
+
 	/**
 	 * The input currently pressing this button, if none, it's `null`. Needed to check for its release.
 	 */
-	private var currentInput:IFlxInput;
+	var currentInput:IFlxInput;
 
-	private var lastStatus = -1;
-	
+	var lastStatus = -1;
+
 	/**
 	 * Creates a new `FlxTypedButton` object with a gray background.
-	 * 
+	 *
 	 * @param   X         The x position of the button.
 	 * @param   Y         The y position of the button.
 	 * @param   OnClick   The function to call whenever the button is clicked.
@@ -202,52 +202,52 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	public function new(X:Float = 0, Y:Float = 0, ?OnClick:Void->Void)
 	{
 		super(X, Y);
-		
+
 		loadDefaultGraphic();
-		
+
 		onUp = new FlxButtonEvent(OnClick);
 		onDown = new FlxButtonEvent();
 		onOver = new FlxButtonEvent();
 		onOut = new FlxButtonEvent();
-		
+
 		status = FlxButton.NORMAL;
-		
+
 		// Since this is a UI element, the default scrollFactor is (0, 0)
 		scrollFactor.set();
-		
+
 		#if FLX_MOUSE
 		FlxG.stage.addEventListener(MouseEvent.MOUSE_UP, onUpEventListener);
 		#end
-		
+
 		#if FLX_NO_MOUSE // no need for highlight frame without mouse input
 		statusAnimations[FlxButton.HIGHLIGHT] = "normal";
 		labelAlphas[FlxButton.HIGHLIGHT] = 1;
 		#end
-		
+
 		input = new FlxInput(0);
 	}
-	
+
 	override public function graphicLoaded():Void
 	{
 		super.graphicLoaded();
-		
+
 		setupAnimation("normal", FlxButton.NORMAL);
 		setupAnimation("highlight", FlxButton.HIGHLIGHT);
 		setupAnimation("pressed", FlxButton.PRESSED);
 	}
-	
-	private function loadDefaultGraphic():Void
+
+	function loadDefaultGraphic():Void
 	{
 		loadGraphic("flixel/images/ui/button.png", true, 80, 20);
 	}
-	
-	private function setupAnimation(animationName:String, frameIndex:Int):Void
+
+	function setupAnimation(animationName:String, frameIndex:Int):Void
 	{
 		// make sure the animation doesn't contain an invalid frame
 		frameIndex = Std.int(Math.min(frameIndex, animation.frames - 1));
 		animation.add(animationName, [frameIndex]);
 	}
-	
+
 	/**
 	 * Called by the game state when state is changed (if this object belongs to the state)
 	 */
@@ -255,78 +255,78 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		label = FlxDestroyUtil.destroy(label);
 		_spriteLabel = null;
-		
+
 		onUp = FlxDestroyUtil.destroy(onUp);
 		onDown = FlxDestroyUtil.destroy(onDown);
 		onOver = FlxDestroyUtil.destroy(onOver);
 		onOut = FlxDestroyUtil.destroy(onOut);
-		
+
 		labelOffsets = FlxDestroyUtil.putArray(labelOffsets);
-		
+
 		labelAlphas = null;
 		currentInput = null;
 		input = null;
-		
+
 		#if FLX_MOUSE
 		FlxG.stage.removeEventListener(MouseEvent.MOUSE_UP, onUpEventListener);
 		#end
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Called by the game loop automatically, handles mouseover and click detection.
 	 */
 	override public function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
-		
-		if (visible) 
+
+		if (visible)
 		{
 			// Update the button, but only if at least either mouse or touches are enabled
 			#if FLX_POINTER_INPUT
 			updateButton();
 			#end
-			
-			// Trigger the animation only if the button's input status changes. 
-			if (lastStatus != status) 
+
+			// Trigger the animation only if the button's input status changes.
+			if (lastStatus != status)
 			{
 				updateStatusAnimation();
 				lastStatus = status;
 			}
 		}
-		
+
 		input.update();
 	}
-	
-	private function updateStatusAnimation():Void
+
+	function updateStatusAnimation():Void
 	{
 		animation.play(statusAnimations[status]);
 	}
-	
+
 	/**
 	 * Just draws the button graphic and text label to the screen.
 	 */
 	override public function draw():Void
 	{
 		super.draw();
-		
+
 		if (_spriteLabel != null && _spriteLabel.visible)
 		{
 			_spriteLabel.cameras = cameras;
 			_spriteLabel.draw();
 		}
 	}
-	
+
 	#if FLX_DEBUG
 	/**
 	 * Helper function to draw the debug graphic for the label as well.
 	 */
-	override public function drawDebug():Void 
+	override public function drawDebug():Void
 	{
 		super.drawDebug();
-		
-		if (_spriteLabel != null) 
+
+		if (_spriteLabel != null)
 		{
 			_spriteLabel.drawDebug();
 		}
@@ -337,7 +337,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 * Stamps button's graphic and label onto specified atlas object and loads graphic from this atlas.
 	 * This method assumes that you're using whole image for button's graphic and image has no spaces between frames.
 	 * And it assumes that label is a single frame sprite.
-	 * 
+	 *
 	 * @param   atlas   Atlas to stamp graphic to.
 	 * @return  Whether the button's graphic and label's graphic were stamped on the atlas successfully.
 	 */
@@ -345,7 +345,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		var buttonNode:FlxNode = atlas.addNode(graphic.bitmap, graphic.key);
 		var result:Bool = (buttonNode != null);
-		
+
 		if (buttonNode != null)
 		{
 			var buttonFrames:FlxTileFrames = cast frames;
@@ -353,45 +353,45 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			var tileFrames:FlxTileFrames = buttonNode.getTileFrames(tileSize);
 			this.frames = tileFrames;
 		}
-		
+
 		if (result && label != null)
 		{
 			var labelNode:FlxNode = atlas.addNode(label.graphic.bitmap, label.graphic.key);
 			result = result && (labelNode != null);
-			
+
 			if (labelNode != null)
 				label.frames = labelNode.getImageFrame();
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Basic button update logic - searches for overlaps with touches and
 	 * the mouse cursor and calls `updateStatus()`.
 	 */
-	private function updateButton():Void
+	function updateButton():Void
 	{
 		// We're looking for any touch / mouse overlaps with this button
 		var overlapFound = checkMouseOverlap();
 		if (!overlapFound)
 			overlapFound = checkTouchOverlap();
-		
+
 		#if FLX_TOUCH // there's only a mouse event listener for onUp
 		if (currentInput != null && currentInput.justReleased && Std.is(currentInput, FlxTouch) && overlapFound)
 		{
 			onUpHandler();
 		}
 		#end
-		
+
 		if (status != FlxButton.NORMAL &&
 			(!overlapFound || (currentInput != null && currentInput.justReleased)))
 		{
 			onOutHandler();
 		}
 	}
-	
-	private function checkMouseOverlap():Bool
+
+	function checkMouseOverlap():Bool
 	{
 		#if FLX_MOUSE
 		for (camera in cameras)
@@ -406,11 +406,11 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			}
 		}
 		#end
-		
+
 		return false;
 	}
-	
-	private function checkTouchOverlap():Bool
+
+	function checkTouchOverlap():Bool
 	{
 		#if FLX_TOUCH
 		for (camera in cameras)
@@ -424,11 +424,11 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			}
 		}
 		#end
-		
+
 		return false;
 	}
-	
-	private function checkInput(pointer:FlxPointer, input:IFlxInput, justPressedPosition:FlxPoint, camera:FlxCamera):Bool
+
+	function checkInput(pointer:FlxPointer, input:IFlxInput, justPressedPosition:FlxPoint, camera:FlxCamera):Bool
 	{
 		if (maxInputMovement != Math.POSITIVE_INFINITY &&
 			justPressedPosition.distanceTo(pointer.getScreenPosition(FlxPoint.weak())) > maxInputMovement &&
@@ -441,14 +441,14 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			updateStatus(input);
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Updates the button status by calling the respective event handler function.
 	 */
-	private function updateStatus(input:IFlxInput):Void
+	function updateStatus(input:IFlxInput):Void
 	{
 		if (input.justPressed)
 		{
@@ -462,14 +462,14 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			{
 				onDownHandler();
 			}
-			else 
+			else
 			{
 				onOverHandler();
 			}
 		}
 	}
-	
-	private function updateLabelPosition()
+
+	function updateLabelPosition()
 	{
 		if (_spriteLabel != null) // Label positioning
 		{
@@ -477,21 +477,21 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			_spriteLabel.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status].y;
 		}
 	}
-	
-	private function updateLabelAlpha()
+
+	function updateLabelAlpha()
 	{
-		if (_spriteLabel != null && labelAlphas.length > status) 
+		if (_spriteLabel != null && labelAlphas.length > status)
 		{
 			_spriteLabel.alpha = alpha * labelAlphas[status];
 		}
 	}
-	
+
 	/**
-	 * Using an event listener is necessary for security reasons on flash - 
+	 * Using an event listener is necessary for security reasons on flash -
 	 * certain things like opening a new window are only allowed when they are user-initiated.
 	 */
 	#if FLX_MOUSE
-	private function onUpEventListener(_):Void
+	function onUpEventListener(_):Void
 	{
 		if (visible && exists && active && status == FlxButton.PRESSED)
 		{
@@ -499,11 +499,11 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		}
 	}
 	#end
-	
+
 	/**
 	 * Internal function that handles the onUp event.
 	 */
-	private function onUpHandler():Void
+	function onUpHandler():Void
 	{
 		status = FlxButton.NORMAL;
 		input.release();
@@ -511,40 +511,40 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		// Order matters here, because onUp.fire() could cause a state change and destroy this object.
 		onUp.fire();
 	}
-	
+
 	/**
 	 * Internal function that handles the onDown event.
 	 */
-	private function onDownHandler():Void
+	function onDownHandler():Void
 	{
 		status = FlxButton.PRESSED;
 		input.press();
 		// Order matters here, because onDown.fire() could cause a state change and destroy this object.
 		onDown.fire();
 	}
-	
+
 	/**
 	 * Internal function that handles the onOver event.
 	 */
-	private function onOverHandler():Void
+	function onOverHandler():Void
 	{
 		status = FlxButton.HIGHLIGHT;
 		// Order matters here, because onOver.fire() could cause a state change and destroy this object.
 		onOver.fire();
 	}
-	
+
 	/**
 	 * Internal function that handles the onOut event.
 	 */
-	private function onOutHandler():Void
+	function onOutHandler():Void
 	{
 		status = FlxButton.NORMAL;
 		input.release();
 		// Order matters here, because onOut.fire() could cause a state change and destroy this object.
 		onOut.fire();
 	}
-	
-	private function set_label(Value:T):T
+
+	function set_label(Value:T):T
 	{
 		if (Value != null)
 		{
@@ -552,81 +552,81 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 			Value.scrollFactor.put();
 			Value.scrollFactor = scrollFactor;
 		}
-		
+
 		label = Value;
 		_spriteLabel = label;
-		
+
 		updateLabelPosition();
-		
+
 		return Value;
 	}
-	
-	private function set_status(Value:Int):Int
+
+	function set_status(Value:Int):Int
 	{
 		status = Value;
 		updateLabelAlpha();
 		return status;
 	}
-	
-	override private function set_alpha(Value:Float):Float
+
+	override function set_alpha(Value:Float):Float
 	{
 		super.set_alpha(Value);
 		updateLabelAlpha();
 		return alpha;
 	}
-	
-	override private function set_x(Value:Float):Float 
+
+	override function set_x(Value:Float):Float
 	{
 		super.set_x(Value);
 		updateLabelPosition();
 		return x;
 	}
-	
-	override private function set_y(Value:Float):Float 
-	{	
+
+	override function set_y(Value:Float):Float
+	{
 		super.set_y(Value);
 		updateLabelPosition();
 		return y;
 	}
-	
-	private inline function get_justReleased():Bool
+
+	inline function get_justReleased():Bool
 	{
 		return input.justReleased;
 	}
-	
-	private inline function get_released():Bool
+
+	inline function get_released():Bool
 	{
 		return input.released;
 	}
-	
-	private inline function get_pressed():Bool
+
+	inline function get_pressed():Bool
 	{
 		return input.pressed;
 	}
-	
-	private inline function get_justPressed():Bool
+
+	inline function get_justPressed():Bool
 	{
 		return input.justPressed;
 	}
 }
 
-/** 
+/**
  * Helper function for `FlxButton` which handles its events.
- */ 
+ */
 private class FlxButtonEvent implements IFlxDestroyable
 {
 	/**
 	 * The callback function to call when this even fires.
 	 */
 	public var callback:Void->Void;
-	
+
 	#if FLX_SOUND_SYSTEM
 	/**
 	 * The sound to play when this event fires.
 	 */
 	public var sound:FlxSound;
 	#end
-	
+
 	/**
 	 * @param   Callback   The callback function to call when this even fires.
 	 * @param   sound      The sound to play when this event fires.
@@ -634,32 +634,32 @@ private class FlxButtonEvent implements IFlxDestroyable
 	public function new(?Callback:Void->Void, ?sound:FlxSound)
 	{
 		callback = Callback;
-		
+
 		#if FLX_SOUND_SYSTEM
 		this.sound = sound;
 		#end
 	}
-	
+
 	/**
 	 * Cleans up memory.
 	 */
 	public inline function destroy():Void
 	{
 		callback = null;
-		
+
 		#if FLX_SOUND_SYSTEM
 		sound = FlxDestroyUtil.destroy(sound);
 		#end
 	}
-	
+
 	/**
 	 * Fires this event (calls the callback and plays the sound)
 	 */
 	public inline function fire():Void
 	{
-		if (callback != null) 
+		if (callback != null)
 			callback();
-		
+
 		#if FLX_SOUND_SYSTEM
 		if (sound != null)
 			sound.play(true);

--- a/flixel/util/FlxBitmapDataPool.hx
+++ b/flixel/util/FlxBitmapDataPool.hx
@@ -5,52 +5,52 @@ import flash.geom.Rectangle;
 
 /**
  * BitmapData pool class.
- * 
+ *
  * Notes on implementation:
  *     get() starts searching for a suitable BitmapData from the start of the pool list
  *     put() adds the BitmapData to the start of the pool list (removing the last one if the pool exceeds maxLength)
- * 
+ *
  * @author azrafe7
  */
 @:access(FlxBitmapDataPoolNode)
 class FlxBitmapDataPool
 {
 	/**
-	 * Maximum number of BitmapData to hold in the pool. 
+	 * Maximum number of BitmapData to hold in the pool.
 	 */
 	public static var maxLength(default, set):Int = 8;
-	
-	/** 
-	 * Current number of BitmapData present in the pool. 
+
+	/**
+	 * Current number of BitmapData present in the pool.
 	 */
 	public static var length(default, null):Int = 0;
-	
-	private static var _head:FlxBitmapDataPoolNode = null;
-	private static var _tail:FlxBitmapDataPoolNode = null;
-	
-	private static var _rect:Rectangle = new Rectangle();
-	
-	/** 
-	 * Returns a BitmapData with the specified parameters. 
+
+	static var _head:FlxBitmapDataPoolNode = null;
+	static var _tail:FlxBitmapDataPoolNode = null;
+
+	static var _rect:Rectangle = new Rectangle();
+
+	/**
+	 * Returns a BitmapData with the specified parameters.
 	 * If a suitable BitmapData cannot be found in the pool a new one will be created.
 	 * If fillColor is specified the returned BitmapData will also be cleared with it.
-	 * 
+	 *
 	 * @param exactSize	If false a BitmapData with size >= [w, h] may be returned.
 	 */
-	public static function get(w:Int, h:Int, transparent:Bool = true, ?fillColor:FlxColor, ?exactSize:Bool = false):BitmapData 
+	public static function get(w:Int, h:Int, transparent:Bool = true, ?fillColor:FlxColor, ?exactSize:Bool = false):BitmapData
 	{
 		var res:BitmapData = null;
-		
+
 		// search the pool
 		var node = _head;
-		while (node != null) 
+		while (node != null)
 		{
 			var bmd = node.bmd;
-			if ((bmd.transparent == transparent && bmd.width >= w && bmd.height >= h) && 
+			if ((bmd.transparent == transparent && bmd.width >= w && bmd.height >= h) &&
 				(!exactSize || (exactSize && bmd.width == w && bmd.height == h)))
 			{
 				res = bmd;
-				
+
 				// remove it from pool
 				if (node.prev != null) node.prev.next = node.next;
 				if (node.next != null) node.next.prev = node.prev;
@@ -62,10 +62,10 @@ class FlxBitmapDataPool
 			}
 			node = node.next;
 		}
-		
+
 		if (res != null) 	// suitable BitmapData found in the pool
 		{
-			if (fillColor != null) 
+			if (fillColor != null)
 			{
 				_rect.x = 0;
 				_rect.y = 0;
@@ -73,25 +73,25 @@ class FlxBitmapDataPool
 				_rect.height = h;
 				res.fillRect(_rect, fillColor);
 			}
-		} 
+		}
 		else 	// not found: create a new one
 		{
 			res = new BitmapData(w, h, transparent, fillColor != null ? fillColor : FlxColor.WHITE);
 		}
-		
+
 		return res;
 	}
-	
-	/** 
-	 * Adds bmd to the pool for future use. 
+
+	/**
+	 * Adds bmd to the pool for future use.
 	 */
-	public static function put(bmd:BitmapData):Void 
+	public static function put(bmd:BitmapData):Void
 	{
-		if (length >= maxLength) 
+		if (length >= maxLength)
 		{
 			var last = _tail;
 			last.bmd.dispose();
-			if (last.prev != null) 
+			if (last.prev != null)
 			{
 				last.prev.next = null;
 				_tail = last.prev;
@@ -99,30 +99,30 @@ class FlxBitmapDataPool
 			last = null;
 			length--;
 		}
-		
+
 		var node = new FlxBitmapDataPoolNode(bmd);
 		node.next = _head;
-		if (_head == null) 
+		if (_head == null)
 		{
 			_head = _tail = node;
-		} 
-		else 
+		}
+		else
 		{
 			_head = node;
 			node.next.prev = node;
 		}
 		length++;
 	}
-	
+
 	/**
-	 * Disposes of all the BitmapData in the pool. 
+	 * Disposes of all the BitmapData in the pool.
 	 */
-	public static function clear():Void 
+	public static function clear():Void
 	{
 		var node = _head;
-		while (node != null) 
+		while (node != null)
 		{
-			var bmd = node.bmd; 
+			var bmd = node.bmd;
 			bmd.dispose();
 			bmd = null;
 			node = node.next;
@@ -130,13 +130,13 @@ class FlxBitmapDataPool
 		length = 0;
 		_head = _tail = null;
 	}
-	
-	static function set_maxLength(value:Int):Int 
+
+	static function set_maxLength(value:Int):Int
 	{
-		if (maxLength != value) 
+		if (maxLength != value)
 		{
 			var node = _tail;
-			while ((node != null) && (length > value)) 
+			while ((node != null) && (length > value))
 			{
 				var bmd = node.bmd;
 				bmd.dispose();
@@ -149,13 +149,13 @@ class FlxBitmapDataPool
 	}
 }
 
-private class FlxBitmapDataPoolNode 
+private class FlxBitmapDataPoolNode
 {
 	public var bmd:BitmapData;
 	public var prev:FlxBitmapDataPoolNode;
 	public var next:FlxBitmapDataPoolNode;
-	
-	public function new(?bmd:BitmapData, ?prev:FlxBitmapDataPoolNode, ?next:FlxBitmapDataPoolNode):Void 
+
+	public function new(?bmd:BitmapData, ?prev:FlxBitmapDataPoolNode, ?next:FlxBitmapDataPoolNode):Void
 	{
 		this.bmd = bmd;
 		this.prev = prev;

--- a/flixel/util/FlxBitmapDataUtil.hx
+++ b/flixel/util/FlxBitmapDataUtil.hx
@@ -14,19 +14,19 @@ import flixel.math.FlxRect;
  */
 class FlxBitmapDataUtil
 {
-	private static var matrix:FlxMatrix = new FlxMatrix();
-	
+	static var matrix:FlxMatrix = new FlxMatrix();
+
 	/**
 	 * Performs per-channel blending from a source image to a destination image.
-	 * 
+	 *
 	 * @param	sourceBitmapData	The input bitmap image to use. The source image can be a different BitmapData object, or it can refer to the current BitmapData object.
-	 * @param	sourceRect			A rectangle that defines the area of the source image to use as input. 
+	 * @param	sourceRect			A rectangle that defines the area of the source image to use as input.
 	 * @param	destBitmapData		The output bitmap image to use.
 	 * @param	destPoint			The point within the destination image (the current BitmapData instance) that corresponds to the upper-left corner of the source rectangle.
 	 * @param	redMultiplier		A hexadecimal uint value by which to multiply the red channel value.
 	 * @param	greenMultiplier		A hexadecimal uint value by which to multiply the green channel value.
 	 * @param	blueMultiplier		A hexadecimal uint value by which to multiply the blue channel value.
-	 * @param	alphaMultiplier		A hexadecimal uint value by which to multiply the alpha transparency value. 
+	 * @param	alphaMultiplier		A hexadecimal uint value by which to multiply the alpha transparency value.
 	 */
 	public static function merge(sourceBitmapData:BitmapData, sourceRect:Rectangle, destBitmapData:BitmapData, destPoint:Point, redMultiplier:Int, greenMultiplier:Int, blueMultiplier:Int, alphaMultiplier:Int):Void
 	{
@@ -42,7 +42,7 @@ class FlxBitmapDataUtil
 		{
 			return;
 		}
-		
+
 		// need to cut off sourceRect if it too big...
 		while (sourceRect.x + sourceRect.width > sourceBitmapData.width ||
 			sourceRect.y + sourceRect.height > sourceBitmapData.height ||
@@ -53,30 +53,30 @@ class FlxBitmapDataUtil
 		{
 			if (sourceRect.x + sourceRect.width > sourceBitmapData.width)	sourceRect.width = sourceBitmapData.width - sourceRect.x;
 			if (sourceRect.y + sourceRect.height > sourceBitmapData.height)	sourceRect.height = sourceBitmapData.height - sourceRect.y;
-			
+
 			if (sourceRect.x < 0)
 			{
 				destPoint.x = destPoint.x - sourceRect.x;
 				sourceRect.width = sourceRect.width + sourceRect.x;
 				sourceRect.x = 0;
 			}
-			
+
 			if (sourceRect.y < 0)
 			{
 				destPoint.y = destPoint.y - sourceRect.y;
 				sourceRect.height = sourceRect.height + sourceRect.y;
 				sourceRect.y = 0;
 			}
-			
+
 			if (destPoint.x >= destBitmapData.width || destPoint.y >= destBitmapData.height)	return;
-			
+
 			if (destPoint.x < 0)
 			{
 				sourceRect.x = sourceRect.x - destPoint.x;
 				sourceRect.width = sourceRect.width + destPoint.x;
 				destPoint.x = 0;
 			}
-			
+
 			if (destPoint.y < 0)
 			{
 				sourceRect.y = sourceRect.y - destPoint.y;
@@ -84,58 +84,58 @@ class FlxBitmapDataUtil
 				destPoint.y = 0;
 			}
 		}
-		
+
 		if (sourceRect.width <= 0 || sourceRect.height <= 0) return;
-		
+
 		var startSourceX:Int = Math.round(sourceRect.x);
-		var startSourceY:Int = Math.round(sourceRect.y); 
-		
+		var startSourceY:Int = Math.round(sourceRect.y);
+
 		var width:Int = Math.round(sourceRect.width);
-		var height:Int = Math.round(sourceRect.height); 
-		
+		var height:Int = Math.round(sourceRect.height);
+
 		var sourceX:Int = startSourceX;
 		var sourceY:Int = startSourceY;
-		
+
 		var destX:Int = Math.round(destPoint.x);
 		var destY:Int = Math.round(destPoint.y);
-		
+
 		var currX:Int = destX;
 		var currY:Int = destY;
-		
+
 		var sourceColor:FlxColor;
 		var destColor:FlxColor;
-		
+
 		var resultRed:Int;
 		var resultGreen:Int;
 		var resultBlue:Int;
 		var resultAlpha:Int;
-		
+
 		var resultColor:FlxColor = 0x0;
 		destBitmapData.lock();
 		// iterate through pixels using following rule:
-		// new redDest = [(redSrc * redMultiplier) + (redDest * (256 - redMultiplier))] / 256; 
+		// new redDest = [(redSrc * redMultiplier) + (redDest * (256 - redMultiplier))] / 256;
 		for (i in 0...width)
 		{
 			for (j in 0...height)
 			{
 				sourceX = startSourceX + i;
 				sourceY = startSourceY + j;
-				
+
 				currX = destX + i;
 				currY = destY + j;
-				
+
 				sourceColor = sourceBitmapData.getPixel32(sourceX, sourceY);
 				destColor = destBitmapData.getPixel32(currX, currY);
-				
+
 				// calculate merged color components
 				resultRed = mergeColorComponent(sourceColor.red, destColor.red, redMultiplier);
 				resultGreen = mergeColorComponent(sourceColor.green, destColor.green, greenMultiplier);
 				resultBlue = mergeColorComponent(sourceColor.blue, destColor.blue, blueMultiplier);
 				resultAlpha = mergeColorComponent(sourceColor.alpha, destColor.alpha, alphaMultiplier);
-				
+
 				// calculate merged color
 				resultColor = FlxColor.fromRGB(resultRed, resultGreen, resultBlue, resultAlpha);
-				
+
 				// set merged color for current pixel
 				destBitmapData.setPixel32(currX, currY, resultColor);
 			}
@@ -143,21 +143,21 @@ class FlxBitmapDataUtil
 		destBitmapData.unlock();
 		#end
 	}
-	
-	private static inline function mergeColorComponent(source:Int, dest:Int, multiplier:Int):Int
+
+	static inline function mergeColorComponent(source:Int, dest:Int, multiplier:Int):Int
 	{
 		return Std.int(((source * multiplier) + (dest * (256 - multiplier))) / 256);
 	}
-	
+
 	/**
 	 * Compares two BitmapData objects.
-	 * 
+	 *
 	 * @param	Bitmap1		The source BitmapData object to compare with.
 	 * @param	Bitmap2		The BitmapData object to compare with the source BitmapData object.
-	 * @return	If the two BitmapData objects have the same dimensions (width and height), 
-	 * the method returns a new BitmapData object that has the difference between the two objects. 
+	 * @return	If the two BitmapData objects have the same dimensions (width and height),
+	 * the method returns a new BitmapData object that has the difference between the two objects.
 	 * If the BitmapData objects are equivalent, the method returns the number 0.
-	 * If the widths of the BitmapData objects are not equal, the method returns the number -3. 
+	 * If the widths of the BitmapData objects are not equal, the method returns the number -3.
 	 * If the heights of the BitmapData objects are not equal, the method returns the number -4.
 	 */
 	public static function compare(Bitmap1:BitmapData, Bitmap2:BitmapData):Dynamic
@@ -183,18 +183,18 @@ class FlxBitmapDataUtil
 			var height:Int = Bitmap1.height;
 			var result = new BitmapData(width, height, true, 0x0);
 			var identical:Bool = true;
-			
+
 			for (i in 0...width)
 			{
 				for (j in 0...height)
 				{
 					var pixel1:FlxColor = Bitmap1.getPixel32(i, j);
 					var pixel2:FlxColor = Bitmap2.getPixel32(i, j);
-					
+
 					if (pixel1 != pixel2)
 					{
 						identical = false;
-						
+
 						if (pixel1.to24Bit() != pixel2.to24Bit())
 						{
 							result.setPixel32(i, j, FlxColor.fromRGB(
@@ -207,33 +207,33 @@ class FlxBitmapDataUtil
 						{
 							var alpha1 = pixel1.alpha;
 							var alpha2 = pixel2.alpha;
-							
+
 							if (alpha1 != alpha2)
 							{
 								result.setPixel32(i, j, FlxColor.fromRGB(0xFF, 0xFF, 0xFF,
 									getDiff(alpha1, alpha2)));
 							}
-						}	
+						}
 					}
 				}
 			}
-			
+
 			if (!identical)
 			{
 				return result;
 			}
 		}
-		
+
 		return 0;
 		#end
 	}
-	
-	private static inline function getDiff(value1:Int, value2:Int):Int
+
+	static inline function getDiff(value1:Int, value2:Int):Int
 	{
 		var diff = value1 - value2;
 		return (diff >= 0) ? diff : (256 + diff);
 	}
-	
+
 	/**
 	 * Returns the amount of bytes a bitmapData occupies in memory.
 	 */
@@ -241,11 +241,11 @@ class FlxBitmapDataUtil
 	{
 		return bitmapData.width * bitmapData.height * 4;
 	}
-	
+
 	/**
-	 * Replaces all BitmapData's pixels with specified color with newColor pixels. 
+	 * Replaces all BitmapData's pixels with specified color with newColor pixels.
 	 * WARNING: very expensive (especially on big graphics) as it iterates over every single pixel.
-	 * 
+	 *
 	 * @param	bitmapData			BitmapData to change
 	 * @param	color				Color to replace
 	 * @param	newColor			New color
@@ -260,12 +260,12 @@ class FlxBitmapDataUtil
 		{
 			positions = new Array<FlxPoint>();
 		}
-		
+
 		var startX:Int = 0;
 		var startY:Int = 0;
 		var columns:Int = bitmapData.width;
 		var rows:Int = bitmapData.height;
-		
+
 		if (rect != null)
 		{
 			startX = Std.int(rect.x);
@@ -273,14 +273,14 @@ class FlxBitmapDataUtil
 			columns = Std.int(rect.width);
 			rows = Std.int(rect.height);
 		}
-		
+
 		columns = Std.int(Math.max(columns, bitmapData.width));
 		rows = Std.int(Math.max(rows, bitmapData.height));
-		
+
 		var row:Int = 0;
 		var column:Int = 0;
 		var x:Int, y:Int;
-		
+
 		var changed:Bool = false;
 		bitmapData.lock();
 		while (row < rows)
@@ -304,15 +304,15 @@ class FlxBitmapDataUtil
 			row++;
 		}
 		bitmapData.unlock();
-		
+
 		if (changed && positions == null)
 		{
 			positions = new Array<FlxPoint>();
 		}
-		
+
 		return positions;
 	}
-	
+
 	/**
 	 * Gets image without spaces between tiles and generates new one with spaces and adds borders around them.
 	 * @param	bitmapData	original image without spaces between tiles.
@@ -328,53 +328,53 @@ class FlxBitmapDataUtil
 		{
 			region = FlxRect.get(0, 0, bitmapData.width, bitmapData.height);
 		}
-		
+
 		var frameWidth:Int = Std.int(region.width);
 		var frameHeight:Int = Std.int(region.height);
-		
+
 		if (frameSize != null)
 		{
 			frameWidth = Std.int(frameSize.x);
 			frameHeight = Std.int(frameSize.y);
 		}
-		
+
 		var numHorizontalFrames:Int = Std.int(region.width / frameWidth);
 		var numVerticalFrames:Int = Std.int(region.height / frameHeight);
-		
+
 		var spaceX:Int = 0;
 		var spaceY:Int = 0;
-		
+
 		if (spacing != null)
 		{
 			spaceX = Std.int(spacing.x);
 			spaceY = Std.int(spacing.y);
 		}
-		
+
 		var borderX:Int = 0;
 		var borderY:Int = 0;
-		
+
 		if (border != null)
 		{
 			borderX = Std.int(border.x);
-			borderY = Std.int(border.y); 
+			borderY = Std.int(border.y);
 		}
-		
+
 		var result = new BitmapData(
-			Std.int(region.width + (numHorizontalFrames - 1) * spaceX + 2 * numHorizontalFrames * borderX), 
-			Std.int(region.height + (numVerticalFrames - 1) * spaceY + 2 * numVerticalFrames * borderY), 
-			true, 
+			Std.int(region.width + (numHorizontalFrames - 1) * spaceX + 2 * numHorizontalFrames * borderX),
+			Std.int(region.height + (numVerticalFrames - 1) * spaceY + 2 * numVerticalFrames * borderY),
+			true,
 			FlxColor.TRANSPARENT);
-		
+
 		result.lock();
 		var tempRect:Rectangle = new Rectangle(0, 0, frameWidth, frameHeight);
 		var tempPoint:Point = new Point();
-		
+
 		// insert spaces
 		for (i in 0...numHorizontalFrames)
 		{
 			tempPoint.x = i * (frameWidth + spaceX + 2 * borderX) + borderX;
 			tempRect.x = i * frameWidth + region.x;
-			
+
 			for (j in 0...numVerticalFrames)
 			{
 				tempPoint.y = j * (frameHeight + spaceY + 2 * borderY) + borderY;
@@ -383,16 +383,16 @@ class FlxBitmapDataUtil
 			}
 		}
 		result.unlock();
-		
+
 		// copy borders
 		copyBorderPixels(result, frameWidth, frameHeight, spaceX, spaceY, borderX, borderY, numHorizontalFrames, numVerticalFrames);
 		return result;
 	}
-	
+
 	/**
 	 * Helper method for copying border pixels around tiles.
 	 * It modifies provided image, and assumes that there are spaces between tile images already.
-	 * 
+	 *
 	 * @param	bitmapData 			image with spaces between tiles to fill with border pixels
 	 * @param	frameWidth			tile width
 	 * @param	frameHeight			tile height
@@ -411,54 +411,54 @@ class FlxBitmapDataUtil
 		var tempRect:Rectangle = new Rectangle(0, 0, 1, bitmapData.height);
 		var tempPoint:Point = new Point();
 		bitmapData.lock();
-		
+
 		for (i in 0...horizontalFrames)
 		{
 			tempRect.x = i * (frameWidth + 2 * borderX + spaceX) + borderX;
-			
+
 			for (j in 0...borderX)
 			{
 				tempPoint.x = tempRect.x - j - 1;
 				bitmapData.copyPixels(bitmapData, tempRect, tempPoint);
 			}
-			
+
 			tempRect.x += frameWidth - 1;
-			
+
 			for (j in 0...borderX)
 			{
 				tempPoint.x = tempRect.x + j + 1;
 				bitmapData.copyPixels(bitmapData, tempRect, tempPoint);
 			}
 		}
-		
+
 		tempPoint.setTo(0, 0);
 		tempRect.setTo(0, 0, bitmapData.width, 1);
 		for (i in 0...verticalFrames)
 		{
 			tempRect.y = i * (frameHeight + 2 * borderY + spaceY) + borderY;
-			
+
 			for (j in 0...borderY)
 			{
 				tempPoint.y = tempRect.y - j - 1;
 				bitmapData.copyPixels(bitmapData, tempRect, tempPoint);
 			}
-			
+
 			tempRect.y += frameHeight - 1;
-			
+
 			for (j in 0...borderY)
 			{
 				tempPoint.y = tempRect.y + j + 1;
 				bitmapData.copyPixels(bitmapData, tempRect, tempPoint);
 			}
 		}
-		
+
 		bitmapData.unlock();
 		return bitmapData;
 	}
-	
+
 	/**
 	 * Generates BitmapData with prerotated brush stamped on it
-	 * 
+	 *
 	 * @param	brush			The image you want to rotate and stamp.
 	 * @param	rotations		The number of rotation frames the final sprite should have. For small sprites this can be quite a large number (360 even) without any problems.
 	 * @param	antiAliasing	Whether to use high quality rotations when creating the graphic.  Default is false.
@@ -471,16 +471,16 @@ class FlxBitmapDataUtil
 		var brushHeight:Int = brush.height;
 		var max:Int = (brushHeight > brushWidth) ? brushHeight : brushWidth;
 		max = autoBuffer ? Std.int(max * 1.5) : max;
-		
+
 		var rows:Int = Std.int(Math.sqrt(rotations));
 		var columns:Int = Math.ceil(rotations / rows);
 		var bakedRotationAngle:Float = 360 / rotations;
-		
+
 		var width:Int = max * columns;
 		var height:Int = max * rows;
-		
+
 		var result:BitmapData = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
-		
+
 		var row:Int = 0;
 		var column:Int = 0;
 		var bakedAngle:Float = 0;
@@ -488,7 +488,7 @@ class FlxBitmapDataUtil
 		var halfBrushHeight:Int = Std.int(brushHeight * 0.5);
 		var midpointX:Int = Std.int(max * 0.5);
 		var midpointY:Int = Std.int(max * 0.5);
-		
+
 		while (row < rows)
 		{
 			column = 0;
@@ -505,7 +505,7 @@ class FlxBitmapDataUtil
 			midpointY += max;
 			row++;
 		}
-		
+
 		return result;
 	}
 }

--- a/flixel/util/FlxCollision.hx
+++ b/flixel/util/FlxCollision.hx
@@ -19,25 +19,25 @@ import flixel.tile.FlxTileblock;
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
 */
-class FlxCollision 
+class FlxCollision
 {
 	// Optimization: Local static vars to reduce allocations
-	private static var pointA:FlxVector = new FlxVector();
-	private static var pointB:FlxVector = new FlxVector();
-	private static var centerA:FlxVector = new FlxVector();
-	private static var centerB:FlxVector = new FlxVector();
-	private static var matrixA:FlxMatrix = new FlxMatrix();
-	private static var matrixB:FlxMatrix = new FlxMatrix();
-	private static var testMatrix:FlxMatrix = new FlxMatrix();
-	private static var boundsA:FlxRect = new FlxRect();
-	private static var boundsB:FlxRect = new FlxRect();
-	private static var intersect:FlxRect = new FlxRect();
-	private static var flashRect:Rectangle = new Rectangle();
-	
+	static var pointA:FlxVector = new FlxVector();
+	static var pointB:FlxVector = new FlxVector();
+	static var centerA:FlxVector = new FlxVector();
+	static var centerB:FlxVector = new FlxVector();
+	static var matrixA:FlxMatrix = new FlxMatrix();
+	static var matrixB:FlxMatrix = new FlxMatrix();
+	static var testMatrix:FlxMatrix = new FlxMatrix();
+	static var boundsA:FlxRect = new FlxRect();
+	static var boundsB:FlxRect = new FlxRect();
+	static var intersect:FlxRect = new FlxRect();
+	static var flashRect:Rectangle = new Rectangle();
+
 	/**
-	 * A Pixel Perfect Collision check between two FlxSprites. It will do a bounds check first, and if that passes it will run a 
+	 * A Pixel Perfect Collision check between two FlxSprites. It will do a bounds check first, and if that passes it will run a
 	 * pixel perfect match on the intersecting area. Works with rotated and animated sprites. May be slow, so use it sparingly.
-	 * 
+	 *
 	 * @param	Contact			The first FlxSprite to test against
 	 * @param	Target			The second FlxSprite to test again, sprite order is irrelevant
 	 * @param	AlphaTolerance	The tolerance value above which alpha pixels are included. Default to 1 (anything that is not fully invisible).
@@ -48,28 +48,28 @@ class FlxCollision
 	{
 		//if either of the angles are non-zero, consider the angles of the sprites in the pixel check
 		var considerRotation:Bool = (Contact.angle != 0) || (Target.angle != 0);
-		
+
 		Camera = (Camera != null) ? Camera : FlxG.camera;
-		
+
 		pointA.x = Contact.x - Std.int(Camera.scroll.x * Contact.scrollFactor.x) - Contact.offset.x;
 		pointA.y = Contact.y - Std.int(Camera.scroll.y * Contact.scrollFactor.y) - Contact.offset.y;
-		
+
 		pointB.x = Target.x - Std.int(Camera.scroll.x * Target.scrollFactor.x) - Target.offset.x;
 		pointB.y = Target.y - Std.int(Camera.scroll.y * Target.scrollFactor.y) - Target.offset.y;
-		
+
 		if (considerRotation)
 		{
 			// find the center of both sprites
 			Contact.origin.copyTo(centerA);
 			Target.origin.copyTo(centerB);
-			
+
 			// now make a bounding box that allows for the sprite to be rotated in 360 degrees
 			var lengthA = centerA.length;
 			boundsA.x = (pointA.x + centerA.x - lengthA);
 			boundsA.y = (pointA.y + centerA.y - lengthA);
 			boundsA.width = lengthA * 2;
 			boundsA.height = boundsA.width;
-			
+
 			var lengthB = centerB.length;
 			boundsB.x = (pointB.x + centerB.x - lengthB);
 			boundsB.y = (pointB.y + centerB.y - lengthB);
@@ -82,137 +82,137 @@ class FlxCollision
 			boundsA.y = pointA.y;
 			boundsA.width = Contact.frameWidth;
 			boundsA.height = Contact.frameHeight;
-			
+
 			boundsB.x = pointB.x;
 			boundsB.y = pointB.y;
 			boundsB.width = Target.frameWidth;
 			boundsB.height = Target.frameHeight;
 		}
-		
+
 		boundsA.intersection(boundsB, intersect.set());
-		
+
 		if (intersect.isEmpty || intersect.width < 1 || intersect.height < 1)
 		{
 			return false;
 		}
-		
+
 		//	Thanks to Chris Underwood for helping with the translate logic :)
 		matrixA.identity();
 		matrixA.translate(-(intersect.x - boundsA.x), -(intersect.y - boundsA.y));
-		
+
 		matrixB.identity();
 		matrixB.translate(-(intersect.x - boundsB.x), -(intersect.y - boundsB.y));
-		
+
 		Contact.drawFrame();
 		Target.drawFrame();
-		
+
 		var testA:BitmapData = Contact.framePixels;
 		var testB:BitmapData = Target.framePixels;
-		
+
 		var overlapWidth:Int = Std.int(intersect.width);
 		var overlapHeight:Int = Std.int(intersect.height);
-		
+
 		// More complicated case, if either of the sprites is rotated
 		if (considerRotation)
 		{
 			testMatrix.identity();
-			
+
 			// translate the matrix to the center of the sprite
 			testMatrix.translate(-Contact.origin.x, -Contact.origin.y);
-			
+
 			// rotate the matrix according to angle
 			testMatrix.rotate(Contact.angle * FlxAngle.TO_RAD);
-			
+
 			// translate it back!
 			testMatrix.translate(boundsA.width / 2, boundsA.height / 2);
-			
+
 			// prepare an empty canvas
 			var testA2:BitmapData = FlxBitmapDataPool.get(Math.floor(boundsA.width), Math.floor(boundsA.height), true, FlxColor.TRANSPARENT, false);
-			
+
 			// plot the sprite using the matrix
 			testA2.draw(testA, testMatrix, null, null, null, false);
 			testA = testA2;
-			
+
 			// (same as above)
 			testMatrix.identity();
 			testMatrix.translate(-Target.origin.x, -Target.origin.y);
 			testMatrix.rotate(Target.angle * FlxAngle.TO_RAD);
 			testMatrix.translate(boundsB.width / 2, boundsB.height / 2);
-			
+
 			var testB2:BitmapData = FlxBitmapDataPool.get(Math.floor(boundsB.width), Math.floor(boundsB.height), true, FlxColor.TRANSPARENT, false);
 			testB2.draw(testB, testMatrix, null, null, null, false);
 			testB = testB2;
 		}
-		
+
 		boundsA.x = Std.int(-matrixA.tx);
 		boundsA.y = Std.int( -matrixA.ty);
 		boundsA.width = overlapWidth;
 		boundsA.height = overlapHeight;
-		
+
 		boundsB.x = Std.int(-matrixB.tx);
 		boundsB.y = Std.int(-matrixB.ty);
 		boundsB.width = overlapWidth;
 		boundsB.height = overlapHeight;
-		
+
 		boundsA.copyToFlash(flashRect);
 		var pixelsA = testA.getPixels(flashRect);
-		
+
 		boundsB.copyToFlash(flashRect);
 		var pixelsB = testB.getPixels(flashRect);
-		
+
 		var hit = false;
-		
+
 		// Analyze overlapping area of BitmapDatas to check for a collision (alpha values >= AlphaTolerance)
 		var alphaA:Int = 0;
 		var alphaB:Int = 0;
 		var overlapPixels:Int = overlapWidth * overlapHeight;
 		var alphaIdx:Int = 0;
-		
+
 		// check even pixels
-		for (i in 0...Math.ceil(overlapPixels / 2)) 
+		for (i in 0...Math.ceil(overlapPixels / 2))
 		{
 			alphaIdx = i << 3;
 			pixelsA.position = pixelsB.position = alphaIdx;
 			alphaA = pixelsA.readUnsignedByte();
 			alphaB = pixelsB.readUnsignedByte();
-			
-			if (alphaA >= AlphaTolerance && alphaB >= AlphaTolerance) 
+
+			if (alphaA >= AlphaTolerance && alphaB >= AlphaTolerance)
 			{
 				hit = true;
-				break; 
+				break;
 			}
 		}
-		
-		if (!hit) 
+
+		if (!hit)
 		{
 			// check odd pixels
-			for (i in 0...overlapPixels >> 1) 
+			for (i in 0...overlapPixels >> 1)
 			{
 				alphaIdx = (i << 3) + 4;
 				pixelsA.position = pixelsB.position = alphaIdx;
 				alphaA = pixelsA.readUnsignedByte();
 				alphaB = pixelsB.readUnsignedByte();
-				
-				if (alphaA >= AlphaTolerance && alphaB >= AlphaTolerance) 
+
+				if (alphaA >= AlphaTolerance && alphaB >= AlphaTolerance)
 				{
 					hit = true;
-					break; 
+					break;
 				}
 			}
 		}
-		
-		if (considerRotation) 
+
+		if (considerRotation)
 		{
 			FlxBitmapDataPool.put(testA);
 			FlxBitmapDataPool.put(testB);
 		}
-		
+
 		return hit;
 	}
-	
+
 	/**
 	 * A Pixel Perfect Collision check between a given x/y coordinate and an FlxSprite
-	 * 
+	 *
 	 * @param	PointX			The x coordinate of the point given in local space (relative to the FlxSprite, not game world coordinates)
 	 * @param	PointY			The y coordinate of the point given in local space (relative to the FlxSprite, not game world coordinates)
 	 * @param	Target			The FlxSprite to check the point against
@@ -227,29 +227,29 @@ class FlxCollision
 		{
 			return false;
 		}
-		
+
 		if (FlxG.renderTile)
 		{
 			Target.drawFrame();
 		}
-		
+
 		// How deep is pointX/Y within the rect?
 		var test:BitmapData = Target.framePixels;
-		
+
 		var pixelAlpha = FlxColor.fromInt(test.getPixel32(Math.floor(PointX - Target.x), Math.floor(PointY - Target.y))).alpha;
-		
+
 		if (FlxG.renderTile)
 		{
 			pixelAlpha = Std.int(pixelAlpha * Target.alpha);
 		}
-		
+
 		// How deep is pointX/Y within the rect?
 		return pixelAlpha >= AlphaTolerance;
 	}
-	
+
 	/**
 	 * Creates a "wall" around the given camera which can be used for FlxSprite collision
-	 * 
+	 *
 	 * @param	Camera				The FlxCamera to use for the wall bounds (can be FlxG.camera for the current one)
 	 * @param	Placement			Whether to place the camera wall outside or inside
 	 * @param	Thickness			The thickness of the wall in pixels
@@ -262,14 +262,14 @@ class FlxCollision
 		var right:FlxTileblock = null;
 		var top:FlxTileblock = null;
 		var bottom:FlxTileblock = null;
-		
+
 		if (PlaceOutside)
 		{
 			left = new FlxTileblock(Math.floor(Camera.x - Thickness), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
 			right = new FlxTileblock(Math.floor(Camera.x + Camera.width), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
 			top = new FlxTileblock(Math.floor(Camera.x - Thickness), Math.floor(Camera.y - Thickness), Camera.width + Thickness * 2, Thickness);
 			bottom = new FlxTileblock(Math.floor(Camera.x - Thickness), Camera.height, Camera.width + Thickness * 2, Thickness);
-			
+
 			if (AdjustWorldBounds)
 			{
 				FlxG.worldBounds.set(Camera.x - Thickness, Camera.y - Thickness, Camera.width + Thickness * 2, Camera.height + Thickness * 2);
@@ -281,20 +281,20 @@ class FlxCollision
 			right = new FlxTileblock(Math.floor(Camera.x + Camera.width - Thickness), Math.floor(Camera.y + Thickness), Thickness, Camera.height - (Thickness * 2));
 			top = new FlxTileblock(Math.floor(Camera.x), Math.floor(Camera.y), Camera.width, Thickness);
 			bottom = new FlxTileblock(Math.floor(Camera.x), Camera.height - Thickness, Camera.width, Thickness);
-			
+
 			if (AdjustWorldBounds)
 			{
 				FlxG.worldBounds.set(Camera.x, Camera.y, Camera.width, Camera.height);
 			}
 		}
-		
+
 		var result = new FlxGroup();
-		
+
 		result.add(left);
 		result.add(right);
 		result.add(top);
 		result.add(bottom);
-		
+
 		return result;
 	}
 }

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -5,14 +5,14 @@ import flixel.system.macros.FlxMacroUtil;
 
 /**
  * Class representing a color, based on Int. Provides a variety of methods for creating and converting colors.
- * 
+ *
  * FlxColors can be written as Ints. This means you can pass a hex value such as
  * 0xff123456 to a function expecting a FlxColor, and it will automatically become a FlxColor "object".
  * Similarly, FlxColors may be treated as Ints.
- * 
+ *
  * Note that when using properties of a FlxColor other than ARGB, the values are ultimately stored as
  * ARGB values, so repeatedly manipulating HSB/HSL/CMYK values may result in a gradual loss of precision.
- * 
+ *
  * @author Joe Williamson (JoeCreates)
  */
 abstract FlxColor(Int) from Int from UInt to Int to UInt
@@ -21,7 +21,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public static inline var WHITE:FlxColor =       0xFFFFFFFF;
 	public static inline var GRAY:FlxColor =        0xFF808080;
 	public static inline var BLACK:FlxColor =       0xFF000000;
-	
+
 	public static inline var GREEN:FlxColor =       0xFF008000;
 	public static inline var LIME:FlxColor =        0xFF00FF00;
 	public static inline var YELLOW:FlxColor =      0xFFFFFF00;
@@ -33,30 +33,30 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public static inline var PINK:FlxColor =        0xFFFFC0CB;
 	public static inline var MAGENTA:FlxColor =     0xFFFF00FF;
 	public static inline var CYAN:FlxColor =        0xFF00FFFF;
-	
+
 	/**
 	 * A `Map<String, Int>` whose values are the static colors of `FlxColor`.
 	 * You can add more colors for `FlxColor.fromString(String)` if you need.
 	 */
 	public static var colorLookup(default, null):Map<String, Int>
 		= FlxMacroUtil.buildMap("flixel.util.FlxColor");
-	
+
 	public var red(get, set):Int;
 	public var blue(get, set):Int;
 	public var green(get, set):Int;
 	public var alpha(get, set):Int;
-	
+
 	public var redFloat(get, set):Float;
 	public var blueFloat(get, set):Float;
 	public var greenFloat(get, set):Float;
 	public var alphaFloat(get, set):Float;
-	
+
 	public var cyan(get, set):Float;
 	public var magenta(get, set):Float;
 	public var yellow(get, set):Float;
 	public var black(get, set):Float;
-	
-	/** 
+
+	/**
 	 * The hue of the color in degrees (from 0 to 359)
 	 */
 	public var hue(get, set):Float;
@@ -72,12 +72,12 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * The lightness of the color (from 0 to 1)
 	 */
 	public var lightness(get, set):Float;
-	
-	private static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
-	
+
+	static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
+
 	/**
 	 * Create a color from the least significant four bytes of an Int
-	 * 
+	 *
 	 * @param	Value And Int with bytes in the format 0xAARRGGBB
 	 * @return	The color as a FlxColor
 	 */
@@ -85,10 +85,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return new FlxColor(Value);
 	}
-	
+
 	/**
 	 * Generate a color from integer RGB values (0 to 255)
-	 * 
+	 *
 	 * @param Red	The red value of the color from 0 to 255
 	 * @param Green	The green value of the color from 0 to 255
 	 * @param Blue	The green value of the color from 0 to 255
@@ -100,10 +100,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var color = new FlxColor();
 		return color.setRGB(Red, Green, Blue, Alpha);
 	}
-	
+
 	/**
 	 * Generate a color from float RGB values (0 to 1)
-	 * 
+	 *
 	 * @param Red	The red value of the color from 0 to 1
 	 * @param Green	The green value of the color from 0 to 1
 	 * @param Blue	The green value of the color from 0 to 1
@@ -115,10 +115,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var color = new FlxColor();
 		return color.setRGBFloat(Red, Green, Blue, Alpha);
 	}
-	
+
 	/**
 	 * Generate a color from CMYK values (0 to 1)
-	 * 
+	 *
 	 * @param Cyan		The cyan value of the color from 0 to 1
 	 * @param Magenta	The magenta value of the color from 0 to 1
 	 * @param Yellow	The yellow value of the color from 0 to 1
@@ -131,10 +131,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var color = new FlxColor();
 		return color.setCMYK(Cyan, Magenta, Yellow, Black, Alpha);
 	}
-	
+
 	/**
 	 * Generate a color from HSB (aka HSV) components.
-	 * 
+	 *
 	 * @param	Hue			A number between 0 and 360, indicating position on a color strip or wheel.
 	 * @param	Saturation	A number between 0 and 1, indicating how colorful or gray the color should be.  0 is gray, 1 is vibrant.
 	 * @param	Brightness	(aka Value) A number between 0 and 1, indicating how bright the color should be.  0 is black, 1 is full bright.
@@ -146,10 +146,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var color = new FlxColor();
 		return color.setHSB(Hue, Saturation, Brightness, Alpha);
 	}
-	
+
 	/**
 	 * Generate a color from HSL components.
-	 * 
+	 *
 	 * @param	Hue			A number between 0 and 360, indicating position on a color strip or wheel.
 	 * @param	Saturation	A number between 0 and 1, indicating how colorful or gray the color should be.  0 is gray, 1 is vibrant.
 	 * @param	Lightness	A number between 0 and 1, indicating the lightness of the color
@@ -161,19 +161,19 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var color = new FlxColor();
 		return color.setHSL(Hue, Saturation, Lightness, Alpha);
 	}
-	
+
 	/**
 	 * Parses a `String` and returns a `FlxColor` or `null` if the `String` couldn't be parsed.
-	 * 
+	 *
 	 * Examples (input -> output in hex):
-	 * 
+	 *
 	 * - `0x00FF00`    -> `0xFF00FF00`
 	 * - `0xAA4578C2`  -> `0xAA4578C2`
 	 * - `#0000FF`     -> `0xFF0000FF`
 	 * - `#3F000011`   -> `0x3F000011`
 	 * - `GRAY`        -> `0xFF808080`
 	 * - `blue`        -> `0xFF0000FF`
-	 * 
+	 *
 	 * @param	str 	The string to be parsed
 	 * @return	A `FlxColor` or `null` if the `String` couldn't be parsed
 	 */
@@ -181,12 +181,12 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var result:Null<FlxColor> = null;
 		str = StringTools.trim(str);
-		
-		if (COLOR_REGEX.match(str)) 
+
+		if (COLOR_REGEX.match(str))
 		{
 			var hexColor:String = "0x" + COLOR_REGEX.matched(2);
 			result = new FlxColor(Std.parseInt(hexColor));
-			if (hexColor.length == 8) 
+			if (hexColor.length == 8)
 			{
 				result.alphaFloat = 1;
 			}
@@ -203,13 +203,13 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 				}
 			}
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Get HSB color wheel values in an array which will be 360 elements in size
-	 * 
+	 *
 	 * @param	Alpha Alpha value for each color of the color wheel, between 0 (transparent) and 255 (opaque)
 	 * @return	HSB color wheel as Array of FlxColors
 	 */
@@ -217,10 +217,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return [for (c in 0...360) fromHSB(c, 1.0, 1.0, Alpha)];
 	}
-	
+
 	/**
 	 * Get an interpolated color based on two different colors.
-	 * 
+	 *
 	 * @param 	Color1 The first color
 	 * @param 	Color2 The second color
 	 * @param 	Factor Value from 0 to 1 representing how much to shift Color1 toward Color2
@@ -232,13 +232,13 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var g:Int = Std.int((Color2.green - Color1.green) * Factor + Color1.green);
 		var b:Int = Std.int((Color2.blue - Color1.blue) * Factor + Color1.blue);
 		var a:Int = Std.int((Color2.alpha - Color1.alpha) * Factor + Color1.alpha);
-		
+
 		return fromRGB(r, g, b, a);
 	}
-	
+
 	/**
 	 * Create a gradient from one color to another
-	 * 
+	 *
 	 * @param Color1 The color to shift from
 	 * @param Color2 The color to shift to
 	 * @param Steps How many colors the gradient should have
@@ -248,7 +248,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public static function gradient(Color1:FlxColor, Color2:FlxColor, Steps:Int, ?Ease:Float->Float):Array<FlxColor>
 	{
 		var output = new Array<FlxColor>();
-		
+
 		if (Ease == null)
 		{
 			Ease = function(t:Float):Float
@@ -256,15 +256,15 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 				return t;
 			}
 		}
-		
+
 		for (step in 0...Steps)
 		{
 			output[step] = interpolate(Color1, Color2, Ease(step / (Steps - 1)));
 		}
-		
+
 		return output;
 	}
-	
+
 	/**
 	 * Multiply the RGB channels of two FlxColors
 	 */
@@ -273,7 +273,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGBFloat(lhs.redFloat * rhs.redFloat, lhs.greenFloat * rhs.greenFloat, lhs.blueFloat * rhs.blueFloat);
 	}
-	
+
 	/**
 	 * Add the RGB channels of two FlxColors
 	 */
@@ -282,7 +282,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGB(lhs.red + rhs.red, lhs.green + rhs.green, lhs.blue + rhs.blue);
 	}
-	
+
 	/**
 	 * Subtract the RGB channels of one FlxColor from another
 	 */
@@ -291,22 +291,22 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGB(lhs.red - rhs.red, lhs.green - rhs.green, lhs.blue - rhs.blue);
 	}
-	
+
 	/**
 	 * Returns a Complementary Color Harmony of this color.
 	 * A complementary hue is one directly opposite the color given on the color wheel
-	 * 
+	 *
 	 * @return	The complimentary color
 	 */
 	public inline function getComplementHarmony():FlxColor
-	{		
+	{
 		return fromHSB(FlxMath.wrap(Std.int(hue) + 180, 0, 350), brightness, saturation, alphaFloat);
 	}
-	
+
 	/**
 	 * Returns an Analogous Color Harmony for the given color.
 	 * An Analogous harmony are hues adjacent to each other on the color wheel
-	 * 
+	 *
 	 * @param	Threshold Control how adjacent the colors will be (default +- 30 degrees)
 	 * @return 	Object containing 3 properties: original (the original color), warmer (the warmer analogous color) and colder (the colder analogous color)
 	 */
@@ -314,14 +314,14 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var warmer:Int = fromHSB(FlxMath.wrap(Std.int(hue) - Threshold, 0, 350), saturation, brightness, alphaFloat);
 		var colder:Int = fromHSB(FlxMath.wrap(Std.int(hue) + Threshold, 0, 350), saturation, brightness, alphaFloat);
-		
+
 		return {original: this, warmer: warmer, colder: colder};
 	}
-	
+
 	/**
 	 * Returns an Split Complement Color Harmony for this color.
 	 * A Split Complement harmony are the two hues on either side of the color's Complement
-	 * 
+	 *
 	 * @param	Threshold Control how adjacent the colors will be to the Complement (default +- 30 degrees)
 	 * @return 	Object containing 3 properties: original (the original color), warmer (the warmer analogous color) and colder (the colder analogous color)
 	 */
@@ -330,37 +330,37 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var oppositeHue:Int = FlxMath.wrap(Std.int(hue) + 180, 0, 350);
 		var warmer:FlxColor = fromHSB(FlxMath.wrap(oppositeHue - Threshold, 0, 350), saturation, brightness, alphaFloat);
 		var colder:FlxColor = fromHSB(FlxMath.wrap(oppositeHue + Threshold, 0, 350), saturation, brightness, alphaFloat);
-		
+
 		return {original: this, warmer: warmer, colder: colder};
 	}
-	
+
 	/**
-	 * Returns a Triadic Color Harmony for this color. A Triadic harmony are 3 hues equidistant 
+	 * Returns a Triadic Color Harmony for this color. A Triadic harmony are 3 hues equidistant
 	 * from each other on the color wheel.
-	 * 
+	 *
 	 * @return 	Object containing 3 properties: color1 (the original color), color2 and color3 (the equidistant colors)
 	 */
 	public inline function getTriadicHarmony():TriadicHarmony
 	{
 		var triadic1:FlxColor = fromHSB(FlxMath.wrap(Std.int(hue) + 120, 0, 359), saturation, brightness, alphaFloat);
 		var triadic2:FlxColor = fromHSB(FlxMath.wrap(Std.int(triadic1.hue) + 120, 0, 359), saturation, brightness, alphaFloat);
-		
+
 		return {color1: this, color2: triadic1, color3: triadic2};
 	}
-	
+
 	/**
 	 * Return a 24 bit version of this color (i.e. without an alpha value)
-	 * 
+	 *
 	 * @return A 24 bit version of this color
 	 */
 	public inline function to24Bit():FlxColor
 	{
 		return this & 0xffffff;
 	}
-	
+
 	/**
 	 * Return a String representation of the color in the format
-	 * 
+	 *
 	 * @param Alpha Whether to include the alpha value in the hes string
 	 * @param Prefix Whether to include "0x" prefix at start of string
 	 * @return	A string of length 10 in the format 0xAARRGGBB
@@ -370,20 +370,20 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return (Prefix ? "0x" : "") + (Alpha ? StringTools.hex(alpha, 2) : "") +
 			StringTools.hex(red, 2) + StringTools.hex(green, 2) + StringTools.hex(blue, 2);
 	}
-	
+
 	/**
 	 * Return a String representation of the color in the format #RRGGBB
-	 * 
+	 *
 	 * @return	A string of length 7 in the format #RRGGBB
 	 */
 	public inline function toWebString():String
 	{
 		return "#" + toHexString(false, false);
 	}
-	
+
 	/**
 	 * Get a string of color information about this color
-	 * 
+	 *
 	 * @return A string containing information about this color
 	 */
 	public function getColorInfo():String
@@ -393,15 +393,15 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		// RGB format
 		result += "Alpha: " + alpha + " Red: " + red + " Green: " + green + " Blue: " + blue + "\n";
 		// HSB/HSL info
-		result += "Hue: " + FlxMath.roundDecimal(hue, 2) + " Saturation: " + FlxMath.roundDecimal(saturation, 2) + 
+		result += "Hue: " + FlxMath.roundDecimal(hue, 2) + " Saturation: " + FlxMath.roundDecimal(saturation, 2) +
 			" Brightness: " + FlxMath.roundDecimal(brightness, 2) + " Lightness: " + FlxMath.roundDecimal(lightness, 2);
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Get a darkened version of this color
-	 * 
+	 *
 	 * @param	Factor Value from 0 to 1 of how much to progress toward black.
 	 * @return 	A darkened version of this color
 	 */
@@ -412,10 +412,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		output.lightness = output.lightness * (1 - Factor);
 		return output;
 	}
-	
+
 	/**
 	 * Get a lightened version of this color
-	 * 
+	 *
 	 * @param	Factor Value from 0 to 1 of how much to progress toward white.
 	 * @return 	A lightened version of this color
 	 */
@@ -426,10 +426,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		output.lightness = output.lightness + (1 - lightness) * Factor;
 		return output;
 	}
-	
+
 	/**
 	 * Get the inversion of this color
-	 * 
+	 *
 	 * @return The inversion of this color
 	 */
 	public inline function getInverted():FlxColor
@@ -439,10 +439,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		output.alpha = oldAlpha;
 		return output;
 	}
-	
+
 	/**
 	 * Set RGB values as integers (0 to 255)
-	 * 
+	 *
 	 * @param Red	The red value of the color from 0 to 255
 	 * @param Green	The green value of the color from 0 to 255
 	 * @param Blue	The green value of the color from 0 to 255
@@ -457,10 +457,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		alpha = Alpha;
 		return this;
 	}
-	
+
 	/**
 	 * Set RGB values as floats (0 to 1)
-	 * 
+	 *
 	 * @param Red	The red value of the color from 0 to 1
 	 * @param Green	The green value of the color from 0 to 1
 	 * @param Blue	The green value of the color from 0 to 1
@@ -475,10 +475,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		alphaFloat = Alpha;
 		return this;
 	}
-	
+
 	/**
 	 * Set CMYK values as floats (0 to 1)
-	 * 
+	 *
 	 * @param Cyan		The cyan value of the color from 0 to 1
 	 * @param Magenta	The magenta value of the color from 0 to 1
 	 * @param Yellow	The yellow value of the color from 0 to 1
@@ -494,10 +494,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		alphaFloat = Alpha;
 		return this;
 	}
-	
+
 	/**
 	 * Set HSB (aka HSV) components
-	 * 
+	 *
 	 * @param	Hue			A number between 0 and 360, indicating position on a color strip or wheel.
 	 * @param	Saturation	A number between 0 and 1, indicating how colorful or gray the color should be.  0 is gray, 1 is vibrant.
 	 * @param	Brightness	(aka Value) A number between 0 and 1, indicating how bright the color should be.  0 is black, 1 is full bright.
@@ -510,10 +510,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var match = Brightness - chroma;
 		return setHSChromaMatch(Hue, Saturation, chroma, match, Alpha);
 	}
-	
+
 	/**
 	 * Set HSL components.
-	 * 
+	 *
 	 * @param	Hue			A number between 0 and 360, indicating position on a color strip or wheel.
 	 * @param	Saturation	A number between 0 and 1, indicating how colorful or gray the color should be.  0 is gray, 1 is vibrant.
 	 * @param	Lightness	A number between 0 and 1, indicating the lightness of the color
@@ -526,17 +526,17 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var match = Lightness - chroma / 2;
 		return setHSChromaMatch(Hue, Saturation, chroma, match, Alpha);
 	}
-	
+
 	/**
 	 * Private utility function to perform common operations between setHSB and setHSL
 	 */
-	private inline function setHSChromaMatch(Hue:Float, Saturation:Float, Chroma:Float, Match:Float, Alpha:Float):FlxColor
+	inline function setHSChromaMatch(Hue:Float, Saturation:Float, Chroma:Float, Match:Float, Alpha:Float):FlxColor
 	{
 		Hue %= 360;
 		var hueD = Hue / 60;
 		var mid = Chroma * (1 - Math.abs(hueD % 2 - 1)) + Match;
 		Chroma += Match;
-		
+
 		switch (Std.int(hueD))
 		{
 			case 0: setRGBFloat(Chroma, mid, Match, Alpha);
@@ -546,16 +546,16 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 			case 4: setRGBFloat(mid, Match, Chroma, Alpha);
 			case 5: setRGBFloat(Chroma, Match, mid, Alpha);
 		}
-		
+
 		return this;
 	}
-	
+
 	public function new(Value:Int = 0)
 	{
 		this = Value;
 	}
-	
-	private inline function getThis():Int
+
+	inline function getThis():Int
 	{
 		#if neko
 		return Std.int(this);
@@ -563,216 +563,216 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return this;
 		#end
 	}
-	
-	private inline function validate():Void
+
+	inline function validate():Void
 	{
 		#if neko
 		this = Std.int(this);
 		#end
 	}
-	
-	private inline function get_red():Int
+
+	inline function get_red():Int
 	{
 		return (getThis() >> 16) & 0xff;
 	}
-	
-	private inline function get_green():Int
+
+	inline function get_green():Int
 	{
 		return (getThis() >> 8) & 0xff;
 	}
-	
-	private inline function get_blue():Int
+
+	inline function get_blue():Int
 	{
 		return getThis() & 0xff;
 	}
-	
-	private inline function get_alpha():Int
+
+	inline function get_alpha():Int
 	{
 		return (getThis() >> 24) & 0xff;
 	}
-	
-	private inline function get_redFloat():Float
+
+	inline function get_redFloat():Float
 	{
 		return red / 255;
 	}
-	
-	private inline function get_greenFloat():Float
+
+	inline function get_greenFloat():Float
 	{
 		return green / 255;
 	}
-	
-	private inline function get_blueFloat():Float
+
+	inline function get_blueFloat():Float
 	{
 		return blue / 255;
 	}
-	
-	private inline function get_alphaFloat():Float
+
+	inline function get_alphaFloat():Float
 	{
 		return alpha / 255;
 	}
-	
-	private inline function set_red(Value:Int):Int
+
+	inline function set_red(Value:Int):Int
 	{
 		validate();
 		this &= 0xff00ffff;
 		this |= boundChannel(Value) << 16;
 		return Value;
 	}
-	
-	private inline function set_green(Value:Int):Int
+
+	inline function set_green(Value:Int):Int
 	{
 		validate();
 		this &= 0xffff00ff;
 		this |= boundChannel(Value) << 8;
 		return Value;
 	}
-	
-	private inline function set_blue(Value:Int):Int
+
+	inline function set_blue(Value:Int):Int
 	{
 		validate();
 		this &= 0xffffff00;
 		this |= boundChannel(Value);
 		return Value;
 	}
-	
-	private inline function set_alpha(Value:Int):Int
+
+	inline function set_alpha(Value:Int):Int
 	{
 		validate();
 		this &= 0x00ffffff;
 		this |= boundChannel(Value) << 24;
 		return Value;
 	}
-	
-	private inline function set_redFloat(Value:Float):Float
+
+	inline function set_redFloat(Value:Float):Float
 	{
 		red = Math.round(Value * 255);
 		return Value;
 	}
-	
-	private inline function set_greenFloat(Value:Float):Float
+
+	inline function set_greenFloat(Value:Float):Float
 	{
 		green = Math.round(Value * 255);
 		return Value;
 	}
-	
-	private inline function set_blueFloat(Value:Float):Float
+
+	inline function set_blueFloat(Value:Float):Float
 	{
 		blue = Math.round(Value * 255);
 		return Value;
 	}
-	
-	private inline function set_alphaFloat(Value:Float):Float
+
+	inline function set_alphaFloat(Value:Float):Float
 	{
 		alpha = Math.round(Value * 255);
 		return Value;
 	}
-	
-	private inline function get_cyan():Float
+
+	inline function get_cyan():Float
 	{
 		return (1 - redFloat - black) / brightness;
 	}
-	
-	private inline function get_magenta():Float
+
+	inline function get_magenta():Float
 	{
 		return (1 - greenFloat - black) / brightness;
 	}
-	
-	private inline function get_yellow():Float
+
+	inline function get_yellow():Float
 	{
 		return (1 - blueFloat - black) / brightness;
 	}
-	
-	private inline function get_black():Float
+
+	inline function get_black():Float
 	{
 		return 1 - brightness;
 	}
-	
-	private inline function set_cyan(Value:Float):Float
+
+	inline function set_cyan(Value:Float):Float
 	{
 		setCMYK(Value, magenta, yellow, black, alphaFloat);
 		return Value;
 	}
-	
-	private inline function set_magenta(Value:Float):Float
+
+	inline function set_magenta(Value:Float):Float
 	{
 		setCMYK(cyan, Value, yellow, black, alphaFloat);
 		return Value;
 	}
-	
-	private inline function set_yellow(Value:Float):Float
+
+	inline function set_yellow(Value:Float):Float
 	{
 		setCMYK(cyan, magenta, Value, black, alphaFloat);
 		return Value;
 	}
-	
-	private inline function set_black(Value:Float):Float
+
+	inline function set_black(Value:Float):Float
 	{
 		setCMYK(cyan, magenta, yellow, Value, alphaFloat);
 		return Value;
 	}
-	
-	private function get_hue():Float
+
+	function get_hue():Float
 	{
 		var hueRad = Math.atan2(Math.sqrt(3) * (greenFloat - blueFloat), 2 * redFloat - greenFloat - blueFloat);
 		var hue:Float = 0;
 		if (hueRad != 0)
 		{
 			hue = 180 / Math.PI * Math.atan2(Math.sqrt(3) * (greenFloat - blueFloat), 2 * redFloat - greenFloat - blueFloat);
-		}		
-			
+		}
+
 		return hue < 0 ? hue + 360 : hue;
 	}
-	
-	private inline function get_brightness():Float
+
+	inline function get_brightness():Float
 	{
 		return maxColor();
 	}
-	
-	private inline function get_saturation():Float
+
+	inline function get_saturation():Float
 	{
 		return (maxColor() - minColor()) / brightness;
 	}
-	
-	private inline function get_lightness():Float
+
+	inline function get_lightness():Float
 	{
 		return (maxColor() + minColor()) / 2;
 	}
-	
-	private inline function set_hue(Value:Float):Float
+
+	inline function set_hue(Value:Float):Float
 	{
 		setHSB(Value, saturation, brightness, alphaFloat);
 		return Value;
 	}
-	
-	private inline function set_saturation(Value:Float):Float
+
+	inline function set_saturation(Value:Float):Float
 	{
 		setHSB(hue, Value, brightness, alphaFloat);
 		return Value;
 	}
-	
-	private inline function set_brightness(Value:Float):Float
+
+	inline function set_brightness(Value:Float):Float
 	{
 		setHSB(hue, saturation, Value, alphaFloat);
 		return Value;
 	}
-	
-	private inline function set_lightness(Value:Float):Float
+
+	inline function set_lightness(Value:Float):Float
 	{
 		setHSL(hue, saturation, Value, alphaFloat);
 		return Value;
 	}
-	
-	private inline function maxColor():Float
+
+	inline function maxColor():Float
 	{
 		return Math.max(redFloat, Math.max(greenFloat, blueFloat));
 	}
-	
-	private inline function minColor():Float
+
+	inline function minColor():Float
 	{
 		return Math.min(redFloat, Math.min(greenFloat, blueFloat));
 	}
-	
-	private inline function boundChannel(Value:Int):Int
+
+	inline function boundChannel(Value:Int):Int
 	{
 		return Value > 0xff ? 0xff : Value < 0 ? 0 : Value;
 	}

--- a/flixel/util/FlxPath.hx
+++ b/flixel/util/FlxPath.hx
@@ -12,31 +12,31 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
  * `FlxTilemap.findPath()` returns a path usable by `FlxPath`, but you can
  * also just make your own, using the `add()` functions below
  * or by creating your own array of points.
- * 
+ *
  * Every `FlxObject` has a `path` property which can make it move along specified array of way points.
  * Usage example:
- * 
+ *
  * ```haxe
  * var path = new FlxPath();
  * var points:Array<FlxPoint> = [new FlxPoint(0, 0), new FlxPoint(100, 0)];
  * object.path = path;
  * path.start(points, 50, FlxPath.FORWARD);
  * ```
- * 
+ *
  * You can also do this in one line:
- * 
+ *
  * ```haxe
  * object.path = new FlxPath().start([new FlxPoint(0, 0), new FlxPoint(100, 0)], 50, FlxPath.FORWARD);
  * ```
- * 
+ *
  * ...or using some more chaining:
- * 
+ *
  * ```haxe
  * object.path = new FlxPath().add(0, 0).add(100, 0).start(50, FlxPath.FORWARD);
  * ```
- * 
+ *
  * If you are fine with the default values of start (speed, mode, auto-rotate) you can also do:
- * 
+ *
  * ```haxe
  * object.path = new FlxPath([new FlxPoint(0, 0), new FlxPoint(100, 0)]).start();
  * ```
@@ -71,22 +71,22 @@ class FlxPath implements IFlxDestroyable
 	 * Path behavior controls: ignores any horizontal component to the path data, only follows up and down.
 	 */
 	public static inline var VERTICAL_ONLY:Int = 0x100000;
-	
+
 	/**
 	 * Internal helper for keeping new variable instantiations under control.
 	 */
-	private static var _point:FlxPoint = FlxPoint.get();
-	
+	static var _point:FlxPoint = FlxPoint.get();
+
 	/**
 	 * The list of FlxPoints that make up the path data.
 	 */
 	public var nodes(get, set):Array<FlxPoint>;
-	
+
 	/**
 	 * An actual array, which holds all the path points.
 	 */
-	private var _nodes:Array<FlxPoint>;
-	
+	var _nodes:Array<FlxPoint>;
+
 	/**
 	 * The speed at which the object is moving on the path.
 	 * When an object completes a non-looping path circuit,
@@ -103,12 +103,12 @@ class FlxPath implements IFlxDestroyable
 	 * Whether the object should auto-center the path or at its origin.
 	 */
 	public var autoCenter:Bool = true;
-	
+
 	/**
 	 * Pauses or checks the pause state of the path.
 	 */
 	public var active:Bool = false;
-	
+
 	public var onComplete:FlxPath->Void;
 
 	#if FLX_DEBUG
@@ -122,37 +122,37 @@ class FlxPath implements IFlxDestroyable
 	 */
 	public var ignoreDrawDebug:Bool = false;
 	#end
-	
+
 	/**
 	 * Tracks which node of the path this object is currently moving toward.
 	 */
 	public var nodeIndex(default, null):Int = 0;
-	
+
 	public var finished(default, null):Bool = false;
-	
+
 	/**
 	 * Internal tracker for path behavior flags (like looping, horizontal only, etc).
 	 */
-	private var _mode:Int;
+	var _mode:Int;
 	/**
 	 * Internal helper for node navigation, specifically yo-yo and backwards movement.
 	 */
-	private var _inc:Int = 1;
+	var _inc:Int = 1;
 	/**
 	 * Internal flag for whether the object's angle should be adjusted to the path angle during path follow behavior.
 	 */
-	private var _autoRotate:Bool = false;
-	
-	private var _wasObjectImmovable:Null<Bool> = null;
-	
-	private var _firstUpdate:Bool = false;
-	
+	var _autoRotate:Bool = false;
+
+	var _wasObjectImmovable:Null<Bool> = null;
+
+	var _firstUpdate:Bool = false;
+
 	/**
 	 * Object which will follow this path
 	 */
 	@:allow(flixel.FlxObject)
-	private var object:FlxObject;
-	
+	var object:FlxObject;
+
 	public function new(?Nodes:Array<FlxPoint>)
 	{
 		if (Nodes != null)
@@ -160,7 +160,7 @@ class FlxPath implements IFlxDestroyable
 		else
 			_nodes = [];
 	}
-	
+
 	/**
 	 * Just resets some debugging related variables (for debugger renderer).
 	 * Also resets `autoCenter` to `true`.
@@ -175,10 +175,10 @@ class FlxPath implements IFlxDestroyable
 		autoCenter = true;
 		return this;
 	}
-	
+
 	/**
 	 * Sets the following properties: `speed`, `mode` and auto rotation.
-	 * 
+	 *
 	 * @param	Speed			The speed at which the object is moving on the path.
 	 * @param	Mode			Path following behavior (like looping, horizontal only, etc).
 	 * @param	AutoRotate		Whether the object's angle should be adjusted to the path angle during path follow behavior.
@@ -192,10 +192,10 @@ class FlxPath implements IFlxDestroyable
 		_autoRotate = AutoRotate;
 		return this;
 	}
-	
+
 	/**
 	 * Starts movement along specified path.
-	 * 
+	 *
 	 * @param	Nodes				An optional array of path waypoints. If null then previously added points will be used. Movement is not started if the resulting array has no points.
 	 * @param	Speed				The speed at which the object is moving on the path.
 	 * @param	Mode				Path following behavior (like looping, horizontal only, etc).
@@ -223,11 +223,11 @@ class FlxPath implements IFlxDestroyable
 		}
 		return this;
 	}
-	
+
 	/**
-	 * Restarts this path. So object starts movement again from the first (or last) path point 
+	 * Restarts this path. So object starts movement again from the first (or last) path point
 	 * (depends on path movement behavior mode).
-	 * 
+	 *
 	 * @return	This path object.
 	 */
 	public function restart():FlxPath
@@ -239,7 +239,7 @@ class FlxPath implements IFlxDestroyable
 		{
 			return this;
 		}
-		
+
 		//get starting node
 		if ((_mode == FlxPath.BACKWARD) || (_mode == FlxPath.LOOP_BACKWARD))
 		{
@@ -251,27 +251,27 @@ class FlxPath implements IFlxDestroyable
 			nodeIndex = 0;
 			_inc = 1;
 		}
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Change the path node this object is currently at.
-	 * 
+	 *
 	 * @param  NodeIndex    The index of the new node out of path.nodes.
 	 */
 	public function setNode(NodeIndex:Int):FlxPath
 	{
-		if (NodeIndex < 0) 
+		if (NodeIndex < 0)
 			NodeIndex = 0;
 		else if (NodeIndex > _nodes.length - 1)
 			NodeIndex = _nodes.length - 1;
-		
-		nodeIndex = NodeIndex; 
+
+		nodeIndex = NodeIndex;
 		advancePath();
 		return this;
-	} 
-	
+	}
+
 	/**
 	 * Internal function for moving the object along the path.
 	 * The first half of the function decides if the object can advance to the next node in the path,
@@ -281,14 +281,14 @@ class FlxPath implements IFlxDestroyable
 	{
 		if (object == null)
 			return;
-		
+
 		if (_firstUpdate)
 		{
 			_wasObjectImmovable = object.immovable;
 			object.immovable = true;
 			_firstUpdate = false;
 		}
-		
+
 		//first check if we need to be pointing at the next node yet
 		_point.x = object.x;
 		_point.y = object.y;
@@ -299,10 +299,10 @@ class FlxPath implements IFlxDestroyable
 		var node:FlxPoint = _nodes[nodeIndex];
 		var deltaX:Float = node.x - _point.x;
 		var deltaY:Float = node.y - _point.y;
-		
+
 		var horizontalOnly:Bool = (_mode & FlxPath.HORIZONTAL_ONLY) > 0;
 		var verticalOnly:Bool = (_mode & FlxPath.VERTICAL_ONLY) > 0;
-		
+
 		if (horizontalOnly)
 		{
 			if (((deltaX > 0) ? deltaX : -deltaX) < speed * elapsed)
@@ -324,19 +324,19 @@ class FlxPath implements IFlxDestroyable
 				node = advancePath();
 			}
 		}
-		
+
 		//then just move toward the current node at the requested speed
 		if (object != null && speed != 0)
 		{
 			//set velocity based on path mode
 			_point.x = object.x;
 			_point.y = object.y;
-			
+
 			if (autoCenter)
 			{
 				_point.add(object.width * 0.5, object.height * 0.5);
 			}
-			
+
 			if (!_point.equals(node))
 			{
 				calculateVelocity(node, horizontalOnly, verticalOnly);
@@ -345,7 +345,7 @@ class FlxPath implements IFlxDestroyable
 			{
 				object.velocity.set();
 			}
-			
+
 			//then set object rotation if necessary
 			if (_autoRotate)
 			{
@@ -353,21 +353,21 @@ class FlxPath implements IFlxDestroyable
 				object.angularAcceleration = 0;
 				object.angle = angle;
 			}
-			
+
 			if (finished)
 			{
 				cancel();
 			}
 		}
 	}
-	
-	private function calculateVelocity(node:FlxPoint, horizontalOnly:Bool, verticalOnly:Bool):Void
+
+	function calculateVelocity(node:FlxPoint, horizontalOnly:Bool, verticalOnly:Bool):Void
 	{
 		if (horizontalOnly || _point.y == node.y)
 		{
 			object.velocity.x = (_point.x < node.x) ? speed : -speed;
 			angle = (object.velocity.x < 0) ? -90 : 90;
-			
+
 			if (!horizontalOnly)
 			{
 				object.velocity.y = 0;
@@ -377,7 +377,7 @@ class FlxPath implements IFlxDestroyable
 		{
 			object.velocity.y = (_point.y < node.y) ? speed : -speed;
 			angle = (object.velocity.y < 0) ? 0 : 180;
-			
+
 			if (!verticalOnly)
 			{
 				object.velocity.x = 0;
@@ -387,20 +387,20 @@ class FlxPath implements IFlxDestroyable
 		{
 			object.velocity.x = (_point.x < node.x) ? speed : -speed;
 			object.velocity.y = (_point.y < node.y) ? speed : -speed;
-			
+
 			angle = _point.angleBetween(node);
-			
+
 			object.velocity.set(0, -speed);
 			object.velocity.rotate(FlxPoint.weak(0, 0), angle);
 		}
 	}
-	
+
 	/**
 	 * Internal function that decides what node in the path to aim for next based on the behavior flags.
-	 * 
+	 *
 	 * @return	The node (a `FlxPoint`) we are aiming for next.
 	 */
-	private function advancePath(Snap:Bool = true):FlxPoint
+	function advancePath(Snap:Bool = true):FlxPoint
 	{
 		if (Snap)
 		{
@@ -410,21 +410,21 @@ class FlxPath implements IFlxDestroyable
 				if ((_mode & FlxPath.VERTICAL_ONLY) == 0)
 				{
 					object.x = oldNode.x;
-					if (autoCenter) 
-						object.x -= object.width * 0.5; 
+					if (autoCenter)
+						object.x -= object.width * 0.5;
 				}
 				if ((_mode & FlxPath.HORIZONTAL_ONLY) == 0)
 				{
 					object.y = oldNode.y;
-					if (autoCenter) 
-						object.y -= object.height * 0.5; 
+					if (autoCenter)
+						object.y -= object.height * 0.5;
 				}
 			}
 		}
-		
+
 		var callComplete:Bool = false;
 		nodeIndex += _inc;
-		
+
 		if ((_mode & FlxPath.BACKWARD) > 0)
 		{
 			if (nodeIndex < 0)
@@ -493,7 +493,7 @@ class FlxPath implements IFlxDestroyable
 				onEnd();
 			}
 		}
-		
+
 		if (callComplete && onComplete != null)
 		{
 			onComplete(this);
@@ -501,27 +501,27 @@ class FlxPath implements IFlxDestroyable
 
 		return _nodes[nodeIndex];
 	}
-	
+
 	/**
 	 * Stops path movement and removes this path it from the path manager.
-	 * 
+	 *
 	 * @return	This path object.
 	 */
 	public function cancel():FlxPath
 	{
 		onEnd();
-		
+
 		if (object != null)
 		{
 			object.velocity.set(0, 0);
 		}
 		return this;
 	}
-	
+
 	/**
 	 * Called when the path ends, either by completing normally or via `cancel()`.
 	 */
-	private function onEnd():Void
+	function onEnd():Void
 	{
 		finished = true;
 		active = false;
@@ -529,7 +529,7 @@ class FlxPath implements IFlxDestroyable
 			object.immovable = _wasObjectImmovable;
 		_wasObjectImmovable = null;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -540,13 +540,13 @@ class FlxPath implements IFlxDestroyable
 		object = null;
 		onComplete = null;
 	}
-	
+
 	/**
 	 * Add a new node to the end of the path at the specified location.
-	 * 
+	 *
 	 * @param	X	X position of the new path point in world coordinates.
 	 * @param	Y	Y position of the new path point in world coordinates.
-	 * 
+	 *
 	 * @return	This path object.
 	 */
 	public function add(X:Float, Y:Float):FlxPath
@@ -554,14 +554,14 @@ class FlxPath implements IFlxDestroyable
 		_nodes.push(FlxPoint.get(X, Y));
 		return this;
 	}
-	
+
 	/**
 	 * Add a new node to the path at the specified location and index within the path.
-	 * 
+	 *
 	 * @param	X		X position of the new path point in world coordinates.
 	 * @param	Y		Y position of the new path point in world coordinates.
 	 * @param	Index	Where within the list of path nodes to insert this new point.
-	 * 
+	 *
 	 * @return	This path object.
 	 */
 	public function addAt(X:Float, Y:Float, Index:Int):FlxPath
@@ -570,15 +570,15 @@ class FlxPath implements IFlxDestroyable
 		_nodes.insert(Index, FlxPoint.get(X, Y));
 		return this;
 	}
-	
+
 	/**
 	 * Sometimes its easier or faster to just pass a point object instead of separate X and Y coordinates.
 	 * This also gives you the option of not creating a new node but actually adding that specific
 	 * FlxPoint object to the path.  This allows you to do neat things, like dynamic paths.
-	 * 
+	 *
 	 * @param	Node			The point in world coordinates you want to add to the path.
 	 * @param	AsReference		Whether to add the point as a reference, or to create a new point with the specified values.
-	 * 
+	 *
 	 * @return	This path object.
 	 */
 	public function addPoint(Node:FlxPoint, AsReference:Bool = false):FlxPath
@@ -593,16 +593,16 @@ class FlxPath implements IFlxDestroyable
 		}
 		return this;
 	}
-	
+
 	/**
 	 * Sometimes its easier or faster to just pass a point object instead of separate X and Y coordinates.
 	 * This also gives you the option of not creating a new node but actually adding that specific
 	 * FlxPoint object to the path.  This allows you to do neat things, like dynamic paths.
-	 * 
+	 *
 	 * @param	Node			The point in world coordinates you want to add to the path.
 	 * @param	Index			Where within the list of path nodes to insert this new point.
 	 * @param	AsReference		Whether to add the point as a reference, or to create a new point with the specified values.
-	 * 
+	 *
 	 *	@return	This path object.
 	 */
 	public function addPointAt(Node:FlxPoint, Index:Int, AsReference:Bool = false):FlxPath
@@ -618,11 +618,11 @@ class FlxPath implements IFlxDestroyable
 		}
 		return this;
 	}
-	
+
 	/**
 	 * Remove a node from the path.
 	 * NOTE: only works with points added by reference or with references from nodes itself!
-	 * 
+	 *
 	 * @param	Node	The point object you want to remove from the path.
 	 * @return	The node that was excised.  Returns null if the node was not found.
 	 */
@@ -635,10 +635,10 @@ class FlxPath implements IFlxDestroyable
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Remove a node from the path using the specified position in the list of path nodes.
-	 * 
+	 *
 	 * @param	Index	Where within the list of path nodes you want to remove a node.
 	 * @return	The node that was excised.  Returns null if there were no nodes in the path.
 	 */
@@ -654,10 +654,10 @@ class FlxPath implements IFlxDestroyable
 		}
 		return _nodes.splice(Index, 1)[0];
 	}
-	
+
 	/**
 	 * Get the first node in the list.
-	 * 
+	 *
 	 * @return	The first node in the path.
 	 */
 	public function head():FlxPoint
@@ -668,10 +668,10 @@ class FlxPath implements IFlxDestroyable
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Get the last node in the list.
-	 * 
+	 *
 	 * @return	The last node in the path.
 	 */
 	public function tail():FlxPoint
@@ -682,14 +682,14 @@ class FlxPath implements IFlxDestroyable
 		}
 		return null;
 	}
-	
+
 	#if FLX_DEBUG
 	/**
 	 * While this doesn't override `FlxBasic.drawDebug()`, the behavior is very similar.
 	 * Based on this path data, it draws a simple lines-and-boxes representation of the path
 	 * if the `drawDebug` mode was toggled in the debugger overlay.
 	 * You can use `debugColor` to control the path's appearance.
-	 * 
+	 *
 	 * @param	Camera		The camera object the path will draw to.
 	 */
 	@:access(flixel.FlxCamera)
@@ -703,9 +703,9 @@ class FlxPath implements IFlxDestroyable
 		{
 			Camera = FlxG.camera;
 		}
-		
+
 		var gfx:Graphics = null;
-		
+
 		//Set up our global flash graphics object to draw out the path
 		if (FlxG.renderBlit)
 		{
@@ -716,7 +716,7 @@ class FlxPath implements IFlxDestroyable
 		{
 			gfx = Camera.debugLayer.graphics;
 		}
-		
+
 		//Then fill up the object with node and path graphics
 		var node:FlxPoint;
 		var nextNode:FlxPoint;
@@ -726,13 +726,13 @@ class FlxPath implements IFlxDestroyable
 		{
 			//get a reference to the current node
 			node = _nodes[i];
-			
+
 			//find the screen position of the node on this camera
 			_point.x = node.x - (Camera.scroll.x * object.scrollFactor.x); //copied from getScreenPosition()
 			_point.y = node.y - (Camera.scroll.y * object.scrollFactor.y);
-			
+
 			_point = Camera.transformPoint(_point);
-			
+
 			//decide what color this node should be
 			var nodeSize:Int = 2;
 			if ((i == 0) || (i == l - 1))
@@ -751,7 +751,7 @@ class FlxPath implements IFlxDestroyable
 					nodeColor = FlxColor.RED;
 				}
 			}
-			
+
 			//draw a box for the node
 			gfx.beginFill(nodeColor, 0.5);
 			gfx.lineStyle();
@@ -768,21 +768,21 @@ class FlxPath implements IFlxDestroyable
 			{
 				nextNode = _nodes[i];
 			}
-			
+
 			//then draw a line to the next node
 			gfx.moveTo(_point.x, _point.y);
 			gfx.lineStyle(1, debugColor, lineAlpha);
 			_point.x = nextNode.x - (Camera.scroll.x * object.scrollFactor.x); //copied from getScreenPosition()
 			_point.y = nextNode.y - (Camera.scroll.y * object.scrollFactor.y);
-			
+
 			if (FlxG.renderBlit)
 				_point.subtract(Camera.viewOffsetX, Camera.viewOffsetY);
-			
+
 			gfx.lineTo(_point.x, _point.y);
-			
+
 			i++;
 		}
-		
+
 		if (FlxG.renderBlit)
 		{
 			//then stamp the path down onto the game buffer
@@ -790,13 +790,13 @@ class FlxPath implements IFlxDestroyable
 		}
 	}
 	#end
-	
-	private function get_nodes():Array<FlxPoint>
+
+	function get_nodes():Array<FlxPoint>
 	{
 		return _nodes;
 	}
-	
-	private function set_nodes(Nodes:Array<FlxPoint>):Array<FlxPoint>
+
+	function set_nodes(Nodes:Array<FlxPoint>):Array<FlxPoint>
 	{
 		if (Nodes != null)
 		{

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -85,7 +85,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 interface IFlxPooled extends IFlxDestroyable
 {
 	public function put():Void;
-	var _inPool:Bool;
+	private var _inPool:Bool;
 }
 
 interface IFlxPool<T:IFlxDestroyable>

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -7,26 +7,26 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
  * WARNING: Pooled objects must have parameter-less constructors: function new()
  */
 #if !display
-@:generic 
+@:generic
 #end
 class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 {
 	public var length(get, never):Int;
-	
-	private var _pool:Array<T> = [];
-	private var _class:Class<T>;
-	
+
+	var _pool:Array<T> = [];
+	var _class:Class<T>;
+
 	/**
 	 * Objects aren't actually removed from the array in order to improve performance.
 	 * _count keeps track of the valid, accessible pool objects.
 	 */
-	private var _count:Int = 0;
-	
-	public function new(classObj:Class<T>) 
+	var _count:Int = 0;
+
+	public function new(classObj:Class<T>)
 	{
 		_class = classObj;
 	}
-	
+
 	public function get():T
 	{
 		if (_count == 0)
@@ -35,7 +35,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 		}
 		return _pool[--_count];
 	}
-	
+
 	public function put(obj:T):Void
 	{
 		// we don't want to have the same object in the accessible pool twice (ok to have multiple in the inaccessible zone)
@@ -50,7 +50,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 			}
 		}
 	}
-	
+
 	public function putUnsafe(obj:T):Void
 	{
 		if (obj != null)
@@ -59,7 +59,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 			_pool[_count++] = obj;
 		}
 	}
-	
+
 	public function preAllocate(numObjects:Int):Void
 	{
 		while (numObjects-- > 0)
@@ -67,7 +67,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 			_pool[_count++] = Type.createInstance(_class, []);
 		}
 	}
-	
+
 	public function clear():Array<T>
 	{
 		_count = 0;
@@ -75,8 +75,8 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 		_pool = [];
 		return oldPool;
 	}
-	
-	private inline function get_length():Int
+
+	inline function get_length():Int
 	{
 		return _count;
 	}
@@ -85,10 +85,10 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 interface IFlxPooled extends IFlxDestroyable
 {
 	public function put():Void;
-	private var _inPool:Bool;
+	var _inPool:Bool;
 }
 
-interface IFlxPool<T:IFlxDestroyable> 
+interface IFlxPool<T:IFlxDestroyable>
 {
 	public function preAllocate(numObjects:Int):Void;
 	public function clear():Array<T>;

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -23,17 +23,17 @@ class FlxSave implements IFlxDestroyable
 	/**
 	 * The local shared object itself.
 	 */
-	private var _sharedObject:SharedObject;
-	
+	var _sharedObject:SharedObject;
+
 	/**
 	 * Internal tracker for callback function in case save takes too long.
 	 */
-	private var _onComplete:Bool->Void;
+	var _onComplete:Bool->Void;
 	/**
 	 * Internal tracker for save object close request.
 	 */
-	private var _closeRequested:Bool = false;
-	
+	var _closeRequested:Bool = false;
+
 	public function new() {}
 
 	/**
@@ -47,10 +47,10 @@ class FlxSave implements IFlxDestroyable
 		_onComplete = null;
 		_closeRequested = false;
 	}
-	
+
 	/**
 	 * Automatically creates or reconnects to locally saved data.
-	 * 
+	 *
 	 * @param	Name	The name of the object (should be the same each time to access old data).
 	 * 					May not contain spaces or any of the following characters: `~ % & \ ; : " ' , < > ? #`
 	 * @return	Whether or not you successfully connected to the save data.
@@ -72,12 +72,12 @@ class FlxSave implements IFlxDestroyable
 		data = _sharedObject.data;
 		return true;
 	}
-	
+
 	/**
 	 * A way to safely call flush() and destroy() on your save file.
 	 * Will correctly handle storage size popups and all that good stuff.
 	 * If you don't want to save your changes first, just call destroy() instead.
-	 * 
+	 *
 	 * @param	MinFileSize		If you need X amount of space for your save, specify it here.
 	 * @param	OnComplete		This callback will be triggered when the data is written successfully.
 	 * @return	The result of result of the flush() call (see below for more details).
@@ -90,7 +90,7 @@ class FlxSave implements IFlxDestroyable
 
 	/**
 	 * Writes the local shared object to disk immediately. Leaves the object open in memory.
-	 * 
+	 *
 	 * @param	MinFileSize		If you need X amount of space for your save, specify it here.
 	 * @param	OnComplete		This callback will be triggered when the data is written successfully.
 	 * @return	Whether or not the data was written immediately. False could be an error OR a storage request popup.
@@ -104,7 +104,7 @@ class FlxSave implements IFlxDestroyable
 		_onComplete = OnComplete;
 		var result = null;
 		try
-		{ 
+		{
 			result = _sharedObject.flush();
 		}
 		catch (_:Error)
@@ -114,12 +114,12 @@ class FlxSave implements IFlxDestroyable
 
 		return onDone(result == SharedObjectFlushStatus.FLUSHED ? SUCCESS : PENDING);
 	}
-	
+
 	/**
 	 * Erases everything stored in the local shared object.
 	 * Data is immediately erased and the object is saved that way,
 	 * so use with caution!
-	 * 
+	 *
 	 * @return	Returns false if the save object is not bound yet.
 	 */
 	public function erase():Bool
@@ -132,15 +132,15 @@ class FlxSave implements IFlxDestroyable
 		data = {};
 		return true;
 	}
-	
+
 	/**
 	 * Event handler for special case storage requests.
 	 * Handles logging of errors and calling of callback.
-	 * 
+	 *
 	 * @param	Result		One of the result codes (PENDING, ERROR, or SUCCESS).
 	 * @return	Whether the operation was a success or not.
 	 */
-	private function onDone(Result:FlxSaveStatus):Bool
+	function onDone(Result:FlxSaveStatus):Bool
 	{
 		switch (Result)
 		{
@@ -150,22 +150,22 @@ class FlxSave implements IFlxDestroyable
 				FlxG.log.error("There was a problem flushing\nthe shared object data from FlxSave.");
 			default:
 		}
-		
+
 		if (_onComplete != null)
 			_onComplete(Result == SUCCESS);
-			
+
 		if (_closeRequested)
 			destroy();
-			
+
 		return Result == SUCCESS;
 	}
-	
+
 	/**
 	 * Handy utility function for checking and warning if the shared object is bound yet or not.
-	 * 
+	 *
 	 * @return	Whether the shared object was bound yet.
 	 */
-	private function checkBinding():Bool
+	function checkBinding():Bool
 	{
 		if (_sharedObject == null)
 		{

--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -11,65 +11,65 @@ typedef FlxSignal = FlxTypedSignal<Void->Void>;
 abstract FlxTypedSignal<T>(IFlxSignal<T>)
 {
 	public var dispatch(get, never):T;
-	
+
 	public function new();
-	
-	public inline function add(listener:T):Void 
+
+	public inline function add(listener:T):Void
 	{
 		this.add(listener);
 	}
-	
-	public inline function addOnce(listener:T):Void 
+
+	public inline function addOnce(listener:T):Void
 	{
 		this.addOnce(listener);
 	}
-	
+
 	public inline function remove(listener:T):Void
 	{
 		this.remove(listener);
 	}
-	
-	public inline function has(listener:T):Bool 
+
+	public inline function has(listener:T):Bool
 	{
 		return this.has(listener);
 	}
-	
-	public inline function removeAll():Void 
+
+	public inline function removeAll():Void
 	{
 		this.removeAll();
 	}
-	
-	private inline function get_dispatch():T
+
+	inline function get_dispatch():T
 	{
 		return this.dispatch;
 	}
-	
-	@:to 
-	private static inline function toSignal0(signal:IFlxSignal<Void->Void>):FlxSignal0 
+
+	@:to
+	static inline function toSignal0(signal:IFlxSignal<Void->Void>):FlxSignal0
 	{
 		return new FlxSignal0();
 	}
-	
-	@:to 
-	private static inline function toSignal1<T1>(signal:IFlxSignal<T1->Void>):FlxSignal1<T1> 
+
+	@:to
+	static inline function toSignal1<T1>(signal:IFlxSignal<T1->Void>):FlxSignal1<T1>
 	{
 		return new FlxSignal1();
 	}
-	
-	@:to 
-	private static inline function toSignal2<T1, T2>(signal:IFlxSignal<T1->T2->Void>):FlxSignal2<T1, T2> 
+
+	@:to
+	static inline function toSignal2<T1, T2>(signal:IFlxSignal<T1->T2->Void>):FlxSignal2<T1, T2>
 	{
 		return new FlxSignal2();
 	}
-	
-	@:to 
-	private static inline function toSignal3<T1, T2, T3>(signal:IFlxSignal<T1->T2->T3->Void>):FlxSignal3<T1, T2, T3> 
+
+	@:to
+	static inline function toSignal3<T1, T2, T3>(signal:IFlxSignal<T1->T2->T3->Void>):FlxSignal3<T1, T2, T3>
 	{
 		return new FlxSignal3();
 	}
-	
-	@:to 
-	private static inline function toSignal4<T1, T2, T3, T4>(signal:IFlxSignal<T1->T2->T3->T4->Void>):FlxSignal4<T1, T2, T3, T4> 
+
+	@:to
+	static inline function toSignal4<T1, T2, T3, T4>(signal:IFlxSignal<T1->T2->T3->T4->Void>):FlxSignal4<T1, T2, T3, T4>
 	{
 		return new FlxSignal4();
 	}
@@ -79,48 +79,48 @@ private class FlxSignalHandler<T> implements IFlxDestroyable
 {
 	public var listener:T;
 	public var dispatchOnce(default, null):Bool = false;
-	
-	public function new(listener:T, dispatchOnce:Bool) 
+
+	public function new(listener:T, dispatchOnce:Bool)
 	{
 		this.listener = listener;
 		this.dispatchOnce = dispatchOnce;
 	}
-	
+
 	public function destroy()
 	{
 		listener = null;
 	}
 }
 
-private class FlxBaseSignal<T> implements IFlxSignal<T> 
-{	
+private class FlxBaseSignal<T> implements IFlxSignal<T>
+{
 	/**
 	 * Typed function reference used to dispatch this signal.
 	 */
 	public var dispatch:T;
-	
-	private var handlers:Array<FlxSignalHandler<T>>;
-	private var pendingRemove:Array<FlxSignalHandler<T>>;
-	private var processingListeners:Bool = false;
-	
-	public function new() 
+
+	var handlers:Array<FlxSignalHandler<T>>;
+	var pendingRemove:Array<FlxSignalHandler<T>>;
+	var processingListeners:Bool = false;
+
+	public function new()
 	{
 		handlers = [];
 		pendingRemove = [];
 	}
-	
+
 	public function add(listener:T)
 	{
 		if (listener != null)
 			registerListener(listener, false);
 	}
-	
+
 	public function addOnce(listener:T):Void
 	{
 		if (listener != null)
 			registerListener(listener, true);
 	}
-	
+
 	public function remove(listener:T):Void
 	{
 		if (listener != null)
@@ -137,32 +137,32 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 				}
 			}
 		}
-		
+
 	}
-	
+
 	public function has(listener:T):Bool
 	{
 		if (listener == null)
 			return false;
 		return getHandler(listener) != null;
 	}
-	
-	public inline function removeAll():Void 
+
+	public inline function removeAll():Void
 	{
 		FlxDestroyUtil.destroyArray(handlers);
 	}
-	
+
 	public function destroy():Void
 	{
 		removeAll();
 		handlers = null;
 		pendingRemove = null;
 	}
-	
-	private function registerListener(listener:T, dispatchOnce:Bool):FlxSignalHandler<T>
+
+	function registerListener(listener:T, dispatchOnce:Bool):FlxSignalHandler<T>
 	{
 		var handler = getHandler(listener);
-		
+
 		if (handler == null)
 		{
 			handler = new FlxSignalHandler<T>(listener, dispatchOnce);
@@ -179,8 +179,8 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 				return handler;
 		}
 	}
-	
-	private function getHandler(listener:T):FlxSignalHandler<T>
+
+	function getHandler(listener:T):FlxSignalHandler<T>
 	{
 		for (handler in handlers)
 		{
@@ -205,7 +205,7 @@ private class FlxSignal0 extends FlxBaseSignal<Void->Void>
 		super();
 		this.dispatch = dispatch0;
 	}
-	
+
 	public function dispatch0():Void
 	{
 		Macro.buildDispatch();
@@ -219,7 +219,7 @@ private class FlxSignal1<T1> extends FlxBaseSignal<T1->Void>
 		super();
 		this.dispatch = dispatch1;
 	}
-	
+
 	public function dispatch1(value1:T1):Void
 	{
 		Macro.buildDispatch(value1);
@@ -233,7 +233,7 @@ private class FlxSignal2<T1, T2> extends FlxBaseSignal<T1->T2->Void>
 		super();
 		this.dispatch = dispatch2;
 	}
-	
+
 	public function dispatch2(value1:T1, value2:T2):Void
 	{
 		Macro.buildDispatch(value1, value2);
@@ -247,7 +247,7 @@ private class FlxSignal3<T1, T2, T3> extends FlxBaseSignal<T1->T2->T3->Void>
 		super();
 		this.dispatch = dispatch3;
 	}
-	
+
 	public function dispatch3(value1:T1, value2:T2, value3:T3):Void
 	{
 		Macro.buildDispatch(value1, value2, value3);
@@ -261,7 +261,7 @@ private class FlxSignal4<T1, T2, T3, T4> extends FlxBaseSignal<T1->T2->T3->T4->V
 		super();
 		this.dispatch = dispatch4;
 	}
-	
+
 	public function dispatch4(value1:T1, value2:T2, value3:T3, value4:T4):Void
 	{
 		Macro.buildDispatch(value1, value2, value3, value4);
@@ -285,18 +285,18 @@ private class Macro
 	public static macro function buildDispatch(exprs:Array<Expr>):Expr
 	{
 		return macro
-		{ 
+		{
 			processingListeners = true;
 			for (handler in handlers)
 			{
 				handler.listener($a{exprs});
-				
+
 				if (handler.dispatchOnce)
 					remove(handler.listener);
 			}
-			
+
 			processingListeners = false;
-			
+
 			for (handler in pendingRemove)
 			{
 				remove(handler.listener);

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -26,7 +26,7 @@ import flixel.tweens.FlxTween;
 
 /**
  * Some handy functions for FlxSprite (FlxObject) manipulation, mostly drawing-related.
- * Note that stage quality impacts the results of the draw() functions - 
+ * Note that stage quality impacts the results of the draw() functions -
  * use FlxG.stage.quality = flash.display.StageQuality.BEST; for best results.
  */
 class FlxSpriteUtil
@@ -37,7 +37,7 @@ class FlxSpriteUtil
 	 */
 	public static var flashGfxSprite(default, null):Sprite = new Sprite();
 	public static var flashGfx(default, null):Graphics = flashGfxSprite.graphics;
-	
+
 	/**
 	 * Takes two source images (typically from Embedded bitmaps) and puts the resulting image into the output FlxSprite.
 	 * Note: It assumes the source and mask are the same size. Different sizes may result in undesired results.
@@ -45,7 +45,7 @@ class FlxSpriteUtil
 	 * have an alpha color value in the mask image. So if you draw a big black circle in your mask with a transparent edge, you'll
 	 * get a circular image to appear.
 	 * May lead to unexpected results if `source` does not have an alpha channel.
-	 * 
+	 *
 	 * @param	output		The FlxSprite you wish the resulting image to be placed in (will adjust width/height of image)
 	 * @param	source		The source image. Typically the one with the image / picture / texture in it.
 	 * @param	mask		The mask to apply. Remember the non-alpha zero areas are the parts that will display.
@@ -55,18 +55,18 @@ class FlxSpriteUtil
 	{
 		var data:BitmapData = FlxAssets.resolveBitmapData(source);
 		var maskData:BitmapData = FlxAssets.resolveBitmapData(mask);
-		
+
 		if (data == null || maskData == null)
 		{
 			return null;
 		}
-		
+
 		data = data.clone();
 		data.copyChannel(maskData, new Rectangle(0, 0, data.width, data.height), new Point(), BitmapDataChannel.ALPHA, BitmapDataChannel.ALPHA);
 		output.pixels = data;
 		return output;
 	}
-	
+
 	/**
 	 * Takes the image data from two FlxSprites and puts the resulting image into the output FlxSprite.
 	 * Note: It assumes the source and mask are the same size. Different sizes may result in undesired results.
@@ -74,7 +74,7 @@ class FlxSpriteUtil
 	 * have an alpha color value in the mask image. So if you draw a big black circle in your mask with a transparent edge, you'll
 	 * get a circular image appear.
 	 * May lead to unexpected results if `sprite`'s graphic does not have an alpha channel.
-	 * 
+	 *
 	 * @param	sprite		The source FlxSprite. Typically the one with the image / picture / texture in it.
 	 * @param	mask		The FlxSprite containing the mask to apply. Remember the non-alpha zero areas are the parts that will display.
 	 * @param	output		The FlxSprite you wish the resulting image to be placed in (will adjust width/height of image)
@@ -85,14 +85,14 @@ class FlxSpriteUtil
 		sprite.drawFrame();
 		var data:BitmapData = sprite.pixels.clone();
 		data.copyChannel(mask.pixels, new Rectangle(0, 0, sprite.width, sprite.height), new Point(), BitmapDataChannel.ALPHA, BitmapDataChannel.ALPHA);
-		output.pixels = data;	
+		output.pixels = data;
 		return output;
 	}
-	
+
 	/**
-	 * Checks the x/y coordinates of the FlxSprite and keeps them within the 
+	 * Checks the x/y coordinates of the FlxSprite and keeps them within the
 	 * area of 0, 0, FlxG.width, FlxG.height (i.e. wraps it around the screen)
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to keep within the screen
 	 * @param	Left		Whether to activate screen wrapping on the left side of the screen
 	 * @param	Right		Whether to activate screen wrapping on the right side of the screen
@@ -102,30 +102,30 @@ class FlxSpriteUtil
 	 */
 	public static function screenWrap(sprite:FlxSprite, Left:Bool = true, Right:Bool = true, Top:Bool = true, Bottom:Bool = true):FlxSprite
 	{
-		if (Left && ((sprite.x + sprite.frameWidth / 2) <= 0)) 
+		if (Left && ((sprite.x + sprite.frameWidth / 2) <= 0))
 		{
 			sprite.x = FlxG.width;
 		}
-		else if (Right && (sprite.x >= FlxG.width)) 
+		else if (Right && (sprite.x >= FlxG.width))
 		{
 			sprite.x = 0;
 		}
-		
-		if (Top && ((sprite.y + sprite.frameHeight / 2) <= 0)) 
+
+		if (Top && ((sprite.y + sprite.frameHeight / 2) <= 0))
 		{
 			sprite.y = FlxG.height;
 		}
-		else if (Bottom && (sprite.y >= FlxG.height)) 
+		else if (Bottom && (sprite.y >= FlxG.height))
 		{
 			sprite.y = 0;
 		}
 		return sprite;
 	}
-	
+
 	/**
 	 * Makes sure a FlxSprite doesn't leave the specified area - most common use case is to call this every frame in update().
 	 * If you call this without specifying an area, the game area (FlxG.width / height as max) will be used. Takes the graphic size into account.
-	 * 
+	 *
 	 * @param	sprite	The FlxSprite to bound to an area
 	 * @param	MinX	The minimum x position allowed
 	 * @param	MaxX	The maximum x position allowed
@@ -143,19 +143,19 @@ class FlxSpriteUtil
 		{
 			MaxY = FlxG.height;
 		}
-		
+
 		MaxX -= sprite.frameWidth;
 		MaxY -= sprite.frameHeight;
-		
+
 		sprite.x = FlxMath.bound(sprite.x, MinX, MaxX);
 		sprite.y = FlxMath.bound(sprite.y, MinY, MaxY);
-		
+
 		return sprite;
 	}
-	
+
 	/**
 	 * Aligns a set of FlxObjects so there is equal spacing between them
-	 * 
+	 *
 	 * @param	objects				An Array of FlxObjects
 	 * @param	startX				The base X coordinate to start the spacing from
 	 * @param	startY				The base Y coordinate to start the spacing from
@@ -163,16 +163,16 @@ class FlxSpriteUtil
 	 * @param	verticalSpacing		The amount of pixels between each sprite vertically (default 0)
 	 * @param	spaceFromBounds		If set to true the h/v spacing values will be added to the width/height of the sprite, if false it will ignore this
 	 */
-	public static function space(objects:Array<FlxObject>, startX:Int, startY:Int, horizontalSpacing:Int = 0, 
+	public static function space(objects:Array<FlxObject>, startX:Int, startY:Int, horizontalSpacing:Int = 0,
 		verticalSpacing:Int = 0, spaceFromBounds:Bool = false):Void
 	{
 		var prevWidth:Int = 0;
 		var prevHeight:Int = 0;
-		
+
 		for (i in 0...objects.length)
 		{
 			var object = objects[i];
-			
+
 			if (spaceFromBounds)
 			{
 				object.x = startX + prevWidth + (i * horizontalSpacing);
@@ -185,11 +185,11 @@ class FlxSpriteUtil
 			}
 		}
 	}
-	
+
 	/**
 	 * This function draws a line on a FlxSprite from position X1,Y1
 	 * to position X2,Y2 with the specified color.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	StartX		X coordinate of the line's start point.
 	 * @param	StartY		Y coordinate of the line's start point.
@@ -199,7 +199,7 @@ class FlxSpriteUtil
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawLine(sprite:FlxSprite, StartX:Float, StartY:Float, EndX:Float, EndY:Float, 
+	public static function drawLine(sprite:FlxSprite, StartX:Float, StartY:Float, EndX:Float, EndY:Float,
 		?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
 		lineStyle = getDefaultLineStyle(lineStyle);
@@ -209,11 +209,11 @@ class FlxSpriteUtil
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	/**
 	 * This function draws a curve on a FlxSprite from position X1,Y1
 	 * to anchor position X2,Y2 using control points X3,Y3 with the specified color.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	StartX		X coordinate of the curve's start point.
 	 * @param	StartY		Y coordinate of the curve's start point.
@@ -226,7 +226,7 @@ class FlxSpriteUtil
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawCurve(sprite:FlxSprite, StartX:Float, StartY:Float, EndX:Float, EndY:Float, ControlX:Float, ControlY:Float, 
+	public static function drawCurve(sprite:FlxSprite, StartX:Float, StartY:Float, EndX:Float, EndY:Float, ControlX:Float, ControlY:Float,
 		FillColor:FlxColor = FlxColor.TRANSPARENT, ?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
 		lineStyle = getDefaultLineStyle(lineStyle);
@@ -236,10 +236,10 @@ class FlxSpriteUtil
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	/**
 	 * This function draws a rectangle on a FlxSprite.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	X			X coordinate of the rectangle's start point.
 	 * @param	Y			Y coordinate of the rectangle's start point.
@@ -258,10 +258,10 @@ class FlxSpriteUtil
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	/**
 	 * This function draws a rounded rectangle on a FlxSprite.
-	 * 
+	 *
 	 * @param	sprite			The FlxSprite to manipulate
 	 * @param	X				X coordinate of the rectangle's start point.
 	 * @param	Y				Y coordinate of the rectangle's start point.
@@ -282,12 +282,12 @@ class FlxSpriteUtil
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	#if flash
 	/**
 	 * This function draws a rounded rectangle on a FlxSprite. Same as drawRoundRect,
 	 * except it allows you to determine the radius of each corner individually.
-	 * 
+	 *
 	 * @param	sprite				The FlxSprite to manipulate
 	 * @param	X					X coordinate of the rectangle's start point.
 	 * @param	Y					Y coordinate of the rectangle's start point.
@@ -302,7 +302,7 @@ class FlxSpriteUtil
 	 * @param	drawStyle			A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawRoundRectComplex(sprite:FlxSprite, X:Float, Y:Float, Width:Float, Height:Float, 
+	public static function drawRoundRectComplex(sprite:FlxSprite, X:Float, Y:Float, Width:Float, Height:Float,
 		TopLeftRadius:Float, TopRightRadius:Float, BottomLeftRadius:Float, BottomRightRadius:Float,
 		FillColor:FlxColor = FlxColor.WHITE, ?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
@@ -312,10 +312,10 @@ class FlxSpriteUtil
 		return sprite;
 	}
 	#end
-	
+
 	/**
 	 * This function draws a circle on a FlxSprite at position X,Y with the specified color.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	X 			X coordinate of the circle's center (automatically centered on the sprite if -1)
 	 * @param	Y 			Y coordinate of the circle's center (automatically centered on the sprite if -1)
@@ -325,36 +325,36 @@ class FlxSpriteUtil
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawCircle(sprite:FlxSprite, X:Float = - 1, Y:Float = - 1, Radius:Float = -1, 
+	public static function drawCircle(sprite:FlxSprite, X:Float = - 1, Y:Float = - 1, Radius:Float = -1,
 		FillColor:FlxColor = FlxColor.WHITE, ?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
-		if (X == -1 || Y == -1) 
+		if (X == -1 || Y == -1)
 		{
 			var midPoint = sprite.getGraphicMidpoint();
-			
+
 			if (X == -1)
 				X = midPoint.x - sprite.x;
 			if (Y == -1)
 				Y = midPoint.y - sprite.y;
-			
+
 			midPoint.put();
 		}
-		
-		if (Radius < 1) 
+
+		if (Radius < 1)
 		{
 			var minVal = Math.min(sprite.frameWidth, sprite.frameHeight);
 			Radius = (minVal / 2);
 		}
-		
+
 		beginDraw(FillColor, lineStyle);
 		flashGfx.drawCircle(X, Y, Radius);
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	/**
 	 * This function draws an ellipse on a FlxSprite.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	X			X coordinate of the ellipse's start point.
 	 * @param	Y			Y coordinate of the ellipse's start point.
@@ -365,7 +365,7 @@ class FlxSpriteUtil
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawEllipse(sprite:FlxSprite, X:Float, Y:Float, Width:Float, Height:Float, 
+	public static function drawEllipse(sprite:FlxSprite, X:Float, Y:Float, Width:Float, Height:Float,
 		FillColor:FlxColor = FlxColor.WHITE, ?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
 		beginDraw(FillColor, lineStyle);
@@ -373,10 +373,10 @@ class FlxSpriteUtil
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	/**
 	 * This function draws a simple, equilateral triangle on a FlxSprite.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	X			X position of the triangle
 	 * @param	Y			Y position of the triangle
@@ -386,7 +386,7 @@ class FlxSpriteUtil
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawTriangle(sprite:FlxSprite, X:Float, Y:Float, Height:Float, 
+	public static function drawTriangle(sprite:FlxSprite, X:Float, Y:Float, Height:Float,
 		FillColor:FlxColor = FlxColor.WHITE, ?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
 		beginDraw(FillColor, lineStyle);
@@ -397,10 +397,10 @@ class FlxSpriteUtil
 		endDraw(sprite, drawStyle);
 		return sprite;
 	}
-	
+
 	/**
 	 * This function draws a polygon on a FlxSprite.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to manipulate
 	 * @param	Vertices	Array of Vertices to use for drawing the polygon
 	 * @param	FillColor		The ARGB color to fill this polygon with. FlxColor.TRANSPARENT (0x0) means no fill.
@@ -408,7 +408,7 @@ class FlxSpriteUtil
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function drawPolygon(sprite:FlxSprite, Vertices:Array<FlxPoint>, 
+	public static function drawPolygon(sprite:FlxSprite, Vertices:Array<FlxPoint>,
 		FillColor:FlxColor = FlxColor.WHITE, ?lineStyle:LineStyle, ?drawStyle:DrawStyle):FlxSprite
 	{
 		beginDraw(FillColor, lineStyle);
@@ -425,7 +425,7 @@ class FlxSpriteUtil
 
 	/**
 	 * Helper function that the drawing functions use at the start to set the color and lineStyle.
-	 * 
+	 *
 	 * @param	FillColor		The ARGB color to use for drawing
 	 * @param	lineStyle	A LineStyle typedef containing the params of Graphics.lineStyle()
 	 */
@@ -434,16 +434,16 @@ class FlxSpriteUtil
 	{
 		flashGfx.clear();
 		setLineStyle(lineStyle);
-		
-		if (FillColor != FlxColor.TRANSPARENT) 
+
+		if (FillColor != FlxColor.TRANSPARENT)
 		{
 			flashGfx.beginFill(FillColor.to24Bit(), FillColor.alphaFloat);
 		}
 	}
-	
+
 	/**
 	 * Helper function that the drawing functions use at the end.
-	 * 
+	 *
 	 * @param	sprite		The FlxSprite to draw to
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
@@ -458,14 +458,14 @@ class FlxSpriteUtil
 	/**
 	 * Just a helper function that is called at the end of the draw functions
 	 * to handle a few things related to updating a sprite's graphic.
-	 * 
+	 *
 	 * @param	Sprite		The FlxSprite to manipulate
 	 * @param	drawStyle	A DrawStyle typedef containing the params of BitmapData.draw()
 	 * @return 	The FlxSprite for chaining
 	 */
 	public static function updateSpriteGraphic(sprite:FlxSprite, ?drawStyle:DrawStyle):FlxSprite
 	{
-		if (drawStyle == null) 
+		if (drawStyle == null)
 		{
 			drawStyle = { smoothing: false };
 		}
@@ -473,17 +473,17 @@ class FlxSpriteUtil
 		{
 			drawStyle.smoothing = false;
 		}
-		
-		sprite.pixels.draw(flashGfxSprite, drawStyle.matrix, drawStyle.colorTransform, 
+
+		sprite.pixels.draw(flashGfxSprite, drawStyle.matrix, drawStyle.colorTransform,
 			drawStyle.blendMode, drawStyle.clipRect, drawStyle.smoothing);
 		sprite.dirty = true;
 		return sprite;
 	}
-	
+
 	/**
 	 * Just a helper function that is called in the draw functions
 	 * to set the lineStyle via Graphics.lineStyle()
-	 * 
+	 *
 	 * @param	lineStyle	The lineStyle typedef
 	 */
 	@:noUsing
@@ -499,10 +499,10 @@ class FlxSpriteUtil
 				lineStyle.pixelHinting = false;
 			if (lineStyle.miterLimit == null)
 				lineStyle.miterLimit = 3;
-			
+
 			flashGfx.lineStyle(
 				lineStyle.thickness,
-				color.to24Bit(), 
+				color.to24Bit(),
 				color.alphaFloat,
 				lineStyle.pixelHinting,
 				lineStyle.scaleMode,
@@ -511,10 +511,10 @@ class FlxSpriteUtil
 				lineStyle.miterLimit);
 		}
 	}
-	
+
 	/**
 	 * Helper function for the default line styles of drawLine() and drawCurve()
-	 * 
+	 *
 	 * @param   lineStyle   The lineStyle typedef
 	 */
 	public static inline function getDefaultLineStyle(?lineStyle:LineStyle):LineStyle
@@ -525,13 +525,13 @@ class FlxSpriteUtil
 			lineStyle.thickness = 1;
 		if (lineStyle.color == null)
 			lineStyle.color = FlxColor.WHITE;
-		
+
 		return lineStyle;
 	}
-	
+
 	/**
 	 * Fills this sprite's graphic with a specific color.
-	 * 
+	 *
 	 * @param	Sprite	The FlxSprite to manipulate
 	 * @param	FillColor	The color with which to fill the graphic, format 0xAARRGGBB.
 	 * @return 	The FlxSprite for chaining
@@ -539,18 +539,18 @@ class FlxSpriteUtil
 	public static function fill(sprite:FlxSprite, FillColor:FlxColor):FlxSprite
 	{
 		sprite.pixels.fillRect(sprite.pixels.rect, FillColor);
-		
+
 		if (sprite.pixels != sprite.framePixels)
 		{
 			sprite.dirty = true;
 		}
-		
+
 		return sprite;
 	}
-	
+
 	/**
 	 * A simple flicker effect for sprites achieved by toggling visibility.
-	 * 
+	 *
 	 * @param	Object				The sprite.
 	 * @param	Duration			How long to flicker for (in seconds). `0` means "forever".
 	 * @param	Interval			In what interval to toggle visibility. Set to `FlxG.elapsed` if `<= 0`!
@@ -560,25 +560,25 @@ class FlxSpriteUtil
 	 * @param	ProgressCallback	An optional callback that will be triggered when visibility is toggled.
 	 * @return The FlxFlicker object. FlxFlickers are pooled internally, so beware of storing references.
 	 */
-	public static inline function flicker(Object:FlxObject, Duration:Float = 1, Interval:Float = 0.04, EndVisibility:Bool = true, 
+	public static inline function flicker(Object:FlxObject, Duration:Float = 1, Interval:Float = 0.04, EndVisibility:Bool = true,
 		ForceRestart:Bool = true, ?CompletionCallback:FlxFlicker->Void, ?ProgressCallback:FlxFlicker->Void):FlxFlicker
 	{
 		return FlxFlicker.flicker(Object, Duration, Interval, EndVisibility, ForceRestart, CompletionCallback, ProgressCallback);
 	}
-	
+
 	/**
 	 * Returns whether an object is flickering or not.
-	 * 
+	 *
 	 * @param  Object 	The object to check against.
 	 */
 	public static inline function isFlickering(Object:FlxObject):Bool
 	{
 		return FlxFlicker.isFlickering(Object);
 	}
-	
+
 	/**
 	 * Stops flickering of the object. Also it will make the object visible.
-	 * 
+	 *
 	 * @param  Object 	The object to stop flickering.
 	 * @return The FlxObject for chaining
 	 */
@@ -587,27 +587,27 @@ class FlxSpriteUtil
 		FlxFlicker.stopFlickering(Object);
 		return Object;
 	}
-	
+
 	/**
 	 * Fade in a sprite, tweening alpha to 1.
-	 * 
+	 *
 	 * @param  sprite 	The object to fade.
 	 * @param  Duration How long the fade will take (in seconds).
 	 * @return The FlxSprite for chaining
 	 */
 	public static inline function fadeIn(sprite:FlxSprite, Duration:Float = 1, ?ResetAlpha:Bool, ?OnComplete:TweenCallback):FlxSprite
 	{
-		if (ResetAlpha) 
+		if (ResetAlpha)
 		{
 			sprite.alpha = 0;
 		}
 		FlxTween.num(sprite.alpha, 1, Duration, { onComplete: OnComplete }, alphaTween.bind(sprite));
 		return sprite;
 	}
-	
+
 	/**
 	 * Fade out a sprite, tweening alpha to 0.
-	 * 
+	 *
 	 * @param  sprite 	The object to fade.
 	 * @param  Duration How long the fade will take (in seconds).
 	 * @return The FlxSprite for chaining
@@ -617,8 +617,8 @@ class FlxSpriteUtil
 		FlxTween.num(sprite.alpha, 0, Duration, { onComplete: OnComplete }, alphaTween.bind(sprite));
 		return sprite;
 	}
-	
-	private static function alphaTween(sprite:FlxSprite, f:Float):Void
+
+	static function alphaTween(sprite:FlxSprite, f:Float):Void
 	{
 		sprite.alpha = f;
 	}

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -13,7 +13,7 @@ import flash.geom.Matrix;
 #end
 
 /**
- * A class primarily containing functions related 
+ * A class primarily containing functions related
  * to formatting different data types to strings.
  */
 class FlxStringUtil
@@ -21,7 +21,7 @@ class FlxStringUtil
 	/**
 	 * Takes two "ticks" timestamps and formats them into the number of seconds that passed as a String.
 	 * Useful for logging, debugging, the watch window, or whatever else.
-	 * 
+	 *
 	 * @param	StartTicks	The first timestamp from the system.
 	 * @param	EndTicks	The second timestamp from the system.
 	 * @return	A String containing the formatted time elapsed information.
@@ -30,10 +30,10 @@ class FlxStringUtil
 	{
 		return (Math.abs(EndTicks - StartTicks) / 1000) + "s";
 	}
-	
+
 	/**
 	 * Format seconds as minutes with a colon, an optionally with milliseconds too.
-	 * 
+	 *
 	 * @param	Seconds		The number of seconds (for example, time remaining, time spent, etc).
 	 * @param	ShowMS		Whether to show milliseconds after a "." as well.  Default value is false.
 	 * @return	A nicely formatted String, like "1:03".
@@ -57,14 +57,14 @@ class FlxStringUtil
 			}
 			timeString += timeStringHelper;
 		}
-		
+
 		return timeString;
 	}
-	
+
 	/**
 	 * Generate a comma-separated string from an array.
 	 * Especially useful for tracing or other debug output.
-	 * 
+	 *
 	 * @param	AnyArray	Any Array object.
 	 * @return	A comma-separated String containing the .toString() output of each element in the array.
 	 */
@@ -86,7 +86,7 @@ class FlxStringUtil
 
 	/**
 	 * Generate a comma-separated string representation of the keys of a StringMap.
-	 * 
+	 *
 	 * @param  AnyMap    A StringMap object.
 	 * @return  A String formatted like this: key1, key2, ..., keyX
 	 */
@@ -98,16 +98,16 @@ class FlxStringUtil
 			string += Std.string(key);
 			string += ", ";
 		}
-		
+
 		return string.substring(0, string.length - 2);
-	} 
-	
+	}
+
 	/**
 	 * Automatically commas and decimals in the right places for displaying money amounts.
 	 * Does not include a dollar sign or anything, so doesn't really do much
 	 * if you call say `FlxString.formatMoney(10, false)`.
 	 * However, very handy for displaying large sums or decimal money values.
-	 * 
+	 *
 	 * @param	Amount			How much moneys (in dollars, or the equivalent "main" currency - i.e. not cents).
 	 * @param	ShowDecimal		Whether to show the decimals/cents component.
 	 * @param	EnglishStyle	Major quantities (thousands, millions, etc) separated by commas, and decimal by a period.
@@ -138,10 +138,10 @@ class FlxStringUtil
 			}
 			string = zeroes + helper + comma + string;
 		}
-		
+
 		if (string == "")
 			string = "0";
-		
+
 		if (ShowDecimal)
 		{
 			amount = Math.ffloor(Amount * 100) - (Math.ffloor(Amount) * 100);
@@ -150,14 +150,14 @@ class FlxStringUtil
 				string += "0";
 			string += amount;
 		}
-		
+
 		if (isNegative)
 			string = "-" + string;
 		return string;
 	}
-	
+
 	/**
-	 * Takes an amount of bytes and finds the fitting unit. Makes sure that the 
+	 * Takes an amount of bytes and finds the fitting unit. Makes sure that the
 	 * value is below 1024. Example: formatBytes(123456789); -> 117.74MB
 	 */
 	public static function formatBytes(Bytes:Float, Precision:Int = 2):String
@@ -171,10 +171,10 @@ class FlxStringUtil
 		}
 		return FlxMath.roundDecimal(Bytes, Precision) + units[curUnit];
 	}
-	
-	/** 
+
+	/**
 	 * Takes a string and filters out everything but the digits.
-	 * 
+	 *
 	 * @param 	Input	The input string
 	 * @return 	The output string, digits-only
 	 */
@@ -191,11 +191,11 @@ class FlxStringUtil
 		}
 		return output.toString();
 	}
-	
+
 	/**
-	 * Format a text with html tags - useful for TextField.htmlText. 
+	 * Format a text with html tags - useful for TextField.htmlText.
 	 * Used by the log window of the debugger.
-	 * 
+	 *
 	 * @param	Text		The text to format
 	 * @param	Size		The text size, using the font-size-tag
 	 * @param	Color		The text color, using font-color-tag
@@ -208,7 +208,7 @@ class FlxStringUtil
 	{
 		var prefix:String = "<font size='" + Size + "' color='#" + Color + "'>";
 		var suffix:String = "</font>";
-		
+
 		if (Bold)
 		{
 			prefix = "<b>" + prefix;
@@ -224,13 +224,13 @@ class FlxStringUtil
 			prefix = "<u>" + prefix;
 			suffix = suffix + "</u>";
 		}
-		
+
 		return prefix + Text + suffix;
 	}
-	
+
 	/**
 	 * Get the string name of any class or class instance. Wraps `Type.getClassName()`.
-	 * 
+	 *
 	 * @param	objectOrClass	The class or class instance in question.
 	 * @param	simple	Returns only the type name, without package(s).
 	 * @return	The name of the class as a string.
@@ -242,13 +242,13 @@ class FlxStringUtil
 			cl = cast objectOrClass;
 		else
 			cl = Type.getClass(objectOrClass);
-		
+
 		return formatPackage(Type.getClassName(cl), simple);
 	}
 
 	/**
 	 * Get the string name of any enum or enum value. Wraps `Type.getEnumName()`.
-	 * 
+	 *
 	 * @param	enumValueOrEnum	The enum value or enum in question.
 	 * @param	simple	Returns only the type name, without package(s).
 	 * @return	The name of the enum as a string.
@@ -261,11 +261,11 @@ class FlxStringUtil
 			e = cast enumValueOrEnum;
 		else
 			e = Type.getEnum(enumValueOrEnum);
-		
+
 		return formatPackage(Type.getEnumName(e), simple);
 	}
 
-	private static function formatPackage(s:String, simple:Bool):String
+	static function formatPackage(s:String, simple:Bool):String
 	{
 		if (s == null)
 			return null;
@@ -295,13 +295,13 @@ class FlxStringUtil
 
 		return "";
 	}
-	
+
 	/**
 	 * Returns the domain from the specified URL.
 	 * The domain, in this case, refers specifically to the first and second levels only.
 	 * For example, the domain for "api.haxe.org" is "haxe.org".
 	 *
-	 * @return	The domain from the URL; or the empty string ("") upon failure. 
+	 * @return	The domain from the URL; or the empty string ("") upon failure.
 	 */
 	public static function getDomain(url:String):String
 	{
@@ -317,10 +317,10 @@ class FlxStringUtil
 
 		return "";
 	}
-	
+
 	/**
 	 * Helper function that uses getClassName to compare two objects' class names.
-	 * 
+	 *
 	 * @param	Obj1	The first object
 	 * @param	Obj2	The second object
 	 * @param	Simple 	Only uses the class name, not the package or packages.
@@ -330,20 +330,20 @@ class FlxStringUtil
 	{
 		return (getClassName(Obj1, Simple) == getClassName(Obj2, Simple));
 	}
-	
+
 	/**
 	 * Split a comma-separated string into an array of ints
-	 * 
+	 *
 	 * @param	Data 	String formatted like this: "1, 2, 5, -10, 120, 27"
 	 * @return	An array of ints
 	 */
 	public static function toIntArray(Data:String):Array<Int>
 	{
-		if ((Data != null) && (Data != "")) 
+		if ((Data != null) && (Data != ""))
 		{
 			var strArray:Array<String> = Data.split(",");
 			var iArray:Array<Int> = new Array<Int>();
-			for (str in strArray) 
+			for (str in strArray)
 			{
 				iArray.push(Std.parseInt(str));
 			}
@@ -351,20 +351,20 @@ class FlxStringUtil
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Split a comma-separated string into an array of floats
-	 * 
+	 *
 	 * @param	Data string formatted like this: "1.0,2.1,5.6,1245587.9, -0.00354"
 	 * @return	An array of floats
-	 */	
+	 */
 	public static function toFloatArray(Data:String):Array<Float>
 	{
-		if ((Data != null) && (Data != "")) 
+		if ((Data != null) && (Data != ""))
 		{
 			var strArray:Array<String> = Data.split(",");
 			var fArray:Array<Float> = new Array<Float>();
-			for (str in strArray) 
+			for (str in strArray)
 			{
 				fArray.push(Std.parseFloat(str));
 			}
@@ -372,10 +372,10 @@ class FlxStringUtil
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Converts a one-dimensional array of tile data to a comma-separated string.
-	 * 
+	 *
 	 * @param	Data		An array full of integer tile references.
 	 * @param	Width		The number of tiles in each row.
 	 * @param	Invert		Recommended only for 1-bit arrays - changes 0s to 1s and vice versa.
@@ -389,15 +389,15 @@ class FlxStringUtil
 		var height:Int = Std.int(Data.length / Width);
 		var index:Int;
 		var offset:Int = 0;
-		
+
 		while (row < height)
 		{
 			column = 0;
-			
+
 			while (column < Width)
 			{
 				index = Data[offset];
-				
+
 				if (Invert)
 				{
 					if (index == 0)
@@ -409,7 +409,7 @@ class FlxStringUtil
 						index = 0;
 					}
 				}
-				
+
 				if (column == 0)
 				{
 					if (row == 0)
@@ -425,21 +425,21 @@ class FlxStringUtil
 				{
 					csv += ", " + index;
 				}
-				
+
 				column++;
 				offset++;
 			}
-			
+
 			row++;
 		}
-		
+
 		return csv;
 	}
-	
+
 	/**
 	 * Converts a BitmapData object to a comma-separated string. Black pixels are flagged as 'solid' by default,
 	 * non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
-	 * 
+	 *
 	 * @param	Bitmap		A Flash BitmapData object, preferably black and white.
 	 * @param	Invert		Load white pixels as solid instead.
 	 * @param	Scale		Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
@@ -452,24 +452,24 @@ class FlxStringUtil
 		{
 			Scale = 1;
 		}
-		
+
 		// Import and scale image if necessary
 		if (Scale > 1)
 		{
 			var bd:BitmapData = Bitmap;
 			Bitmap = new BitmapData(Bitmap.width * Scale, Bitmap.height * Scale);
-			
+
 			#if !flash
 			var bdW:Int = bd.width;
 			var bdH:Int = bd.height;
 			var pCol:Int = 0;
-			
+
 			for (i in 0...bdW)
 			{
 				for (j in 0...bdH)
 				{
 					pCol = bd.getPixel(i, j);
-					
+
 					for (k in 0...Scale)
 					{
 						for (m in 0...Scale)
@@ -485,7 +485,7 @@ class FlxStringUtil
 			Bitmap.draw(bd, mtx);
 			#end
 		}
-		
+
 		if (ColorMap != null)
 		{
 			for (i in 0...ColorMap.length)
@@ -493,7 +493,7 @@ class FlxStringUtil
 				ColorMap[i] = ColorMap[i].to24Bit();
 			}
 		}
-		
+
 		// Walk image and export pixel values
 		var row:Int = 0;
 		var column:Int;
@@ -501,16 +501,16 @@ class FlxStringUtil
 		var csv:String = "";
 		var bitmapWidth:Int = Bitmap.width;
 		var bitmapHeight:Int = Bitmap.height;
-		
+
 		while (row < bitmapHeight)
 		{
 			column = 0;
-			
+
 			while (column < bitmapWidth)
 			{
 				// Decide if this pixel/tile is solid (1) or not (0)
 				pixel = Bitmap.getPixel(column, row);
-				
+
 				if (ColorMap != null)
 				{
 					pixel = ColorMap.indexOf(pixel);
@@ -523,7 +523,7 @@ class FlxStringUtil
 				{
 					pixel = 0;
 				}
-				
+
 				// Write the result to the string
 				if (column == 0)
 				{
@@ -540,20 +540,20 @@ class FlxStringUtil
 				{
 					csv += ", " + pixel;
 				}
-				
+
 				column++;
 			}
-			
+
 			row++;
 		}
-		
+
 		return csv;
 	}
-	
+
 	/**
 	 * Converts a resource image file to a comma-separated string. Black pixels are flagged as 'solid' by default,
 	 * non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
-	 * 
+	 *
 	 * @param	ImageFile	An embedded graphic, preferably black and white.
 	 * @param	Invert		Load white pixels as solid instead.
 	 * @param	Scale		Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
@@ -563,7 +563,7 @@ class FlxStringUtil
 	public static function imageToCSV(ImageFile:Dynamic, Invert:Bool = false, Scale:Int = 1, ?ColorMap:Array<FlxColor>):String
 	{
 		var tempBitmapData:BitmapData;
-		
+
 		if (Std.is(ImageFile, String))
 		{
 			tempBitmapData = FlxAssets.getBitmapData(ImageFile);
@@ -572,14 +572,14 @@ class FlxStringUtil
 		{
 			tempBitmapData = (Type.createInstance(ImageFile, [])).bitmapData;
 		}
-		
+
 		return bitmapToCSV(tempBitmapData, Invert, Scale, ColorMap);
 	}
-	
+
 	/**
 	 * Helper function to create a string for toString() functions. Automatically rounds values according to FlxG.debugger.precision.
 	 * Strings are formatted in the format: (x: 50 | y: 60 | visible: false)
-	 * 
+	 *
 	 * @param	LabelValuePairs		Array with the data for the string
 	 */
 	public static function getDebugString(LabelValuePairs:Array<LabelValuePair>):String
@@ -600,12 +600,12 @@ class FlxStringUtil
 		output = output.substr(0, output.length - 2).trim();
 		return (output + ")");
 	}
-	
+
 	public static inline function contains(s:String, str:String):Bool
 	{
 		return s.indexOf(str) != -1;
 	}
-	
+
 	/**
 	 * Removes occurrences of a substring by calling `StringTools.replace(s, sub, "")`.
 	 */
@@ -613,7 +613,7 @@ class FlxStringUtil
 	{
 		return s.replace(sub, "");
 	}
-	
+
 	/**
 	 * Inserts `insertion` into `s` at index `pos`.
 	 */
@@ -621,7 +621,7 @@ class FlxStringUtil
 	{
 		return s.substring(0, pos) + insertion + s.substr(pos);
 	}
-	
+
 	public static function sortAlphabetically(list:Array<String>):Array<String>
 	{
 		list.sort(function(a, b)
@@ -634,7 +634,7 @@ class FlxStringUtil
 		});
 		return list;
 	}
-	
+
 	/**
 	 * Returns true if `s` equals `null` or is empty.
 	 * @since 4.1.0
@@ -647,28 +647,28 @@ class FlxStringUtil
 
 class LabelValuePair implements IFlxDestroyable
 {
-	private static var _pool = new FlxPool<LabelValuePair>(LabelValuePair);
-	
+	static var _pool = new FlxPool<LabelValuePair>(LabelValuePair);
+
 	public static inline function weak(label:String, value:Dynamic):LabelValuePair
 	{
 		return _pool.get().create(label, value);
 	}
-	
+
 	public var label:String;
 	public var value:Dynamic;
-	
+
 	public inline function create(label:String, value:Dynamic):LabelValuePair
 	{
 		this.label = label;
 		this.value = value;
 		return this;
 	}
-	
+
 	public inline function put():Void
 	{
 		_pool.put(this);
 	}
-	
+
 	public inline function destroy():Void
 	{
 		label = null;
@@ -676,5 +676,5 @@ class LabelValuePair implements IFlxDestroyable
 	}
 
 	@:keep
-	private function new() {}
+	function new() {}
 }

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -16,7 +16,7 @@ class FlxTimer implements IFlxDestroyable
 	 * @since 4.2.0
 	 */
 	public static var globalManager:FlxTimerManager;
-	
+
 	/**
 	 * The manager to which this timer belongs
 	 * @since 4.2.0
@@ -63,18 +63,18 @@ class FlxTimer implements IFlxDestroyable
 	 * Read-only: how far along the timer is, on a scale of 0.0 to 1.0.
 	 */
 	public var progress(get, never):Float;
-	
+
 	/**
 	 * Internal tracker for the actual timer counting up.
 	 */
-	private var _timeCounter:Float = 0;
+	var _timeCounter:Float = 0;
 	/**
 	 * Internal tracker for the loops counting up.
 	 */
-	private var _loopsCounter:Int = 0;
-	
-	private var _inManager:Bool = false;
-	
+	var _loopsCounter:Int = 0;
+
+	var _inManager:Bool = false;
+
 	/**
 	 * Creates a new timer.
 	 */
@@ -82,7 +82,7 @@ class FlxTimer implements IFlxDestroyable
 	{
 		this.manager = manager != null ? manager : globalManager;
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -90,10 +90,10 @@ class FlxTimer implements IFlxDestroyable
 	{
 		onComplete = null;
 	}
-	
+
 	/**
 	 * Starts the timer and adds the timer to the timer manager.
-	 * 
+	 *
 	 * @param	Time		How many seconds it takes for the timer to go off.
 	 * 						If 0 then timer will fire OnComplete callback only once at the first call of update method (which means that Loops argument will be ignored).
 	 * @param	OnComplete	Optional, triggered whenever the time runs out, once for each loop.
@@ -108,22 +108,22 @@ class FlxTimer implements IFlxDestroyable
 			manager.add(this);
 			_inManager = true;
 		}
-		
+
 		active = true;
 		finished = false;
 		time = Math.abs(Time);
-		
-		if (Loops < 0) 
+
+		if (Loops < 0)
 			Loops *= -1;
-		
+
 		loops = Loops;
 		onComplete = OnComplete;
 		_timeCounter = 0;
 		_loopsCounter = 0;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Restart the timer using the new duration
 	 * @param	NewDuration	The duration of this timer in ms.
@@ -132,11 +132,11 @@ class FlxTimer implements IFlxDestroyable
 	{
 		if (NewTime < 0)
 			NewTime = time;
-		
+
 		start(NewTime, onComplete, loops);
 		return this;
 	}
-	
+
 	/**
 	 * Stops the timer and removes it from the timer manager.
 	 */
@@ -144,14 +144,14 @@ class FlxTimer implements IFlxDestroyable
 	{
 		finished = true;
 		active = false;
-		
+
 		if (manager != null && _inManager)
 		{
 			manager.remove(this);
 			_inManager = false;
 		}
 	}
-	
+
 	/**
 	 * Called by the timer manager plugin to update the timer.
 	 * If time runs out, the loop counter is advanced, the timer reset, and the callback called if it exists.
@@ -161,76 +161,76 @@ class FlxTimer implements IFlxDestroyable
 	public function update(elapsed:Float):Void
 	{
 		_timeCounter += elapsed;
-		
+
 		while ((_timeCounter >= time) && active && !finished)
 		{
 			_timeCounter -= time;
 			_loopsCounter++;
-			
+
 			if (loops > 0 && (_loopsCounter >= loops))
 			{
 				finished = true;
 			}
 		}
 	}
-	
+
 	@:allow(flixel.util.FlxTimerManager)
-	private function onLoopFinished():Void
+	function onLoopFinished():Void
 	{
 		if (finished)
 			cancel();
-		
+
 		if (onComplete != null)
 			onComplete(this);
 	}
-	
-	private inline function get_timeLeft():Float
+
+	inline function get_timeLeft():Float
 	{
 		return time - _timeCounter;
 	}
-	
-	private inline function get_elapsedTime():Float
+
+	inline function get_elapsedTime():Float
 	{
 		return _timeCounter;
 	}
-	
-	private inline function get_loopsLeft():Int
+
+	inline function get_loopsLeft():Int
 	{
 		return loops - _loopsCounter;
 	}
-	
-	private inline function get_elapsedLoops():Int
+
+	inline function get_elapsedLoops():Int
 	{
 		return _loopsCounter;
 	}
-	
-	private inline function get_progress():Float
+
+	inline function get_progress():Float
 	{
 		return (time > 0) ? (_timeCounter / time) : 0;
 	}
 }
 
 /**
- * A simple manager for tracking and updating game timer objects. 
+ * A simple manager for tracking and updating game timer objects.
  * Normally accessed via the static `FlxTimer.manager` rather than being created separately.
  */
 class FlxTimerManager extends FlxBasic
 {
-	private var _timers:Array<FlxTimer> = [];
-	
+	var _timers:Array<FlxTimer> = [];
+
 	/**
 	 * Instantiates a new timer manager.
 	 */
 	public function new()
 	{
 		super();
-		
+
 		// Don't call draw on this plugin
 		visible = false;
-		
+
 		FlxG.signals.stateSwitched.add(clear);
 	}
-	
+
 	/**
 	 * Clean up memory.
 	 */
@@ -241,7 +241,7 @@ class FlxTimerManager extends FlxBasic
 		FlxG.signals.stateSwitched.remove(clear);
 		super.destroy();
 	}
-	
+
 	/**
 	 * Called by FlxG.plugins.update() before the game state has been updated.
 	 * Cycles through timers and calls update() on each one.
@@ -249,24 +249,24 @@ class FlxTimerManager extends FlxBasic
 	override public function update(elapsed:Float):Void
 	{
 		var loopedTimers:Array<FlxTimer> = null;
-		
+
 		for (timer in _timers)
 		{
 			if (timer.active && !timer.finished && timer.time >= 0)
 			{
 				var timerLoops:Int = timer.elapsedLoops;
 				timer.update(elapsed);
-				
+
 				if (timerLoops != timer.elapsedLoops)
 				{
 					if (loopedTimers == null)
 						loopedTimers = [];
-					
+
 					loopedTimers.push(timer);
 				}
 			}
 		}
-		
+
 		if (loopedTimers != null)
 		{
 			while (loopedTimers.length > 0)
@@ -275,31 +275,31 @@ class FlxTimerManager extends FlxBasic
 			}
 		}
 	}
-	
+
 	/**
 	 * Add a new timer to the timer manager.
 	 * Called when FlxTimer is started.
-	 * 
+	 *
 	 * @param	Timer	The FlxTimer you want to add to the manager.
 	 */
 	@:allow(flixel.util.FlxTimer)
-	private function add(Timer:FlxTimer):Void
+	function add(Timer:FlxTimer):Void
 	{
 		_timers.push(Timer);
 	}
-	
+
 	/**
 	 * Remove a timer from the timer manager.
 	 * Called automatically by FlxTimer's cancel() function.
-	 * 
+	 *
 	 * @param	Timer	The FlxTimer you want to remove from the manager.
 	 */
 	@:allow(flixel.util.FlxTimer)
-	private function remove(Timer:FlxTimer):Void
+	function remove(Timer:FlxTimer):Void
 	{
 		FlxArrayUtil.fastSplice(_timers, Timer);
 	}
-	
+
 	/**
 	 * Immediately updates all `active`, non-infinite timers to their end points, repeatedly,
 	 * until all their loops are finished, resulting in `loopsLeft` callbacks being run.
@@ -332,7 +332,7 @@ class FlxTimerManager extends FlxBasic
 
 	/**
 	 * Applies a function to all timers
-	 * 
+	 *
 	 * @param   Function   A function that modifies one timer at a time
 	 * @since   4.2.0
 	 */


### PR DESCRIPTION
As discussed here: https://github.com/HaxeFlixel/flixel/issues/1916

Removes every occurrence of the private keyword that is not a class, an interface, an enum or a comment, just variables and functions.

It also removes a lot of trailing whitespace from some files...

edit: We should also edit the haxe checkstyle config file so it yield when we use `private`, to avoid future additions.