### PR TITLE
add SignalFrontEnd.preGameStart

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -137,12 +137,12 @@ class FlxGame extends Sprite
 	 * Whether the game lost focus.
 	 */
 	var _lostFocus:Bool = false;
-
+	
 	/**
 	 * The filters array to be applied to the game.
 	 */
 	var _filters:Array<BitmapFilter>;
-
+	
 	#if (desktop && lime_legacy)
 	/**
 	 * Ugly workaround to ensure consistent behaviour between flash and cpp
@@ -150,21 +150,21 @@ class FlxGame extends Sprite
 	 */
 	var _onFocusFiredOnce:Bool = false;
 	#end
-
+	
 	#if FLX_FOCUS_LOST_SCREEN
 	/**
 	 * The "focus lost" screen.
 	 */
 	var _focusLostScreen:FlxFocusLostScreen;
 	#end
-
+	
 	/**
 	 * Mouse cursor.
 	 */
 	@:allow(flixel.FlxG)
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	var _inputContainer:Sprite;
-
+	
 	#if FLX_SOUND_TRAY
 	/**
 	 * Change this after calling `super()` in the `FlxGame` constructor
@@ -172,7 +172,7 @@ class FlxGame extends Sprite
 	 */
 	var _customSoundTray:Class<FlxSoundTray> = FlxSoundTray;
 	#end
-
+	
 	#if FLX_FOCUS_LOST_SCREEN
 	/**
 	 * Change this after calling `super()` in the `FlxGame` constructor
@@ -180,12 +180,12 @@ class FlxGame extends Sprite
 	 */
 	var _customFocusLostScreen:Class<FlxFocusLostScreen> = FlxFocusLostScreen;
 	#end
-
+	
 	/**
 	 * Whether the splash screen should be skipped.
 	 */
 	var _skipSplash:Bool = false;
-
+	
 	#if desktop
 	/**
 	 * Should we start fullscreen or not? This is useful if you want to load fullscreen settings from a
@@ -193,7 +193,7 @@ class FlxGame extends Sprite
 	 */
 	var _startFullscreen:Bool = false;
 	#end
-
+	
 	/**
 	 * If a state change was requested, the new state object is stored here until we switch to it.
 	 */
@@ -202,7 +202,7 @@ class FlxGame extends Sprite
 	 * A flag for keeping track of whether a game reset was requested or not.
 	 */
 	var _resetGame:Bool = false;
-
+	
 	#if FLX_RECORD
 	/**
 	 * Container for a game replay object.
@@ -220,7 +220,7 @@ class FlxGame extends Sprite
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
 	var _recordingRequested:Bool = false;
 	#end
-
+	
 	#if FLX_POST_PROCESS
 	/**
 	 * `Sprite` for postprocessing effects
@@ -231,7 +231,7 @@ class FlxGame extends Sprite
 	 */
 	var postProcesses:Array<PostProcess> = [];
 	#end
-
+	
 	/**
 	 * Instantiate a new game object.
 	 *
@@ -250,14 +250,14 @@ class FlxGame extends Sprite
 		UpdateFramerate:Int = 60, DrawFramerate:Int = 60, SkipSplash:Bool = false, StartFullscreen:Bool = false)
 	{
 		super();
-
+		
 		#if desktop
 		_startFullscreen = StartFullscreen;
 		#end
-
+		
 		// Super high priority init stuff
 		_inputContainer = new Sprite();
-
+		
 		if (GameWidth == 0)
 			GameWidth = FlxG.stage.stageWidth;
 		if (GameHeight == 0)
@@ -265,22 +265,22 @@ class FlxGame extends Sprite
 
 		// Basic display and update setup stuff
 		FlxG.init(this, GameWidth, GameHeight, Zoom);
-
+		
 		FlxG.updateFramerate = UpdateFramerate;
 		FlxG.drawFramerate = DrawFramerate;
 		_accumulator = _stepMS;
 		_skipSplash = SkipSplash;
-
+		
 		#if FLX_RECORD
 		_replay = new FlxReplay();
 		#end
 		
 		// Then get ready to create the game object for real
 		_initialState = (InitialState == null) ? FlxState : InitialState;
-
+		
 		addEventListener(Event.ADDED_TO_STAGE, create);
 	}
-
+	
 	/**
 	 * Sets the filter array to be applied to the game.
 	 */
@@ -288,7 +288,7 @@ class FlxGame extends Sprite
 	{
 		_filters = filters;
 	}
-
+	
 	/**
 	 * Used to instantiate the guts of the flixel game object once we have a valid reference to the root.
 	 */
@@ -298,32 +298,32 @@ class FlxGame extends Sprite
 			return;
 
 		removeEventListener(Event.ADDED_TO_STAGE, create);
-
+		
 		_startTime = getTimer();
 		_total = getTicks();
-
+		
 		#if desktop
 		FlxG.fullscreen = _startFullscreen;
 		#end
-
+		
 		// Set up the view window and double buffering
 		stage.scaleMode = StageScaleMode.NO_SCALE;
 		stage.align = StageAlign.TOP_LEFT;
 		stage.frameRate = FlxG.drawFramerate;
-
+		
 		addChild(_inputContainer);
-
+		
 		#if FLX_POST_PROCESS
 		if (OpenGLView.isSupported)
 			addChild(postProcessLayer);
 		#end
-
+		
 		// Creating the debugger overlay
 		#if FLX_DEBUG
 		debugger = new FlxDebugger(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
 		addChild(debugger);
 		#end
-
+		
 		// No need for overlays on mobile.
 		#if !mobile
 		// Volume display tab
@@ -331,13 +331,13 @@ class FlxGame extends Sprite
 		soundTray = Type.createInstance(_customSoundTray, []);
 		addChild(soundTray);
 		#end
-
+		
 		#if FLX_FOCUS_LOST_SCREEN
 		_focusLostScreen = Type.createInstance(_customFocusLostScreen, []);
 		addChild(_focusLostScreen);
 		#end
 		#end
-
+		
 		// Focus gained/lost monitoring
 		#if (desktop && openfl <= "4.0.0")
 		stage.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
@@ -346,25 +346,25 @@ class FlxGame extends Sprite
 		stage.addEventListener(Event.DEACTIVATE, onFocusLost);
 		stage.addEventListener(Event.ACTIVATE, onFocus);
 		#end
-
+		
 		// Instantiate the initial state
 		resetGame();
 		switchState();
-
+		
 		if (FlxG.updateFramerate < FlxG.drawFramerate)
 			FlxG.log.warn("FlxG.updateFramerate: The update framerate shouldn't be smaller" +
 				" than the draw framerate, since it can slow down your game.");
 
 		// Finally, set up an event for the actual game loop stuff.
 		stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);
-
+		
 		// We need to listen for resize event which means new context
 		// it means that we need to recreate BitmapDatas of dumped tilesheets
 		stage.addEventListener(Event.RESIZE, onResize);
-
+		
 		// make sure the cursor etc are properly scaled from the start
 		resizeGame(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
-
+		
 		Assets.addEventListener(Event.CHANGE, FlxG.bitmap.onAssetsReload);
 	}
 
@@ -374,7 +374,7 @@ class FlxGame extends Sprite
 		if (!_lostFocus)
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
-
+		
 		#if (desktop && lime_legacy)
 		// make sure the on focus event doesn't fire on startup
 		if (!_onFocusFiredOnce)
@@ -383,113 +383,113 @@ class FlxGame extends Sprite
 			return;
 		}
 		#end
-
+		
 		#if mobile
 		// just check if device orientation has been changed
 		onResize(_);
 		#end
-
+		
 		_lostFocus = false;
 		FlxG.signals.focusGained.dispatch();
 		_state.onFocus();
-
+		
 		if (!FlxG.autoPause)
 			return;
-
+		
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = false;
 		#end
-
+		
 		#if FLX_DEBUG
 		debugger.stats.onFocus();
 		#end
-
+		
 		stage.frameRate = FlxG.drawFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocus();
 		#end
 		FlxG.inputs.onFocus();
 	}
-
+	
 	function onFocusLost(event:Event):Void
 	{
 		#if next
 		if (event != null && event.target != FlxG.stage)
 			return;
 		#end
-
+		
 		#if flash
 		if (_lostFocus)
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
-
+		
 		_lostFocus = true;
 		FlxG.signals.focusLost.dispatch();
 		_state.onFocusLost();
-
+		
 		if (!FlxG.autoPause)
 			return;
-
+		
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = true;
 		#end
-
+		
 		#if FLX_DEBUG
 		debugger.stats.onFocusLost();
 		#end
-
+		
 		stage.frameRate = focusLostFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocusLost();
 		#end
 		FlxG.inputs.onFocusLost();
 	}
-
+	
 	@:allow(flixel.FlxG)
 	function onResize(_):Void
 	{
 		var width:Int = FlxG.stage.stageWidth;
 		var height:Int = FlxG.stage.stageHeight;
-
+		
 		#if !flash
 		if (FlxG.renderTile)
 			FlxG.bitmap.onContext();
 		#end
-
+		
 		resizeGame(width, height);
 	}
-
+	
 	function resizeGame(width:Int, height:Int):Void
 	{
 		FlxG.resizeGame(width, height);
-
+		
 		_state.onResize(width, height);
-
+		
 		FlxG.cameras.resize();
 		FlxG.signals.gameResized.dispatch(width, height);
-
+		
 		#if FLX_DEBUG
 		debugger.onResize(width, height);
 		#end
-
+		
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.draw();
 		#end
-
+		
 		#if FLX_SOUND_TRAY
 		if (soundTray != null)
 			soundTray.screenCenter();
 		#end
-
+		
 		#if FLX_POST_PROCESS
 		for (postProcess in postProcesses)
 			postProcess.rebuild();
 		#end
 	}
-
+	
 	/**
 	 * Handles the `onEnterFrame` call and figures out how many updates and draw calls to do.
 	 */
@@ -498,12 +498,12 @@ class FlxGame extends Sprite
 		ticks = getTicks();
 		_elapsedMS = ticks - _total;
 		_total = ticks;
-
+		
 		#if FLX_SOUND_TRAY
 		if (soundTray != null && soundTray.active)
 			soundTray.update(_elapsedMS);
 		#end
