### PR TITLE
Add a null check to BitmapFrontEnd

### DIFF
--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -193,7 +193,8 @@ class BitmapFrontEnd
 	{
 		for (key in _cache.keys())
 		{
-			if (_cache.get(key).bitmap == bmd)
+			var obj = _cache.get(key);
+			if (obj != null && obj.bitmap == bmd)
 				return key;
 		}
 		return null;


### PR DESCRIPTION
I am working on a project where `BitmapFrontEnd` is used and a large number of bitmap assets is loaded. Most of the time, I would get a crash on `if (_cache.get(key).bitmap == bmd)`, because `_cache.get(key)` is `null`. I am not sure why this code exists (it looks really strange to me that the entire map is iterated every time, what is the point of it even being a hash map then), but I aligned `findKeyForBitmap` with other methods by adding an explicit `null` check.