### PR TITLE
Add switch pro controller mappings and gamepad.getInputLabel

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -13,6 +13,7 @@ import flixel.input.gamepad.mappings.OUYAMapping;
 import flixel.input.gamepad.mappings.PS4Mapping;
 import flixel.input.gamepad.mappings.PSVitaMapping;
 import flixel.input.gamepad.mappings.WiiRemoteMapping;
+import flixel.input.gamepad.mappings.SwitchProMapping;
 import flixel.input.gamepad.mappings.XInputMapping;
 import flixel.math.FlxVector;
 import flixel.util.FlxDestroyUtil;
@@ -837,6 +838,7 @@ class FlxGamepad implements IFlxDestroyable
 			case MAYFLASH_WII_REMOTE: new MayflashWiiRemoteMapping(attachment);
 			case WII_REMOTE: new WiiRemoteMapping(attachment);
 			case MFI: new MFiMapping(attachment);
+			case SWITCH_PRO: new SwitchProMapping(attachment);
 			// default to XInput if we don't have a mapping for this
 			case _: new XInputMapping(attachment);
 		}
@@ -911,6 +913,7 @@ enum FlxGamepadModel
 	MAYFLASH_WII_REMOTE;
 	WII_REMOTE;
 	MFI;
+	SWITCH_PRO;
 	UNKNOWN;
 }
 

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -14,6 +14,8 @@ import flixel.input.gamepad.mappings.PS4Mapping;
 import flixel.input.gamepad.mappings.PSVitaMapping;
 import flixel.input.gamepad.mappings.WiiRemoteMapping;
 import flixel.input.gamepad.mappings.SwitchProMapping;
+import flixel.input.gamepad.mappings.SwitchJoyconLeftMapping;
+import flixel.input.gamepad.mappings.SwitchJoyconRightMapping;
 import flixel.input.gamepad.mappings.XInputMapping;
 import flixel.math.FlxVector;
 import flixel.util.FlxDestroyUtil;
@@ -839,6 +841,8 @@ class FlxGamepad implements IFlxDestroyable
 			case WII_REMOTE: new WiiRemoteMapping(attachment);
 			case MFI: new MFiMapping(attachment);
 			case SWITCH_PRO: new SwitchProMapping(attachment);
+			case SWITCH_JOYCON_LEFT: new SwitchJoyconLeftMapping(attachment);
+			case SWITCH_JOYCON_RIGHT: new SwitchJoyconRightMapping(attachment);
 			// default to XInput if we don't have a mapping for this
 			case _: new XInputMapping(attachment);
 		}
@@ -918,7 +922,9 @@ enum FlxGamepadModel
 	MAYFLASH_WII_REMOTE;
 	WII_REMOTE;
 	MFI;
-	SWITCH_PRO;
+	SWITCH_PRO;// also dual joycons
+	SWITCH_JOYCON_LEFT;
+	SWITCH_JOYCON_RIGHT;
 	UNKNOWN;
 }
 

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -312,24 +312,9 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return switch (ID)
 		{
-			case FlxGamepadInputID.ANY:
-				switch (Status)
-				{
-					case PRESSED: pressed.ANY;
-					case JUST_PRESSED: justPressed.ANY;
-					case RELEASED: released.ANY;
-					case JUST_RELEASED: justReleased.ANY;
-				}
-			case FlxGamepadInputID.NONE:
-				switch (Status)
-				{
-					case PRESSED: pressed.NONE;
-					case JUST_PRESSED: justPressed.NONE;
-					case RELEASED: released.NONE;
-					case JUST_RELEASED: justReleased.NONE;
-				}
-			default:
-				checkStatusRaw(mapping.getRawID(ID), Status);
+			case FlxGamepadInputID.ANY: anyButton(Status);
+			case FlxGamepadInputID.NONE: !anyButton(Status);
+			default: checkStatusRaw(mapping.getRawID(ID), Status);
 		}
 	}
 

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -867,6 +867,9 @@ class FlxGamepad implements IFlxDestroyable
 		return _deadZone = deadZone;
 	}
 	
+	/** 
+	 * @since 4.8.0
+	 */
 	public inline function getInputLabel(id:FlxGamepadInputID)
 	{
 		return mapping.getInputLabel(id);
@@ -907,9 +910,22 @@ enum FlxGamepadModel
 	MAYFLASH_WII_REMOTE;
 	WII_REMOTE;
 	MFI;
-	SWITCH_PRO;// also dual joycons
+
+	/** 
+	 * @since 4.8.0
+	 */
+	SWITCH_PRO; // also dual joycons
+
+	/** 
+	 * @since 4.8.0
+	 */
 	SWITCH_JOYCON_LEFT;
+
+	/** 
+	 * @since 4.8.0
+	 */
 	SWITCH_JOYCON_RIGHT;
+
 	UNKNOWN;
 }
 

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -877,6 +877,11 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return _deadZone = deadZone;
 	}