-
+		
 		if (!_lostFocus || !FlxG.autoPause)
 		{
 			if (FlxG.vcr.paused)
@@ -527,12 +527,12 @@ class FlxGame extends Sprite
 					return;
 				}
 			}
-
+			
 			if (FlxG.fixedTimestep)
 			{
 				_accumulator += _elapsedMS;
 				_accumulator = (_accumulator > _maxAccumulation) ? _maxAccumulation : _accumulator;
-
+				
 				while (_accumulator >= _stepMS)
 				{
 					step();
@@ -543,20 +543,20 @@ class FlxGame extends Sprite
 			{
 				step();
 			}
-
+			
 			#if FLX_DEBUG
 			FlxBasic.visibleCount = 0;
 			#end
-
+			
 			draw();
-
+			
 			#if FLX_DEBUG
 			debugger.stats.visibleObjects(FlxBasic.visibleCount);
 			debugger.update();
 			#end
 		}
 	}
-
+	
 	/**
 	 * Internal method to create a new instance of `_initialState` and reset the game.
 	 * This gets called when the game is created, as well as when a new state is requested.
@@ -564,11 +564,11 @@ class FlxGame extends Sprite
 	inline function resetGame():Void
 	{
 		FlxG.signals.preGameReset.dispatch();
-
+		
 		#if FLX_DEBUG
 		_skipSplash = true;
 		#end
-
+		
 		if (_skipSplash || FlxSplash.nextState != null) // already played
 		{
 			_requestedState = cast Type.createInstance(_initialState, []);
@@ -581,17 +581,17 @@ class FlxGame extends Sprite
 			_requestedState = new FlxSplash();
 			_skipSplash = true; // only play it once
 		}
-
+		
 		#if FLX_DEBUG
 		if (Std.is(_requestedState, FlxSubState))
 			throw "You can't set FlxSubState class instance as the state for you game";
 		#end
-
+		
 		FlxG.reset();
-
+		
 		FlxG.signals.postGameReset.dispatch();
 	}
-
+	
 	/**
 	 * If there is a state change requested during the update loop,
 	 * this function handles actual destroying the old state and related processes,
@@ -605,44 +605,44 @@ class FlxGame extends Sprite
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.destroy();
 		#end
-
+		
 		FlxG.signals.stateSwitched.dispatch();
-
+		
 		#if FLX_RECORD
 		FlxRandom.updateStateSeed();
 		#end
-
+		
 		// Destroy the old state (if there is an old state)
 		if (_state != null)
 			_state.destroy();
-
+		
 		// we need to clear bitmap cache only after previous state is destroyed, which will reset useCount for FlxGraphic objects
 		FlxG.bitmap.clearCache();
-
+		
 		// Finally assign and create the new state
 		_state = _requestedState;
-
+		
 		if (_gameJustStarted)
 			FlxG.signals.preGameStart.dispatch();
-
+		
 		FlxG.signals.preStateCreate.dispatch(_state);
-
+		
 		_state.create();
-
+		
 		if (_gameJustStarted)
 			gameStart();
-
+		
 		#if FLX_DEBUG
 		debugger.console.registerObject("state", _state);
 		#end
 	}
-
+	
 	function gameStart():Void
 	{
 		FlxG.signals.postGameStart.dispatch();
 		_gameJustStarted = false;
 	}
-
+	
 	/**
 	 * This is the main game update logic section.
 	 * The `onEnterFrame()` handler is in charge of calling this
@@ -657,16 +657,16 @@ class FlxGame extends Sprite
 			resetGame();
 			_resetGame = false;
 		}
-
+		
 		handleReplayRequests();
-
+		
 		#if FLX_DEBUG
 		// Finally actually step through the game physics
 		FlxBasic.activeCount = 0;
 		#end
-
+		
 		update();
-
+		
 		#if FLX_DEBUG
 		debugger.stats.activeObjects(FlxBasic.activeCount);
 		#end
@@ -681,7 +681,7 @@ class FlxGame extends Sprite
 			_recordingRequested = false;
 			_replay.create(FlxRandom.getRecordingSeed());
 			recording = true;
-
+			
 			#if FLX_DEBUG
 			debugger.vcr.recording();
 			FlxG.log.notice("Starting new flixel gameplay record.");
@@ -692,16 +692,16 @@ class FlxGame extends Sprite
 			_replayRequested = false;
 			_replay.rewind();
 			FlxG.random.initialSeed = _replay.seed;
-
+			
 			#if FLX_DEBUG
 			debugger.vcr.playingReplay();
 			#end
-
+			
 			replaying = true;
 		}
 		#end
 	}
-
+	
 	/**
 	 * This function is called by `step()` and updates the actual game state.
 	 * May be called multiple times per "frame" or draw call.
@@ -710,47 +710,47 @@ class FlxGame extends Sprite
 	{
 		if (!_state.active || !_state.exists)
 			return;
-
+		
 		if (_state != _requestedState)
 			switchState();
-
+		
 		#if FLX_DEBUG
 		if (FlxG.debugger.visible)
 			ticks = getTicks();
 		#end
-
+		
 		updateElapsed();
-
+		
 		FlxG.signals.preUpdate.dispatch();
-
+		
 		updateInput();
-
+		
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)
 			postProcesses[0].update(FlxG.elapsed);
 		#end
-
+		
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.update(FlxG.elapsed);
 		#end
 		FlxG.plugins.update(FlxG.elapsed);
-
+		
 		_state.tryUpdate(FlxG.elapsed);
-
+		
 		FlxG.cameras.update(FlxG.elapsed);
 		FlxG.signals.postUpdate.dispatch();
-
+		
 		#if FLX_DEBUG
 		debugger.stats.flixelUpdate(getTicks() - ticks);
 		#end
-
+		
 		#if FLX_POINTER_INPUT
 		FlxArrayUtil.clearArray(FlxG.swipes);
 		#end
-
+		
 		filters = filtersEnabled ? _filters : null;
 	}
-
+	
 	function updateElapsed():Void
 	{
 		if (FlxG.fixedTimestep)
@@ -760,24 +760,24 @@ class FlxGame extends Sprite
 		else
 		{
 			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
-
+			
 			var max = FlxG.maxElapsed * FlxG.timeScale;
 			if (FlxG.elapsed > max)
 				FlxG.elapsed = max;
 		}
 	}
-
+	
 	function updateInput():Void
 	{
 		#if FLX_RECORD
 		if (replaying)
 		{
 			_replay.playNextFrame();
-
+			
 			if (FlxG.vcr.timeout > 0)
 			{
 				FlxG.vcr.timeout -= _stepMS;
-
+				
 				if (FlxG.vcr.timeout <= 0)
 				{
 					if (FlxG.vcr.replayCallback != null)
@@ -791,18 +791,18 @@ class FlxGame extends Sprite
 					}
 				}
 			}
-
+			
 			if (replaying && _replay.finished)
 			{
 				FlxG.vcr.stopReplay();
-
+				
 				if (FlxG.vcr.replayCallback != null)
 				{
 					FlxG.vcr.replayCallback();
 					FlxG.vcr.replayCallback = null;
 				}
 			}
-
+			
 			#if FLX_DEBUG
 			debugger.vcr.updateRuntime(_stepMS);
 			#end
@@ -814,19 +814,19 @@ class FlxGame extends Sprite
 		#else
 		FlxG.inputs.update();
 		#end
-
+		
 		#if FLX_RECORD
 		if (recording)
 		{
 			_replay.recordFrame();
-
+			
 			#if FLX_DEBUG
 			debugger.vcr.updateRuntime(_stepMS);
 			#end
 		}
 		#end
 	}
-
+	
 	/**
 	 * Goes through the game state and draws all the game objects and special effects.
 	 */
@@ -834,51 +834,51 @@ class FlxGame extends Sprite
 	{
 		if (!_state.visible || !_state.exists)
 			return;
-
+		
 		#if FLX_DEBUG
 		if (FlxG.debugger.visible)
 			ticks = getTicks();
 		#end
-
+		
 		FlxG.signals.preDraw.dispatch();
-
+		
 		if (FlxG.renderTile)
 			FlxDrawBaseItem.drawCalls = 0;
-
+		
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)
 			postProcesses[0].capture();
 		#end
-
+		
 		FlxG.cameras.lock();
-
+		
 		FlxG.plugins.draw();
-
+		
 		_state.draw();
-
+		
 		if (FlxG.renderTile)
 		{
 			FlxG.cameras.render();
-
+			
 			#if FLX_DEBUG
 			debugger.stats.drawCalls(FlxDrawBaseItem.drawCalls);
 			#end
 		}
-
+		
 		FlxG.cameras.unlock();
-
+		
 		FlxG.signals.postDraw.dispatch();
-
+		
 		#if FLX_DEBUG
 		debugger.stats.flixelDraw(getTicks() - ticks);
 		#end
 	}
-
+	
 	inline function getTicks()
 	{
 		return getTimer() - _startTime;
 	}
