### PR TITLE
Disable mouse input when the debugger interaction tool is active

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -34,7 +34,7 @@ private class GraphicCursor extends BitmapData {}
 class FlxMouse extends FlxPointer implements IFlxInputManager
 {
 	/**
-	 * Whether or not mouse input is currently enabled. 
+	 * Whether or not mouse input is currently enabled.
 	 * @since 4.1.0
 	 */
 	public var enabled:Bool = true;

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -34,10 +34,11 @@ private class GraphicCursor extends BitmapData {}
 class FlxMouse extends FlxPointer implements IFlxInputManager
 {
 	/**
-	 * Whether or not mouse input is currently enabled.
+	 * Whether or not mouse input is currently enabled. It will be temporarily
+	 * set to `false` while the debugger interaction tool is active.  
 	 * @since 4.1.0
 	 */
-	public var enabled:Bool = true;
+	@:isVar public var enabled(get, set):Bool = true;
 	/**
 	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up, 
 	 * it will have a positive value and vice versa. Otherwise the value will be 0.
@@ -616,6 +617,17 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			hideCursor();
 		
 		return visible = Value;
+	}
+
+	function get_enabled():Bool
+	{
+		var isDebuggerInteractionActive = FlxG.game.debugger.visible && FlxG.game.debugger.interaction.visible;
+		return enabled && !isDebuggerInteractionActive;	
+	}
+
+	function set_enabled(value:Bool):Bool
+	{
+		return enabled = value;
 	}
 	
 	@:allow(flixel.system.replay.FlxReplay)

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -34,11 +34,10 @@ private class GraphicCursor extends BitmapData {}
 class FlxMouse extends FlxPointer implements IFlxInputManager
 {
 	/**
-	 * Whether or not mouse input is currently enabled. It will be temporarily
-	 * set to `false` while the debugger interaction tool is active.  
+	 * Whether or not mouse input is currently enabled. 
 	 * @since 4.1.0
 	 */
-	@:isVar public var enabled(get, set):Bool = true;
+	public var enabled:Bool = true;
 	/**
 	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up, 
 	 * it will have a positive value and vice versa. Otherwise the value will be 0.
@@ -617,17 +616,6 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			hideCursor();
 		
 		return visible = Value;
-	}
-
-	function get_enabled():Bool
-	{
-		var isDebuggerInteractionActive = FlxG.game.debugger.visible && FlxG.game.debugger.interaction.visible;
-		return enabled && !isDebuggerInteractionActive;	
-	}
-
-	function set_enabled(value:Bool):Bool
-	{
-		return enabled = value;
 	}
 	
 	@:allow(flixel.system.replay.FlxReplay)

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -476,13 +476,6 @@ class FlxMouseEventManager extends FlxBasic
 	override public function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
-
-		#if FLX_MOUSE
-		// If mouse input is not enabled globally, keep all tracked objects
-		// in their currennt state until mouse input is re-enabled.
-		if (!FlxG.mouse.enabled)
-			return;
-		#end
 		
 		var currentOverObjects = new Array<ObjectMouseData<FlxObject>>();
 		
@@ -531,6 +524,11 @@ class FlxMouseEventManager extends FlxBasic
 		}
 		
 		#if FLX_MOUSE
+		// If mouse input is not enabled globally, prevent all tracked objects from responding to
+		// down/click/doubleclick/up events until mouse input is re-enabled.
+		if (!FlxG.mouse.enabled)
+			return;
+
 		// MouseMove - Look for objects with mouse over that have mouseMove callbacks
 		if (FlxG.mouse.justMoved)
 		{

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -476,6 +476,13 @@ class FlxMouseEventManager extends FlxBasic
 	override public function update(elapsed:Float):Void
 	{
 		super.update(elapsed);
+
+		#if FLX_MOUSE
+		// If mouse input is not enabled globally, keep all tracked objects
+		// in their currennt state until mouse input is re-enabled.
+		if (!FlxG.mouse.enabled)
+			return;
+		#end
 		
 		var currentOverObjects = new Array<ObjectMouseData<FlxObject>>();
 		

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -487,15 +487,13 @@ class FlxDebugger extends Sprite
 		// Disable mouse input if the interaction tool is active/visible,
 		// so users can select interactable elements, e.g. buttons.
 		FlxG.mouse.enabled = !interaction.visible;	
-		#end
 
 		if (_usingSystemCursor)
 		{
-			#if FLX_MOUSE
 			FlxG.mouse.useSystemCursor = _wasUsingSystemCursor;
 			FlxG.mouse.visible = _wasMouseVisible;
-			#end
-		}	
+		}
+		#end	
 	}
 
 	inline function toggleDrawDebug():Void

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -484,9 +484,9 @@ class FlxDebugger extends Sprite
 	function onMouseFocusLost():Void
 	{
 		#if FLX_MOUSE
-		// Disable mouse input if the interaction tool is active/visible,
+		// Disable mouse input if the interaction tool is in use,
 		// so users can select interactable elements, e.g. buttons.
-		FlxG.mouse.enabled = !interaction.visible;	
+		FlxG.mouse.enabled = !interaction.isInUse();	
 
 		if (_usingSystemCursor)
 		{

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -483,10 +483,15 @@ class FlxDebugger extends Sprite
 	@:allow(flixel.system.debug)
 	function onMouseFocusLost():Void
 	{
+		#if FLX_MOUSE
+		// Disable mouse input if the interaction tool is active/visible,
+		// so users can select interactable elements, e.g. buttons.
+		FlxG.mouse.enabled = !interaction.visible;	
+		#end
+
 		if (_usingSystemCursor)
 		{
 			#if FLX_MOUSE
-			FlxG.mouse.enabled = true;
 			FlxG.mouse.useSystemCursor = _wasUsingSystemCursor;
 			FlxG.mouse.visible = _wasMouseVisible;
 			#end

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -448,6 +448,8 @@ class Interaction extends Window
 			activeTool.button.toggled = true;
 		}
 		
+		// If the requested new tool is the same as the already active one,
+		// we deactive it (toggle behavior).
 		if (activeTool == value)
 			value = null;
 		
@@ -468,6 +470,12 @@ class Interaction extends Window
 			// so the user can click buttons, drag windows, etc.
 			setSystemCursorVisibility(true);
 		}
+
+		#if FLX_MOUSE
+		// Allow mouse input only if the interaction tool is visible
+		// and no tool is active.
+		FlxG.mouse.enabled = !isInUse();
+		#end
 	}
 	
 	function setSystemCursorVisibility(status:Bool):Void
@@ -509,6 +517,17 @@ class Interaction extends Window
 	{
 		var value:Int = _keysUp.get(key) == null ? 0 : _keysUp.get(key);
 		return (_turn - value) == 1;
+	}
+
+	/**
+	 * Informs whether the interactive debug is in use or not. Usage is defined
+	 * as the interactive debug being visible and one of its tools is selected/active. 
+	 * 
+	 * @return `true` if the interactive debug is visible and one of its tools is selected/active. 
+	 */
+	public function isInUse():Bool
+	{
+		return FlxG.debugger.visible && visible && activeTool != null;
 	}
 	
 	public function findItemsWithinState(items:Array<FlxBasic>, state:FlxState, area:FlxRect):Void

--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -168,6 +168,18 @@ class DebuggerFrontEnd
 			FlxG.stage.focus = null;
 			// setting focus to null will trigger a focus lost event, let's undo that
 			FlxG.game.onFocus(null);
+
+			#if FLX_MOUSE
+			FlxG.mouse.enabled = true;
+			#end
+		}
+		else
+		{
+			#if FLX_MOUSE
+			// Debugger is visible, allow mouse input in the game only if the
+			// interaction tool is not active.
+			FlxG.mouse.enabled = !FlxG.game.debugger.interaction.visible;
+			#end
 		}
 		
 		visibilityChanged.dispatch();

--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -177,8 +177,8 @@ class DebuggerFrontEnd
 		{
 			#if FLX_MOUSE
 			// Debugger is visible, allow mouse input in the game only if the
-			// interaction tool is not active.
-			FlxG.mouse.enabled = !FlxG.game.debugger.interaction.visible;
+			// interaction tool is not in use.
+			FlxG.mouse.enabled = !FlxG.game.debugger.interaction.isInUse();
 			#end
 		}
 		

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -372,6 +372,11 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 */
 	function updateButton():Void
 	{
+		// If mouse input is not enabled, this button must remain in whatever
+		// state it currently is untill mouse input is enabled again.
+		if (!FlxG.mouse.enabled)
+			return;
+
 		// We're looking for any touch / mouse overlaps with this button
 		var overlapFound = checkMouseOverlap();
 		if (!overlapFound)

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -372,10 +372,12 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 */
 	function updateButton():Void
 	{
+		#if FLX_MOUSE
 		// If mouse input is not enabled, this button must remain in whatever
 		// state it currently is untill mouse input is enabled again.
 		if (!FlxG.mouse.enabled)
 			return;
+		#end
 
 		// We're looking for any touch / mouse overlaps with this button
 		var overlapFound = checkMouseOverlap();

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -372,13 +372,6 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 */
 	function updateButton():Void
 	{
-		#if FLX_MOUSE
-		// If mouse input is not enabled, this button must remain in whatever
-		// state it currently is untill mouse input is enabled again.
-		if (!FlxG.mouse.enabled)
-			return;
-		#end
-
 		// We're looking for any touch / mouse overlaps with this button
 		var overlapFound = checkMouseOverlap();
 		if (!overlapFound)
@@ -535,6 +528,15 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 */
 	function onOverHandler():Void
 	{
+		#if FLX_MOUSE
+		// If mouse input is not enabled, this button must ignore over actions
+		// by remaining in the normal state (until mouse input is re-enabled).
+		if (!FlxG.mouse.enabled)
+		{
+			status = FlxButton.NORMAL;
+			return;
+		}
+		#end
 		status = FlxButton.HIGHLIGHT;
 		// Order matters here, because onOver.fire() could cause a state change and destroy this object.
 		onOver.fire();


### PR DESCRIPTION
`FlxG.mouse.enabled` will temporarily return `false` if the debugger interaction tool is active (visible). `FlxButton` (and any subclass) and `FlxMouseEventManager` will now account for `FlxG.mouse.enabled` when dealing with states, so clickable elements related to those will not work when the debugger interaction tool is active.

I decided to preserve the state of clickable elements when the debugger interaction tool becomes active, i.e. over remains over instead of released. I think it makes more sense to developers to not have a lot of state changes fired when the debugger is enabled. If you dislike this approach, let me know so I can adapt the code to no preserve the state of clickable elements.

Fixes: #2155 