### PR TITLE
FlxSound.loadStream callback

### DIFF
--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -23,7 +23,6 @@ import openfl.utils.AssetType;
 /**
  * This is the universal flixel sound object, used for streaming, music, and sound effects.
  */
- @:allow(flixel.system.frontEnds.SoundFrontEnd)
 class FlxSound extends FlxBasic
 {
 	/**
@@ -150,6 +149,7 @@ class FlxSound extends FlxBasic
 	/**
 	 * Internal tracker for a Flash sound object.
 	 */
+	@:allow(flixel.system.frontEnds.SoundFrontEnd.load)
 	var _sound:Sound;
 
 	/**

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -23,6 +23,7 @@ import openfl.utils.AssetType;
 /**
  * This is the universal flixel sound object, used for streaming, music, and sound effects.
  */
+ @:allow(flixel.system.frontEnds.SoundFrontEnd)
 class FlxSound extends FlxBasic
 {
 	/**

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -80,6 +80,7 @@ class FlxSound extends FlxBasic
 	/**
 	 * Tracker for sound load complete callback. If assigned, will be called
 	 * when the sound finishes loading.
+	 * @since 4.9.0
 	 */
 	public var onLoad:Void->Void;
 

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -387,9 +387,9 @@ class FlxSound extends FlxBasic
 		if (OnLoad != null)
 		{
 			var loadCallback:Event->Void = null;
-			loadCallback = function (e:Event)
+			loadCallback = function(e:Event)
 			{
-				(e.target:IEventDispatcher).removeEventListener(e.type, loadCallback);
+				(e.target : IEventDispatcher).removeEventListener(e.type, loadCallback);
 				// Check if the sound was destroyed before calling. Weak ref doesn't guarantee GC.
 				if (_sound == e.target)
 					OnLoad();

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -132,7 +132,7 @@ class SoundFrontEnd
 		}
 
 		var sound:FlxSound = list.recycle(FlxSound);
-		
+
 		if (EmbeddedSound != null)
 		{
 			sound.loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
@@ -157,7 +157,7 @@ class SoundFrontEnd
 				sound._sound.addEventListener(Event.COMPLETE, playStream, false, 1, true);
 			}
 		}
-		
+
 		return sound;
 	}
 
@@ -221,9 +221,7 @@ class SoundFrontEnd
 		{
 			EmbeddedSound = cache(EmbeddedSound);
 		}
-		
-		var sound:FlxSound = list.recycle(FlxSound);
-		sound.loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
+		var sound = list.recycle(FlxSound).loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
 		return loadHelper(sound, Volume, Group, true);
 	}
 

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -127,7 +127,7 @@ class SoundFrontEnd
 	{
 		if ((EmbeddedSound == null) && (URL == null))
 		{
-			FlxG.log.warn("FlxG.load() requires either\nan embedded sound or a URL to work.");
+			FlxG.log.warn("FlxG.sound.load() requires either\nan embedded sound or a URL to work.");
 			return null;
 		}
 
@@ -227,7 +227,7 @@ class SoundFrontEnd
 
 	/**
 	 * Plays a sound from a URL. Tries to recycle a cached sound first.
-	 * NOTE: Just calls FlxG.load() with AutoPlay == true.
+	 * NOTE: Just calls FlxG.sound.load() with AutoPlay == true.
 	 *
 	 * @param	URL				Load a sound from an external web resource instead.
 	 * @param	Volume			How loud to play it (0 to 1).

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -114,9 +114,11 @@ class SoundFrontEnd
 	 * @param	Volume			How loud to play it (0 to 1).
 	 * @param	Looped			Whether to loop this sound.
 	 * @param	Group			The group to add this sound to.
-	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.  Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.
+	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
 	 * @param	AutoPlay		Whether to play the sound.
 	 * @param	URL				Load a sound from an external web resource instead.  Only used if EmbeddedSound = null.
+	 * @param	OnComplete		Called when the sound finished playing
 	 * @param	OnLoad			Called when the sound finished loading.  Only used if EmbeddedSound = null
 	 * @return	A FlxSound object.
 	 */
@@ -125,7 +127,7 @@ class SoundFrontEnd
 	{
 		if ((EmbeddedSound == null) && (URL == null))
 		{
-			FlxG.log.warn("FlxG.loadSound() requires either\nan embedded sound or a URL to work.");
+			FlxG.log.warn("FlxG.load() requires either\nan embedded sound or a URL to work.");
 			return null;
 		}
 
@@ -149,8 +151,10 @@ class SoundFrontEnd
 					(e.target:IEventDispatcher).removeEventListener(e.type, playStream);
 					sound.play();
 				}
+				// Don't use OnLoad for this, so it can be used for other things
 				// Use weak reference in case this is destroyed before loading
-				sound._sound.addEventListener(Event.COMPLETE, playStream, false, 0, true);
+				// Use priority 1 so it's playing before OnLoad is called
+				sound._sound.addEventListener(Event.COMPLETE, playStream, false, 1, true);
 			}
 		}
 		