-
+	
 	dynamic function getTimer():Int
 	{
 		// expensive, only call if necessary

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -50,7 +50,7 @@ class FlxGame extends Sprite
 	 * Framerate to use on focus lost. Default is `10`.
 	 */
 	public var focusLostFramerate:Int = 10;
-	
+
 	#if FLX_RECORD
 	/**
 	 * Flag for whether a replay is currently playing.
@@ -63,21 +63,21 @@ class FlxGame extends Sprite
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
 	public var recording(default, null):Bool = false;
 	#end
-	
+
 	#if FLX_SOUND_TRAY
 	/**
 	 * The sound tray display container.
 	 */
 	public var soundTray(default, null):FlxSoundTray;
 	#end
-	
+
 	#if FLX_DEBUG
 	/**
 	 * The debugger overlay object.
 	 */
 	public var debugger(default, null):FlxDebugger;
 	#end
-	
+
 	/**
 	 * Time in milliseconds that has passed (amount of "ticks" passed) since the game has started.
 	 */
@@ -86,13 +86,13 @@ class FlxGame extends Sprite
 	 * Enables or disables the filters set via `setFilters()`.
 	 */
 	public var filtersEnabled:Bool = true;
-	
+
 	/**
-	 * A flag for triggering the `gameStarted` "event".
+	 * A flag for triggering the `preGameStart` and `postGameStart` "events".
 	 */
 	@:allow(flixel.system.FlxSplash)
 	var _gameJustStarted:Bool = false;
-	
+
 	/**
 	 * Class type of the initial/first game state for the game, usually `MenuState` or something like that.
 	 */
@@ -132,39 +132,39 @@ class FlxGame extends Sprite
 	 * Should always (and automatically) be set to roughly 2x the stage framerate.
 	 */
 	var _maxAccumulation:Float;
-	
+
 	/**
 	 * Whether the game lost focus.
 	 */
 	var _lostFocus:Bool = false;
-	
+
 	/**
 	 * The filters array to be applied to the game.
 	 */
 	var _filters:Array<BitmapFilter>;
-	
+
 	#if (desktop && lime_legacy)
 	/**
-	 * Ugly workaround to ensure consistent behaviour between flash and cpp 
+	 * Ugly workaround to ensure consistent behaviour between flash and cpp
 	 * (the focus event should not fire when the game starts up!)
 	 */
 	var _onFocusFiredOnce:Bool = false;
 	#end
-	
-	#if FLX_FOCUS_LOST_SCREEN 
+
+	#if FLX_FOCUS_LOST_SCREEN
 	/**
 	 * The "focus lost" screen.
 	 */
 	var _focusLostScreen:FlxFocusLostScreen;
 	#end
-	
+
 	/**
 	 * Mouse cursor.
 	 */
 	@:allow(flixel.FlxG)
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	var _inputContainer:Sprite;
-	
+
 	#if FLX_SOUND_TRAY
 	/**
 	 * Change this after calling `super()` in the `FlxGame` constructor
@@ -172,7 +172,7 @@ class FlxGame extends Sprite
 	 */
 	var _customSoundTray:Class<FlxSoundTray> = FlxSoundTray;
 	#end
-	
+
 	#if FLX_FOCUS_LOST_SCREEN
 	/**
 	 * Change this after calling `super()` in the `FlxGame` constructor
@@ -180,12 +180,12 @@ class FlxGame extends Sprite
 	 */
 	var _customFocusLostScreen:Class<FlxFocusLostScreen> = FlxFocusLostScreen;
 	#end
-	
+
 	/**
 	 * Whether the splash screen should be skipped.
 	 */
 	var _skipSplash:Bool = false;
-	
+
 	#if desktop
 	/**
 	 * Should we start fullscreen or not? This is useful if you want to load fullscreen settings from a
@@ -193,7 +193,7 @@ class FlxGame extends Sprite
 	 */
 	var _startFullscreen:Bool = false;
 	#end
-	
+
 	/**
 	 * If a state change was requested, the new state object is stored here until we switch to it.
 	 */
@@ -202,7 +202,7 @@ class FlxGame extends Sprite
 	 * A flag for keeping track of whether a game reset was requested or not.
 	 */
 	var _resetGame:Bool = false;
-	
+
 	#if FLX_RECORD
 	/**
 	 * Container for a game replay object.
@@ -220,7 +220,7 @@ class FlxGame extends Sprite
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
 	var _recordingRequested:Bool = false;
 	#end
-	
+
 	#if FLX_POST_PROCESS
 	/**
 	 * `Sprite` for postprocessing effects
@@ -231,10 +231,10 @@ class FlxGame extends Sprite
 	 */
 	var postProcesses:Array<PostProcess> = [];
 	#end
-	
+
 	/**
 	 * Instantiate a new game object.
-	 * 
+	 *
 	 * @param GameWidth       The width of your game in game pixels, not necessarily final display pixels (see `Zoom`).
 	 *                        If equal to `0`, the window width specified in the `Project.xml` is used.
 	 * @param GameHeight      The height of your game in game pixels, not necessarily final display pixels (see `Zoom`).
@@ -250,14 +250,14 @@ class FlxGame extends Sprite
 		UpdateFramerate:Int = 60, DrawFramerate:Int = 60, SkipSplash:Bool = false, StartFullscreen:Bool = false)
 	{
 		super();
-		
+
 		#if desktop
 		_startFullscreen = StartFullscreen;
 		#end
-		
+
 		// Super high priority init stuff
 		_inputContainer = new Sprite();
-		
+
 		if (GameWidth == 0)
 			GameWidth = FlxG.stage.stageWidth;
 		if (GameHeight == 0)
@@ -265,22 +265,22 @@ class FlxGame extends Sprite
 
 		// Basic display and update setup stuff
 		FlxG.init(this, GameWidth, GameHeight, Zoom);
-		
+
 		FlxG.updateFramerate = UpdateFramerate;
 		FlxG.drawFramerate = DrawFramerate;
 		_accumulator = _stepMS;
 		_skipSplash = SkipSplash;
-		
+
 		#if FLX_RECORD
 		_replay = new FlxReplay();
 		#end
-		
+
 		// Then get ready to create the game object for real
 		_initialState = (InitialState == null) ? FlxState : InitialState;
-		
+
 		addEventListener(Event.ADDED_TO_STAGE, create);
 	}
-	
+
 	/**
 	 * Sets the filter array to be applied to the game.
 	 */
@@ -288,7 +288,7 @@ class FlxGame extends Sprite
 	{
 		_filters = filters;
 	}
-	
+
 	/**
 	 * Used to instantiate the guts of the flixel game object once we have a valid reference to the root.
 	 */
@@ -298,32 +298,32 @@ class FlxGame extends Sprite
 			return;
 
 		removeEventListener(Event.ADDED_TO_STAGE, create);
-		
+
 		_startTime = getTimer();
 		_total = getTicks();
-		
+
 		#if desktop
 		FlxG.fullscreen = _startFullscreen;
 		#end
-		
+
 		// Set up the view window and double buffering
 		stage.scaleMode = StageScaleMode.NO_SCALE;
 		stage.align = StageAlign.TOP_LEFT;
 		stage.frameRate = FlxG.drawFramerate;
-		
+
 		addChild(_inputContainer);
-		
+
 		#if FLX_POST_PROCESS
 		if (OpenGLView.isSupported)
 			addChild(postProcessLayer);
 		#end
-		
+
 		// Creating the debugger overlay
 		#if FLX_DEBUG
 		debugger = new FlxDebugger(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
 		addChild(debugger);
 		#end
-		
+
 		// No need for overlays on mobile.
 		#if !mobile
 		// Volume display tab
@@ -331,13 +331,13 @@ class FlxGame extends Sprite
 		soundTray = Type.createInstance(_customSoundTray, []);
 		addChild(soundTray);
 		#end
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		_focusLostScreen = Type.createInstance(_customFocusLostScreen, []);
 		addChild(_focusLostScreen);
 		#end
 		#end
-		
+
 		// Focus gained/lost monitoring
 		#if (desktop && openfl <= "4.0.0")
 		stage.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
@@ -346,150 +346,150 @@ class FlxGame extends Sprite
 		stage.addEventListener(Event.DEACTIVATE, onFocusLost);
 		stage.addEventListener(Event.ACTIVATE, onFocus);
 		#end
-		
+
 		// Instantiate the initial state
 		resetGame();
 		switchState();
-		
+
 		if (FlxG.updateFramerate < FlxG.drawFramerate)
 			FlxG.log.warn("FlxG.updateFramerate: The update framerate shouldn't be smaller" +
 				" than the draw framerate, since it can slow down your game.");
-		
+
 		// Finally, set up an event for the actual game loop stuff.
 		stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);
-		
+
 		// We need to listen for resize event which means new context
 		// it means that we need to recreate BitmapDatas of dumped tilesheets
 		stage.addEventListener(Event.RESIZE, onResize);
-		
+
 		// make sure the cursor etc are properly scaled from the start
 		resizeGame(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
-		
+
 		Assets.addEventListener(Event.CHANGE, FlxG.bitmap.onAssetsReload);
 	}
-	
+
 	function onFocus(_):Void
 	{
 		#if flash
-		if (!_lostFocus) 
+		if (!_lostFocus)
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
-		
+
 		#if (desktop && lime_legacy)
-		// make sure the on focus event doesn't fire on startup 
+		// make sure the on focus event doesn't fire on startup
 		if (!_onFocusFiredOnce)
 		{
 			_onFocusFiredOnce = true;
 			return;
 		}
 		#end
-		
+
 		#if mobile
 		// just check if device orientation has been changed
 		onResize(_);
 		#end
-		
+
 		_lostFocus = false;
 		FlxG.signals.focusGained.dispatch();
 		_state.onFocus();
-		
+
 		if (!FlxG.autoPause)
 			return;
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = false;
-		#end 
-		
+		#end
+
 		#if FLX_DEBUG
 		debugger.stats.onFocus();
 		#end
-		
+
 		stage.frameRate = FlxG.drawFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocus();
 		#end
 		FlxG.inputs.onFocus();
 	}
-	
+
 	function onFocusLost(event:Event):Void
 	{
 		#if next
 		if (event != null && event.target != FlxG.stage)
 			return;
 		#end
-		
+
 		#if flash
 		if (_lostFocus)
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
-		
+
 		_lostFocus = true;
 		FlxG.signals.focusLost.dispatch();
 		_state.onFocusLost();
-		
+
 		if (!FlxG.autoPause)
 			return;
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = true;
-		#end 
-		
+		#end
+
 		#if FLX_DEBUG
 		debugger.stats.onFocusLost();
 		#end
-		
+
 		stage.frameRate = focusLostFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocusLost();
 		#end
 		FlxG.inputs.onFocusLost();
 	}
-	
+
 	@:allow(flixel.FlxG)
-	function onResize(_):Void 
+	function onResize(_):Void
 	{
 		var width:Int = FlxG.stage.stageWidth;
 		var height:Int = FlxG.stage.stageHeight;
-		
+
 		#if !flash
 		if (FlxG.renderTile)
 			FlxG.bitmap.onContext();
 		#end
-		
+
 		resizeGame(width, height);
 	}
-	
+
 	function resizeGame(width:Int, height:Int):Void
 	{
 		FlxG.resizeGame(width, height);
-		
+
 		_state.onResize(width, height);
-		
+
 		FlxG.cameras.resize();
 		FlxG.signals.gameResized.dispatch(width, height);
-		
+
 		#if FLX_DEBUG
 		debugger.onResize(width, height);
 		#end
-		
+
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.draw();
 		#end
-		
+
 		#if FLX_SOUND_TRAY
 		if (soundTray != null)
 			soundTray.screenCenter();
 		#end
-		
+
 		#if FLX_POST_PROCESS
 		for (postProcess in postProcesses)
 			postProcess.rebuild();
 		#end
 	}
-	
+
 	/**
 	 * Handles the `onEnterFrame` call and figures out how many updates and draw calls to do.
 	 */
@@ -498,12 +498,12 @@ class FlxGame extends Sprite
 		ticks = getTicks();
 		_elapsedMS = ticks - _total;
 		_total = ticks;
-		
+
 		#if FLX_SOUND_TRAY
 		if (soundTray != null && soundTray.active)
 			soundTray.update(_elapsedMS);
 		#end
-		
+
 		if (!_lostFocus || !FlxG.autoPause)
 		{
 			if (FlxG.vcr.paused)
@@ -527,36 +527,36 @@ class FlxGame extends Sprite
 					return;
 				}
 			}