+	
+	public inline function getInputLabel(id:FlxGamepadInputID)
+	{
+		return mapping.getInputLabel(id);
+	}
 
 	public function toString():String
 	{

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -401,20 +401,26 @@ class FlxGamepadManager implements IFlxInputManager
 		// and the most popular tools just turn it into a 360 controller
 
 		name = name.toLowerCase().remove("-").remove("_");
-		return if (name.contains("ouya")) OUYA; // "OUYA Game Controller"
-		else if (name.contains("wireless controller") || name.contains("ps4")) PS4; // "Wireless Controller" or "PS4 controller"
-		else if (name.contains("logitech")) LOGITECH; else if (name.contains("xbox") && name.contains("360")) XINPUT; else if (name.contains("xinput"))
-			XINPUT;
-		else if (name.contains("nintendo rvlcnt01tr"))
-			WII_REMOTE; // WiiRemote with motion plus
-		else if (name.contains("nintendo rvlcnt01"))
-			WII_REMOTE; // WiiRemote w/o  motion plus
-		else if (name.contains("mayflash wiimote pc adapter"))
-			MAYFLASH_WII_REMOTE; // WiiRemote paired to MayFlash DolphinBar (with or w/o motion plus)
-		else if (name.contains("mfi"))
-			MFI;
-		else
-			UNKNOWN;
+		return if (name.contains("ouya"))
+				OUYA; // "OUYA Game Controller"
+			else if (name.contains("wireless controller") || name.contains("ps4"))
+				PS4; // "Wireless Controller" or "PS4 controller"
+			else if (name.contains("logitech"))
+				LOGITECH;
+			else if ((name.contains("xbox") && name.contains("360")) || name.contains("xinput"))
+				XINPUT;
+			else if (name.contains("nintendo rvlcnt01tr"))
+				WII_REMOTE; // WiiRemote with motion plus
+			else if (name.contains("nintendo rvlcnt01"))
+				WII_REMOTE; // WiiRemote w/o  motion plus
+			else if (name.contains("mayflash wiimote pc adapter"))
+				MAYFLASH_WII_REMOTE; // WiiRemote paired to MayFlash DolphinBar (with or w/o motion plus)
+			else if (name.contains("mfi"))
+				MFI;
+			else if (name.contains("pro controller"))
+				SWITCH_PRO;
+			else
+				UNKNOWN;
 	}
 
 	function removeGamepad(Device:GameInputDevice):Void

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -417,8 +417,12 @@ class FlxGamepadManager implements IFlxInputManager
 				MAYFLASH_WII_REMOTE; // WiiRemote paired to MayFlash DolphinBar (with or w/o motion plus)
 			else if (name.contains("mfi"))
 				MFI;
-			else if (name.contains("pro controller"))
+			else if (name.contains("pro controller") || name.contains("joycon l+r"))
 				SWITCH_PRO;
+			else if (name.contains("joycon (l)"))
+				SWITCH_JOYCON_LEFT;
+			else if (name.contains("joycon (r)"))
+				SWITCH_JOYCON_RIGHT;
 			else
 				UNKNOWN;
 	}

--- a/flixel/input/gamepad/id/SWProID.hx
+++ b/flixel/input/gamepad/id/SWProID.hx
@@ -1,0 +1,84 @@
+package flixel.input.gamepad.id;
+
+import flixel.input.gamepad.FlxGamepadAnalogStick;
+
+/**
+	* IDs for Switch Pro controllers
+	*
+	*-------
+	* NOTES
+	*-------
+	*
+	* WINDOWS: untested.
+	*
+	* LINUX: untested
+	*
+	* MAC: Worked out of box for me when connected via microUSB cable or Bluetooth
+ */
+class SWProID
+{
+	#if flash
+	public static inline var DPAD_UP:Int = 4;
+	public static inline var DPAD_DOWN:Int = 5;
+	public static inline var DPAD_LEFT:Int = 6;
+	public static inline var DPAD_RIGHT:Int = 7;
+	public static inline var A:Int = 8;
+	public static inline var B:Int = 9;
+	public static inline var X:Int = 10;
+	public static inline var Y:Int = 11;
+	public static inline var L:Int = 12;
+	public static inline var R:Int = 13;
+	public static inline var ZL:Int = 14;
+	public static inline var ZR:Int = 15;
+	public static inline var MINUS:Int = 16;
+	public static inline var PLUS:Int = 17;
+	public static inline var HOME:Int = 20;
+	public static inline var CAPTURE:Int = 21;
+	public static inline var LEFT_STICK_CLICK:Int = 22;
+	public static inline var RIGHT_STICK_CLICK:Int = 23;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+		up: 24,
+		down: 25,
+		left: 26,
+		right: 27
+	});
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+		up: 28,
+		down: 29,
+		left: 30,
+		right: 31
+	});
+	#else
+	public static inline var ZL:Int = 4;
+	public static inline var ZR:Int = 5;
+	public static inline var B:Int = 6;
+	public static inline var A:Int = 7;
+	public static inline var Y:Int = 8;
+	public static inline var X:Int = 9;
+	public static inline var MINUS:Int = 10;
+	public static inline var HOME:Int = 11;
+	public static inline var PLUS:Int = 12;
+	public static inline var LEFT_STICK_CLICK:Int = 13;
+	public static inline var RIGHT_STICK_CLICK:Int = 14;
+	public static inline var L:Int = 15;
+	public static inline var R:Int = 16;
+	public static inline var DPAD_UP:Int = 17;
+	public static inline var DPAD_DOWN:Int = 18;
+	public static inline var DPAD_LEFT:Int = 19;
+	public static inline var DPAD_RIGHT:Int = 20;
+	public static inline var CAPTURE:Int = 21;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+		up: 22,
+		down: 23,
+		left: 24,
+		right: 25
+	});
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+		up: 26,
+		down: 27,
+		left: 28,
+		right: 29
+	});
+	#end
+	
+}

