### PR TITLE
FlxSave: allow optional local storage paths

### DIFF
--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -21,6 +21,10 @@ class FlxSave implements IFlxDestroyable
 	 */
 	public var name(default, null):String;
 	/**
+	 * The path of the local shared object.
+	 */
+	public var path(default, null):String;
+	/**
 	 * The local shared object itself.
 	 */
 	var _sharedObject:SharedObject;
@@ -43,6 +47,7 @@ class FlxSave implements IFlxDestroyable
 	{
 		_sharedObject = null;
 		name = null;
+		path = null;
 		data = null;
 		_onComplete = null;
 		_closeRequested = false;
@@ -53,15 +58,19 @@ class FlxSave implements IFlxDestroyable
 	 * 
 	 * @param	Name	The name of the object (should be the same each time to access old data).
 	 * 					May not contain spaces or any of the following characters: `~ % & \ ; : " ' , < > ? #`
+	 * @param	Path	The full or partial path to the file that created the shared object,
+	 * 					and that determines where the shared object will be stored locally.
+	 * 					If you do not specify this parameter, the full path is used.
 	 * @return	Whether or not you successfully connected to the save data.
 	 */
-	public function bind(Name:String):Bool
+	public function bind(Name:String, Path:String = null):Bool
 	{
 		destroy();
 		name = Name;
+		path = Path;
 		try
 		{
-			_sharedObject = SharedObject.getLocal(name);
+			_sharedObject = SharedObject.getLocal(name, path);
 		}
 		catch (e:Error)
 		{

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -22,6 +22,7 @@ class FlxSave implements IFlxDestroyable
 	public var name(default, null):String;
 	/**
 	 * The path of the local shared object.
+	 * @since 4.6.0
 	 */
 	public var path(default, null):String;
 	/**

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -63,7 +63,7 @@ class FlxSave implements IFlxDestroyable
 	 * 					If you do not specify this parameter, the full path is used.
 	 * @return	Whether or not you successfully connected to the save data.
 	 */
-	public function bind(Name:String, Path:String = null):Bool
+	public function bind(Name:String, ?Path:String):Bool
 	{
 		destroy();
 		name = Name;


### PR DESCRIPTION
By adding a path param, we allow some advanced behavior on local storage, for instance on Newgrounds this allows save files to persist across multiple versions, or allow different games on different urls to be able to share data with one another (so long as they are on the same domain)

This does not exist to fix any existing issue and is a feature suggestion, so let me now if I'm doing something wrong, here

fixes: #2203 