-			
+
 			if (FlxG.fixedTimestep)
 			{
 				_accumulator += _elapsedMS;
 				_accumulator = (_accumulator > _maxAccumulation) ? _maxAccumulation : _accumulator;
-				
+
 				while (_accumulator >= _stepMS)
 				{
 					step();
-					_accumulator -= _stepMS; 
+					_accumulator -= _stepMS;
 				}
 			}
 			else
 			{
 				step();
 			}
-			
+
 			#if FLX_DEBUG
 			FlxBasic.visibleCount = 0;
 			#end
-			
+
 			draw();
-			
+
 			#if FLX_DEBUG
 			debugger.stats.visibleObjects(FlxBasic.visibleCount);
 			debugger.update();
 			#end
 		}
 	}
-	
+
 	/**
 	 * Internal method to create a new instance of `_initialState` and reset the game.
 	 * This gets called when the game is created, as well as when a new state is requested.
@@ -564,11 +564,11 @@ class FlxGame extends Sprite
 	inline function resetGame():Void
 	{
 		FlxG.signals.preGameReset.dispatch();
-		
+
 		#if FLX_DEBUG
 		_skipSplash = true;
 		#end
-		
+
 		if (_skipSplash || FlxSplash.nextState != null) // already played
 		{
 			_requestedState = cast Type.createInstance(_initialState, []);
@@ -581,14 +581,14 @@ class FlxGame extends Sprite
 			_requestedState = new FlxSplash();
 			_skipSplash = true; // only play it once
 		}
-		
+
 		#if FLX_DEBUG
 		if (Std.is(_requestedState, FlxSubState))
 			throw "You can't set FlxSubState class instance as the state for you game";
 		#end
-		
+
 		FlxG.reset();
-		
+
 		FlxG.signals.postGameReset.dispatch();
 	}
 
@@ -605,41 +605,44 @@ class FlxGame extends Sprite
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.destroy();
 		#end
-		
+
 		FlxG.signals.stateSwitched.dispatch();
-		
+
 		#if FLX_RECORD
 		FlxRandom.updateStateSeed();
 		#end
-		
+
 		// Destroy the old state (if there is an old state)
 		if (_state != null)
 			_state.destroy();
-		
+
 		// we need to clear bitmap cache only after previous state is destroyed, which will reset useCount for FlxGraphic objects
 		FlxG.bitmap.clearCache();
-		
+
 		// Finally assign and create the new state
 		_state = _requestedState;
-		
+
+		if (_gameJustStarted)
+			FlxG.signals.preGameStart.dispatch();
+
 		FlxG.signals.preStateCreate.dispatch(_state);
-		
+
 		_state.create();
-		
+
 		if (_gameJustStarted)
 			gameStart();
-		
+
 		#if FLX_DEBUG
 		debugger.console.registerObject("state", _state);
 		#end
 	}
-	
+
 	function gameStart():Void
 	{
-		FlxG.signals.gameStarted.dispatch();
+		FlxG.signals.postGameStart.dispatch();
 		_gameJustStarted = false;
 	}
-	
+
 	/**
 	 * This is the main game update logic section.
 	 * The `onEnterFrame()` handler is in charge of calling this
@@ -654,21 +657,21 @@ class FlxGame extends Sprite
 			resetGame();
 			_resetGame = false;
 		}
-		
+
 		handleReplayRequests();
-		
+
 		#if FLX_DEBUG
 		// Finally actually step through the game physics
 		FlxBasic.activeCount = 0;
 		#end
-		
+
 		update();
-		
+
 		#if FLX_DEBUG
 		debugger.stats.activeObjects(FlxBasic.activeCount);
 		#end
 	}
-	
+
 	function handleReplayRequests():Void
 	{
 		#if FLX_RECORD
@@ -678,7 +681,7 @@ class FlxGame extends Sprite
 			_recordingRequested = false;
 			_replay.create(FlxRandom.getRecordingSeed());
 			recording = true;
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.recording();
 			FlxG.log.notice("Starting new flixel gameplay record.");
@@ -689,16 +692,16 @@ class FlxGame extends Sprite
 			_replayRequested = false;
 			_replay.rewind();
 			FlxG.random.initialSeed = _replay.seed;
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.playingReplay();
 			#end
-			
+
 			replaying = true;
 		}
 		#end
 	}
-	
+
 	/**
 	 * This function is called by `step()` and updates the actual game state.
 	 * May be called multiple times per "frame" or draw call.
@@ -707,47 +710,47 @@ class FlxGame extends Sprite
 	{
 		if (!_state.active || !_state.exists)
 			return;
-		
+
 		if (_state != _requestedState)
 			switchState();
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.visible)
 			ticks = getTicks();
 		#end
-		
+
 		updateElapsed();
-		
+
 		FlxG.signals.preUpdate.dispatch();
-		
+
 		updateInput();
-		
+
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)
 			postProcesses[0].update(FlxG.elapsed);
 		#end
-		
+
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.update(FlxG.elapsed);
 		#end
 		FlxG.plugins.update(FlxG.elapsed);
-		
+
 		_state.tryUpdate(FlxG.elapsed);
-		
+
 		FlxG.cameras.update(FlxG.elapsed);
 		FlxG.signals.postUpdate.dispatch();
-		
+
 		#if FLX_DEBUG
 		debugger.stats.flixelUpdate(getTicks() - ticks);
 		#end
-		
+
 		#if FLX_POINTER_INPUT
 		FlxArrayUtil.clearArray(FlxG.swipes);
 		#end
-		
+
 		filters = filtersEnabled ? _filters : null;
 	}
-	
+
 	function updateElapsed():Void
 	{
 		if (FlxG.fixedTimestep)
@@ -757,24 +760,24 @@ class FlxGame extends Sprite
 		else
 		{
 			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
-			
+
 			var max = FlxG.maxElapsed * FlxG.timeScale;
 			if (FlxG.elapsed > max)
 				FlxG.elapsed = max;
 		}
 	}
-	
+
 	function updateInput():Void
 	{
 		#if FLX_RECORD
 		if (replaying)
 		{
 			_replay.playNextFrame();
-			
+
 			if (FlxG.vcr.timeout > 0)
 			{
 				FlxG.vcr.timeout -= _stepMS;
-				
+
 				if (FlxG.vcr.timeout <= 0)
 				{
 					if (FlxG.vcr.replayCallback != null)
@@ -788,18 +791,18 @@ class FlxGame extends Sprite
 					}
 				}
 			}
-			
+
 			if (replaying && _replay.finished)
 			{
 				FlxG.vcr.stopReplay();
-				
+
 				if (FlxG.vcr.replayCallback != null)
 				{
 					FlxG.vcr.replayCallback();
 					FlxG.vcr.replayCallback = null;
 				}
 			}
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.updateRuntime(_stepMS);
 			#end
@@ -811,19 +814,19 @@ class FlxGame extends Sprite
 		#else
 		FlxG.inputs.update();
 		#end
-		
+
 		#if FLX_RECORD
 		if (recording)
 		{
 			_replay.recordFrame();
-			
+
 			#if FLX_DEBUG
 			debugger.vcr.updateRuntime(_stepMS);
 			#end
 		}
 		#end
 	}
-	
+
 	/**
 	 * Goes through the game state and draws all the game objects and special effects.
 	 */
@@ -831,51 +834,51 @@ class FlxGame extends Sprite
 	{
 		if (!_state.visible || !_state.exists)
 			return;
-		
+
 		#if FLX_DEBUG
 		if (FlxG.debugger.visible)
 			ticks = getTicks();
 		#end
-		
+
 		FlxG.signals.preDraw.dispatch();
-		
+
 		if (FlxG.renderTile)
 			FlxDrawBaseItem.drawCalls = 0;
-		
+
 		#if FLX_POST_PROCESS
 		if (postProcesses[0] != null)
 			postProcesses[0].capture();
 		#end
-		
+
 		FlxG.cameras.lock();
-		
+
 		FlxG.plugins.draw();
-		
+
 		_state.draw();
-		
+
 		if (FlxG.renderTile)
 		{
 			FlxG.cameras.render();
-			
+
 			#if FLX_DEBUG
 			debugger.stats.drawCalls(FlxDrawBaseItem.drawCalls);
 			#end
 		}
-	
+
 		FlxG.cameras.unlock();
-		
+
 		FlxG.signals.postDraw.dispatch();
-		
+
 		#if FLX_DEBUG
 		debugger.stats.flixelDraw(getTicks() - ticks);
 		#end
 	}
-	
+
 	inline function getTicks()
 	{
 		return getTimer() - _startTime;
 	}
-	
+
 	dynamic function getTimer():Int
 	{
 		// expensive, only call if necessary

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -864,7 +864,7 @@ class FlxGame extends Sprite
 			debugger.stats.drawCalls(FlxDrawBaseItem.drawCalls);
 			#end
 		}
-
+	
 		FlxG.cameras.unlock();
 		
 		FlxG.signals.postDraw.dispatch();

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -145,13 +145,13 @@ class FlxGame extends Sprite
 	
 	#if (desktop && lime_legacy)
 	/**
-	 * Ugly workaround to ensure consistent behaviour between flash and cpp
+	 * Ugly workaround to ensure consistent behaviour between flash and cpp 
 	 * (the focus event should not fire when the game starts up!)
 	 */
 	var _onFocusFiredOnce:Bool = false;
 	#end
 	
-	#if FLX_FOCUS_LOST_SCREEN
+	#if FLX_FOCUS_LOST_SCREEN 
 	/**
 	 * The "focus lost" screen.
 	 */
