### PR TITLE
Keyboard gamepad fixes

### DIFF
--- a/flixel/input/FlxBaseKeyList.hx
+++ b/flixel/input/FlxBaseKeyList.hx
@@ -5,6 +5,7 @@ import flixel.input.FlxInput.FlxInputState;
 class FlxBaseKeyList
 {
 	public var ANY(get, never):Bool;
+	public var NONE(get, never):Bool;
 
 	var status:FlxInputState;
 	var keyManager:FlxKeyManager<Dynamic, Dynamic>;
@@ -31,5 +32,18 @@ class FlxBaseKeyList
 		}
 
 		return false;
+	}
+	
+	function get_NONE():Bool
+	{
+		for (key in keyManager._keyListArray)
+		{
+			if (key != null && check(key.ID))
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -148,6 +148,13 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 					case RELEASED: released.ANY;
 					case JUST_RELEASED: justReleased.ANY;
 				}
+			case FlxKey.NONE:
+				switch (Status)
+				{
+					case PRESSED: pressed.NONE;
+					case JUST_PRESSED: justPressed.NONE;
+					case JUST_RELEASED: justReleased.NONE;
+				}
 			default:
 				var key = getKey(KeyCode);
 				if (key == null)

--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -30,6 +30,11 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	public var justPressed(default, null):KeyList;
 
 	/**
+	 * Helper class to check if a key is released.
+	 */
+	public var released(default, null):KeyList;
+
+	/**
 	 * Helper class to check if a key was just released.
 	 */
 	public var justReleased(default, null):KeyList;
@@ -153,6 +158,7 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 				{
 					case PRESSED: pressed.NONE;
 					case JUST_PRESSED: justPressed.NONE;
+					case RELEASED: released.NONE;
 					case JUST_RELEASED: justReleased.NONE;
 				}
 			default:
@@ -216,6 +222,7 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_UP, onKeyUp);
 
 		pressed = createKeyList(FlxInputState.PRESSED, this);
+		released = createKeyList(FlxInputState.RELEASED, this);
 		justPressed = createKeyList(FlxInputState.JUST_PRESSED, this);
 		justReleased = createKeyList(FlxInputState.JUST_RELEASED, this);
 	}

--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -3,6 +3,7 @@ package flixel.input;
 import flash.events.KeyboardEvent;
 import flixel.FlxG;
 import flixel.input.FlxInput.FlxInputState;
