### PR TITLE
FlxBitmapText: add clipRect support

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -7,6 +7,7 @@ import flixel.FlxSprite;
 import flixel.graphics.frames.FlxBitmapFont;
 import flixel.graphics.frames.FlxFrame;
 import flixel.math.FlxPoint;
+import flixel.math.FlxRect;
 import flixel.text.FlxText.FlxTextAlign;
 import flixel.text.FlxText.FlxTextBorderStyle;
 import flixel.util.FlxColor;
@@ -357,6 +358,21 @@ class FlxBitmapText extends FlxSprite
 				oy = frameHeight - oy;
 			}
 			
+			var frameRect = FlxRect.get(0, 0, frameWidth, frameHeight);
+			var clippedFrameRect = FlxRect.get();
+			
+			if (clipRect != null)
+			{
+				clippedFrameRect = clipRect.intersection(frameRect, clippedFrameRect);
+				
+				if (clippedFrameRect.isEmpty)
+					return;
+			}
+			else
+			{
+				clippedFrameRect = frameRect;
+			}
+			
 			for (camera in cameras)
 			{
 				if (!camera.visible || !camera.exists || !isOnScreen(camera))
@@ -378,7 +394,7 @@ class FlxBitmapText extends FlxSprite
 					// backround tile transformations
 					currFrame = FlxG.bitmap.whitePixel;
 					_matrix.identity();
-					_matrix.scale(0.1 * frameWidth, 0.1 * frameHeight);
+					_matrix.scale(0.1 * clippedFrameRect.width, 0.1 * clippedFrameRect.height);
 					_matrix.translate(-ox, -oy);
 					_matrix.scale(sx, sy);
 					
@@ -387,7 +403,7 @@ class FlxBitmapText extends FlxSprite
 						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
 					
-					_matrix.translate(_point.x + ox, _point.y + oy);
+					_matrix.translate(_point.x + ox + clippedFrameRect.x, _point.y + oy + clippedFrameRect.y);
 					_colorParams.setMultipliers(bgRed, bgGreen, bgBlue, bgAlpha);
 					camera.drawPixels(currFrame, null, _matrix, _colorParams, blend, antialiasing);
 				}
@@ -404,6 +420,21 @@ class FlxBitmapText extends FlxSprite
 					
 					currTileX = borderDrawData[dataPos + 1];
 					currTileY = borderDrawData[dataPos + 2];
+					
+					if (clipRect != null)
+					{
+						frameRect.set(currTileX, currTileY, currFrame.frame.width, currFrame.frame.height);
+						clippedFrameRect.set(0, 0, 0, 0);
+						if (clipRect.intersection(frameRect, clippedFrameRect).isEmpty)
+							continue;
+						
+						if (clippedFrameRect.width != frameRect.width || clippedFrameRect.height != frameRect.height)
+						{
+							clippedFrameRect.x -= frameRect.x;
+							clippedFrameRect.y -= frameRect.y;
+							currFrame = currFrame.clipTo(clippedFrameRect);
+						}
+					}
 					
 					currFrame.prepareMatrix(_matrix);
 					_matrix.translate(currTileX - ox, currTileY - oy);
@@ -426,6 +457,21 @@ class FlxBitmapText extends FlxSprite
 					
 					currTileX = textDrawData[dataPos + 1];
 					currTileY = textDrawData[dataPos + 2];
+					
+					if (clipRect != null)
+					{
+						frameRect.set(currTileX, currTileY, currFrame.frame.width, currFrame.frame.height);
+						clippedFrameRect.set(0, 0, 0, 0);
+						if (clipRect.intersection(frameRect, clippedFrameRect).isEmpty)
+							continue;
+						
+						if (clippedFrameRect.width != frameRect.width || clippedFrameRect.height != frameRect.height)
+						{
+							clippedFrameRect.x -= frameRect.x;
+							clippedFrameRect.y -= frameRect.y;
+							currFrame = currFrame.clipTo(clippedFrameRect);
+						}
+					}
 					
 					currFrame.prepareMatrix(_matrix);
 					_matrix.translate(currTileX - ox, currTileY - oy);

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -358,15 +358,17 @@ class FlxBitmapText extends FlxSprite
 				oy = frameHeight - oy;
 			}
 			
