### PR TITLE
Color transform fix, closes #2192

### DIFF
--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -71,10 +71,13 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 		for (i in 0...VERTICES_PER_QUAD)
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
 
-		if (colored)
+		if (colored || hasColorOffsets)
 		{
 			if (colorMultipliers == null)
 				colorMultipliers = [];
+			
+			if (colorOffsets == null)
+				colorOffsets = [];
 
 			for (i in 0...VERTICES_PER_QUAD)
 			{
@@ -83,27 +86,7 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 					colorMultipliers.push(transform.redMultiplier);
 					colorMultipliers.push(transform.greenMultiplier);
 					colorMultipliers.push(transform.blueMultiplier);
-				}
-				else
-				{
-					colorMultipliers.push(1);
-					colorMultipliers.push(1);
-					colorMultipliers.push(1);
-				}
-
-				colorMultipliers.push(1);
-			}
-		}
-
-		if (hasColorOffsets)
-		{
-			if (colorOffsets == null)
-				colorOffsets = [];
-
-			for (i in 0...VERTICES_PER_QUAD)
-			{
-				if (transform != null)
-				{
+					
 					colorOffsets.push(transform.redOffset);
 					colorOffsets.push(transform.greenOffset);
 					colorOffsets.push(transform.blueOffset);
@@ -111,11 +94,17 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 				}
 				else
 				{
+					colorMultipliers.push(1);
+					colorMultipliers.push(1);
+					colorMultipliers.push(1);
+					
 					colorOffsets.push(0);
 					colorOffsets.push(0);
 					colorOffsets.push(0);
 					colorOffsets.push(0);
 				}
+
+				colorMultipliers.push(1);
 			}
 		}
 	}
@@ -131,10 +120,10 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
 		shader.alpha.value = alphas;
 
-		if (colored)
+		if (colored || hasColorOffsets) {
 			shader.colorMultiplier.value = colorMultipliers;
-		if (hasColorOffsets)
 			shader.colorOffset.value = colorOffsets;
+		}
 
 		setParameterValue(shader.hasTransform, true);
 		setParameterValue(shader.hasColorTransform, colored || hasColorOffsets);


### PR DESCRIPTION
There were two issues in #2192.

Firstly, the color transform was being applied twice because the generated graphics were not being set to unique.

Secondly was the actual shader issue. The problem was that the shader applies the offsets and multipliers based off of a single flag, `hasColorTransform`. However, in actually populating the values to be used for these, each `colored` and `hasColorOffsets` are checked individually to populate the inputs for the shader.

In the case of a transform with multipliers but no offsets, this was fine, because the lack of offsets had no affect on the result as they effectively default to 0. In the case of offsets but no multipliers, however, treating the multipliers as 0 by default resulted in a black sprite.

I had two options for resolving this. One was to split up the application of offsets and multipliers in the shader and pass in two flag,s one for each, or make it so that if either are true when we are giving the shader the inputs that we populate both inputs instead of only one.

I opted for the latter solution as this means that the shader interface does not change, and I wasn't sure what else might have broken if I did change the shader interface.