@@ -201,15 +205,17 @@ class SoundFrontEnd
 	/**
 	 * Plays a sound from an embedded sound. Tries to recycle a cached sound first.
 	 *
-	 * @param	EmbeddedSound	The sound you want to play.
+	 * @param	EmbeddedSound	The embedded sound resource you want to play.
 	 * @param	Volume			How loud to play it (0 to 1).
 	 * @param	Looped			Whether to loop this sound.
 	 * @param	Group			The group to add this sound to.
-	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.  Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @return	The FlxSound object.
+	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.
+	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param	OnComplete		Called when the sound finished playing
+	 * @return	A FlxSound object.
 	 */
-	public function play(EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup, AutoDestroy:Bool = true,
-			?OnComplete:Void->Void):FlxSound
+	public function play(EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup,
+			AutoDestroy:Bool = true, ?OnComplete:Void->Void):FlxSound
 	{
 		if ((EmbeddedSound is String))
 		{
@@ -222,13 +228,16 @@ class SoundFrontEnd
 	}
 
 	/**
-	 * Creates a new sound object from a URL.
-	 * NOTE: Just calls FlxG.loadSound() with AutoPlay == true.
+	 * Plays a sound from a URL. Tries to recycle a cached sound first.
+	 * NOTE: Just calls FlxG.load() with AutoPlay == true.
 	 *
-	 * @param	URL		The URL of the sound you want to play.
-	 * @param	Volume	How loud to play it (0 to 1).
-	 * @param	Looped	Whether or not to loop this sound.
+	 * @param	URL				Load a sound from an external web resource instead.
+	 * @param	Volume			How loud to play it (0 to 1).
+	 * @param	Looped			Whether to loop this sound.
 	 * @param	Group			The group to add this sound to.
+	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.
+	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param	OnComplete		Called when the sound finished playing
 	 * @param	OnLoad			Called when the sound finished loading.
 	 * @return	A FlxSound object.
 	 */

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -118,8 +118,8 @@ class SoundFrontEnd
 	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
 	 * @param	AutoPlay		Whether to play the sound.
 	 * @param	URL				Load a sound from an external web resource instead.  Only used if EmbeddedSound = null.
-	 * @param	OnComplete		Called when the sound finished playing
-	 * @param	OnLoad			Called when the sound finished loading.  Only used if EmbeddedSound = null
+	 * @param	OnComplete		Called when the sound finished playing.
+	 * @param	OnLoad			Called when the sound finished loading.
 	 * @return	A FlxSound object.
 	 */
 	public function load(?EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup, AutoDestroy:Bool = false,
@@ -136,7 +136,11 @@ class SoundFrontEnd
 		if (EmbeddedSound != null)
 		{
 			sound.loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
+			sound.onLoad = OnLoad();
 			loadHelper(sound, Volume, Group, AutoPlay);
+			// Call OnlLoad() because the sound already loaded
+			if (OnLoad != null && sound._sound != null)
+				OnLoad();
 		}
 		else
 		{

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -136,7 +136,7 @@ class SoundFrontEnd
 		if (EmbeddedSound != null)
 		{
 			sound.loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
-			sound.onLoad = OnLoad();
+			sound.onLoad = OnLoad;
 			loadHelper(sound, Volume, Group, AutoPlay);
 			// Call OnlLoad() because the sound already loaded
 			if (OnLoad != null && sound._sound != null)

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -148,12 +148,12 @@ class SoundFrontEnd
 				loadCallback = function()
 				{
 					sound.play();
-					
+
 					if (OnLoad != null)
 						OnLoad();
 				}
 			}
-			
+
 			sound.loadStream(URL, Looped, AutoDestroy, OnComplete, loadCallback);
 			loadHelper(sound, Volume, Group);
 		}


### PR DESCRIPTION
Added an onLoad call to FlxSounds that get called when sounds are loaded from a URL. OnLoad was also added as an argument to methods like `loadStream` `FlxG.sound.load` and `FlxG.sound.stream`.

I added a `loadHelper` method to `SoundFrontEnd` to perform common setup for load/play/stream methods.

`SoundFrontEnd` methods `load` and `stream` now listen for load events to autoPlay the sound when it's set to true, rather than calling play immediately, since there's no sound to play

fixes #2274 

Also fixed some documentation and logging for the methods that were modified. they were all missing some @params and made references to old methods like `FlxG.sound.loadSound`