-			var frameRect = FlxRect.get(0, 0, frameWidth, frameHeight);
-			var clippedFrameRect = frameRect;
-			
+			var clippedFrameRect;
 			if (clipRect != null)
 			{
-				clippedFrameRect = clipRect.intersection(frameRect);
+				clippedFrameRect = clipRect.intersection(FlxRect.weak(0, 0, frameWidth, frameHeight));
 				
 				if (clippedFrameRect.isEmpty)
 					return;
+			}
+			else
+			{
+				clippedFrameRect = FlxRect.get(0, 0, frameWidth, frameHeight);
 			}
 			
 			for (camera in cameras)
@@ -419,16 +421,7 @@ class FlxBitmapText extends FlxSprite
 					
 					if (clipRect != null)
 					{
-						frameRect.set(currTileX, currTileY, currFrame.frame.width, currFrame.frame.height);
-						clippedFrameRect.set(0, 0, 0, 0);
-						clipRect.intersection(frameRect, clippedFrameRect);
-						
-						if (clippedFrameRect.width != frameRect.width || clippedFrameRect.height != frameRect.height)
-						{
-							clippedFrameRect.x -= frameRect.x;
-							clippedFrameRect.y -= frameRect.y;
-							currFrame = currFrame.clipTo(clippedFrameRect);
-						}
+						currFrame = currFrame.clipTo(clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY));
 					}
 					
 					currFrame.prepareMatrix(_matrix);
@@ -455,16 +448,7 @@ class FlxBitmapText extends FlxSprite
 					
 					if (clipRect != null)
 					{
-						frameRect.set(currTileX, currTileY, currFrame.frame.width, currFrame.frame.height);
-						clippedFrameRect.set(0, 0, 0, 0);
-						clipRect.intersection(frameRect, clippedFrameRect);
-						
-						if (clippedFrameRect.width != frameRect.width || clippedFrameRect.height != frameRect.height)
-						{
-							clippedFrameRect.x -= frameRect.x;
-							clippedFrameRect.y -= frameRect.y;
-							currFrame = currFrame.clipTo(clippedFrameRect);
-						}
+						currFrame = currFrame.clipTo(clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY));
 					}
 					
 					currFrame.prepareMatrix(_matrix);
@@ -476,7 +460,6 @@ class FlxBitmapText extends FlxSprite
 					}
 					
 					_matrix.translate(_point.x + ox, _point.y + oy);
-					
 					_colorParams.setMultipliers(textRed, textGreen, textBlue, tAlpha);
 					drawItem.addQuad(currFrame, _matrix, _colorParams);
 				}
@@ -487,7 +470,6 @@ class FlxBitmapText extends FlxSprite
 			}
 			
 			// dispose clipRect helpers
-			frameRect.put();
 			clippedFrameRect.put();
 			
 			#if FLX_DEBUG
@@ -1524,21 +1506,19 @@ class FlxBitmapText extends FlxSprite
 		var pos:Int = data.length;
 		var textPos:Int;
 		var textLen:Int = Std.int(textData.length / 3);
-		var frameRect = FlxRect.get();
-		var clippedFrameRect = FlxRect.get();
-		var frameVisible = true;
-		var frame;
+		var rect = FlxRect.get();
+		var frameVisible;
 		
 		for (i in 0...textLen)
 		{
 			textPos = 3 * i;
 			
+			frameVisible = true;
+			
 			if (clipRect != null)
 			{
-				frame = font.getCharFrame(Std.int(textData[textPos])).frame;
-				frameRect.set(posX + textData[textPos + 1], posY + textData[textPos + 2], frame.width, frame.height);
-				clippedFrameRect.set(0, 0, 0, 0);
-				frameVisible = !clipRect.intersection(frameRect, clippedFrameRect).isEmpty;
+				rect.copyFrom(clipRect).offset(-textData[textPos + 1] - posX, -textData[textPos + 2] - posY);
+				frameVisible = font.getCharFrame(Std.int(textData[textPos])).clipTo(rect).type != FlxFrameType.EMPTY;
 			}
 			
 			if (frameVisible)
@@ -1549,8 +1529,7 @@ class FlxBitmapText extends FlxSprite
 			}
 		}
 		