--- a/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
@@ -1,0 +1,60 @@
+package flixel.input.gamepad.id;
+
+import flixel.input.gamepad.FlxGamepadAnalogStick;
+
+/**
+ * IDs for Switch's Left JoyCon controllers
+ *
+ *-------
+ * NOTES
+ *-------
+ *
+ * WINDOWS: untested.
+ *
+ * LINUX: untested.
+ *
+ * MAC: Worked on html out of box for me when connected via microUSB cable or Bluetooth.
+ * Flash and neko couldn't detect the controller via bluetooth,
+ * which is weird because The pro worked wirelessly.
+ */
+class SwitchJoyconLeftID
+{
+	#if flash
+	public static inline var UP:Int = 8;
+	public static inline var LEFT:Int = 9;
+	public static inline var DOWN:Int = 10;
+	public static inline var RIGHT:Int = 11;
+	public static inline var SL:Int = 12;
+	public static inline var SR:Int = 13;
+	public static inline var ZL:Int = 14;
+	public static inline var L:Int = 15;
+	public static inline var MINUS:Int = 17;
+	public static inline var CAPTURE:Int = 21;
+	public static inline var LEFT_STICK_CLICK:Int = 22;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+		up: 24,
+		down: 25,
+		left: 26,
+		right: 27
+	});
+	#else
+	public static inline var ZL:Int = 4;
+	public static inline var DOWN:Int = 6;
+	public static inline var RIGHT:Int = 7;
+	public static inline var LEFT:Int = 8;
+	public static inline var UP:Int = 9;
+	public static inline var L:Int = 10;
+	public static inline var MINUS:Int = 12;
+	public static inline var LEFT_STICK_CLICK:Int = 13;
+	public static inline var SL:Int = 15;
+	public static inline var SR:Int = 16;
+	public static inline var CAPTURE:Int = 21;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+		up: 22,
+		down: 23,
+		left: 24,
+		right: 25
+	});
+	#end
+	
+}

--- a/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
@@ -16,6 +16,8 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  * MAC: Worked on html out of box for me when connected via microUSB cable or Bluetooth.
  * Flash and neko couldn't detect the controller via bluetooth,
  * which is weird because The pro worked wirelessly.
+ * 
+ * @since 4.8.0
  */
 class SwitchJoyconLeftID
 {

--- a/flixel/input/gamepad/id/SwitchJoyconRightID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconRightID.hx
@@ -16,6 +16,8 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  * MAC: Worked on html out of box for me when connected via microUSB cable or Bluetooth.
  * Flash and neko couldn't detect the controller via bluetooth,
  * which is weird because The pro worked wirelessly.
+ * 
+ * @since 4.8.0
  */
 class SwitchJoyconRightID
 {

--- a/flixel/input/gamepad/id/SwitchJoyconRightID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconRightID.hx
@@ -1,0 +1,67 @@
+package flixel.input.gamepad.id;
+
+import flixel.input.gamepad.FlxGamepadAnalogStick;
+
+/**
+ * IDs for Switch's Right JoyCon controllers
+ *
+ *-------
+ * NOTES
+ *-------
+ *
+ * WINDOWS: untested.
+ *
+ * LINUX: untested.
+ *
+ * MAC: Worked on html out of box for me when connected via microUSB cable or Bluetooth.
+ * Flash and neko couldn't detect the controller via bluetooth,
+ * which is weird because The pro worked wirelessly.
+ */
+class SwitchJoyconRightID
+{
+	#if flash
+	public static inline var A:Int = 8;
+	public static inline var B:Int = 9;
+	public static inline var X:Int = 10;
+	public static inline var Y:Int = 11;
+	public static inline var SL:Int = 12;
+	public static inline var SR:Int = 13;
+	public static inline var ZR:Int = 15;
+	public static inline var R:Int = 16;
+	public static inline var PLUS:Int = 17;
+	public static inline var HOME:Int = 20;
+	public static inline var CAPTURE:Int = 21;
+	public static inline var LEFT_STICK_CLICK:Int = 22;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+		up: 24,
+		down: 25,
+		left: 26,
+		right: 27
+	});
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+		up: 28,
+		down: 29,
+		left: 30,
+		right: 31
+	});
+	#else
+	public static inline var ZR:Int = 5;
+	public static inline var B:Int = 6;
+	public static inline var A:Int = 7;
+	public static inline var Y:Int = 8;
+	public static inline var X:Int = 9;
+	public static inline var R:Int = 10;
+	public static inline var HOME:Int = 11;
+	public static inline var PLUS:Int = 12;
+	public static inline var LEFT_STICK_CLICK:Int = 13;
+	public static inline var SL:Int = 15;
+	public static inline var SR:Int = 16;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+		up: 22,
+		down: 23,
+		left: 24,
+		right: 25
+	});
+	#end
+	
+}

--- a/flixel/input/gamepad/id/SwitchProID.hx
+++ b/flixel/input/gamepad/id/SwitchProID.hx
@@ -15,7 +15,7 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
 	*
 	* MAC: Worked out of box for me when connected via microUSB cable or Bluetooth
  */
