### PR TITLE
FlxTilemap: added null check of tile in ray() function

### DIFF
--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -27,7 +27,7 @@ typedef FlxEmitter = FlxTypedEmitter<FlxParticle>;
 #if (haxe_ver >= "4.0.0")
 class FlxTypedEmitter<T:FlxSprite & IFlxParticle> extends FlxTypedGroup<T>
 #else
-class FlxTypedEmitter<T:(FlxSprite, IFlxParticle) > extends FlxTypedGroup<T>
+class FlxTypedEmitter<T:(FlxSprite, IFlxParticle)> extends FlxTypedGroup<T>
 #end
 {
 	/**
@@ -289,6 +289,8 @@ class FlxTypedEmitter<T:(FlxSprite, IFlxParticle) > extends FlxTypedGroup<T>
 	 */
 	public function makeParticles(Width:Int = 2, Height:Int = 2, Color:FlxColor = FlxColor.WHITE, Quantity:Int = 50):FlxTypedEmitter<T>
 	{
+		maxSize = Quantity;
+
 		for (i in 0...Quantity)
 		{
 			var particle:T = Type.createInstance(particleClass, []);

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -788,7 +788,9 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			tileX = Math.floor(curX / _scaledTileWidth);
 			tileY = Math.floor(curY / _scaledTileHeight);
 
-			if (_tileObjects[_data[tileY * widthInTiles + tileX]].allowCollisions != FlxObject.NONE)
+			var tile = _tileObjects[_data[tileY * widthInTiles + tileX]];
+
+			if (tile != null && tile.allowCollisions != FlxObject.NONE)
 			{
 				// Some basic helper stuff
 				tileX *= Std.int(_scaledTileWidth);


### PR DESCRIPTION
When targeting html5 the game crashes while trying to read property `tile.allowCollisions` if the tile is null.

```Uncaught TypeError: Cannot read property 'allowCollisions' of undefined```