### PR TITLE
FlxBitmapFont: Remove background of XNA fonts

### DIFF
--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -424,12 +424,8 @@ class FlxBitmapFont extends FlxFramesCollection
 		var frameRect = flashRect;
 		frame.frame.copyToFlash(frameRect);
 		
-		#if flash
-		// TODO: fix this issue...
-		// for some reason this line causes app crash on targets other than flash...
 		var bgColor32:Int = bmd.getPixel32(Std.int(frame.frame.x), Std.int(frame.frame.y));
 		bmd.threshold(bmd, frameRect, point, "==", bgColor32, FlxColor.TRANSPARENT, FlxColor.WHITE, true);
-		#end
 		
 		if (charBGColor != FlxColor.TRANSPARENT)
 		{


### PR DESCRIPTION
When a FlxBitmapText uses a font that was created using FlxBitmapFont.fromXNA(), and the zoom of the current FlxCamera is a non-integer value, the background color that separates characters in the font's source image can sometimes appear between characters in the FlxBitmapText (see example [here](https://i.imgur.com/lJddn4K.png).) There is already code in place to remove this background color from the font, but it's currently restricted to the Flash target only, apparently due to crashes on other platforms. I removed the conditional check for Flash and tested FlxBitmapFont.fromXNA() on HTML5, Linux, Neko, and Windows; none of them crashed, and as desired, the background color no longer appears between the characters.