### PR TITLE
Add support for next OpenFL release

### DIFF
--- a/assets/templates/html5/index.html
+++ b/assets/templates/html5/index.html
@@ -3,12 +3,14 @@
 <head>
 	
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	
 	<title>::APP_TITLE::</title>
 	
 	<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="apple-mobile-web-app-capable" content="yes">
+	
+	::if favicons::::foreach (favicons)::
+	<link rel="::__current__.rel::" type="::__current__.type::" href="::__current__.href::">::end::::end::
 	
 	::if linkedLibraries::::foreach (linkedLibraries)::
 	<script type="text/javascript" src="::__current__::"></script>::end::::end::
@@ -25,16 +27,17 @@
 	<style>
 		html,body { margin: 0; padding: 0; height: 100%; overflow: hidden; background: black; }
 		#openfl-content { margin: 0 auto; width: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_WIDTH::px::else::100%::end::; height: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_HEIGHT::px::else::100%::end::; }
-		::foreach assets::::if (type == "font")::
+::foreach assets::::if (type == "font")::::if (cssFontFace)::::cssFontFace::::else::
 		@font-face {
 			font-family: '::fontName::';
 			src: url('::targetPath::.eot');
 			src: url('::targetPath::.eot?#iefix') format('embedded-opentype'),
 			url('::targetPath::.svg#my-font-family') format('svg'),
+			url('::targetPath::.woff') format('woff'),
 			url('::targetPath::.ttf') format('truetype');
 			font-weight: normal;
 			font-style: normal;
-		}::end::::end::
+		}::end::::end::::end::
 	</style>
 	
 </head>
@@ -45,7 +48,7 @@
 	<div id="openfl-content"></div>
 	
 	<script type="text/javascript">
-		lime.embed ("openfl-content", ::WIN_WIDTH::, ::WIN_HEIGHT::, "::WIN_FLASHBACKGROUND::");
+		lime.embed ("::APP_FILE::", "openfl-content", ::WIN_WIDTH::, ::WIN_HEIGHT::, { parameters: {} });
 	</script>
 	
 </body>

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1481,7 +1481,7 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			#if openfl_legacy // can't skip this on next, see #1793
+			#if (openfl_legacy || (openfl >= "4.0.0")) // can't skip this on next, see #1793
 			if (FxAlpha == 0)
 				return;
 			#end

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -6,12 +6,30 @@ import flash.geom.Rectangle;
 import flixel.FlxG;
 import openfl.Assets;
 import openfl.display.OpenGLView;
+
+#if openfl_legacy
 import openfl.gl.GL;
 import openfl.gl.GLFramebuffer;
 import openfl.gl.GLRenderbuffer;
 import openfl.gl.GLTexture;
 import openfl.gl.GLBuffer;
 import openfl.utils.Float32Array;
