### PR TITLE
add check for null colorTransforms

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -842,6 +842,9 @@ class FlxSprite extends FlxObject
 		color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier).to24Bit();
 		alpha = alphaMultiplier;
 		
+		if (colorTransform == null)
+			colorTransform = new ColorTransform();
+		
 		colorTransform.setMultipliers(redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier);
 		colorTransform.setOffsets(redOffset, greenOffset, blueOffset, alphaOffset);
 		


### PR DESCRIPTION
The same safety check as in updateColorTransform(), which will prevent null ref exceptions in case of colorTransform == null.