### PR TITLE
Note that FlxRandom.float() range excludes Max

### DIFF
--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -98,7 +98,7 @@ class FlxRandom
 	}
 
 	/**
-	 * Returns a pseudorandom float value between Min and Max, inclusive.
+	 * Returns a pseudorandom float value between Min (inclusive) and Max (exclusive).
 	 * Will not return a number in the Excludes array, if provided.
 	 * Please note that large Excludes arrays can slow calculations.
 	 *


### PR DESCRIPTION
Before this change, the documentation for the float function implied
that it could potentially return any float value within the closed range
[Min, Max]. For example, with the default values of Min = 0 and Max = 1,
both 0 and 1 could be returned.

However, in reality the Max value could never be returned. The
generate() function used internally will return a positive value modulo
the MODULUS constant (i.e. never greater than or equal to MODULUS). This
value is then divided by MODULUS for subsequent calculations, leaving a
value in the range [0, 1) for use. As a result, the Max bound can
mathematically never be reached.

This behavior is canonical and consistent with Haxe's Math.random()
utility. However, the documentation needed to be updated to reflect this
reality.

---

Thank you for considering this pull request. This PR is my first in this repository (and community), so if I overlooked any standards or best practices in contributing, please don't hesitate to let me know. I noticed that a [separate repository](https://github.com/HaxeFlixel/flixel-docs) exists for generating/publishing the online documentation, but it seems as though that repository references this one for the API docs anyhow.