+import flixel.input.keyboard.FlxKey;
 
 class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 {
@@ -135,25 +136,29 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	 * @param	Status		The key state to check for.
 	 * @return	Whether the provided key has the specified status.
 	 */
-	public function checkStatus(KeyCode:Key, Status:FlxInputState):Bool
+	public inline function checkStatus(KeyCode:Key, Status:FlxInputState):Bool
 	{
-		var key:FlxInput<Key> = getKey(KeyCode);
-
-		if (key != null)
+		return switch (KeyCode)
 		{
-			if (key.hasState(Status))
-			{
-				return true;
-			}
+			case FlxKey.ANY:
+				switch (Status)
+				{
+					case PRESSED: pressed.ANY;
+					case JUST_PRESSED: justPressed.ANY;
+					case RELEASED: released.ANY;
+					case JUST_RELEASED: justReleased.ANY;
+				}
+			default:
+				var key = getKey(KeyCode);
+				if (key == null)
+				{
+					#if debug
+					throw 'Invalid key code: $KeyCode.';
+					#end
+					return false;
+				}
+				return key.hasState(Status);
 		}
-		#if FLX_DEBUG
-		else
-		{
-			throw 'Invalid key code: $KeyCode.';
-		}
-		#end
-
-		return false;
 	}
 
 	/**
@@ -238,15 +243,8 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 
 		for (code in KeyArray)
 		{
-			var key:FlxInput<Key> = getKey(code);
-
-			if (key != null)
-			{
-				if (key.hasState(State))
-				{
-					return true;
-				}
-			}
+			if (checkStatus(code, State))
+				return true;
 		}
 
 		return false;

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -344,7 +344,7 @@ class FlxGamepad implements IFlxDestroyable
 	}
 
 	/**
-	 * Helper function to check the status of an array of keys
+	 * Helper function to check the status of an array of buttons
 	 *
 	 * @param	IDArray	An array of button IDs
 	 * @param	State	The button state to check for
@@ -366,7 +366,7 @@ class FlxGamepad implements IFlxDestroyable
 		return false;
 	}
 	/**
-	 * Helper function to check the status of an array of keys
+	 * Helper function to check the status of an array of buttons
 	 *
 	 * @param	IDArray	An array of keys as Strings
 	 * @param	State	The key state to check for

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -326,20 +326,7 @@ class FlxGamepad implements IFlxDestroyable
 					case JUST_RELEASED: justReleased.NONE;
 				}
 			default:
-				var rawID = mapping.getRawID(ID);
-				var button = buttons[rawID];
-				if (button == null)
-				{
-					return false;
-				}
-				var value = button.current;
-				switch (Status)
-				{
-					case PRESSED: value == PRESSED;
-					case RELEASED: value == RELEASED;
-					case JUST_PRESSED: value == JUST_PRESSED;
-					case JUST_RELEASED: value == JUST_RELEASED;
-				}
+				checkStatusRaw(mapping.getRawID(ID), Status);
 		}
 	}
 
@@ -350,35 +337,66 @@ class FlxGamepad implements IFlxDestroyable
 	 * @param	Status	The key state to check for
 	 * @return	Whether the provided button has the specified status
 	 */
-	public function checkStatusRaw(RawID:Int, Status:FlxInputState):Bool
+	public inline function checkStatusRaw(RawID:Int, Status:FlxInputState):Bool
 	{
-		if (buttons[RawID] != null)
-		{
-			return buttons[RawID].current == Status;
-		}
-		return false;
+		var button = buttons[RawID];
+		return button != null && button.hasState(Status);
 	}
 
+	/**
+	 * Helper function to check the status of an array of keys
+	 *
+	 * @param	IDArray	An array of button IDs
+	 * @param	State	The button state to check for
+	 * @return	Whether at least one of the keys has the specified status
+	 */
+	function checkButtonArrayState(IDArray:Array<FlxGamepadInputID>, Status:FlxInputState):Bool
+	{
+		if (IDArray == null)
+		{
+			return false;
+		}
+
+		for (code in IDArray)
+		{
+			if (checkStatus(code, Status))
+				return true;
+		}
+
+		return false;
+	}
+	/**
+	 * Helper function to check the status of an array of keys
+	 *
+	 * @param	IDArray	An array of keys as Strings
+	 * @param	State	The key state to check for
+	 * @return	Whether at least one of the keys has the specified status
+	 */
+	function checkButtonArrayStateRaw(IDArray:Array<Int>, Status:FlxInputState):Bool
+	{
+		if (IDArray == null)
+		{
+			return false;
+		}
+
+		for (code in IDArray)
+		{
+			if (checkStatusRaw(code, Status))
+				return true;
+		}
+		
+		return false;
+	}
+	
 	/**
 	 * Check if at least one button from an array of button IDs is pressed.
 	 *
 	 * @param	IDArray	An array of "universal" gamepad input IDs
 	 * @return	Whether at least one of the buttons is pressed
 	 */
-	public function anyPressed(IDArray:Array<FlxGamepadInputID>):Bool
+	public inline function anyPressed(IDArray:Array<FlxGamepadInputID>):Bool
 	{
-		for (id in IDArray)
-		{
-			var raw = mapping.getRawID(id);
-			if (buttons[raw] != null)
-			{
-				if (buttons[raw].pressed)
-				{
-					return true;
-				}
-			}
-		}
-		return false;
+		return checkButtonArrayState(IDArray, PRESSED);
 	}
 
 	/**
@@ -387,18 +405,9 @@ class FlxGamepad implements IFlxDestroyable
 	 * @param	RawIDArray	An array of raw button IDs
 	 * @return	Whether at least one of the buttons is pressed
 	 */
-	public function anyPressedRaw(RawIDArray:Array<Int>):Bool
+	public inline function anyPressedRaw(RawIDArray:Array<Int>):Bool
 	{
-		for (b in RawIDArray)
-		{
-			if (buttons[b] != null)
-			{
-				if (buttons[b].pressed)
-					return true;
-			}
-		}
-
-		return false;
+		return checkButtonArrayStateRaw(RawIDArray, PRESSED);
 	}
 
 	/**
@@ -407,19 +416,9 @@ class FlxGamepad implements IFlxDestroyable
 	 * @param	IDArray	An array of "universal" gamepad input IDs
 	 * @return	Whether at least one of the buttons was just pressed
 	 */
-	public function anyJustPressed(IDArray:Array<FlxGamepadInputID>):Bool
+	public inline function anyJustPressed(IDArray:Array<FlxGamepadInputID>):Bool
 	{
-		for (b in IDArray)
-		{
-			var raw = mapping.getRawID(b);
-			if (buttons[raw] != null)
-			{
-				if (buttons[raw].justPressed)
-					return true;
-			}
-		}
-
-		return false;
+		return checkButtonArrayState(IDArray, JUST_PRESSED);
 	}
 
 	/**
@@ -428,18 +427,9 @@ class FlxGamepad implements IFlxDestroyable
 	 * @param	RawIDArray	An array of raw button IDs
 	 * @return	Whether at least one of the buttons was just pressed
 	 */
-	public function anyJustPressedRaw(RawIDArray:Array<Int>):Bool
+	public inline function anyJustPressedRaw(RawIDArray:Array<Int>):Bool
 	{
-		for (b in RawIDArray)
-		{
-			if (buttons[b] != null)
-			{
-				if (buttons[b].justPressed)
-					return true;
-			}
-		}
-
-		return false;
+		return checkButtonArrayStateRaw(RawIDArray, JUST_PRESSED);
 	}
 
 	/**
@@ -448,19 +438,9 @@ class FlxGamepad implements IFlxDestroyable
 	 * @param	IDArray	An array of "universal" gamepad input IDs
 	 * @return	Whether at least one of the buttons was just released
 	 */
-	public function anyJustReleased(IDArray:Array<FlxGamepadInputID>):Bool
+	public inline function anyJustReleased(IDArray:Array<FlxGamepadInputID>):Bool
 	{
-		for (b in IDArray)
-		{
-			var raw = mapping.getRawID(b);
-			if (buttons[raw] != null)
-			{
-				if (buttons[raw].justReleased)
-					return true;
-			}
-		}
-
-		return false;
+		return checkButtonArrayState(IDArray, JUST_RELEASED);
 	}
 
 	/**
@@ -469,18 +449,9 @@ class FlxGamepad implements IFlxDestroyable
 	 * @param	RawArray	An array of raw button IDs
 	 * @return	Whether at least one of the buttons was just released
 	 */
-	public function anyJustReleasedRaw(RawIDArray:Array<Int>):Bool
+	public inline function anyJustReleasedRaw(RawIDArray:Array<Int>):Bool
 	{
-		for (b in RawIDArray)
-		{
-			if (buttons[b] != null)
-			{
-				if (buttons[b].justReleased)
-					return true;
-			}
-		}
-
-		return false;
+		return checkButtonArrayStateRaw(RawIDArray, JUST_RELEASED);
 	}
 
 	/**


### PR DESCRIPTION
Was made to close #2249 but it unveiled some other, related inconsistencies. I can split this up into multiple PRs if needed.

- Made `FlxG.keys.anyPressed([ANY])` return true if any key is pressed, previously it would always return false.
- Make `myGamePad.pressed.A` true when A is either `PRESSED` or `JUST_PRESSED`. Previously, it would be false if just pressed.
- Added `FlxKey.NONE` to FlxKeyList, since game pads have this feature.
- Added `FlxG.keys.released` since game pads had that too.
