### PR TITLE
Update comment to show the correct axis

### DIFF
--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -52,7 +52,7 @@ class FlxRect implements IFlxPooled
 	public var right(get, set):Float;
 
 	/**
-	 * The x coordinate of the top of the rectangle.
+	 * The y coordinate of the top of the rectangle.
 	 */
 	public var top(get, set):Float;
 


### PR DESCRIPTION
The top should return the `y`, not `x`.