### PR TITLE
Check mass when separating objects

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -216,6 +216,19 @@ class FlxObject extends FlxBasic
 
 			if (!obj1immovable && !obj2immovable)
 			{
+				if (Object1.mass > Object2.mass)
+				{
+					Object2.x += overlap;
+					Object2.velocity.x = obj1v - obj2v * Object2.elasticity;
+					return true;
+				}
+				if (Object2.mass > Object1.mass)
+				{
+					Object1.x += overlap;
+					Object1.velocity.x = obj1v - obj2v * Object1.elasticity;
+					return true;
+				}
+
 				overlap *= 0.5;
 				Object1.x = Object1.x - overlap;
 				Object2.x += overlap;
@@ -375,6 +388,27 @@ class FlxObject extends FlxBasic
 
 			if (!obj1immovable && !obj2immovable)
 			{
+				if (Object1.mass > Object2.mass)
+				{
+					Object2.y += overlap;
+					Object2.velocity.y = obj1v - obj2v * Object2.elasticity;
+					// This is special case code that handles cases like horizontal moving platforms you can ride
+					if (Object2.collisonXDrag && Object1.active && Object1.moves && (obj1delta < obj2delta))
+					{
+						Object2.x += Object1.x - Object1.last.x;
+					}
+				}
+				if (Object2.mass > Object1.mass)
+				{
+					Object1.y = Object1.y - overlap;
+					Object1.velocity.y = obj2v - obj1v * Object1.elasticity;
+					// This is special case code that handles cases like horizontal moving platforms you can ride
+					if (Object1.collisonXDrag && Object2.active && Object2.moves && (obj1delta > obj2delta))
+					{
+						Object1.x += Object2.x - Object2.last.x;
+					}
+				}
+				
 				overlap *= 0.5;
 				Object1.y = Object1.y - overlap;
 				Object2.y += overlap;


### PR DESCRIPTION
Instead of relying on `FlxObject.immovable` to create objects that aren't pushed by other objects, set an object's mass higher than another one to get the same effect while allowing for other collisions as well.

It seems like this should already be implemented, so I'm guessing there's some edge case that I haven't seen yet that prevented it :P