### PR TITLE
Improve alpha functionality

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -42,6 +42,12 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	public var length(get, null):Int;
 	
 	/**
+	 * Whether to attempt to preserve the ratio of alpha values of group members, or set them directly through 
+	 * the alpha property. Defaults to `false` (preservation).
+	 */
+	public var directAlpha:Bool = false;
+	
+	/**
 	 * The maximum capacity of this group. Default is `0`, meaning no max capacity, and the group can just grow.
 	 */
 	public var maxSize(get, set):Int;
@@ -712,7 +718,13 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		if (exists && alpha != Value)
 		{
 			var factor:Float = (alpha > 0) ? Value / alpha : 0;
-			transformChildren(alphaTransform, factor);
+			if (!directAlpha && alpha != 0)
+			{
+				transformChildren(alphaTransform, factor);
+			}
+			else{
+				transformChildren(directAlphaTransform, Value);
+			}
 		}
 		return alpha = Value;
 	}
@@ -876,7 +888,17 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	inline function xTransform(Sprite:FlxSprite, X:Float)                          Sprite.x += X; // addition
 	inline function yTransform(Sprite:FlxSprite, Y:Float)                          Sprite.y += Y; // addition
 	inline function angleTransform(Sprite:FlxSprite, Angle:Float)                  Sprite.angle += Angle; // addition
-	inline function alphaTransform(Sprite:FlxSprite, Alpha:Float)                  Sprite.alpha *= Alpha; // multiplication
+	inline function alphaTransform(Sprite:FlxSprite, Alpha:Float)
+	{
+		if (Sprite.alpha != 0 || Alpha == 0){
+			Sprite.alpha *= Alpha; // multiplication
+		}
+		else
+		{
+			Sprite.alpha = 1 / Alpha; //direct set to avoid stuck sprites
+		}
+	}
+	inline function directAlphaTransform(Sprite:FlxSprite, Alpha:Float)            Sprite.alpha = Alpha;  // direct set
 	inline function facingTransform(Sprite:FlxSprite, Facing:Int)                  Sprite.facing = Facing;
 	inline function flipXTransform(Sprite:FlxSprite, FlipX:Bool)                   Sprite.flipX = FlipX;
 	inline function flipYTransform(Sprite:FlxSprite, FlipY:Bool)                   Sprite.flipY = FlipY;


### PR DESCRIPTION
Improved default alpha behaviour by directly setting the alpha of any member whose alpha is set to zero when the group's alpha is set. This prevents group members from 'sticking' at zero alpha. 

Also added an optional flag, directAlpha, which makes setting the alpha value of the group simply propagate that value to all group members. Currently this is set to false by default, but I honestly believe it should be set to true.

I understand there is the potential for the first change to cause unexpected behaviour, but I think that behaviour is considerably less unexpected than sprites sticking at zero alpha.