### PR TITLE
add Tags to `FlxObject`

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -638,6 +638,9 @@ class FlxObject extends FlxBasic
 	@:noCompletion
 	var _rect:FlxRect = FlxRect.get();
 
+	@:noCompletion
+	var _tags:Null<Array<String>>;
+
 	/**
 	 * @param   X        The X-coordinate of the point in space.
 	 * @param   Y        The Y-coordinate of the point in space.
@@ -704,6 +707,7 @@ class FlxObject extends FlxBasic
 		last = FlxDestroyUtil.put(last);
 		_point = FlxDestroyUtil.put(_point);
 		_rect = FlxDestroyUtil.put(_rect);
+		_tags = null;
 	}
 
 	/**
@@ -1093,6 +1097,49 @@ class FlxObject extends FlxBasic
 	{
 		width = Width;
 		height = Height;
+	}
+
+	/**
+	 * Adds a tag to this object.
+	 *
+	 * @param		Tag 	The tag to add.
+	 */
+	public function addTag(Tag:String)
+	{
+		// Lazily initialize the `_tags` Array.
+		if (_tags == null)
+			_tags = [];
+
+		// Only add the Tag if this object doesn't already have it.
+		if (!_tags.contains(Tag))
+			_tags.push(Tag);
+	}
+
+	/**
+	 * Removes a tag from this object.
+	 *
+	 * @param		Tag 	The tag to remove.
+	 */
+	public function removeTag(Tag:String)
+	{
+		if (_tags == null)
+			return;
+
+		_tags.remove(Tag);
+	}
+
+	/**
+	 * Checks if this object has been tagged with the provided `String`.
+	 *
+	 * @param		Tag		The tag to check for on this object.
+	 * @return 	Whether this object has been tagged with the provided `String`.
+	 */
+	public function hasTag(Tag:String):Bool
+	{
+		if (_tags == null)
+			return false;
+
+		return _tags.contains(Tag);
 	}
 
 	#if FLX_DEBUG

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -13,6 +13,8 @@ import flixel.util.FlxPath;
 import flixel.util.FlxSpriteUtil;
 import flixel.util.FlxStringUtil;
 
+using flixel.util.FlxArrayUtil;
+
 /**
  * This is the base class for most of the display objects (`FlxSprite`, `FlxText`, etc).
  * It includes some basic attributes about game objects, basic state information,

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -639,7 +639,7 @@ class FlxObject extends FlxBasic
 	var _rect:FlxRect = FlxRect.get();
 
 	@:noCompletion
-	var _tags:Null<Array<String>>;
+	var _tags:Array<String>;
 
 	/**
 	 * @param   X        The X-coordinate of the point in space.


### PR DESCRIPTION
This PR adds a simple Tagging API to help enable a more compositional approach with FlxObjects. The Tags are just Strings that get stored in the private `_tags` Array, which the user interacts with through `addTag`, `removeTag`, and `hasTag` functions. 

Note: The `_tags` array is lazily initialized, so it won't add any real memory bloat to FlxObjects unless the user is using Tags.