+#else
+import lime.graphics.opengl.GL;
+import lime.graphics.opengl.GLFramebuffer;
+import lime.graphics.opengl.GLRenderbuffer;
+import lime.graphics.opengl.GLTexture;
+import lime.graphics.opengl.GLBuffer;
+import lime.utils.Float32Array;
+#end
+
+#if (lime >= "4.0.0")
+import lime.graphics.opengl.WebGLContext;
+#end
+
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
 
 private class Uniform
 {
@@ -66,7 +84,11 @@ class PostProcess extends OpenGLView
 
 		buffer = GL.createBuffer();
 		GL.bindBuffer(GL.ARRAY_BUFFER, buffer);
+		#if (lime >= "4.0.0")
+		(GL:WebGLContext).bufferData(GL.ARRAY_BUFFER, new Float32Array(vertices), GL.STATIC_DRAW);
+		#else
 		GL.bufferData(GL.ARRAY_BUFFER, new Float32Array(#if !openfl_next cast #end vertices), GL.STATIC_DRAW);
+		#end
 		GL.bindBuffer(GL.ARRAY_BUFFER, null);
 
 		postProcessShader = new Shader([
@@ -158,7 +180,7 @@ class PostProcess extends OpenGLView
 		texture = GL.createTexture();
 		
 		GL.bindTexture(GL.TEXTURE_2D, texture);
-		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGB,  width, height,  0,  GL.RGB, GL.UNSIGNED_BYTE, null);
+		GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGB,  width, height,  0,  GL.RGB, GL.UNSIGNED_BYTE, #if (lime >= "4.0.0") 0 #else null #end);
 
 		GL.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
 		GL.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);

--- a/flixel/effects/postprocess/PostProcess.hx
+++ b/flixel/effects/postprocess/PostProcess.hx
@@ -27,10 +27,6 @@ import lime.utils.Float32Array;
 import lime.graphics.opengl.WebGLContext;
 #end
 
-#if (openfl >= "5.0.0")
-import openfl.utils.AssetType;
-#end
-
 private class Uniform
 {
 	public var id:Int;

--- a/flixel/effects/postprocess/Shader.hx
+++ b/flixel/effects/postprocess/Shader.hx
@@ -1,9 +1,15 @@
 package flixel.effects.postprocess;
 
 #if FLX_POST_PROCESS
+#if openfl_legacy
 import openfl.gl.GL;
 import openfl.gl.GLProgram;
 import openfl.gl.GLShader;
+#else
+import lime.graphics.opengl.GL;
+import lime.graphics.opengl.GLProgram;
+import lime.graphics.opengl.GLShader;
+#end
 
 /**
  * GLSL Shader object

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -6,12 +6,12 @@ import flixel.graphics.frames.FlxAtlasFrames;
 import flixel.graphics.frames.FlxFrame;
 import flixel.graphics.frames.FlxFramesCollection;
 import flixel.graphics.frames.FlxImageFrame;
+import flixel.graphics.tile.FlxTilesheet;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
-import openfl.display.Tilesheet;
 
 /**
  * `BitmapData` wrapper which is used for rendering.
@@ -316,7 +316,7 @@ class FlxGraphic implements IFlxDestroyable
 	/**
 	 * Tilesheet for this graphic object. It is used only for `FlxG.renderTile` mode.
 	 */
-	public var tilesheet(get, null):Tilesheet;
+	public var tilesheet(get, null):FlxTilesheet;
 	
 	/**
 	 * Usage counter for this `FlxGraphic` object.
@@ -364,7 +364,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * Internal var holding Tilesheet for bitmap of this graphic.
 	 * It is used only in `FlxG.renderTile` mode
 	 */
-	private var _tilesheet:Tilesheet;
+	private var _tilesheet:FlxTilesheet;
 	
 	private var _useCount:Int = 0;
 	
@@ -522,7 +522,7 @@ class FlxGraphic implements IFlxDestroyable
 	/**
 	 * Tilesheet getter. Generates new one (and regenerates) if there is no tilesheet for this graphic yet.
 	 */
-	private function get_tilesheet():Tilesheet
+	private function get_tilesheet():FlxTilesheet
 	{
 		if (_tilesheet == null)
 		{
@@ -531,7 +531,7 @@ class FlxGraphic implements IFlxDestroyable
 			if (dumped)
 				undump();
 			
-			_tilesheet = new Tilesheet(bitmap);
+			_tilesheet = new FlxTilesheet(bitmap);
 			
 			if (dumped)
 				dump();
@@ -613,7 +613,7 @@ class FlxGraphic implements IFlxDestroyable
 			height = bitmap.height;
 			#if !flash
 			if (FlxG.renderTile && _tilesheet != null)
-				_tilesheet = new Tilesheet(bitmap);
+				_tilesheet = new FlxTilesheet(bitmap);
 			#end
 		}
 		

--- a/flixel/graphics/tile/FlxDrawBaseItem.hx
+++ b/flixel/graphics/tile/FlxDrawBaseItem.hx
@@ -4,7 +4,6 @@ import flixel.FlxCamera;
 import flixel.graphics.frames.FlxFrame;
 import flixel.math.FlxMatrix;
 import openfl.display.BlendMode;
-import openfl.display.Tilesheet;
 import openfl.geom.ColorTransform;
 
 /**
@@ -16,36 +15,36 @@ class FlxDrawBaseItem<T>
 	public static function blendToInt(blend:BlendMode):Int
 	{
 		if (blend == null)
-			return Tilesheet.TILE_BLEND_NORMAL;
+			return FlxTilesheet.TILE_BLEND_NORMAL;
 		
 		return switch (blend)
 		{
 			case BlendMode.ADD:
-				Tilesheet.TILE_BLEND_ADD;
+				FlxTilesheet.TILE_BLEND_ADD;
 			#if !flash
 			case BlendMode.MULTIPLY:
-				Tilesheet.TILE_BLEND_MULTIPLY;
+				FlxTilesheet.TILE_BLEND_MULTIPLY;
 			case BlendMode.SCREEN:
-				Tilesheet.TILE_BLEND_SCREEN;
+				FlxTilesheet.TILE_BLEND_SCREEN;
 			case BlendMode.SUBTRACT:
-				Tilesheet.TILE_BLEND_SUBTRACT;
+				FlxTilesheet.TILE_BLEND_SUBTRACT;
 			#if !lime_legacy
 			case BlendMode.DARKEN:
-				Tilesheet.TILE_BLEND_DARKEN;
+				FlxTilesheet.TILE_BLEND_DARKEN;
 			case BlendMode.LIGHTEN:
-				Tilesheet.TILE_BLEND_LIGHTEN;
+				FlxTilesheet.TILE_BLEND_LIGHTEN;
 			case BlendMode.OVERLAY:
-				Tilesheet.TILE_BLEND_OVERLAY;
+				FlxTilesheet.TILE_BLEND_OVERLAY;
 			case BlendMode.HARDLIGHT:
-				Tilesheet.TILE_BLEND_HARDLIGHT;
+				FlxTilesheet.TILE_BLEND_HARDLIGHT;
 			case BlendMode.DIFFERENCE:
-				Tilesheet.TILE_BLEND_DIFFERENCE;
+				FlxTilesheet.TILE_BLEND_DIFFERENCE;
 			case BlendMode.INVERT:
-				Tilesheet.TILE_BLEND_INVERT;
+				FlxTilesheet.TILE_BLEND_INVERT;
 			#end
 			#end
 			default:
-				Tilesheet.TILE_BLEND_NORMAL;
+				FlxTilesheet.TILE_BLEND_NORMAL;
 		}
 	}
 	

--- a/flixel/graphics/tile/FlxDrawTilesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTilesItem.hx
@@ -6,7 +6,6 @@ import flixel.graphics.tile.FlxDrawBaseItem.FlxDrawItemType;
 import flixel.math.FlxMatrix;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxShader;
-import openfl.display.Tilesheet;
 import openfl.geom.ColorTransform;
 
 class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
@@ -83,20 +82,20 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 		if (!FlxG.renderTile || position <= 0)
 			return;
 		
-		var flags:Int = Tilesheet.TILE_TRANS_2x2 | Tilesheet.TILE_RECT | Tilesheet.TILE_ALPHA;
+		var flags:Int = FlxTilesheet.TILE_TRANS_2x2 | FlxTilesheet.TILE_RECT | FlxTilesheet.TILE_ALPHA;
 		
 		if (colored)
-			flags |= Tilesheet.TILE_RGB;
+			flags |= FlxTilesheet.TILE_RGB;
 		
 		#if (!openfl_legacy && openfl >= "3.6.0")
 		if (hasColorOffsets)
-			flags |= Tilesheet.TILE_TRANS_COLOR;
+			flags |= FlxTilesheet.TILE_TRANS_COLOR;
 		#end
 
 		flags |= blending;
 
 		#if !(nme && flash)
-		camera.canvas.graphics.drawTiles(graphics.tilesheet, drawData,
+		graphics.tilesheet.draw(camera.canvas, drawData,
 			(camera.antialiasing || antialiasing), flags,
 			#if !openfl_legacy shader, #end
 			position);

--- a/flixel/graphics/tile/FlxDrawTilesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTilesItem.hx
@@ -82,7 +82,7 @@ class FlxDrawTilesItem extends FlxDrawBaseItem<FlxDrawTilesItem>
 		if (!FlxG.renderTile || position <= 0)
 			return;
 		
-		var flags:Int = FlxTilesheet.TILE_TRANS_2x2 | FlxTilesheet.TILE_RECT | FlxTilesheet.TILE_ALPHA;
+		var flags:Int = FlxTilesheet.TILE_TRANS_2X2 | FlxTilesheet.TILE_RECT | FlxTilesheet.TILE_ALPHA;
 		
 		if (colored)
 			flags |= FlxTilesheet.TILE_RGB;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -11,11 +11,11 @@ import openfl.display.Graphics;
 import openfl.display.TriangleCulling;
 import openfl.geom.ColorTransform;
 
-#if flash
+#if (flash || openfl >= "4.0.0")
 import openfl.Vector;
 #end
 
-typedef DrawData<T> = #if flash Vector<T> #else Array<T> #end;
+typedef DrawData<T> = #if (flash || openfl >= "4.0.0") Vector<T> #else Array<T> #end;
 
 /**
  * ...

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -223,7 +223,7 @@ class FlxTilesheet extends Tileset
 		}
 		
 		canvas.graphics.beginShaderFill (shader);
-		canvas.graphics.drawQuads (matrices, rects);
+		canvas.graphics.drawQuads (rects, null, matrices);
 		
 		#end
 	}

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -1,5 +1,7 @@
-package flixel.graphics.tile;
+package flixel.graphics.tile; #if (openfl < "4.0.0")
 
+import openfl.display.Shader;
+import openfl.display.Sprite;
 import openfl.display.Tilesheet;
 
 class FlxTilesheet extends Tilesheet
@@ -8,4 +10,83 @@ class FlxTilesheet extends Tilesheet
 	 * Tracks total number of `drawTiles()` calls made each frame.
 	 */
 	public static var _DRAWCALLS:Int = 0;
+	
+	public static inline var TILE_SCALE = Tilesheet.TILE_SCALE;
+	public static inline var TILE_ROTATION = Tilesheet.TILE_ROTATION;
+	public static inline var TILE_RGB = Tilesheet.TILE_RGB;
+	public static inline var TILE_ALPHA = Tilesheet.TILE_ALPHA;
+	public static inline var TILE_TRANS_2x2 = Tilesheet.TILE_TRANS_2x2;
+	public static inline var TILE_RECT = Tilesheet.TILE_RECT;
+	public static inline var TILE_ORIGIN = Tilesheet.TILE_ORIGIN;
+	public static inline var TILE_BLEND_NORMAL = Tilesheet.TILE_BLEND_NORMAL;
+	public static inline var TILE_BLEND_ADD = Tilesheet.TILE_BLEND_ADD;
+	public static inline var TILE_BLEND_MULTIPLY = Tilesheet.TILE_BLEND_MULTIPLY;
+	public static inline var TILE_BLEND_SCREEN = Tilesheet.TILE_BLEND_SCREEN;
+	public static inline var TILE_BLEND_SUBTRACT = Tilesheet.TILE_BLEND_SUBTRACT;
+	
+	#if !openfl_legacy
+	public static inline var TILE_TRANS_COLOR = Tilesheet.TILE_TRANS_COLOR;
+	public static inline var TILE_BLEND_DARKEN = Tilesheet.TILE_BLEND_DARKEN;
+	public static inline var TILE_BLEND_LIGHTEN = Tilesheet.TILE_BLEND_LIGHTEN;
+	public static inline var TILE_BLEND_OVERLAY = Tilesheet.TILE_BLEND_OVERLAY;
+	public static inline var TILE_BLEND_HARDLIGHT = Tilesheet.TILE_BLEND_HARDLIGHT;
+	public static inline var TILE_BLEND_DIFFERENCE = Tilesheet.TILE_BLEND_DIFFERENCE;
+	public static inline var TILE_BLEND_INVERT = Tilesheet.TILE_BLEND_INVERT;
+	#end
+	
+	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, #if !openfl_legacy shader:Shader, #end count:Int = -1):Void
+	{
+		canvas.graphics.drawTiles (this, tileData, smooth, flags, #if !openfl_legacy shader, #end count);
+	}
 }
+
+#else
+
+import openfl.display.BitmapData;
+import openfl.display.BlendMode;
+import openfl.display.Graphics;
+import openfl.display.Shader;
+import openfl.display.Sprite;
+import openfl.display.Tileset;
+import openfl.events.Event;
+import openfl.geom.ColorTransform;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
+import openfl.geom.Point;
+import openfl.Lib;
+import openfl.Vector;
+
+class FlxTilesheet extends Tileset
+{
+	/**
+	 * Tracks total number of `drawTiles()` calls made each frame.
+	 */
+	public static var _DRAWCALLS:Int = 0;
+	
+	public static inline var TILE_SCALE = 0x0001;
+	public static inline var TILE_ROTATION = 0x0002;
+	public static inline var TILE_RGB = 0x0004;
+	public static inline var TILE_ALPHA = 0x0008;
+	public static inline var TILE_TRANS_2x2 = 0x0010;
+	public static inline var TILE_RECT = 0x0020;
+	public static inline var TILE_ORIGIN = 0x0040;
+	public static inline var TILE_TRANS_COLOR = 0x0080;
+	public static inline var TILE_BLEND_NORMAL = 0x00000000;
+	public static inline var TILE_BLEND_ADD = 0x00010000;
+	public static inline var TILE_BLEND_MULTIPLY = 0x00020000;
+	public static inline var TILE_BLEND_SCREEN = 0x00040000;
+	public static inline var TILE_BLEND_SUBTRACT = 0x00080000;
+	public static inline var TILE_BLEND_DARKEN = 0x00100000;
+	public static inline var TILE_BLEND_LIGHTEN = 0x00200000;
+	public static inline var TILE_BLEND_OVERLAY = 0x00400000;
+	public static inline var TILE_BLEND_HARDLIGHT = 0x00800000;
+	public static inline var TILE_BLEND_DIFFERENCE = 0x01000000;
+	public static inline var TILE_BLEND_INVERT = 0x02000000;
+	
+	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, shader:Shader, count:Int = -1):Void
+	{
+		
+	}
+}
+
+#end

--- a/flixel/graphics/tile/FlxTilesheet.hx
+++ b/flixel/graphics/tile/FlxTilesheet.hx
@@ -1,7 +1,10 @@
-package flixel.graphics.tile; #if (openfl < "4.0.0")
+package flixel.graphics.tile;
 
 import openfl.display.Shader;
 import openfl.display.Sprite;
+
+#if (openfl < "4.0.0")
+
 import openfl.display.Tilesheet;
 
 class FlxTilesheet extends Tilesheet
@@ -15,7 +18,7 @@ class FlxTilesheet extends Tilesheet
 	public static inline var TILE_ROTATION = Tilesheet.TILE_ROTATION;
 	public static inline var TILE_RGB = Tilesheet.TILE_RGB;
 	public static inline var TILE_ALPHA = Tilesheet.TILE_ALPHA;
-	public static inline var TILE_TRANS_2x2 = Tilesheet.TILE_TRANS_2x2;
+	public static inline var TILE_TRANS_2X2 = Tilesheet.TILE_TRANS_2x2;
 	public static inline var TILE_RECT = Tilesheet.TILE_RECT;
 	public static inline var TILE_ORIGIN = Tilesheet.TILE_ORIGIN;
 	public static inline var TILE_BLEND_NORMAL = Tilesheet.TILE_BLEND_NORMAL;
@@ -42,20 +45,13 @@ class FlxTilesheet extends Tilesheet
 
 #else
 
-import openfl.display.BitmapData;
 import openfl.display.BlendMode;
-import openfl.display.Graphics;
-import openfl.display.GraphicsShader;
-import openfl.display.Shader;
-import openfl.display.Sprite;
 import openfl.display.Tileset;
-import openfl.events.Event;
-import openfl.geom.ColorTransform;
-import openfl.geom.Matrix;
-import openfl.geom.Rectangle;
-import openfl.geom.Point;
-import openfl.Lib;
 import openfl.Vector;
+
+#if (openfl >= "8.0.0")
+import openfl.display.GraphicsShader;
+#end
 
 class FlxTilesheet extends Tileset
 {
@@ -68,7 +64,7 @@ class FlxTilesheet extends Tileset
 	public static inline var TILE_ROTATION = 0x0002;
 	public static inline var TILE_RGB = 0x0004;
 	public static inline var TILE_ALPHA = 0x0008;
-	public static inline var TILE_TRANS_2x2 = 0x0010;
+	public static inline var TILE_TRANS_2X2 = 0x0010;
 	public static inline var TILE_RECT = 0x0020;
 	public static inline var TILE_ORIGIN = 0x0040;
 	public static inline var TILE_TRANS_COLOR = 0x0080;
@@ -84,8 +80,6 @@ class FlxTilesheet extends Tileset
 	public static inline var TILE_BLEND_DIFFERENCE = 0x01000000;
 	public static inline var TILE_BLEND_INVERT = 0x02000000;
 	
-	private static var defaultShader = new GraphicsShader ();
-	
 	public function draw (canvas:Sprite, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, shader:Shader, count:Int = -1):Void
 	{
 		#if (openfl >= "8.0.0")
@@ -97,24 +91,27 @@ class FlxTilesheet extends Tileset
 		
 		var useScale = (flags & TILE_SCALE) > 0;
 		var useRotation = (flags & TILE_ROTATION) > 0;
-		var useTransform = (flags & TILE_TRANS_2x2) > 0;
+		var useTransform = (flags & TILE_TRANS_2X2) > 0;
 		var useRGB = (flags & TILE_RGB) > 0;
 		var useAlpha = (flags & TILE_ALPHA) > 0;
 		var useRect = (flags & TILE_RECT) > 0;
 		var useOrigin = (flags & TILE_ORIGIN) > 0;
 		var useRGBOffset = ((flags & TILE_TRANS_COLOR) > 0);
 		
-		var blendMode:BlendMode = switch(flags & 0xF0000) {
+		var blendMode:BlendMode = switch (flags & 0xF0000)
+		{
 			case TILE_BLEND_ADD:                ADD;
 			case TILE_BLEND_MULTIPLY:           MULTIPLY;
 			case TILE_BLEND_SCREEN:             SCREEN;
 			case TILE_BLEND_SUBTRACT:           SUBTRACT;
-			case _: switch(flags & 0xF00000) {
+			case _: switch (flags & 0xF00000)
+			{
 				case TILE_BLEND_DARKEN:         DARKEN;
 				case TILE_BLEND_LIGHTEN:        LIGHTEN;
 				case TILE_BLEND_OVERLAY:        OVERLAY;
 				case TILE_BLEND_HARDLIGHT:      HARDLIGHT;
-				case _: switch(flags & 0xF000000) {
+				case _: switch (flags & 0xF000000)
+				{
 					case TILE_BLEND_DIFFERENCE: DIFFERENCE;
 					case TILE_BLEND_INVERT:     INVERT;
 					case _:                               NORMAL;
@@ -122,7 +119,11 @@ class FlxTilesheet extends Tileset
 			}
 		};
 		
-		if (useTransform) { useScale = false; useRotation = false; }
+		if (useTransform)
+		{
+			useScale = false;
+			useRotation = false;
+		}
 		
 		var scaleIndex = 0;
 		var rotationIndex = 0;
@@ -133,13 +134,46 @@ class FlxTilesheet extends Tileset
 		
 		var numValues = 3;
 		
-		if (useRect) { numValues = useOrigin ? 8 : 6; }
-		if (useScale) { scaleIndex = numValues; numValues ++; }
-		if (useRotation) { rotationIndex = numValues; numValues ++; }
-		if (useTransform) { transformIndex = numValues; numValues += 4; }
-		if (useRGB) { rgbIndex = numValues; numValues += 3; }
-		if (useAlpha) { alphaIndex = numValues; numValues ++; }
-		if (useRGBOffset) { rgbOffsetIndex = numValues; numValues += 4; }
+		if (useRect)
+		{
+			numValues = useOrigin ? 8 : 6;
+		}
+		
+		if (useScale)
+		{
+			scaleIndex = numValues;
+			numValues++;
+		}
+		
+		if (useRotation)
+		{
+			rotationIndex = numValues;
+			numValues++;
+		}
+		
+		if (useTransform)
+		{
+			transformIndex = numValues;
+			numValues += 4;
+		}
+		
+		if (useRGB)
+		{
+			rgbIndex = numValues;
+			numValues += 3;
+		}
+		
+		if (useAlpha)
+		{
+			alphaIndex = numValues;
+			numValues++;
+		}
+		
+		if (useRGBOffset)
+		{
+			rgbOffsetIndex = numValues;
+			numValues += 4;
+		}
 		
 		var totalCount = tileData.length;
 		if (count >= 0 && totalCount > count) totalCount = count;
@@ -147,9 +181,7 @@ class FlxTilesheet extends Tileset
 		var iIndex = 0;
 		var tint = 0xFFFFFF;
 		
-		//var shader:GraphicsShader = shader != null ? cast shader : defaultShader;
 		var shader = new GraphicsShader ();
-		
 		shader.data.texture0.input = bitmapData;
 		shader.data.texture0.smoothing = smooth;
 		
@@ -194,7 +226,7 @@ class FlxTilesheet extends Tileset
 			
 			for (j in 0...6)
 			{
-				alphaValues.push (1);
+				alphaValues.push (tileData[iIndex + alphaIndex]);
 			}
 			
 			if (useRGB)

--- a/flixel/input/gamepad/id/XInputID.hx
+++ b/flixel/input/gamepad/id/XInputID.hx
@@ -149,5 +149,34 @@ class XInputID
 		public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(3, 4, { up: 25, down: 26, left: 27, right: 28 });
 
 	#end
+	#else // dummy values
+	
+		public static inline var A:Int = 0;
+		public static inline var B:Int = 0;
+		public static inline var X:Int = 0;
+		public static inline var Y:Int = 0;
+		
+		public static inline var LB:Int = 4;
+		public static inline var RB:Int = 5;
+		
+		public static inline var LEFT_STICK_CLICK:Int = 6;
+		public static inline var RIGHT_STICK_CLICK:Int = 7;
+		
+		public static inline var BACK:Int = 9;
+		public static inline var START:Int = 8;
+		
+		public static inline var GUIDE:Int = 10;
+		
+		public static inline var DPAD_UP:Int = 11;
+		public static inline var DPAD_DOWN:Int = 12;
+		public static inline var DPAD_LEFT:Int = 13;
+		public static inline var DPAD_RIGHT:Int = 14;
+		
+		public static inline var LEFT_TRIGGER:Int = 2;
+		public static inline var RIGHT_TRIGGER:Int = 5;
+		
+		public static var LEFT_ANALOG_STICK(default, null)  = new FlxGamepadAnalogStick(0, 1, { up: 21, down: 22, left: 23, right: 24 });
+		public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(3, 4, { up: 25, down: 26, left: 27, right: 28 });
+		
 	#end
 }

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -18,14 +18,17 @@ class XInputMapping extends FlxGamepadMapping
 	
 	override function initValues():Void 
 	{
+		#if FLX_JOYSTICK_API
 		leftStick = XInputID.LEFT_ANALOG_STICK;
 		rightStick = XInputID.RIGHT_ANALOG_STICK;
+		#end
 	}
 	
 	override public function getID(rawID:Int):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
+			#if (flash || FLX_GAMEINPUT_API || FLX_JOYSTICK_API)
 			case XInputID.A: B;
 			case XInputID.B: A;
 			case XInputID.X: Y;
@@ -56,6 +59,7 @@ class XInputMapping extends FlxGamepadMapping
 			case id if (id == rightStick.rawDown): RIGHT_STICK_DIGITAL_DOWN;
 			case id if (id == rightStick.rawLeft): RIGHT_STICK_DIGITAL_LEFT;
 			case id if (id == rightStick.rawRight): RIGHT_STICK_DIGITAL_RIGHT;
+			#end
 			case _: NONE;
 		}
 	}
@@ -64,6 +68,7 @@ class XInputMapping extends FlxGamepadMapping
 	{
 		return switch (ID)
 		{
+			#if (flash || FLX_GAMEINPUT_API || FLX_JOYSTICK_API)
 			case A: XInputID.A;
 			case B: XInputID.B;
 			case X: XInputID.X;
@@ -93,6 +98,7 @@ class XInputMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: XInputID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: XInputID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.RIGHT_ANALOG_STICK.rawRight;
+			#end
 			default: -1;
 		}
 	}

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -507,14 +507,13 @@ class FlxBasePreloader extends DefaultPreloader
 	{
 		var percentLoaded = 0.0;
 		
-		if (bytesTotal > 0) {
-			
+		if (bytesTotal > 0)
+		{
 			percentLoaded = bytesLoaded / bytesTotal;
 			
-			if (percentLoaded > 1) {
-				
+			if (percentLoaded > 1)
+			{
 				percentLoaded = 1;
-				
 			}
 			
 		}
@@ -524,8 +523,8 @@ class FlxBasePreloader extends DefaultPreloader
 	
 	// Event Handlers
 	
-	private function mOnAddedToStage (event:Event):Void {
-		
+	private function mOnAddedToStage (event:Event):Void
+	{
 		removeEventListener (Event.ADDED_TO_STAGE, mOnAddedToStage);
 		
 		onInit ();

--- a/flixel/system/FlxBasePreloader.hx
+++ b/flixel/system/FlxBasePreloader.hx
@@ -405,17 +405,15 @@ class FlxBasePreloader extends DefaultPreloader
 }
 
 #if (openfl >= "4.0.0")
-@:dox(hide) class DefaultPreloader extends Sprite {
-	
-	
+@:dox(hide) class DefaultPreloader extends Sprite
+{
 	private var endAnimation:Int;
 	private var outline:Sprite;
 	private var progress:Sprite;
 	private var startAnimation:Int;
 	
-	
-	public function new () {
-		
+	public function new ()
+	{
 		super ();
 		
 		var backgroundColor = getBackgroundColor ();
@@ -425,10 +423,9 @@ class FlxBasePreloader extends DefaultPreloader
 		var perceivedLuminosity = (0.299 * r + 0.587 * g + 0.114 * b);
 		var color = 0x000000;
 		
-		if (perceivedLuminosity < 70) {
-			
+		if (perceivedLuminosity < 70)
+		{
 			color = 0xFFFFFF;
-			
 		}
 		
 		var x = 30;
@@ -458,70 +455,56 @@ class FlxBasePreloader extends DefaultPreloader
 		startAnimation = Lib.getTimer () + 100;
 		endAnimation = startAnimation + 1000;
 		
-		addEventListener (Event.ADDED_TO_STAGE, this_onAddedToStage);
-		
+		addEventListener (Event.ADDED_TO_STAGE, mOnAddedToStage);
 	}
 	
-	
-	public function getBackgroundColor ():Int {
-		
+	public function getBackgroundColor ():Int
+	{
 		return Lib.current.stage.window.config.background;
-		
 	}
 	
-	
-	public function getHeight ():Float {
-		
+	public function getHeight ():Float
+	{
 		var height = Lib.current.stage.window.config.height;
 		
-		if (height > 0) {
-			
+		if (height > 0)
+		{
 			return height;
-			
-		} else {
-			
-			return Lib.current.stage.stageHeight;
-			
 		}
-		
+		else
+		{
+			return Lib.current.stage.stageHeight;
+		}
 	}
 	
-	
-	public function getWidth ():Float {
-		
+	public function getWidth ():Float
+	{
 		var width = Lib.current.stage.window.config.width;
 		
-		if (width > 0) {
-			
+		if (width > 0)
+		{
 			return width;
-			
-		} else {
-			
-			return Lib.current.stage.stageWidth;
-			
 		}
-		
+		else
+		{
+			return Lib.current.stage.stageWidth;
+		}
 	}
 	
-	
-	@:keep public function onInit ():Void {
-		
-		addEventListener (Event.ENTER_FRAME, this_onEnterFrame);
-		
+	@:keep public function onInit ():Void
+	{
+		addEventListener (Event.ENTER_FRAME, mOnEnterFrame);
 	}
 	
-	
-	@:keep public function onLoaded ():Void {
-		
-		removeEventListener (Event.ENTER_FRAME, this_onEnterFrame);
+	@:keep public function onLoaded ():Void
+	{
+		removeEventListener (Event.ENTER_FRAME, mOnEnterFrame);
 		
 		dispatchEvent (new Event (Event.UNLOAD));
-		
 	}
 	
-	
-	@:keep public function onUpdate (bytesLoaded:Int, bytesTotal:Int):Void {
-		
+	@:keep public function onUpdate (bytesLoaded:Int, bytesTotal:Int):Void
+	{
 		var percentLoaded = 0.0;
 		
 		if (bytesTotal > 0) {
@@ -537,52 +520,41 @@ class FlxBasePreloader extends DefaultPreloader
 		}
 		
 		progress.scaleX = percentLoaded;
-		
 	}
-	
-	
-	
 	
 	// Event Handlers
 	
-	
-	
-	
-	private function this_onAddedToStage (event:Event):Void {
+	private function mOnAddedToStage (event:Event):Void {
 		
-		removeEventListener (Event.ADDED_TO_STAGE, this_onAddedToStage);
+		removeEventListener (Event.ADDED_TO_STAGE, mOnAddedToStage);
 		
 		onInit ();
 		onUpdate (loaderInfo.bytesLoaded, loaderInfo.bytesTotal);
 		
-		addEventListener (ProgressEvent.PROGRESS, this_onProgress);
-		addEventListener (Event.COMPLETE, this_onComplete);
+		addEventListener (ProgressEvent.PROGRESS, mOnProgress);
+		addEventListener (Event.COMPLETE, mOnComplete);
 		
 	}
 	
-	
-	private function this_onComplete (event:Event):Void {
-		
+	private function mOnComplete (event:Event):Void
+	{
 		event.preventDefault ();
 		
-		removeEventListener (ProgressEvent.PROGRESS, this_onProgress);
-		removeEventListener (Event.COMPLETE, this_onComplete);
+		removeEventListener (ProgressEvent.PROGRESS, mOnProgress);
+		removeEventListener (Event.COMPLETE, mOnComplete);
 		
 		#if (openfl < "5.0.0")
-		addEventListener (Event.COMPLETE, function (event) {
-			
+		addEventListener (Event.COMPLETE, function (event)
+		{
 			dispatchEvent (new Event (Event.UNLOAD));
-			
 		});
 		#end
 		
 		onLoaded ();
-		
 	}
 	
-	
-	private function this_onEnterFrame (event:Event):Void {
-		
+	private function mOnEnterFrame (event:Event):Void
+	{
 		var elapsed = Lib.getTimer () - startAnimation;
 		var total = endAnimation - startAnimation;
 		
@@ -593,16 +565,12 @@ class FlxBasePreloader extends DefaultPreloader
 		
 		outline.alpha = percent;
 		progress.alpha = percent;
-		
 	}
 	
-	
-	private function this_onProgress (event:ProgressEvent):Void {
-		
+	private function mOnProgress (event:ProgressEvent):Void
+	{
 		onUpdate (Std.int (event.bytesLoaded), Std.int (event.bytesTotal));
-		
 	}
-	
 	
 }
 #else

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -14,6 +14,10 @@ import flixel.tweens.FlxTween;
 import flixel.util.FlxStringUtil;
 import openfl.Assets;
 
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
+
 #if flash11
 import flash.utils.ByteArray;
 #end

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -128,7 +128,7 @@ class Interaction extends Window
 	{
 		// Did the user click a debugger UI element instead of performing
 		// a click related to a tool?
-		if (event.type == MouseEvent.MOUSE_DOWN && belongsToDebugger(event.target))
+		if (event.type == MouseEvent.MOUSE_DOWN && belongsToDebugger(cast event.target))
 			return;
 		
 		pointerJustPressed = event.type == MouseEvent.MOUSE_DOWN;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -10,7 +10,11 @@ import flixel.util.FlxColor;
 import openfl.Assets;
 
 #if !flash
+#if openfl_legacy
 import openfl.gl.GL;
+#else
+import lime.graphics.opengl.GL;
+#end
 #end
 
 /**

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -11,6 +11,10 @@ import flixel.math.FlxMath;
 import flixel.input.keyboard.FlxKey;
 import openfl.Assets;
 
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
+
 @:allow(flixel.FlxG)
 class SoundFrontEnd
 {

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -92,12 +92,14 @@ class FlxDefines
 		abortMinVersion("Lime", "2.8.1", (macro null).pos);
 		#end
 
+		#if openfl_legacy
 		#if (openfl >= "4.0.0")
 		abortMaxVersion("OpenFL", "4.0.0", "3.6.1", (macro null).pos);
 		#end
 		
 		#if ((lime >= "3.0.0") || (tools >= "3.0.0"))
 		abortMaxVersion("Lime", "3.0.0", "2.9.1", (macro null).pos);
+		#end
 		#end
 	}
 

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -23,6 +23,10 @@ import openfl.Assets;
 import haxe.Utf8;
 using flixel.util.FlxStringUtil;
 
+#if (openfl >= "5.0.0")
+import openfl.utils.AssetType;
+#end
+
 #if flash
 import openfl.geom.Rectangle;
 #end
@@ -771,13 +775,7 @@ class FlxText extends FlxSprite
 			height = newHeight;
 			var key:String = FlxG.bitmap.getUniqueKey("text");
 			
-			// retain the clipRect through text changes
-			var tempRect = clipRect;
-			
 			makeGraphic(Std.int(newWidth), Std.int(newHeight), FlxColor.TRANSPARENT, false, key);
-			
-			clipRect = tempRect;
-			
 			if (_hasBorderAlpha)
 				_borderPixels = graphic.bitmap.clone();
 			frameHeight = Std.int(height);

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -775,7 +775,13 @@ class FlxText extends FlxSprite
 			height = newHeight;
 			var key:String = FlxG.bitmap.getUniqueKey("text");
 			
+			// retain the clipRect through text changes
+			var tempRect = clipRect;
+			
 			makeGraphic(Std.int(newWidth), Std.int(newHeight), FlxColor.TRANSPARENT, false, key);
+			
+			clipRect = tempRect;
+			
 			if (_hasBorderAlpha)
 				_borderPixels = graphic.bitmap.clone();
 			frameHeight = Std.int(height);


### PR DESCRIPTION
This provides 1.) compile fixes for newer OpenFL releases then 2.) adds a naive implementation of rendering for the forthcoming `graphics.drawQuads` API and the newly implemented `graphics.beginShaderFill` method.

