### PR TITLE
FlxCamera skip unnecessary draw_rect calls

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1532,10 +1532,8 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			#if openfl_legacy // can't skip this on next, see #1793
 			if (FxAlpha == 0)
 				return;
-			#end
 
 			var targetGraphics:Graphics = (graphics == null) ? canvas.graphics : graphics;
 


### PR DESCRIPTION
removed obsolete (?) condition.
things still work with FlxG.cameras.bgColor = 0x0;
tested on neko/win/android/html5

huge performance boost on low end devices