### PR TITLE
FlxSpriteUtil: add a positioning function to space()

### DIFF
--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -218,7 +218,8 @@ class FlxSpriteUtil
 				curX = runningX + prevWidth + horizontalSpacing;
 				runningX = curX;
 			}
-			else{
+			else
+			{
 				curX = object.x;
 			}
 

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -187,6 +187,75 @@ class FlxSpriteUtil
 	}
 	
 	/**
+	 * Distributes an array of FlxObjects from a given point, vertically or horizontally, such that they won't overlap (unless padding is negative).
+	 * Has the option to have a supplied function do the positioning (for tweening purposes)
+	 * EG: FlxSpriteUtil.distribute(VERTICAL, mySprites, 50, 10, function(obj, y){FlxTween.tween(obj, {x:10, y:y}, 0.5);} );
+	 * 	   //Tweens the sprites in mySprites from their current position to being in a column 10px from the left, 50px from the top, 10px apart.
+	 * @param	axis          HORIZONTAL or VERTICAL
+	 * @param	targets       An array of FlxObjects. Cast may be needed.
+	 * @param	from          x position to start placing from for HORIZONTAL, or y position for VERTICAL.
+	 * @param	padding		  Gap in px to leave between objects
+	 * @param	positioner    Function that accepts a FlxObject and a Float representing the new x or y position for that object, returning Void.
+	 */
+	public static function distribute(axis:Axis, targets:Array<FlxObject>, from:Float = null, padding:Float = 0, positioner:FlxObject->Float->Void = null):Void
+	{
+		if (targets.length == 0)
+		{
+			return;
+		}
+		var running_offset:Float = 0;
+		var prev:FlxObject = targets[0];
+		if (from != null)
+		{
+			if (positioner == null)
+			{
+				if (axis == HORIZONTAL)
+				{
+					prev.x = from;
+				}
+				else{
+					prev.y = from;
+				}
+			}
+			else{
+				positioner(prev, from);
+				running_offset = from;
+			}
+		}
+		var i:Int = 1;
+		while (i < targets.length)
+		{
+			if (axis == HORIZONTAL)
+			{
+				if (positioner == null)
+				{
+					targets[i].x = prev.x + prev.width + padding;
+				}
+				else
+				{
+					positioner(targets[i], running_offset + prev.width + padding);
+					running_offset += prev.width + padding;
+				}
+			}
+			else
+			{
+				if (positioner == null)
+				{
+					targets[i].y = prev.y + prev.height + padding;
+				}
+				else
+				{
+					positioner(targets[i], running_offset + prev.height + padding);
+					running_offset += prev.height + padding;
+				}
+			}
+			prev = targets[i];
+			i++;
+		}
+		return;
+	}
+	
+	/**
 	 * This function draws a line on a FlxSprite from position X1,Y1
 	 * to position X2,Y2 with the specified color.
 	 * 
@@ -622,6 +691,12 @@ class FlxSpriteUtil
 	{
 		sprite.alpha = f;
 	}
+}
+
+enum Axis
+{
+	HORIZONTAL;
+	VERTICAL;
 }
 
 typedef LineStyle =

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -197,13 +197,13 @@ class FlxSpriteUtil
 	 * @param	padding		  Gap in px to leave between objects
 	 * @param	positioner    Function that accepts a FlxObject and a Float representing the new x or y position for that object, returning Void.
 	 */
-	public static function distribute(axis:Axis, targets:Array<FlxObject>, from:Float = null, padding:Float = 0, positioner:FlxObject->Float->Void = null):Void
+	public static function distribute(axis:Axis, targets:Array<FlxObject>, ?from:Float, padding:Float = 0, ?positioner:FlxObject->Float->Void):Void
 	{
 		if (targets.length == 0)
 		{
 			return;
 		}
-		var running_offset:Float = 0;
+		var runningOffset:Float = 0;
 		var prev:FlxObject = targets[0];
 		if (from != null)
 		{
@@ -213,13 +213,15 @@ class FlxSpriteUtil
 				{
 					prev.x = from;
 				}
-				else{
+				else
+				{
 					prev.y = from;
 				}
 			}
-			else{
+			else
+			{
 				positioner(prev, from);
-				running_offset = from;
+				runningOffset = from;
 			}
 		}
 		var i:Int = 1;
@@ -233,8 +235,8 @@ class FlxSpriteUtil
 				}
 				else
 				{
-					positioner(targets[i], running_offset + prev.width + padding);
-					running_offset += prev.width + padding;
+					positioner(targets[i], runningOffset + prev.width + padding);
+					runningOffset += prev.width + padding;
 				}
 			}
 			else
@@ -245,8 +247,8 @@ class FlxSpriteUtil
 				}
 				else
 				{
-					positioner(targets[i], running_offset + prev.height + padding);
-					running_offset += prev.height + padding;
+					positioner(targets[i], runningOffset + prev.height + padding);
+					runningOffset += prev.height + padding;
 				}
 			}
 			prev = targets[i];

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -209,13 +209,10 @@ class FlxSpriteUtil
 			objects[0].y = runningY;
 		}
 		
