### PR TITLE
prevent null _transform in FlxSound

### DIFF
--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -589,11 +589,14 @@ class FlxSound extends FlxBasic
 	@:allow(flixel.system.FlxSoundGroup)
 	function updateTransform():Void
 	{
-		_transform.volume = #if FLX_SOUND_SYSTEM (FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume * #end
-			(group != null ? group.volume : 1) * _volume * _volumeAdjust;
+		if(_transform != null)
+		{
+			_transform.volume = #if FLX_SOUND_SYSTEM (FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume * #end
+				(group != null ? group.volume : 1) * _volume * _volumeAdjust;
 
-		if (_channel != null)
-			_channel.soundTransform = _transform;
+			if (_channel != null)
+				_channel.soundTransform = _transform;
+		}
 	}
 
 	/**


### PR DESCRIPTION
added a null check to ensure _transform has a value prior to operating on it. use-case that caused this was that the sound levels were changed in a sub-state, the sub-state exited, and then a new state entered. this caused a CTD due to a null reference exception