### PR TITLE
Fix XML access warning

### DIFF
--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -10,8 +10,13 @@ import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.system.FlxAssets.FlxTexturePackerSource;
 import haxe.Json;
-import haxe.xml.Fast;
 import openfl.Assets;
+
+#if (haxe_ver >= 4)
+import haxe.xml.Access in Fast;
+#else
+import haxe.xml.Fast;
+#end
 
 /**
  * Atlas frames collection. It makes possible to use texture atlases in Flixel.
@@ -252,7 +257,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		if (Assets.exists(Description))
 			Description = Assets.getText(Description);
 		
-		var data:Fast = new haxe.xml.Fast(Xml.parse(Description).firstElement());
+		var data:Fast = new Fast(Xml.parse(Description).firstElement());
 		
 		for (texture in data.nodes.SubTexture)
 		{


### PR DESCRIPTION
This fixes the following warnings when compiling Flixel projects on Haxe versions 4.0+:

```
haxe/lib/flixel/git/flixel/graphics/frames/FlxAtlasFrames.hx:255: characters 12-16 : Warning : This typedef is deprecated in favor of haxe.xml.Access
haxe/lib/flixel/git/flixel/graphics/frames/FlxAtlasFrames.hx:255: characters 23-36 : Warning : This typedef is deprecated in favor of haxe.xml.Access
```

The approach used matches that in @jgranick's recent commit to Lime (https://github.com/openfl/lime/commit/263e73922e26a574f123e84b92219cff70ad56db).