@@ -234,7 +234,7 @@ class FlxGame extends Sprite
 	
 	/**
 	 * Instantiate a new game object.
-	 *
+	 * 
 	 * @param GameWidth       The width of your game in game pixels, not necessarily final display pixels (see `Zoom`).
 	 *                        If equal to `0`, the window width specified in the `Project.xml` is used.
 	 * @param GameHeight      The height of your game in game pixels, not necessarily final display pixels (see `Zoom`).
@@ -354,7 +354,7 @@ class FlxGame extends Sprite
 		if (FlxG.updateFramerate < FlxG.drawFramerate)
 			FlxG.log.warn("FlxG.updateFramerate: The update framerate shouldn't be smaller" +
 				" than the draw framerate, since it can slow down your game.");
-
+		
 		// Finally, set up an event for the actual game loop stuff.
 		stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);
 		
@@ -367,16 +367,16 @@ class FlxGame extends Sprite
 		
 		Assets.addEventListener(Event.CHANGE, FlxG.bitmap.onAssetsReload);
 	}
-
+	
 	function onFocus(_):Void
 	{
 		#if flash
-		if (!_lostFocus)
+		if (!_lostFocus) 
 			return; // Don't run this function twice (bug in standalone flash player)
 		#end
 		
 		#if (desktop && lime_legacy)
-		// make sure the on focus event doesn't fire on startup
+		// make sure the on focus event doesn't fire on startup 
 		if (!_onFocusFiredOnce)
 		{
 			_onFocusFiredOnce = true;
@@ -399,7 +399,7 @@ class FlxGame extends Sprite
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = false;
-		#end
+		#end 
 		
 		#if FLX_DEBUG
 		debugger.stats.onFocus();
@@ -434,7 +434,7 @@ class FlxGame extends Sprite
 		#if FLX_FOCUS_LOST_SCREEN
 		if (_focusLostScreen != null)
 			_focusLostScreen.visible = true;
-		#end
+		#end 
 		
 		#if FLX_DEBUG
 		debugger.stats.onFocusLost();
@@ -448,7 +448,7 @@ class FlxGame extends Sprite
 	}
 	
 	@:allow(flixel.FlxG)
-	function onResize(_):Void
+	function onResize(_):Void 
 	{
 		var width:Int = FlxG.stage.stageWidth;
 		var height:Int = FlxG.stage.stageHeight;
@@ -536,7 +536,7 @@ class FlxGame extends Sprite
 				while (_accumulator >= _stepMS)
 				{
 					step();
-					_accumulator -= _stepMS;
+					_accumulator -= _stepMS; 
 				}
 			}
 			else
@@ -591,7 +591,7 @@ class FlxGame extends Sprite
 		
 		FlxG.signals.postGameReset.dispatch();
 	}
-	
+
 	/**
 	 * If there is a state change requested during the update loop,
 	 * this function handles actual destroying the old state and related processes,
@@ -671,7 +671,7 @@ class FlxGame extends Sprite
 		debugger.stats.activeObjects(FlxBasic.activeCount);
 		#end
 	}
-
+	
 	function handleReplayRequests():Void
 	{
 		#if FLX_RECORD
@@ -864,7 +864,7 @@ class FlxGame extends Sprite
 			debugger.stats.drawCalls(FlxDrawBaseItem.drawCalls);
 			#end
 		}
-		
+
 		FlxG.cameras.unlock();
 		
 		FlxG.signals.postDraw.dispatch();

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -50,7 +50,7 @@ class FlxGame extends Sprite
 	 * Framerate to use on focus lost. Default is `10`.
 	 */
 	public var focusLostFramerate:Int = 10;
-
+	
 	#if FLX_RECORD
 	/**
 	 * Flag for whether a replay is currently playing.
@@ -63,21 +63,21 @@ class FlxGame extends Sprite
 	@:allow(flixel.system.frontEnds.VCRFrontEnd)
 	public var recording(default, null):Bool = false;
 	#end
-
+	
 	#if FLX_SOUND_TRAY
 	/**
 	 * The sound tray display container.
 	 */
 	public var soundTray(default, null):FlxSoundTray;
 	#end
-
+	
 	#if FLX_DEBUG
 	/**
 	 * The debugger overlay object.
 	 */
 	public var debugger(default, null):FlxDebugger;
 	#end
-
+	
 	/**
 	 * Time in milliseconds that has passed (amount of "ticks" passed) since the game has started.
 	 */
@@ -86,13 +86,13 @@ class FlxGame extends Sprite
 	 * Enables or disables the filters set via `setFilters()`.
 	 */
 	public var filtersEnabled:Bool = true;
-
+	
 	/**
 	 * A flag for triggering the `preGameStart` and `postGameStart` "events".
 	 */
 	@:allow(flixel.system.FlxSplash)
 	var _gameJustStarted:Bool = false;
-
+	
 	/**
 	 * Class type of the initial/first game state for the game, usually `MenuState` or something like that.
 	 */
@@ -132,7 +132,7 @@ class FlxGame extends Sprite
 	 * Should always (and automatically) be set to roughly 2x the stage framerate.
 	 */
 	var _maxAccumulation:Float;
-
+	
 	/**
 	 * Whether the game lost focus.
 	 */

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -274,7 +274,7 @@ class FlxGame extends Sprite
 		#if FLX_RECORD
 		_replay = new FlxReplay();
 		#end
-
+		
 		// Then get ready to create the game object for real
 		_initialState = (InitialState == null) ? FlxState : InitialState;
 

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -39,18 +39,18 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var enabled:Bool = true;
 	/**
-	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up, 
+	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up,
 	 * it will have a positive value and vice versa. Otherwise the value will be 0.
 	 */
 	public var wheel(default, null):Int = 0;
-	
+
 	/**
-	 * A display container for the mouse cursor. It is a child of FlxGame and 
+	 * A display container for the mouse cursor. It is a child of FlxGame and
 	 * sits at the right "height". Not used on flash with the native cursor API.
 	 */
 	public var cursorContainer(default, null):Sprite;
 	/**
-	 * Used to toggle the visiblity of the mouse cursor - works on both 
+	 * Used to toggle the visiblity of the mouse cursor - works on both
 	 * the flixel and the system cursor, depending on which one is active.
 	 */
 	public var visible(default, set):Bool = #if (mobile || switch) false #else true #end;
@@ -118,13 +118,13 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var justPressedTimeInTicksMiddle(get, never):Int;
 	#end
-	
+
 	/**
 	 * The left mouse button.
 	 */
 	@:allow(flixel.input.mouse.FlxMouseButton)
 	var _leftButton:FlxMouseButton;
-	
+
 	#if FLX_MOUSE_ADVANCED
 	/**
 	 * The middle mouse button.
@@ -137,7 +137,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	@:allow(flixel.input.mouse.FlxMouseButton)
 	var _rightButton:FlxMouseButton;
 	#end
-	
+
 	/**
 	 * This is just a reference to the current cursor image, if there is one.
 	 */
@@ -145,7 +145,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	var _cursorBitmapData:BitmapData;
 	var _wheelUsed:Bool = false;
 	var _visibleWhenFocusLost:Bool = true;
-	
+
 	/**
 	 * Helper variables for recording purposes.
 	 */
@@ -153,16 +153,16 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	var _lastY:Int = 0;
 	var _lastWheel:Int = 0;
 	var _lastLeftButtonState:FlxInputState;
-	
+
 	/**
 	 * Helper variables to see if the mouse has moved since the last update.
 	 */
 	var _prevX:Int = 0;
 	var _prevY:Int = 0;
-	
+
 	//Helper variable for cleaning up memory
 	var _stage:Stage;
-	
+
 	/**
 	 * Helper variables for flash native cursors
 	 */
@@ -171,11 +171,11 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	var _currentNativeCursor:String;
 	var _matrix = new Matrix();
 	#end
-	
+
 	/**
-	 * Load a new mouse cursor graphic - if you're using native cursors on flash, 
+	 * Load a new mouse cursor graphic - if you're using native cursors on flash,
 	 * check registerNativeCursor() for more control.
-	 * 
+	 *
 	 * @param   Graphic   The image you want to use for the cursor.
 	 * @param   Scale     Change the size of the cursor.
 	 * @param   XOffset   The number of pixels between the mouse's screen position and the graphic's top left corner.
@@ -191,12 +191,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			FlxDestroyUtil.removeChild(cursorContainer, _cursor);
 		}
 		#end
-		
+
 		if (Graphic == null)
 		{
 			Graphic = new GraphicCursor(0, 0);
 		}
-		
+
 		if (Std.is(Graphic, Class))
 		{
 			_cursor = Type.createInstance(Graphic, []);
@@ -213,29 +213,29 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			_cursor = new Bitmap(new GraphicCursor(0, 0));
 		}
-		
+
 		_cursor.x = XOffset;
 		_cursor.y = YOffset;
 		_cursor.scaleX = Scale;
 		_cursor.scaleY = Scale;
-		
+
 		#if FLX_NATIVE_CURSOR
 		if (XOffset < 0 || YOffset < 0)
 		{
 			throw "Negative offsets aren't supported for native cursors.";
 		}
-		
+
 		if (Scale < 0)
 		{
 			throw "Negative scale isn't supported for native cursors.";
 		}
-		
+
 		var scaledWidth:Int = Std.int(Scale * _cursor.bitmapData.width);
 		var scaledHeight:Int = Std.int(Scale * _cursor.bitmapData.height);
-		
+
 		var bitmapWidth:Int = scaledWidth + XOffset;
 		var bitmapHeight:Int = scaledHeight + YOffset;
-		
+
 		var cursorBitmap:BitmapData = new BitmapData(bitmapWidth, bitmapHeight, true, 0x0);
 		if (_matrix != null)
 		{
@@ -273,15 +273,15 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	/**
 	 * Set a Native cursor that has been registered by Name
 	 * Warning, you need to use registerNativeCursor() before you use it here
-	 * 
+	 *
 	 * @param   Name   The name ID used when registered
 	 */
 	public function setNativeCursor(Name:String):Void
 	{
 		_currentNativeCursor = Name;
-		
+
 		Mouse.show();
-		
+
 		//Flash requires the use of AUTO before a custom cursor to work
 		Mouse.cursor = MouseCursor.AUTO;
 		Mouse.cursor = _currentNativeCursor;
@@ -289,7 +289,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 	/**
 	 * Shortcut to register a native cursor in flash
-	 * 
+	 *
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 * @param   Show         Whether to call setNativeCursor afterwards
@@ -301,7 +301,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 	/**
 	 * Shortcut to register a simple MouseCursorData
-	 * 
+	 *
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 * @since   4.2.0
@@ -310,22 +310,22 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		var cursorVector = new Vector<BitmapData>();
 		cursorVector[0] = CursorBitmap;
-		
+
 		if (CursorBitmap.width > 32 || CursorBitmap.height > 32)
 			throw "BitmapData files used for native cursors cannot exceed 32x32 pixels due to an OS limitation.";
-		
+
 		var cursorData = new MouseCursorData();
 		cursorData.hotSpot = new Point(0, 0);
 		cursorData.data = cursorVector;
-		
+
 		registerNativeCursor(Name, cursorData);
-		
+
 		return cursorData;
 	}
 
 	/**
 	 * Shortcut to create and set a simple MouseCursorData
-	 * 
+	 *
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 */
@@ -337,7 +337,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		return data;
 	}
 	#end
