### PR TITLE
FlxObject: fix for getting stuck on y-axis collisions, closes #1566

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -269,8 +269,8 @@ class FlxObject extends FlxBasic
 			var obj1deltaAbs:Float = (obj1delta > 0) ? obj1delta : -obj1delta;
 			var obj2deltaAbs:Float = (obj2delta > 0) ? obj2delta : -obj2delta;
 			
-			var obj1rect:FlxRect = _firstSeparateFlxRect.set(Object1.x, Object1.y - ((obj1delta > 0) ? obj1delta : 0), Object1.width, Object1.height + obj1deltaAbs);
-			var obj2rect:FlxRect = _secondSeparateFlxRect.set(Object2.x, Object2.y - ((obj2delta > 0) ? obj2delta : 0), Object2.width, Object2.height + obj2deltaAbs);
+			var obj1rect:FlxRect = _firstSeparateFlxRect.set(Object1.last.x, Object1.y - ((obj1delta > 0) ? obj1delta : 0), Object1.width, Object1.height + obj1deltaAbs);
+			var obj2rect:FlxRect = _secondSeparateFlxRect.set(Object2.last.x, Object2.y - ((obj2delta > 0) ? obj2delta : 0), Object2.width, Object2.height + obj2deltaAbs);
 			
 			if ((obj1rect.x + obj1rect.width > obj2rect.x) && (obj1rect.x < obj2rect.x + obj2rect.width) && (obj1rect.y + obj1rect.height > obj2rect.y) && (obj1rect.y < obj2rect.y + obj2rect.height))
 			{


### PR DESCRIPTION
I'm not entirely confident, but this fixed the issue I had while not breaking anything else as far as I've tested (not very much).

I was getting stucked while going towards and up a vertical wall, but this didn't happen while towards and up or down an horizontal wall.

## Before:
![before](https://user-images.githubusercontent.com/6261257/38169376-fe2594ba-3568-11e8-9346-be78ef86b77b.gif)

(I realize it's not obvious with that animation, but when I'm not moving, I'm actually trying to walk up-left)


## After:
![after](https://user-images.githubusercontent.com/6261257/38169366-bdfa955c-3568-11e8-923b-fc0848e2d31a.gif)


Interestingly, it didn't happen while going down, that's why I'm not that confident... That plus the fact that I have no clue how the overlap computation works.