-class SWProID
+class SwitchProID
 {
 	#if flash
 	public static inline var DPAD_UP:Int = 4;

--- a/flixel/input/gamepad/id/SwitchProID.hx
+++ b/flixel/input/gamepad/id/SwitchProID.hx
@@ -3,17 +3,19 @@ package flixel.input.gamepad.id;
 import flixel.input.gamepad.FlxGamepadAnalogStick;
 
 /**
-	* IDs for Switch Pro controllers
-	*
-	*-------
-	* NOTES
-	*-------
-	*
-	* WINDOWS: untested.
-	*
-	* LINUX: untested
-	*
-	* MAC: Worked out of box for me when connected via microUSB cable or Bluetooth
+ * IDs for Switch Pro controllers
+ *
+ *-------
+ * NOTES
+ *-------
+ *
+ * WINDOWS: untested.
+ *
+ * LINUX: untested
+ *
+ * MAC: Worked out of box for me when connected via microUSB cable or Bluetooth
+ * 
+ * @since 4.8.0
  */
 class SwitchProID
 {

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -101,6 +101,51 @@ class FlxGamepadMapping
 	{
 		return this.attachment = attachment;
 	}
+	
+	public function getInputLabel(id:FlxGamepadInputID):Null<String>
+	{
+		if (getRawID(id) == -1)
+			return null;// return empty string, "unknown" or enum maybe?
+		
+		return switch (id)
+		{
+			case A: "a";
+			case B: "b";
+			case X: "x";
+			case Y: "y";
+			case BACK: "back";
+			case GUIDE: "guide";
+			case START: "start";
+			case LEFT_STICK_CLICK: "ls-click";
+			case RIGHT_STICK_CLICK: "rs-click";
+			case LEFT_SHOULDER: "lb";
+			case RIGHT_SHOULDER: "rb";
+			case LEFT_TRIGGER: "lt";
+			case RIGHT_TRIGGER: "rt";
+			case LEFT_TRIGGER_BUTTON: "l2-click";
+			case RIGHT_TRIGGER_BUTTON: "r2-click";
+			case DPAD: "dpad";
+			case DPAD_UP: "up";
+			case DPAD_DOWN: "down";
+			case DPAD_LEFT: "left";
+			case DPAD_RIGHT: "right";
+			case LEFT_ANALOG_STICK: "ls";
+			case RIGHT_ANALOG_STICK: "rs";
+			case LEFT_STICK_DIGITAL_UP: "ls-up";
+			case LEFT_STICK_DIGITAL_DOWN: "ls-down";
+			case LEFT_STICK_DIGITAL_LEFT: "ls-left";
+			case LEFT_STICK_DIGITAL_RIGHT: "ls-right";
+			case RIGHT_STICK_DIGITAL_UP: "rs-up";
+			case RIGHT_STICK_DIGITAL_DOWN: "rs-down";
+			case RIGHT_STICK_DIGITAL_LEFT: "rs-left";
+			case RIGHT_STICK_DIGITAL_RIGHT: "rs-right";
+			#if FLX_JOYSTICK_API
+			case LEFT_TRIGGER_FAKE: "l2";
+			case RIGHT_TRIGGER_FAKE: "r2";
+			#end
+			default: null;
+		}
+	}
 }
 
 @SuppressWarnings("checkstyle:MemberName")

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -88,6 +88,29 @@ class LogitechMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
+	
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "2";
+			case B: "3";
+			case X: "1";
+			case Y: "4";
+			case BACK: "9";
+			case GUIDE: "logitech";
+			case START: "10";
+			case LEFT_SHOULDER: "5";
+			case RIGHT_SHOULDER: "6";
+			case LEFT_TRIGGER: "7";
+			case RIGHT_TRIGGER: "8";
+			#if FLX_JOYSTICK_API
+			case LEFT_TRIGGER_FAKE: "7";
+			case RIGHT_TRIGGER_FAKE: "8";
+			#end
+			default: super.getInputLabel(id);
+		}
+	}
 
 	#if FLX_JOYSTICK_API
 	override public function axisIndexToRawID(axisID:Int):Int

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -257,4 +257,13 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 
 		return super.set_attachment(attachment);
 	}