-	
+
 	/**
 	 * Clean up memory. Internal use only.
 	 */
@@ -348,49 +348,49 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			_stage.removeEventListener(MouseEvent.MOUSE_DOWN, _leftButton.onDown);
 			_stage.removeEventListener(MouseEvent.MOUSE_UP, _leftButton.onUp);
-			
+
 			#if FLX_MOUSE_ADVANCED
 			_stage.removeEventListener(untyped MouseEvent.MIDDLE_MOUSE_DOWN, _middleButton.onDown);
 			_stage.removeEventListener(untyped MouseEvent.MIDDLE_MOUSE_UP, _middleButton.onUp);
 			_stage.removeEventListener(untyped MouseEvent.RIGHT_MOUSE_DOWN, _rightButton.onDown);
 			_stage.removeEventListener(untyped MouseEvent.RIGHT_MOUSE_UP, _rightButton.onUp);
-			
+
 			_stage.removeEventListener(Event.MOUSE_LEAVE, onMouseLeave);
 			#end
-			
+
 			_stage.removeEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
 		}
-		
+
 		cursorContainer = null;
 		_cursor = null;
-		
+
 		#if FLX_NATIVE_CURSOR
 		_matrix = null;
 		#end
-		
+
 		_leftButton = FlxDestroyUtil.destroy(_leftButton);
 		#if FLX_MOUSE_ADVANCED
 		_middleButton = FlxDestroyUtil.destroy(_middleButton);
 		_rightButton = FlxDestroyUtil.destroy(_rightButton);
 		#end
-		
+
 		_cursorBitmapData = FlxDestroyUtil.dispose(_cursorBitmapData);
-		FlxG.signals.gameStarted.remove(onGameStart);
+		FlxG.signals.postGameStart.remove(onGameStart);
 	}
-	
+
 	/**
 	 * Resets the just pressed/just released flags and sets mouse to not pressed.
 	 */
 	public function reset():Void
 	{
 		_leftButton.reset();
-		
+
 		#if FLX_MOUSE_ADVANCED
 		_middleButton.reset();
 		_rightButton.reset();
 		#end
 	}
-	
+
 	/**
 	 * @param   CursorContainer   The cursor container sprite passed by FlxGame
 	 */
@@ -401,31 +401,31 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		cursorContainer = CursorContainer;
 		cursorContainer.mouseChildren = false;
 		cursorContainer.mouseEnabled = false;
-		
+
 		_leftButton = new FlxMouseButton(FlxMouseButtonID.LEFT);
-		
+
 		_stage = Lib.current.stage;
 		_stage.addEventListener(MouseEvent.MOUSE_DOWN, _leftButton.onDown);
 		_stage.addEventListener(MouseEvent.MOUSE_UP, _leftButton.onUp);
-		
+
 		#if FLX_MOUSE_ADVANCED
 		_middleButton = new FlxMouseButton(FlxMouseButtonID.MIDDLE);
 		_rightButton = new FlxMouseButton(FlxMouseButtonID.RIGHT);
-		
+
 		_stage.addEventListener(untyped MouseEvent.MIDDLE_MOUSE_DOWN, _middleButton.onDown);
 		_stage.addEventListener(untyped MouseEvent.MIDDLE_MOUSE_UP, _middleButton.onUp);
 		_stage.addEventListener(untyped MouseEvent.RIGHT_MOUSE_DOWN, _rightButton.onDown);
 		_stage.addEventListener(untyped MouseEvent.RIGHT_MOUSE_UP, _rightButton.onUp);
-		
+
 		_stage.addEventListener(Event.MOUSE_LEAVE, onMouseLeave);
 		#end
-		
+
 		_stage.addEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
-		
-		FlxG.signals.gameStarted.add(onGameStart);
+
+		FlxG.signals.postGameStart.add(onGameStart);
 		Mouse.hide();
 	}
-	
+
 	/**
 	 * Called by the internal game loop to update the mouse pointer's position in the game world.
 	 * Also updates the just pressed/just released flags.
@@ -434,10 +434,10 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		_prevX = x;
 		_prevY = y;
-		
+
 		#if !FLX_UNIT_TEST // Travis segfaults when game.mouseX / Y is accessed
-		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY); 
-		
+		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY);
+
 		//actually position the flixel mouse cursor graphic
 		if (visible)
 		{
@@ -445,14 +445,14 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			cursorContainer.y = FlxG.game.mouseY;
 		}
 		#end
-		
+
 		// Update the buttons
 		_leftButton.update();
 		#if FLX_MOUSE_ADVANCED
 		_middleButton.update();
 		_rightButton.update();
 		#end
-		
+
 		// Update the wheel
 		if (!_wheelUsed)
 		{
@@ -460,17 +460,17 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		_wheelUsed = false;
 	}
-	
+
 	/**
 	 * Called from the main Event.ACTIVATE that is dispatched in FlxGame
 	 */
 	function onFocus():Void
 	{
 		reset();
-		
+
 		#if !FLX_NATIVE_CURSOR
 		set_useSystemCursor(useSystemCursor);
-		
+
 		visible = _visibleWhenFocusLost;
 		#end
 	}
@@ -482,23 +482,23 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		#if !FLX_NATIVE_CURSOR
 		_visibleWhenFocusLost = visible;
-		
+
 		if (visible)
 		{
 			visible = false;
 		}
-		
+
 		Mouse.show();
 		#end
 	}
-	
+
 	function onGameStart():Void
 	{
 		// Call set_visible with the value visible has been initialized with
 		// (unless set in create() of the initial state)
 		set_visible(visible);
 	}
-	
+
 	/**
 	 * Internal event handler for input and focus.
 	 */
@@ -510,10 +510,10 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			wheel = FlashEvent.delta;
 		}
 	}
-	
+
 	#if FLX_MOUSE_ADVANCED
 	/**
-	 * We're detecting the mouse leave event to prevent a bug where `pressed` remains true 
+	 * We're detecting the mouse leave event to prevent a bug where `pressed` remains true
 	 * for the middle and right mouse button when pressed and dragged outside the window.
 	 */
 	inline function onMouseLeave(_):Void
@@ -522,7 +522,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		_middleButton.onUp();
 	}
 	#end
-	
+
 	inline function get_justMoved():Bool					 return _prevX != x || _prevY != y;
 	inline function get_pressed():Bool                       return _leftButton.pressed;
 	inline function get_justPressed():Bool                   return _leftButton.justPressed;
@@ -534,13 +534,13 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	inline function get_justPressedRight():Bool              return _rightButton.justPressed;
 	inline function get_justReleasedRight():Bool             return _rightButton.justReleased;
 	inline function get_justPressedTimeInTicksRight():Int    return _rightButton.justPressedTimeInTicks;
-	
+
 	inline function get_pressedMiddle():Bool                 return _middleButton.pressed;
 	inline function get_justPressedMiddle():Bool             return _middleButton.justPressed;
 	inline function get_justReleasedMiddle():Bool            return _middleButton.justReleased;
 	inline function get_justPressedTimeInTicksMiddle():Int   return _middleButton.justPressedTimeInTicks;
 	#end
-	
+
 	function showSystemCursor():Void
 	{
 		#if FLX_NATIVE_CURSOR
@@ -561,38 +561,38 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		#else
 		Mouse.hide();
-		
+
 		if (visible)
 		{
 			cursorContainer.visible = true;
 		}
 		#end
 	}
-	
+
 	function set_useSystemCursor(Value:Bool):Bool
 	{
 		if (Value)
 		{
 			showSystemCursor();
-		} 
-		else 
+		}
+		else
 		{
 			hideSystemCursor();
 		}
 		return useSystemCursor = Value;
 	}