-		
 		for (i in 1...objects.length)
 		{
 			var object = objects[i];
-			
-			
-			
+				
 			if (horizontalSpacing != null)
 			{
 				curX = runningX + prevWidth + horizontalSpacing;
@@ -230,7 +227,8 @@ class FlxSpriteUtil
 				curY = runningY + prevHeight + verticalSpacing;
 				runningY = curY;
 			}
-			else{
+			else
+			{
 				curY = object.y;
 			}
 			

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -162,7 +162,7 @@ class FlxSpriteUtil
 	 * @param	horizontalSpacing	The amount of pixels between each sprite horizontally. Set to `null` to just keep the current X position of each object.
 	 * @param	verticalSpacing		The amount of pixels between each sprite vertically. Set to `null` to just keep the current Y position of each object.
 	 * @param	spaceFromBounds		If set to true the h/v spacing values will be added to the width/height of the sprite, if false it will ignore this
-	 * @param	position			An function with the signature `(target:FlxObject, x:Float, y:Float):Void`. You can use this to tween objects into their spaced position, etc.
+	 * @param	position			A function with the signature `(target:FlxObject, x:Float, y:Float):Void`. You can use this to tween objects into their spaced position, etc.
 	 */
 	public static function space(objects:Array<FlxObject>, startX:Float, startY:Float, ?horizontalSpacing:Float, 
 		?verticalSpacing:Float, spaceFromBounds:Bool = false, ?position:FlxObject->Float->Float->Void):Void

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -159,20 +159,16 @@ class FlxSpriteUtil
 	 * @param	objects				An Array of FlxObjects
 	 * @param	startX				The base X coordinate to start the spacing from
 	 * @param	startY				The base Y coordinate to start the spacing from
-	 * @param	horizontalSpacing	The amount of pixels between each sprite horizontally. Set to 'null' to just keep the current X position of each object.
-	 * @param	verticalSpacing		The amount of pixels between each sprite vertically. Set to 'null' to just keep the current Y position of each object.
+	 * @param	horizontalSpacing	The amount of pixels between each sprite horizontally. Set to `null` to just keep the current X position of each object.
+	 * @param	verticalSpacing		The amount of pixels between each sprite vertically. Set to `null` to just keep the current Y position of each object.
 	 * @param	spaceFromBounds		If set to true the h/v spacing values will be added to the width/height of the sprite, if false it will ignore this
-	 * @param 	positioner			An function with the signature (target:FlxObject, x:Float, y:Float):Void. You can use this to tween objects into their spaced position, etc.
+	 * @param	position			An function with the signature `(target:FlxObject, x:Float, y:Float):Void`. You can use this to tween objects into their spaced position, etc.
 	 */
 	public static function space(objects:Array<FlxObject>, startX:Float, startY:Float, ?horizontalSpacing:Float, 
-		?verticalSpacing:Float, spaceFromBounds:Bool = false, ?positioner:FlxObject->Float->Float->Void):Void
+		?verticalSpacing:Float, spaceFromBounds:Bool = false, ?position:FlxObject->Float->Float->Void):Void
 	{
 		var prevWidth:Float = 0;
-		var prevHeight:Float = 0;
 		var runningX:Float = 0;
-		var runningY:Float = 0;
-		var curX:Float = 0;
-		var curY:Float = 0;
 		
 		if (horizontalSpacing != null)
 		{
@@ -186,6 +182,10 @@ class FlxSpriteUtil
 		{
 			runningX = objects[0].x;
 		}
+
+		var prevHeight:Float = 0;
+		var runningY:Float = 0;
+
 		if (verticalSpacing != null)
 		{
 			if (spaceFromBounds)
@@ -199,9 +199,9 @@ class FlxSpriteUtil
 			runningY = objects[0].y;
 		}
 		
-		if (positioner != null)
+		if (position != null)
 		{
-			positioner(objects[0], runningX, runningY);
+			position(objects[0], runningX, runningY);
 		}
 		else
 		{
@@ -209,10 +209,13 @@ class FlxSpriteUtil
 			objects[0].y = runningY;
 		}
 		
+		var curX:Float = 0;
+		var curY:Float = 0;
+
 		for (i in 1...objects.length)
 		{
 			var object = objects[i];
-				
+			
 			if (horizontalSpacing != null)
 			{
 				curX = runningX + prevWidth + horizontalSpacing;
@@ -233,9 +236,9 @@ class FlxSpriteUtil
 				curY = object.y;
 			}
 			
-			if (positioner != null)
+			if (position != null)
 			{
-				positioner(object, curX, curY);
+				position(object, curX, curY);
 			}
 			else
 			{


### PR DESCRIPTION
Adds distribute( to FlxSpriteUtil, a function that allows you to place objects in an array into a given order on the screen with the option to provide a tweening function for those objects.

I elected at the moment to go with a new function rather than modifying space, as the functionality was different to what I was going for, and the space function is already bloated without adding new features.