+	
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		var label = WiiRemoteMapping.getWiiInputLabel(id, attachment);
+		if (label == null)
+			return super.getInputLabel(id);
+		
+		return label;
+	}
 }

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -80,6 +80,19 @@ class OUYAMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
+	
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "o";
+			case B: "a";
+			case X: "u";
+			case Y: "y";
+			case GUIDE: "home";
+			case _: super.getInputLabel(id);
+		}
+	}
 
 	#if FLX_JOYSTICK_API
 	override public function axisIndexToRawID(axisID:Int):Int

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -99,7 +99,26 @@ class PS4Mapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
-
+	
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "x";
+			case B: "circle";
+			case X: "square";
+			case Y: "triangle";
+			case BACK: "share";
+			case GUIDE: "ps";
+			case START: "options";
+			case LEFT_SHOULDER: "l1";
+			case RIGHT_SHOULDER: "r1";
+			case LEFT_TRIGGER: "l2";
+			case RIGHT_TRIGGER: "r2";
+			case _: super.getInputLabel(id);
+		}
+	}
+	
 	#if FLX_JOYSTICK_API
 	override public function axisIndexToRawID(axisID:Int):Int
 	{

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -66,6 +66,23 @@ class PSVitaMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
+	
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "x";
+			case B: "circle";
+			case X: "square";
+			case Y: "triangle";
+			case BACK: "select";
+			case LEFT_SHOULDER: "l1";
+			case RIGHT_SHOULDER: "r1";
+			case LEFT_TRIGGER: "l2";
+			case RIGHT_TRIGGER: "r2";
+			case _: super.getInputLabel(id);
+		}
+	}
 
 	override public function isAxisFlipped(axisID:Int):Bool
 	{

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -1,0 +1,111 @@
+package flixel.input.gamepad.mappings;
+
+import flixel.input.gamepad.FlxGamepadInputID;
+import flixel.input.gamepad.id.SwitchJoyconLeftID;
+
+class SwitchJoyconLeftMapping extends FlxGamepadMapping
+{
+	#if FLX_JOYSTICK_API
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 32;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 33;
+
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 34;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 35;
+
+	static inline var LEFT_TRIGGER_FAKE:Int = 36;
+	static inline var RIGHT_TRIGGER_FAKE:Int = 37;
+	#end
+
+	override function initValues():Void
+	{
+		leftStick = SwitchJoyconLeftID.LEFT_ANALOG_STICK;
+		supportsMotion = true;
+		supportsPointer = false;
+	}
+
+	override public function getID(rawID:Int):FlxGamepadInputID
+	{
+		return switch (rawID)
+		{
+			case SwitchJoyconLeftID.DOWN: A;
+			case SwitchJoyconLeftID.RIGHT: B;
+			case SwitchJoyconLeftID.LEFT: X;
+			case SwitchJoyconLeftID.UP: Y;
+			case SwitchJoyconLeftID.MINUS: START;
+			case SwitchJoyconLeftID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
+			case SwitchJoyconLeftID.SL: LEFT_SHOULDER;
+			case SwitchJoyconLeftID.SR: RIGHT_SHOULDER;
+			case SwitchJoyconLeftID.L: EXTRA_0;
+			case SwitchJoyconLeftID.ZL: LEFT_TRIGGER;
+			case id if (id == leftStick.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == leftStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == leftStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == leftStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case _: NONE;
+		}
+	}
+
+	override public function getRawID(id:FlxGamepadInputID):Int
+	{
+		return switch (id)
+		{
+			case A: SwitchJoyconLeftID.DOWN;
+			case B: SwitchJoyconLeftID.RIGHT;
+			case X: SwitchJoyconLeftID.LEFT;
+			case Y: SwitchJoyconLeftID.UP;
+			case START: SwitchJoyconLeftID.MINUS;
+			case LEFT_STICK_CLICK: SwitchJoyconLeftID.LEFT_STICK_CLICK;
+			case LEFT_SHOULDER: SwitchJoyconLeftID.SL;
+			case RIGHT_SHOULDER: SwitchJoyconLeftID.SR;
+			case LEFT_TRIGGER: SwitchJoyconLeftID.ZL;
+			case EXTRA_0: SwitchJoyconLeftID.L;
+			case LEFT_STICK_DIGITAL_UP: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawRight;
+			#if FLX_JOYSTICK_API
+			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
+			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
+			#end
+			default: -1;
+		}
+	}
+
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "down";
+			case B: "right";
+			case X: "left";
+			case Y: "up";
+			case START: "minus";
+			case EXTRA_0: "l";
+			case LEFT_SHOULDER: "sl";
+			case RIGHT_SHOULDER: "sr";
+			case LEFT_TRIGGER: "zl";
+			case _: super.getInputLabel(id);
+		}
+	}
+	
+	#if FLX_JOYSTICK_API
+	override public function axisIndexToRawID(axisID:Int):Int
+	{
+		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
+		return if (axisID == leftStick.x)
+				LEFT_ANALOG_STICK_FAKE_X;
+			else if (axisID == leftStick.y)
+				LEFT_ANALOG_STICK_FAKE_Y;
+			else if (axisID == rightStick.x)
+				RIGHT_ANALOG_STICK_FAKE_X;
+			else if (axisID == rightStick.y)
+				RIGHT_ANALOG_STICK_FAKE_Y;
+			else if (axisID == SwitchJoyconLeftID.SL)
+				LEFT_TRIGGER_FAKE;
+			else if (axisID == SwitchJoyconLeftID.SR)
+				RIGHT_TRIGGER_FAKE;
+			else
+				axisID;
+	}
+	#end
+}

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -3,6 +3,9 @@ package flixel.input.gamepad.mappings;
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.SwitchJoyconLeftID;
 
+/**
+ * @since 4.8.0
+ */
 class SwitchJoyconLeftMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -3,6 +3,9 @@ package flixel.input.gamepad.mappings;
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.SwitchJoyconRightID;
 
+/**
+ * @since 4.8.0
+ */
 class SwitchJoyconRightMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -1,0 +1,114 @@
+package flixel.input.gamepad.mappings;
+
+import flixel.input.gamepad.FlxGamepadInputID;
+import flixel.input.gamepad.id.SwitchJoyconRightID;
+
+class SwitchJoyconRightMapping extends FlxGamepadMapping
+{
+	#if FLX_JOYSTICK_API
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 32;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 33;
+
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 34;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 35;
+
+	static inline var LEFT_TRIGGER_FAKE:Int = 36;
+	static inline var RIGHT_TRIGGER_FAKE:Int = 37;
+	#end
+
+	override function initValues():Void
+	{
+		leftStick = SwitchJoyconRightID.LEFT_ANALOG_STICK;
+		supportsMotion = true;
+		supportsPointer = false;
+	}
+
+	override public function getID(rawID:Int):FlxGamepadInputID
+	{
+		return switch (rawID)
+		{
+			case SwitchJoyconRightID.A: A;
+			case SwitchJoyconRightID.B: X;
+			case SwitchJoyconRightID.X: B;
+			case SwitchJoyconRightID.Y: Y;
+			case SwitchJoyconRightID.HOME: GUIDE;
+			case SwitchJoyconRightID.PLUS: START;
+			case SwitchJoyconRightID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
+			case SwitchJoyconRightID.SL: LEFT_SHOULDER;
+			case SwitchJoyconRightID.SR: RIGHT_SHOULDER;
+			case SwitchJoyconRightID.ZR: RIGHT_TRIGGER;
+			case SwitchJoyconRightID.R: EXTRA_0;
+			case id if (id == leftStick.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == leftStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == leftStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == leftStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case _: NONE;
+		}
+	}
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
+	{
+		return switch (ID)
+		{
+			case A: SwitchJoyconRightID.B;
+			case B: SwitchJoyconRightID.A;
+			case X: SwitchJoyconRightID.Y;
+			case Y: SwitchJoyconRightID.X;
+			case GUIDE: SwitchJoyconRightID.HOME;
+			case START: SwitchJoyconRightID.PLUS;
+			case LEFT_STICK_CLICK: SwitchJoyconRightID.LEFT_STICK_CLICK;
+			case LEFT_SHOULDER: SwitchJoyconRightID.SL;
+			case RIGHT_SHOULDER: SwitchJoyconRightID.SR;
+			case EXTRA_0: SwitchJoyconRightID.R;
+			case RIGHT_TRIGGER: SwitchJoyconRightID.ZR;
+			case LEFT_STICK_DIGITAL_UP: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawRight;
+			#if FLX_JOYSTICK_API
+			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
+			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
+			#end
+			default: -1;
+		}
+	}
+
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "b";
+			case B: "a";
+			case X: "y";
+			case Y: "x";
+			case GUIDE: "home";
+			case START: "plus";
+			case LEFT_SHOULDER: "sl";
+			case RIGHT_SHOULDER: "sr";
+			case LEFT_TRIGGER: "zl";
+			case EXTRA_0: "l";
+			case _: super.getInputLabel(id);
+		}
+	}
+	
+	#if FLX_JOYSTICK_API
+	override public function axisIndexToRawID(axisID:Int):Int
+	{
+		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
+		return if (axisID == leftStick.x)
+				LEFT_ANALOG_STICK_FAKE_X;
+			else if (axisID == leftStick.y)
+				LEFT_ANALOG_STICK_FAKE_Y;
+			else if (axisID == rightStick.x)
+				RIGHT_ANALOG_STICK_FAKE_X;
+			else if (axisID == rightStick.y)
+				RIGHT_ANALOG_STICK_FAKE_Y;
+			else if (axisID == SwitchJoyconRightID.ZL)
+				LEFT_TRIGGER_FAKE;
+			else if (axisID == SwitchJoyconRightID.ZR)
+				RIGHT_TRIGGER_FAKE;
+			else
+				axisID;
+	}
+	#end
+}

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -1,7 +1,7 @@
 package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