-	
+
 	function showCursor():Void
 	{
 		if (useSystemCursor)
 		{
 			Mouse.show();
 		}
-		else 
+		else
 		{
 			if (_cursor == null)
 				load();
-		
+
 			#if FLX_NATIVE_CURSOR
 			Mouse.show();
 			#else
@@ -612,28 +612,28 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		if (Value)
 			showCursor();
-		else 
+		else
 			hideCursor();
-		
+
 		return visible = Value;
 	}
-	
+
 	@:allow(flixel.system.replay.FlxReplay)
 	function record():MouseRecord
 	{
-		if ((_lastX == _globalScreenX) && (_lastY == _globalScreenY) 
+		if ((_lastX == _globalScreenX) && (_lastY == _globalScreenY)
 			&& (_lastLeftButtonState == _leftButton.current) && (_lastWheel == wheel))
 		{
 			return null;
 		}
-		
+
 		_lastX = _globalScreenX;
 		_lastY = _globalScreenY;
 		_lastLeftButtonState = _leftButton.current;
 		_lastWheel = wheel;
 		return new MouseRecord(_lastX, _lastY, _leftButton.current, _lastWheel);
 	}
-	
+
 	@:allow(flixel.system.replay.FlxReplay)
 	function playback(Record:MouseRecord):Void
 	{

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -39,18 +39,18 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var enabled:Bool = true;
 	/**
-	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up,
+	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up, 
 	 * it will have a positive value and vice versa. Otherwise the value will be 0.
 	 */
 	public var wheel(default, null):Int = 0;
-
+	
 	/**
-	 * A display container for the mouse cursor. It is a child of FlxGame and
+	 * A display container for the mouse cursor. It is a child of FlxGame and 
 	 * sits at the right "height". Not used on flash with the native cursor API.
 	 */
 	public var cursorContainer(default, null):Sprite;
 	/**
-	 * Used to toggle the visiblity of the mouse cursor - works on both
+	 * Used to toggle the visiblity of the mouse cursor - works on both 
 	 * the flixel and the system cursor, depending on which one is active.
 	 */
 	public var visible(default, set):Bool = #if (mobile || switch) false #else true #end;
@@ -118,13 +118,13 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	public var justPressedTimeInTicksMiddle(get, never):Int;
 	#end
-
+	
 	/**
 	 * The left mouse button.
 	 */
 	@:allow(flixel.input.mouse.FlxMouseButton)
 	var _leftButton:FlxMouseButton;
-
+	
 	#if FLX_MOUSE_ADVANCED
 	/**
 	 * The middle mouse button.
@@ -137,7 +137,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	@:allow(flixel.input.mouse.FlxMouseButton)
 	var _rightButton:FlxMouseButton;
 	#end
-
+	
 	/**
 	 * This is just a reference to the current cursor image, if there is one.
 	 */
@@ -145,7 +145,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	var _cursorBitmapData:BitmapData;
 	var _wheelUsed:Bool = false;
 	var _visibleWhenFocusLost:Bool = true;
-
+	
 	/**
 	 * Helper variables for recording purposes.
 	 */
@@ -153,16 +153,16 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	var _lastY:Int = 0;
 	var _lastWheel:Int = 0;
 	var _lastLeftButtonState:FlxInputState;
-
+	
 	/**
 	 * Helper variables to see if the mouse has moved since the last update.
 	 */
 	var _prevX:Int = 0;
 	var _prevY:Int = 0;
-
+	
 	//Helper variable for cleaning up memory
 	var _stage:Stage;
-
+	
 	/**
 	 * Helper variables for flash native cursors
 	 */
@@ -171,11 +171,11 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	var _currentNativeCursor:String;
 	var _matrix = new Matrix();
 	#end
-
+	
 	/**
-	 * Load a new mouse cursor graphic - if you're using native cursors on flash,
+	 * Load a new mouse cursor graphic - if you're using native cursors on flash, 
 	 * check registerNativeCursor() for more control.
-	 *
+	 * 
 	 * @param   Graphic   The image you want to use for the cursor.
 	 * @param   Scale     Change the size of the cursor.
 	 * @param   XOffset   The number of pixels between the mouse's screen position and the graphic's top left corner.
@@ -191,12 +191,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			FlxDestroyUtil.removeChild(cursorContainer, _cursor);
 		}
 		#end
-
+		
 		if (Graphic == null)
 		{
 			Graphic = new GraphicCursor(0, 0);
 		}
-
+		
 		if (Std.is(Graphic, Class))
 		{
 			_cursor = Type.createInstance(Graphic, []);
@@ -213,29 +213,29 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			_cursor = new Bitmap(new GraphicCursor(0, 0));
 		}
-
+		
 		_cursor.x = XOffset;
 		_cursor.y = YOffset;
 		_cursor.scaleX = Scale;
 		_cursor.scaleY = Scale;
-
+		
 		#if FLX_NATIVE_CURSOR
 		if (XOffset < 0 || YOffset < 0)
 		{
 			throw "Negative offsets aren't supported for native cursors.";
 		}
-
+		
 		if (Scale < 0)
 		{
 			throw "Negative scale isn't supported for native cursors.";
 		}
-
+		
 		var scaledWidth:Int = Std.int(Scale * _cursor.bitmapData.width);
 		var scaledHeight:Int = Std.int(Scale * _cursor.bitmapData.height);
-
+		
 		var bitmapWidth:Int = scaledWidth + XOffset;
 		var bitmapHeight:Int = scaledHeight + YOffset;
-
+		
 		var cursorBitmap:BitmapData = new BitmapData(bitmapWidth, bitmapHeight, true, 0x0);
 		if (_matrix != null)
 		{
@@ -273,15 +273,15 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	/**
 	 * Set a Native cursor that has been registered by Name
 	 * Warning, you need to use registerNativeCursor() before you use it here
-	 *
+	 * 
 	 * @param   Name   The name ID used when registered
 	 */
 	public function setNativeCursor(Name:String):Void
 	{
 		_currentNativeCursor = Name;
-
+		
 		Mouse.show();
-
+		
 		//Flash requires the use of AUTO before a custom cursor to work
 		Mouse.cursor = MouseCursor.AUTO;
 		Mouse.cursor = _currentNativeCursor;
@@ -289,7 +289,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 	/**
 	 * Shortcut to register a native cursor in flash
-	 *
+	 * 
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 * @param   Show         Whether to call setNativeCursor afterwards
@@ -301,7 +301,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 	/**
 	 * Shortcut to register a simple MouseCursorData
-	 *
+	 * 
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 * @since   4.2.0
@@ -310,22 +310,22 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		var cursorVector = new Vector<BitmapData>();
 		cursorVector[0] = CursorBitmap;
-
+		
 		if (CursorBitmap.width > 32 || CursorBitmap.height > 32)
 			throw "BitmapData files used for native cursors cannot exceed 32x32 pixels due to an OS limitation.";
-
+		
 		var cursorData = new MouseCursorData();
 		cursorData.hotSpot = new Point(0, 0);
 		cursorData.data = cursorVector;
-
+		
 		registerNativeCursor(Name, cursorData);
-
+		
 		return cursorData;
 	}
 
 	/**
 	 * Shortcut to create and set a simple MouseCursorData
-	 *
+	 * 
 	 * @param   Name         The ID name used for the cursor
 	 * @param   CursorData   MouseCursorData contains the bitmap, hotspot etc
 	 */
@@ -337,7 +337,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		return data;
 	}
 	#end
-
+	
 	/**
 	 * Clean up memory. Internal use only.
 	 */
@@ -348,49 +348,49 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			_stage.removeEventListener(MouseEvent.MOUSE_DOWN, _leftButton.onDown);
 			_stage.removeEventListener(MouseEvent.MOUSE_UP, _leftButton.onUp);
-
+			
 			#if FLX_MOUSE_ADVANCED
 			_stage.removeEventListener(untyped MouseEvent.MIDDLE_MOUSE_DOWN, _middleButton.onDown);
 			_stage.removeEventListener(untyped MouseEvent.MIDDLE_MOUSE_UP, _middleButton.onUp);
 			_stage.removeEventListener(untyped MouseEvent.RIGHT_MOUSE_DOWN, _rightButton.onDown);
 			_stage.removeEventListener(untyped MouseEvent.RIGHT_MOUSE_UP, _rightButton.onUp);
-
+			
 			_stage.removeEventListener(Event.MOUSE_LEAVE, onMouseLeave);
 			#end
-
+			
 			_stage.removeEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
 		}
-
+		
 		cursorContainer = null;
 		_cursor = null;
-
+		
 		#if FLX_NATIVE_CURSOR
 		_matrix = null;
 		#end
-
+		
 		_leftButton = FlxDestroyUtil.destroy(_leftButton);
 		#if FLX_MOUSE_ADVANCED
 		_middleButton = FlxDestroyUtil.destroy(_middleButton);
 		_rightButton = FlxDestroyUtil.destroy(_rightButton);
 		#end
-
+		
 		_cursorBitmapData = FlxDestroyUtil.dispose(_cursorBitmapData);
 		FlxG.signals.postGameStart.remove(onGameStart);
 	}
-
+	
 	/**
 	 * Resets the just pressed/just released flags and sets mouse to not pressed.
 	 */
 	public function reset():Void
 	{
 		_leftButton.reset();
-
+		
 		#if FLX_MOUSE_ADVANCED
 		_middleButton.reset();
 		_rightButton.reset();
 		#end
 	}
-
+	
 	/**
 	 * @param   CursorContainer   The cursor container sprite passed by FlxGame
 	 */
@@ -401,31 +401,31 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		cursorContainer = CursorContainer;
 		cursorContainer.mouseChildren = false;
 		cursorContainer.mouseEnabled = false;
-
+		
 		_leftButton = new FlxMouseButton(FlxMouseButtonID.LEFT);
-
+		
 		_stage = Lib.current.stage;
 		_stage.addEventListener(MouseEvent.MOUSE_DOWN, _leftButton.onDown);
 		_stage.addEventListener(MouseEvent.MOUSE_UP, _leftButton.onUp);
-
+		
 		#if FLX_MOUSE_ADVANCED
 		_middleButton = new FlxMouseButton(FlxMouseButtonID.MIDDLE);
 		_rightButton = new FlxMouseButton(FlxMouseButtonID.RIGHT);
-
+		
 		_stage.addEventListener(untyped MouseEvent.MIDDLE_MOUSE_DOWN, _middleButton.onDown);
 		_stage.addEventListener(untyped MouseEvent.MIDDLE_MOUSE_UP, _middleButton.onUp);
 		_stage.addEventListener(untyped MouseEvent.RIGHT_MOUSE_DOWN, _rightButton.onDown);
 		_stage.addEventListener(untyped MouseEvent.RIGHT_MOUSE_UP, _rightButton.onUp);
-
+		
 		_stage.addEventListener(Event.MOUSE_LEAVE, onMouseLeave);
 		#end
-
+		
 		_stage.addEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
-
+		
 		FlxG.signals.postGameStart.add(onGameStart);
 		Mouse.hide();
 	}
-
+	
 	/**
 	 * Called by the internal game loop to update the mouse pointer's position in the game world.
 	 * Also updates the just pressed/just released flags.
@@ -434,10 +434,10 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		_prevX = x;
 		_prevY = y;
-
+		
 		#if !FLX_UNIT_TEST // Travis segfaults when game.mouseX / Y is accessed
-		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY);
-
+		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY); 
+		
 		//actually position the flixel mouse cursor graphic
 		if (visible)
 		{
@@ -445,14 +445,14 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			cursorContainer.y = FlxG.game.mouseY;
 		}
 		#end
-
+		
 		// Update the buttons
 		_leftButton.update();
 		#if FLX_MOUSE_ADVANCED
 		_middleButton.update();
 		_rightButton.update();
 		#end
-
+		
 		// Update the wheel
 		if (!_wheelUsed)
 		{
@@ -460,17 +460,17 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		_wheelUsed = false;
 	}
-
+	
 	/**
 	 * Called from the main Event.ACTIVATE that is dispatched in FlxGame
 	 */
 	function onFocus():Void
 	{
 		reset();
-
+		
 		#if !FLX_NATIVE_CURSOR
 		set_useSystemCursor(useSystemCursor);
-
+		
 		visible = _visibleWhenFocusLost;
 		#end
 	}
