### PR TITLE
FlxTilemap: fix crashes with negative tile indices

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -283,6 +283,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		widthInTiles = WidthInTiles;
 		heightInTiles = HeightInTiles;
 		_data = MapData.copy(); // make a copy to make sure we don't mess with the original array, which might be used for something!
+		for (i in 0..._data.length) if (_data[i] < 0) _data[i] = 0;
 
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;
@@ -312,6 +313,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		widthInTiles = MapData[0].length;
 		heightInTiles = MapData.length;
 		_data = FlxArrayUtil.flatten2DArray(MapData);
+		for (i in 0..._data.length) if (_data[i] < 0) _data[i] = 0;
 
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -283,7 +283,6 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		widthInTiles = WidthInTiles;
 		heightInTiles = HeightInTiles;
 		_data = MapData.copy(); // make a copy to make sure we don't mess with the original array, which might be used for something!
-		for (i in 0..._data.length) if (_data[i] < 0) _data[i] = 0;
 
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;
@@ -313,7 +312,6 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		widthInTiles = MapData[0].length;
 		heightInTiles = MapData.length;
 		_data = FlxArrayUtil.flatten2DArray(MapData);
-		for (i in 0..._data.length) if (_data[i] < 0) _data[i] = 0;
 
 		loadMapHelper(TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
 		return this;
@@ -353,6 +351,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	function loadMapHelper(TileGraphic:FlxTilemapGraphicAsset, TileWidth:Int = 0, TileHeight:Int = 0, ?AutoTile:FlxTilemapAutoTiling, StartingIndex:Int = 0,
 			DrawIndex:Int = 1, CollideIndex:Int = 1)
 	{
+		for (i in 0...data.length) if (data[i] < 0) data[i] = 0;
 		totalTiles = _data.length;
 		auto = (AutoTile == null) ? OFF : AutoTile;
 		_startingIndex = (StartingIndex <= 0) ? 0 : StartingIndex;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -242,10 +242,6 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 				if (curTile == null)
 					throw 'String in row $row, column $column is not a valid integer: "$columnString"';
 
-				// anything < 0 should be treated as 0 for compatibility with certain map formats (ogmo)
-				if (curTile < 0)
-					curTile = 0;
-
 				_data.push(curTile);
 				column++;
 			}
@@ -351,7 +347,13 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	function loadMapHelper(TileGraphic:FlxTilemapGraphicAsset, TileWidth:Int = 0, TileHeight:Int = 0, ?AutoTile:FlxTilemapAutoTiling, StartingIndex:Int = 0,
 			DrawIndex:Int = 1, CollideIndex:Int = 1)
 	{
-		for (i in 0...data.length) if (data[i] < 0) data[i] = 0;
+		// anything < 0 should be treated as 0 for compatibility with certain map formats (ogmo)
+		for (i in 0...data.length)
+		{
+			if (data[i] < 0)
+				data[i] = 0;
+		}
+
 		totalTiles = _data.length;
 		auto = (AutoTile == null) ? OFF : AutoTile;
 		_startingIndex = (StartingIndex <= 0) ? 0 : StartingIndex;


### PR DESCRIPTION
Tilemap functions like `ray()` and `FlxTilemapExt` crash when negative indexes are used. This just forces them all to 0 when loading maps