### PR TITLE
FlxBar: rounding value of filled bar

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -733,7 +733,7 @@ class FlxBar extends FlxSprite
 		var percent:Float = fraction * _maxPercent;
 		var maxScale:Float = (_fillHorizontal) ? barWidth : barHeight;
 		var scaleInterval:Float = maxScale / numDivisions;
-		var interval:Float = Std.int(fraction * maxScale / scaleInterval) * scaleInterval;
+		var interval:Float = Math.round(Std.int(fraction * maxScale / scaleInterval) * scaleInterval);
 		
 		if (_fillHorizontal)
 		{


### PR DESCRIPTION
This fixes an issue where a `FlxBar` would be at 100%, but not look like it was at 100% thanks to rounding/precision...