@@ -482,23 +482,23 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		#if !FLX_NATIVE_CURSOR
 		_visibleWhenFocusLost = visible;
-
+		
 		if (visible)
 		{
 			visible = false;
 		}
-
+		
 		Mouse.show();
 		#end
 	}
-
+	
 	function onGameStart():Void
 	{
 		// Call set_visible with the value visible has been initialized with
 		// (unless set in create() of the initial state)
 		set_visible(visible);
 	}
-
+	
 	/**
 	 * Internal event handler for input and focus.
 	 */
@@ -510,10 +510,10 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			wheel = FlashEvent.delta;
 		}
 	}
-
+	
 	#if FLX_MOUSE_ADVANCED
 	/**
-	 * We're detecting the mouse leave event to prevent a bug where `pressed` remains true
+	 * We're detecting the mouse leave event to prevent a bug where `pressed` remains true 
 	 * for the middle and right mouse button when pressed and dragged outside the window.
 	 */
 	inline function onMouseLeave(_):Void
@@ -522,7 +522,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		_middleButton.onUp();
 	}
 	#end
-
+	
 	inline function get_justMoved():Bool					 return _prevX != x || _prevY != y;
 	inline function get_pressed():Bool                       return _leftButton.pressed;
 	inline function get_justPressed():Bool                   return _leftButton.justPressed;
@@ -534,13 +534,13 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	inline function get_justPressedRight():Bool              return _rightButton.justPressed;
 	inline function get_justReleasedRight():Bool             return _rightButton.justReleased;
 	inline function get_justPressedTimeInTicksRight():Int    return _rightButton.justPressedTimeInTicks;
-
+	
 	inline function get_pressedMiddle():Bool                 return _middleButton.pressed;
 	inline function get_justPressedMiddle():Bool             return _middleButton.justPressed;
 	inline function get_justReleasedMiddle():Bool            return _middleButton.justReleased;
 	inline function get_justPressedTimeInTicksMiddle():Int   return _middleButton.justPressedTimeInTicks;
 	#end
-
+	
 	function showSystemCursor():Void
 	{
 		#if FLX_NATIVE_CURSOR
@@ -561,38 +561,38 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		#else
 		Mouse.hide();
-
+		
 		if (visible)
 		{
 			cursorContainer.visible = true;
 		}
 		#end
 	}
-
+	
 	function set_useSystemCursor(Value:Bool):Bool
 	{
 		if (Value)
 		{
 			showSystemCursor();
-		}
-		else
+		} 
+		else 
 		{
 			hideSystemCursor();
 		}
 		return useSystemCursor = Value;
 	}
-
+	
 	function showCursor():Void
 	{
 		if (useSystemCursor)
 		{
 			Mouse.show();
 		}
-		else
+		else 
 		{
 			if (_cursor == null)
 				load();
-
+		
 			#if FLX_NATIVE_CURSOR
 			Mouse.show();
 			#else
@@ -612,28 +612,28 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		if (Value)
 			showCursor();
-		else
+		else 
 			hideCursor();
-
+		
 		return visible = Value;
 	}
-
+	
 	@:allow(flixel.system.replay.FlxReplay)
 	function record():MouseRecord
 	{
-		if ((_lastX == _globalScreenX) && (_lastY == _globalScreenY)
+		if ((_lastX == _globalScreenX) && (_lastY == _globalScreenY) 
 			&& (_lastLeftButtonState == _leftButton.current) && (_lastWheel == wheel))
 		{
 			return null;
 		}
-
+		
 		_lastX = _globalScreenX;
 		_lastY = _globalScreenY;
 		_lastLeftButtonState = _leftButton.current;
 		_lastWheel = wheel;
 		return new MouseRecord(_lastX, _lastY, _leftButton.current, _lastWheel);
 	}
-
+	
 	@:allow(flixel.system.replay.FlxReplay)
 	function playback(Record:MouseRecord):Void
 	{

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -10,23 +10,27 @@ class SignalFrontEnd
 	public var stateSwitched(default, null):FlxSignal = new FlxSignal();
 	public var preStateCreate(default, null):FlxTypedSignal<FlxState->Void> = new FlxTypedSignal<FlxState->Void>();
 	/**
-	 * Gets dispatched when the game is resized. 
+	 * Gets dispatched when the game is resized.
 	 * Passes the new window width and height to callback functions.
 	 */
 	public var gameResized(default, null):FlxTypedSignal<Int->Int->Void> = new FlxTypedSignal<Int->Int->Void>();
 	public var preGameReset(default, null):FlxSignal = new FlxSignal();
 	public var postGameReset(default, null):FlxSignal = new FlxSignal();
 	/**
+	 * Gets dispatched just before the game is started (before the first state after the splash screen is created)
+	 */
+	public var preGameStart(default, null):FlxSignal = new FlxSignal();
+	/**
 	 * Gets dispatched when the game is started (first state after the splash screen).
 	 */
-	public var gameStarted(default, null):FlxSignal = new FlxSignal();
+	public var postGameStart(default, null):FlxSignal = new FlxSignal();
 	public var preUpdate(default, null):FlxSignal = new FlxSignal();
 	public var postUpdate(default, null):FlxSignal = new FlxSignal();
 	public var preDraw(default, null):FlxSignal = new FlxSignal();
 	public var postDraw(default, null):FlxSignal = new FlxSignal();
 	public var focusGained(default, null):FlxSignal = new FlxSignal();
 	public var focusLost(default, null):FlxSignal = new FlxSignal();
-	
+
 	@:allow(flixel.FlxG)
 	function new() {}
 }

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -10,7 +10,7 @@ class SignalFrontEnd
 	public var stateSwitched(default, null):FlxSignal = new FlxSignal();
 	public var preStateCreate(default, null):FlxTypedSignal<FlxState->Void> = new FlxTypedSignal<FlxState->Void>();
 	/**
-	 * Gets dispatched when the game is resized.
+	 * Gets dispatched when the game is resized. 
 	 * Passes the new window width and height to callback functions.
 	 */
 	public var gameResized(default, null):FlxTypedSignal<Int->Int->Void> = new FlxTypedSignal<Int->Int->Void>();
@@ -30,7 +30,7 @@ class SignalFrontEnd
 	public var postDraw(default, null):FlxSignal = new FlxSignal();
 	public var focusGained(default, null):FlxSignal = new FlxSignal();
 	public var focusLost(default, null):FlxSignal = new FlxSignal();
-
+	
 	@:allow(flixel.FlxG)
 	function new() {}
 }

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -24,6 +24,8 @@ class SignalFrontEnd
 	 * Gets dispatched when the game is started (first state after the splash screen).
 	 */
 	public var postGameStart(default, null):FlxSignal = new FlxSignal();
+	@:deprecated("Use postGameStart instead of gameStarted")
+	public var gameStarted(get, null):FlxSignal;
 	public var preUpdate(default, null):FlxSignal = new FlxSignal();
 	public var postUpdate(default, null):FlxSignal = new FlxSignal();
 	public var preDraw(default, null):FlxSignal = new FlxSignal();
@@ -33,4 +35,8 @@ class SignalFrontEnd
 	
 	@:allow(flixel.FlxG)
 	function new() {}
+	
+	function get_gameStarted():FlxSignal {
+		return postGameStart;
+	}
 }

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -36,7 +36,8 @@ class SignalFrontEnd
 	@:allow(flixel.FlxG)
 	function new() {}
 	
-	function get_gameStarted():FlxSignal {
+	function get_gameStarted():FlxSignal
+	{
 		return postGameStart;
 	}
 }

--- a/flixel/system/frontEnds/SignalFrontEnd.hx
+++ b/flixel/system/frontEnds/SignalFrontEnd.hx
@@ -25,7 +25,7 @@ class SignalFrontEnd
 	 */
 	public var postGameStart(default, null):FlxSignal = new FlxSignal();
 	@:deprecated("Use postGameStart instead of gameStarted")
-	public var gameStarted(get, null):FlxSignal;
+	public var gameStarted(get, never):FlxSignal;
 	public var preUpdate(default, null):FlxSignal = new FlxSignal();
 	public var postUpdate(default, null):FlxSignal = new FlxSignal();
 	public var preDraw(default, null):FlxSignal = new FlxSignal();


### PR DESCRIPTION
I believe there should be a way to call a function _after_ a FlxGame is initialized, but immediately _before_ the game begins (i.e. immediately before the first state is created). 

To give an example use case: I recently finished a game with a lot of FlxBitmapText objects that used the same font. In order to avoid calling FlxBitmapFont.fromAngelCode(), FlxBitmapFont.fromMonospace(), or FlxBitmapFont.fromXNA() every single time I created a new text object (which would've negatively affected performance, among other things), I created a single FlxBitmapFont object and passed it to FlxBitmapText.new() whenever I needed a new text object. But when could I initialize this single FlxBitmapFont object?

I couldn't initialize the FlxBitmapFont before initializing the FlxGame in Main.hx, because that throws an error; I believe this is because FlxBitmapFont requires some functionality that isn't set up until you initialize FlxGame. I couldn't add the font initialization to FlxG.signals.gameStarted either, because that would have been too late; gameStarted only dispatches _after_ the initial state is created, and I needed to use the FlxBitmapFont in my initial state. I could only initialize my FlxBitmapFont after the creation of FlxGame, but before the creation of my initial state. I ended up writing a static function named init() to be called from the beginning of the create() function of the initial state, but this is a flawed approach- if the initial state is visited multiple times, init() is called multiple times, and if the initial state is changed, the init() call needs to be moved.

For a better solution, I added a preGameStart signal to SignalFrontEnd, which works just like gameStarted, except that it dispatches before the creation of the initial state, rather than after. Any function added to this signal is called once and only once, before the creation of the initial state, whatever the initial state may be. I also renamed gameStarted to postGameStart, to match naming conventions for other signals in SignalFrontEnd.