### PR TITLE
New substate should tryUpdate on the same frame it is entered

### DIFF
--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -176,7 +176,7 @@ class FlxState extends FlxGroup
 			_requestSubStateReset = false;
 			resetSubState();
 		}
-		else if (subState != null)
+		if (subState != null)
 		{
 			subState.tryUpdate(elapsed);
 		}


### PR DESCRIPTION
Presently a substate is drawn for one frame when it is enetered before an update has ever been called on it, sometimes leading to things being out of position if they are positioned in update.

This change brings FlxSubState in line with FlxState so that the substate update is called on the same frame it is entered.