### PR TITLE
FlxFilterFrames.applyToSprite: add to, rather than wipe previous offset

### DIFF
--- a/flixel/graphics/frames/FlxFilterFrames.hx
+++ b/flixel/graphics/frames/FlxFilterFrames.hx
@@ -91,7 +91,7 @@ class FlxFilterFrames extends FlxFramesCollection
 		var w:Float = spr.width;
 		var h:Float = spr.height;
 		spr.setFrames(this, saveAnimations);
-		spr.offset.set(0.5 * widthInc, 0.5 * heightInc);
+		spr.offset.add(0.5 * widthInc, 0.5 * heightInc);
 		spr.setSize(w, h);
 	}
 	


### PR DESCRIPTION
Adjusts the current offset rather than ignoring its previous offset entirely. `applyToSprite` is typically used to add a glow or blur filter to an existing sprite sheet, typically it's desired for the hitbox to only cover the original graphical area so the offset is changed, but it assumed the original offset was 0,0. this change accounts for the previous value

fixes #2175 