-import flixel.input.gamepad.id.SWProID;
+import flixel.input.gamepad.id.SwitchProID;
 
 class SwitchProMapping extends FlxGamepadMapping
 {
@@ -18,8 +18,8 @@ class SwitchProMapping extends FlxGamepadMapping
 
 	override function initValues():Void
 	{
-		leftStick = SWProID.LEFT_ANALOG_STICK;
-		rightStick = SWProID.RIGHT_ANALOG_STICK;
+		leftStick = SwitchProID.LEFT_ANALOG_STICK;
+		rightStick = SwitchProID.RIGHT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
 	}
@@ -28,24 +28,24 @@ class SwitchProMapping extends FlxGamepadMapping
 	{
 		return switch (rawID)
 		{
-			case SWProID.A: B;
-			case SWProID.B: A;
-			case SWProID.X: Y;
-			case SWProID.Y: X;
-			case SWProID.MINUS: BACK;
-			case SWProID.CAPTURE: EXTRA_0;//TODO: Define common Capture inputID?
-			case SWProID.HOME: GUIDE;
-			case SWProID.PLUS: START;
-			case SWProID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
-			case SWProID.RIGHT_STICK_CLICK: RIGHT_STICK_CLICK;
-			case SWProID.L: LEFT_SHOULDER;
-			case SWProID.R: RIGHT_SHOULDER;
-			case SWProID.ZL: LEFT_TRIGGER;
-			case SWProID.ZR: RIGHT_TRIGGER;
-			case SWProID.DPAD_DOWN: DPAD_DOWN;
-			case SWProID.DPAD_UP: DPAD_UP;
-			case SWProID.DPAD_LEFT: DPAD_LEFT;
-			case SWProID.DPAD_RIGHT: DPAD_RIGHT;
+			case SwitchProID.A: B;
+			case SwitchProID.B: A;
+			case SwitchProID.X: Y;
+			case SwitchProID.Y: X;
+			case SwitchProID.MINUS: BACK;
+			case SwitchProID.CAPTURE: EXTRA_0;//TODO: Define common Capture inputID?
+			case SwitchProID.HOME: GUIDE;
+			case SwitchProID.PLUS: START;
+			case SwitchProID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
+			case SwitchProID.RIGHT_STICK_CLICK: RIGHT_STICK_CLICK;
+			case SwitchProID.L: LEFT_SHOULDER;
+			case SwitchProID.R: RIGHT_SHOULDER;
+			case SwitchProID.ZL: LEFT_TRIGGER;
+			case SwitchProID.ZR: RIGHT_TRIGGER;
+			case SwitchProID.DPAD_DOWN: DPAD_DOWN;
+			case SwitchProID.DPAD_UP: DPAD_UP;
+			case SwitchProID.DPAD_LEFT: DPAD_LEFT;
+			case SwitchProID.DPAD_RIGHT: DPAD_RIGHT;
 			case id if (id == leftStick.rawUp): LEFT_STICK_DIGITAL_UP;
 			case id if (id == leftStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
 			case id if (id == leftStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
@@ -62,32 +62,32 @@ class SwitchProMapping extends FlxGamepadMapping
 	{
 		return switch (ID)
 		{
-			case A: SWProID.B;
-			case B: SWProID.A;
-			case X: SWProID.Y;
-			case Y: SWProID.X;
-			case BACK: SWProID.MINUS;
-			case EXTRA_0: SWProID.CAPTURE;
-			case GUIDE: SWProID.HOME;
-			case START: SWProID.PLUS;
-			case LEFT_STICK_CLICK: SWProID.LEFT_STICK_CLICK;
-			case RIGHT_STICK_CLICK: SWProID.RIGHT_STICK_CLICK;
-			case LEFT_SHOULDER: SWProID.L;
-			case RIGHT_SHOULDER: SWProID.R;
-			case LEFT_TRIGGER: SWProID.ZL;
-			case RIGHT_TRIGGER: SWProID.ZR;
-			case DPAD_UP: SWProID.DPAD_UP;
-			case DPAD_DOWN: SWProID.DPAD_DOWN;
-			case DPAD_LEFT: SWProID.DPAD_LEFT;
-			case DPAD_RIGHT: SWProID.DPAD_RIGHT;
-			case LEFT_STICK_DIGITAL_UP: SWProID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SWProID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SWProID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SWProID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: SWProID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: SWProID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: SWProID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: SWProID.RIGHT_ANALOG_STICK.rawRight;
+			case A: SwitchProID.B;
+			case B: SwitchProID.A;
+			case X: SwitchProID.Y;
+			case Y: SwitchProID.X;
+			case BACK: SwitchProID.MINUS;
+			case EXTRA_0: SwitchProID.CAPTURE;
+			case GUIDE: SwitchProID.HOME;
+			case START: SwitchProID.PLUS;
+			case LEFT_STICK_CLICK: SwitchProID.LEFT_STICK_CLICK;
+			case RIGHT_STICK_CLICK: SwitchProID.RIGHT_STICK_CLICK;
+			case LEFT_SHOULDER: SwitchProID.L;
+			case RIGHT_SHOULDER: SwitchProID.R;
+			case LEFT_TRIGGER: SwitchProID.ZL;
+			case RIGHT_TRIGGER: SwitchProID.ZR;
+			case DPAD_UP: SwitchProID.DPAD_UP;
+			case DPAD_DOWN: SwitchProID.DPAD_DOWN;
+			case DPAD_LEFT: SwitchProID.DPAD_LEFT;
+			case DPAD_RIGHT: SwitchProID.DPAD_RIGHT;
+			case LEFT_STICK_DIGITAL_UP: SwitchProID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchProID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchProID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchProID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: SwitchProID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: SwitchProID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: SwitchProID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: SwitchProID.RIGHT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
@@ -128,9 +128,9 @@ class SwitchProMapping extends FlxGamepadMapping
 				RIGHT_ANALOG_STICK_FAKE_X;
 			else if (axisID == rightStick.y)
 				RIGHT_ANALOG_STICK_FAKE_Y;
-			else if (axisID == SWProID.ZL)
+			else if (axisID == SwitchProID.ZL)
 				LEFT_TRIGGER_FAKE;
-			else if (axisID == SWProID.ZR)
+			else if (axisID == SwitchProID.ZR)
 				RIGHT_TRIGGER_FAKE;
 			else
 				axisID;

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -1,0 +1,119 @@
+package flixel.input.gamepad.mappings;
+
+import flixel.input.gamepad.FlxGamepadInputID;
+import flixel.input.gamepad.id.SWProID;
+
+class SwitchProMapping extends FlxGamepadMapping
+{
+	#if FLX_JOYSTICK_API
+	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 32;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 33;
+
+	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 34;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 35;
+
+	static inline var LEFT_TRIGGER_FAKE:Int = 36;
+	static inline var RIGHT_TRIGGER_FAKE:Int = 37;
+	#end
+
+	override function initValues():Void
+	{
+		leftStick = SWProID.LEFT_ANALOG_STICK;
+		rightStick = SWProID.RIGHT_ANALOG_STICK;
+		supportsMotion = true;
+		supportsPointer = false;
+	}
+
+	override public function getID(rawID:Int):FlxGamepadInputID
+	{
+		return switch (rawID)
+		{
+			case SWProID.A: B;
+			case SWProID.B: A;
+			case SWProID.X: Y;
+			case SWProID.Y: X;
+			case SWProID.MINUS: BACK;
+			case SWProID.CAPTURE: EXTRA_0;//TODO: Define common Capture inputID?
+			case SWProID.HOME: GUIDE;
+			case SWProID.PLUS: START;
+			case SWProID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
+			case SWProID.RIGHT_STICK_CLICK: RIGHT_STICK_CLICK;
+			case SWProID.L: LEFT_SHOULDER;
+			case SWProID.R: RIGHT_SHOULDER;
+			case SWProID.ZL: LEFT_TRIGGER;
+			case SWProID.ZR: RIGHT_TRIGGER;
+			case SWProID.DPAD_DOWN: DPAD_DOWN;
+			case SWProID.DPAD_UP: DPAD_UP;
+			case SWProID.DPAD_LEFT: DPAD_LEFT;
+			case SWProID.DPAD_RIGHT: DPAD_RIGHT;
+			case id if (id == leftStick.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == leftStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == leftStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == leftStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case id if (id == rightStick.rawUp): RIGHT_STICK_DIGITAL_UP;
+			case id if (id == rightStick.rawDown): RIGHT_STICK_DIGITAL_DOWN;
+			case id if (id == rightStick.rawLeft): RIGHT_STICK_DIGITAL_LEFT;
+			case id if (id == rightStick.rawRight): RIGHT_STICK_DIGITAL_RIGHT;
+			case _: NONE;
+		}
+	}
+
+	override public function getRawID(ID:FlxGamepadInputID):Int
+	{
+		return switch (ID)
+		{
+			case A: SWProID.B;
+			case B: SWProID.A;
+			case X: SWProID.Y;
+			case Y: SWProID.X;
+			case BACK: SWProID.MINUS;
+			case EXTRA_0: SWProID.CAPTURE;
+			case GUIDE: SWProID.HOME;
+			case START: SWProID.PLUS;
+			case LEFT_STICK_CLICK: SWProID.LEFT_STICK_CLICK;
+			case RIGHT_STICK_CLICK: SWProID.RIGHT_STICK_CLICK;
+			case LEFT_SHOULDER: SWProID.L;
+			case RIGHT_SHOULDER: SWProID.R;
+			case LEFT_TRIGGER: SWProID.ZL;
+			case RIGHT_TRIGGER: SWProID.ZR;
+			case DPAD_UP: SWProID.DPAD_UP;
+			case DPAD_DOWN: SWProID.DPAD_DOWN;
+			case DPAD_LEFT: SWProID.DPAD_LEFT;
+			case DPAD_RIGHT: SWProID.DPAD_RIGHT;
+			case LEFT_STICK_DIGITAL_UP: SWProID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SWProID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SWProID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SWProID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: SWProID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: SWProID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: SWProID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: SWProID.RIGHT_ANALOG_STICK.rawRight;
+			#if FLX_JOYSTICK_API
+			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
+			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
+			#end
+			default: -1;
+		}
+	}
+	
+	#if FLX_JOYSTICK_API
+	override public function axisIndexToRawID(axisID:Int):Int
+	{
+		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
+		return if (axisID == leftStick.x)
+				LEFT_ANALOG_STICK_FAKE_X;
+			else if (axisID == leftStick.y)
+				LEFT_ANALOG_STICK_FAKE_Y;
+			else if (axisID == rightStick.x)
+				RIGHT_ANALOG_STICK_FAKE_X;
+			else if (axisID == rightStick.y)
+				RIGHT_ANALOG_STICK_FAKE_Y;
+			else if (axisID == SWProID.ZL)
+				LEFT_TRIGGER_FAKE;
+			else if (axisID == SWProID.ZR)
+				RIGHT_TRIGGER_FAKE;
+			else
+				axisID;
+	}
+	#end
+}

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -3,6 +3,9 @@ package flixel.input.gamepad.mappings;
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.SwitchProID;
 
+/**
+ * @since 4.8.0
+ */
 class SwitchProMapping extends FlxGamepadMapping
 {
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -95,6 +95,26 @@ class SwitchProMapping extends FlxGamepadMapping
 			default: -1;
 		}
 	}
+
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		return switch (id)
+		{
+			case A: "b";
+			case B: "a";
+			case X: "y";
+			case Y: "x";
+			case BACK: "minus";
+			case GUIDE: "home";
+			case START: "plus";
+			case EXTRA_0: "capture";
+			case LEFT_SHOULDER: "l";
+			case RIGHT_SHOULDER: "r";
+			case LEFT_TRIGGER: "zl";
+			case RIGHT_TRIGGER: "zr";
+			case _: super.getInputLabel(id);
+		}
+	}
 	
 	#if FLX_JOYSTICK_API
 	override public function axisIndexToRawID(axisID:Int):Int

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -278,4 +278,74 @@ class WiiRemoteMapping extends FlxGamepadMapping
 
 		return super.set_attachment(attachment);
 	}
+	
+	override function getInputLabel(id:FlxGamepadInputID)
+	{
+		var label = WiiRemoteMapping.getWiiInputLabel(id, attachment);
+		if (label == null)
+			return super.getInputLabel(id);
+		
+		return label;
+	}
+	
+	static public function getWiiInputLabel(id:FlxGamepadInputID, attachment:FlxGamepadAttachment)
+	{
+		switch (id)
+		{
+			case BACK: return "minus";
+			case GUIDE: return "home";
+			case START: return"plus";
+			default:
+		}
+		
+		return switch (attachment)
+		{
+			case WII_CLASSIC_CONTROLLER: getLabelClassicController(id);
+			case WII_NUNCHUCK: getLabelNunchuk(id);
+			case NONE: getLabelDefault(id);
+		}
+	}
+
+	static inline function getLabelClassicController(ID:FlxGamepadInputID):Null<String>
+	{
+		return switch (ID)
+		{
+			case A: "b";
+			case B: "a";
+			case X: "y";
+			case Y: "x";
+			case LEFT_SHOULDER: "zl";
+			case RIGHT_SHOULDER: "zr";
+			case LEFT_TRIGGER: "l";
+			case RIGHT_TRIGGER: "r";
+			case EXTRA_0: "1";
+			case EXTRA_1: "2";
+			default: null;
+		}
+	}
+
+	static inline function getLabelNunchuk(ID:FlxGamepadInputID):Null<String>
+	{
+		return switch (ID)
+		{
+			case X: "1";
+			case Y: "2";
+			case LEFT_SHOULDER: "c";
+			case LEFT_TRIGGER: "z";
+			default: null;
+		}
+	}
+
+	static inline function getLabelDefault(ID:FlxGamepadInputID):Null<String>
+	{
+		return switch (ID)
+		{
+			case X: "1";
+			case Y: "2";
+			case BACK: "minus";
+			case GUIDE: "home";
+			case START: "plus";
+			default: null;
+		}
+	}
 }

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -288,7 +288,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		return label;
 	}
 	
-	static public function getWiiInputLabel(id:FlxGamepadInputID, attachment:FlxGamepadAttachment)
+	public static function getWiiInputLabel(id:FlxGamepadInputID, attachment:FlxGamepadAttachment)
 	{
 		switch (id)
 		{


### PR DESCRIPTION
Mappings Added:
- Switch Pro Controller
- Solo L and R Switch Joycons
- Dual Joycons as single gamepad

Because Nintendo's controllers have very contradictory labelling compared to our input scheme, I thought it was important that flixel offer easy ways for devs to accurately distinguish these buttons to players. I've gone and mapped inputIDs to custom labels so they can display a string label for any button on any mapped gamepad device.

Example:
```hx
trace(myGamePad.getInputLabel(LEFT_SHOULDER), myGamePad.getInputLabel(LEFT_TRIGGER))
```
will have the following values:
```
Switch Pro: l, zl
Switch Left Joycon: sl, zl
Switch Right Joycon: sl, null
XBox/XInput: lb, lt
PS4/Vita: l1, l2
Wii+Nunchuck: c, z
```