### PR TITLE
Put flixel dependencies back into haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -7,5 +7,5 @@
 	"version": "4.6.2",
 	"releasenote": "Fixes for Android and iOS with OpenFL 8+.",
 	"contributors": ["haxeflixel", "Gama11"],
-	"dependencies": {}
+	"dependencies": { "lime": "", "openfl": "" }
 }


### PR DESCRIPTION
Apparently those got lost after 5fbca9d4, yet they were present before.