### PR TITLE
check farbling, prevent infinite loops and warn the dev

### DIFF
--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -108,6 +108,9 @@ class FlxBitmapFont extends FlxFramesCollection
 
 	/**
 	 * Retrieves the default `FlxBitmapFont`.
+	 * May work incorrectly on HTML5.
+	 * Utterly unreliable on Brave Browser with shields up.
+	 * @see `FlxG.html.farblesImages`
 	 */
 	public static function getDefaultFont():FlxBitmapFont
 	{
@@ -296,6 +299,8 @@ class FlxBitmapFont extends FlxFramesCollection
 	/**
 	 * Load bitmap font in XNA/Pixelizer format.
 	 * May work incorrectly on HTML5.
+	 * Utterly unreliable on Brave Browser with shields up.
+	 * @see `FlxG.html.farblesImages`
 	 *
 	 * @param   source        Source image for this font.
 	 * @param   letters       `String` of characters contained in the source image,
@@ -351,6 +356,11 @@ class FlxBitmapFont extends FlxFramesCollection
 		var gw:Int;
 		var gh:Int;
 
+		#if js
+		if (FlxG.html5.farblesImages)
+			FlxG.log.error('Cannot reliably create font:${font.fontName} due to browser restrictions');
+		#end
+
 		while (cy < frameHeight && letterIdx < numLetters)
 		{
 			var rowHeight:Int = 0;
@@ -371,7 +381,7 @@ class FlxBitmapFont extends FlxFramesCollection
 					transformPoint(p, frame);
 
 					// find width and height of char
-					while (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
+					while (gx < frameWidth && bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
 					{
 						gx++;
 						p.setTo(gx, cy);
@@ -381,7 +391,7 @@ class FlxBitmapFont extends FlxFramesCollection
 					p.setTo(gx - 1, gy);
 					transformPoint(p, frame);
 
-					while (bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
+					while (gy < frameHeight && bmd.getPixel(Std.int(p.x), Std.int(p.y)) != cast globalBGColor)
 					{
 						gy++;
 						p.setTo(cx, gy);

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -16,6 +16,13 @@ class HTML5FrontEnd
 	/** @since 4.2.0 */
 	public var onMobile(default, null):Bool;
 
+	/**
+	 * Some browsers like Brave "farble" or manipulate image data to prevent user fingerprinting.
+	 * This can make image reading and editing difficult or even impossible.
+	 * @since 4.9.0
+	 */
+	public var farblesImages(default, null):Bool;
+
 	public var browserWidth(get, never):Int;
 	public var browserHeight(get, never):Int;
 	public var browserPosition(get, null):FlxPoint;
@@ -26,6 +33,7 @@ class HTML5FrontEnd
 		browser = getBrowser();
 		platform = getPlatform();
 		onMobile = getOnMobile();
+		farblesImages = checkImageFarbling();
 	}
 
 	function getBrowser():FlxBrowser
@@ -132,6 +140,18 @@ class HTML5FrontEnd
 	inline function get_browserHeight():Int
 	{
 		return Browser.window.innerHeight;
+	}
+
+	function isBrowserFarbling()
+	{
+		var bmd = new openfl.display.BitmapData(10, 10, false, 0xFF00FF);
+		for(i in 0...bmd.width * bmd.height)
+		{
+			if (bmd.getPixel(i % 10, Std.int(i / 10)) != 0xFF00FF)
+				return true;
+		}
+
+		return false;
 	}
 }
 

--- a/flixel/system/frontEnds/HTML5FrontEnd.hx
+++ b/flixel/system/frontEnds/HTML5FrontEnd.hx
@@ -142,10 +142,10 @@ class HTML5FrontEnd
 		return Browser.window.innerHeight;
 	}
 
-	function isBrowserFarbling()
+	function checkImageFarbling()
 	{
 		var bmd = new openfl.display.BitmapData(10, 10, false, 0xFF00FF);
-		for(i in 0...bmd.width * bmd.height)
+		for (i in 0...bmd.width * bmd.height)
 		{
 			if (bmd.getPixel(i % 10, Std.int(i / 10)) != 0xFF00FF)
 				return true;

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -196,6 +196,10 @@ class FlxBitmapText extends FlxSprite
 
 	/**
 	 * Constructs a new text field component.
+	 * Warning: The default font may work incorrectly on HTML5.
+	 * Utterly unreliable on Brave Browser with shields up.
+	 * @see `FlxG.html.farblesImages`
+	 * 
 	 * @param 	font	Optional parameter for component's font prop
 	 */
 	public function new(?font:FlxBitmapFont)


### PR DESCRIPTION
I'm all ears for a better name than `FlxG.html.farblesImages`, all my ideas were stupidly long. It comes from [this article by Brave](https://brave.com/privacy-updates-4/).

This is not a perfect solution, but IMO it is a decent temporary one. In the long run we should either get the default font some other way than `fromXNA`, perhaps `fromAngleCode`.

related to #2285 