-		frameRect.put();
-		clippedFrameRect.put();
+		rect.put();
 	}
 	
 	/**

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -421,7 +421,8 @@ class FlxBitmapText extends FlxSprite
 					
 					if (clipRect != null)
 					{
-						currFrame = currFrame.clipTo(clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY));
+						clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY);
+						currFrame = currFrame.clipTo(clippedFrameRect);
 					}
 					
 					currFrame.prepareMatrix(_matrix);
@@ -448,7 +449,8 @@ class FlxBitmapText extends FlxSprite
 					
 					if (clipRect != null)
 					{
-						currFrame = currFrame.clipTo(clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY));
+						clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY);
+						currFrame = currFrame.clipTo(clippedFrameRect);
 					}
 					
 					currFrame.prepareMatrix(_matrix);

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -421,8 +421,7 @@ class FlxBitmapText extends FlxSprite
 					{
 						frameRect.set(currTileX, currTileY, currFrame.frame.width, currFrame.frame.height);
 						clippedFrameRect.set(0, 0, 0, 0);
-						if (clipRect.intersection(frameRect, clippedFrameRect).isEmpty)
-							continue;
+						clipRect.intersection(frameRect, clippedFrameRect);
 						
 						if (clippedFrameRect.width != frameRect.width || clippedFrameRect.height != frameRect.height)
 						{
@@ -458,8 +457,7 @@ class FlxBitmapText extends FlxSprite
 					{
 						frameRect.set(currTileX, currTileY, currFrame.frame.width, currFrame.frame.height);
 						clippedFrameRect.set(0, 0, 0, 0);
-						if (clipRect.intersection(frameRect, clippedFrameRect).isEmpty)
-							continue;
+						clipRect.intersection(frameRect, clippedFrameRect);
 						
 						if (clippedFrameRect.width != frameRect.width || clippedFrameRect.height != frameRect.height)
 						{
@@ -499,6 +497,16 @@ class FlxBitmapText extends FlxSprite
 			}
 			#end
 		}
+	}
+	
+	override function set_clipRect(Rect:FlxRect):FlxRect
+	{
+		super.set_clipRect(Rect);
+		if (!FlxG.renderBlit)
+		{
+			pendingTextBitmapChange = true;
+		}
+		return clipRect;
 	}
 	
 	override function set_color(Color:FlxColor):FlxColor
@@ -1283,6 +1291,9 @@ class FlxBitmapText extends FlxSprite
 		}
 		
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
+		var frameRect:FlxRect = FlxRect.get();
+		var clippedFrameRect:FlxRect = FlxRect.get();
+		var frameVisible;
 		
 		for (i in 0...lineLength)
 		{
@@ -1301,15 +1312,29 @@ class FlxBitmapText extends FlxSprite
 				charFrame = font.getCharFrame(charCode);
 				if (charFrame != null)
 				{
-					textData[pos++] = charCode;
-					textData[pos++] = curX;
-					textData[pos++] = curY;
+					frameVisible = true;
+					if (clipRect != null)
+					{
+						frameRect.set(curX, curY, charFrame.frame.width, charFrame.frame.height);
+						clippedFrameRect.set(0, 0, 0, 0);
+						frameVisible = !clipRect.intersection(frameRect, clippedFrameRect).isEmpty;
+					}
+					
+					if (frameVisible)
+					{
+						textData[pos++] = charCode;
+						textData[pos++] = curX;
+						textData[pos++] = curY;
+					}
 					curX += font.getCharAdvance(charCode);
 				}
 			}
 			
 			curX += letterSpacing;
 		}
+		
+		frameRect.put();
+		clippedFrameRect.put();
 	}
 	
 	function updatePixels(useTiles:Bool = false):Void

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -488,6 +488,10 @@ class FlxBitmapText extends FlxSprite
 				#end
 			}
 			
+			// dispose clipRect helpers
+			frameRect.put();
+			clippedFrameRect.put();
+			
 			#if FLX_DEBUG
 			if (FlxG.debugger.drawDebug)
 			{

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -395,7 +395,7 @@ class FlxBitmapText extends FlxSprite
 					currFrame = FlxG.bitmap.whitePixel;
 					_matrix.identity();
 					_matrix.scale(0.1 * clippedFrameRect.width, 0.1 * clippedFrameRect.height);
-					_matrix.translate(-ox, -oy);
+					_matrix.translate(clippedFrameRect.x - ox, clippedFrameRect.y - oy);
 					_matrix.scale(sx, sy);
 					
 					if (angle != 0)
@@ -403,7 +403,7 @@ class FlxBitmapText extends FlxSprite
 						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
 					
-					_matrix.translate(_point.x + ox + clippedFrameRect.x, _point.y + oy + clippedFrameRect.y);
+					_matrix.translate(_point.x + ox, _point.y + oy);
 					_colorParams.setMultipliers(bgRed, bgGreen, bgBlue, bgAlpha);
 					camera.drawPixels(currFrame, null, _matrix, _colorParams, blend, antialiasing);
 				}

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -359,18 +359,14 @@ class FlxBitmapText extends FlxSprite
 			}
 			
 			var frameRect = FlxRect.get(0, 0, frameWidth, frameHeight);
-			var clippedFrameRect = FlxRect.get();
+			var clippedFrameRect = frameRect;
 			
 			if (clipRect != null)
 			{
-				clippedFrameRect = clipRect.intersection(frameRect, clippedFrameRect);
+				clippedFrameRect = clipRect.intersection(frameRect);
 				
 				if (clippedFrameRect.isEmpty)
 					return;
-			}
-			else
-			{
-				clippedFrameRect = frameRect;
 			}
 			
 			for (camera in cameras)

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1291,9 +1291,6 @@ class FlxBitmapText extends FlxSprite
 		}
 		
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
-		var frameRect:FlxRect = FlxRect.get();
-		var clippedFrameRect:FlxRect = FlxRect.get();
-		var frameVisible;
 		
 		for (i in 0...lineLength)
 		{
@@ -1312,29 +1309,15 @@ class FlxBitmapText extends FlxSprite
 				charFrame = font.getCharFrame(charCode);
 				if (charFrame != null)
 				{
-					frameVisible = true;
-					if (clipRect != null)
-					{
-						frameRect.set(curX, curY, charFrame.frame.width, charFrame.frame.height);
-						clippedFrameRect.set(0, 0, 0, 0);
-						frameVisible = !clipRect.intersection(frameRect, clippedFrameRect).isEmpty;
-					}
-					
-					if (frameVisible)
-					{
-						textData[pos++] = charCode;
-						textData[pos++] = curX;
-						textData[pos++] = curY;
-					}
+					textData[pos++] = charCode;
+					textData[pos++] = curX;
+					textData[pos++] = curY;
 					curX += font.getCharAdvance(charCode);
 				}
 			}
 			
 			curX += letterSpacing;
 		}
-		
-		frameRect.put();
-		clippedFrameRect.put();
 	}
 	
 	function updatePixels(useTiles:Bool = false):Void
@@ -1541,14 +1524,33 @@ class FlxBitmapText extends FlxSprite
 		var pos:Int = data.length;
 		var textPos:Int;
 		var textLen:Int = Std.int(textData.length / 3);
+		var frameRect = FlxRect.get();
+		var clippedFrameRect = FlxRect.get();
+		var frameVisible = true;
+		var frame;
 		
 		for (i in 0...textLen)
 		{
 			textPos = 3 * i;
-			data[pos++] = textData[textPos];
-			data[pos++] = textData[textPos + 1] + posX;
-			data[pos++] = textData[textPos + 2] + posY;
+			
+			if (clipRect != null)
+			{
+				frame = font.getCharFrame(Std.int(textData[textPos])).frame;
+				frameRect.set(posX + textData[textPos + 1], posY + textData[textPos + 2], frame.width, frame.height);
+				clippedFrameRect.set(0, 0, 0, 0);
+				frameVisible = !clipRect.intersection(frameRect, clippedFrameRect).isEmpty;
+			}
+			
+			if (frameVisible)
+			{
+				data[pos++] = textData[textPos];
+				data[pos++] = textData[textPos + 1] + posX;
+				data[pos++] = textData[textPos + 2] + posY;
+			}
 		}
+		
+		frameRect.put();
+		clippedFrameRect.put();
 	}
 	
 	/**


### PR DESCRIPTION
this change culls and clips letters on the draw() method based on the Text's clipRect property. I'm actively searching for a way to do this on updateTextBitmap rather than on each draw, but that might not be worthwhile.

fixes #2170 