### PR TITLE
Improve default cameras handling

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -56,7 +56,8 @@ class FlxBasic implements IFlxDestroyable
 
 	/**
 	 * This determines on which `FlxCamera`s this object will be drawn. If it is `null` / has not been
-	 * set, it uses `FlxCamera.defaultCameras`, which is a reference to `FlxG.cameras.list` (all cameras) by default.
+	 * set, it uses the list of default draw targets, which is controlled via `FlxG.camera.setDefaultDrawTarget`
+	 * as well as the `DefaultDrawTarget` argument of `FlxG.camera.add`.
 	 */
 	public var cameras(get, set):Array<FlxCamera>;
 

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -166,7 +166,7 @@ class FlxBasic implements IFlxDestroyable
 	@:noCompletion
 	function get_camera():FlxCamera
 	{
-		return (_cameras == null || _cameras.length == 0) ? FlxCamera.defaultCameras[0] : _cameras[0];
+		return (_cameras == null || _cameras.length == 0) ? FlxCamera._defaultCameras[0] : _cameras[0];
 	}
 
 	@:noCompletion
@@ -182,7 +182,7 @@ class FlxBasic implements IFlxDestroyable
 	@:noCompletion
 	function get_cameras():Array<FlxCamera>
 	{
-		return (_cameras == null) ? FlxCamera.defaultCameras : _cameras;
+		return (_cameras == null) ? FlxCamera._defaultCameras : _cameras;
 	}
 
 	@:noCompletion

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -224,7 +224,7 @@ class FlxCamera extends FlxBasic
 	public var zoom(default, set):Float;
 
 	/**
-	 * Whether sprites use this object by default.
+	 * Whether sprites render to this camera by default.
 	 * Set this to false when adding additional cameras meant to display specific sprites
 	 * @since 4.8.2
 	 */

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1888,7 +1888,7 @@ class FlxCamera extends FlxBasic
 	
 	function set_isDefault(value:Bool):Bool
 	{
-		this.isDefault = value
+		this.isDefault = value;
 		isDefaultChange.dispatch(this);
 		
 		return this.isDefault;

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -54,8 +54,10 @@ class FlxCamera extends FlxBasic
 	 * Used behind-the-scenes during the draw phase so that members use the same default
 	 * cameras as their parent.
 	 * 
-	 * Prior to 4.8.2 it was useful to change this value, but that feature is deprecated.
-	 * Instead use `FlxG.cameras.setDrawsDefault`.
+	 * Prior to 4.9.0 it was useful to change this value, but that feature is deprecated.
+	 * Instead use the `defaultDrawTarget` argument in `FlxG.cameras.add `.
+	 * or`FlxG.cameras.setDefaultDrawTarget` .
+	 * @see FlxG.cameras.setDefaultDrawTarget
 	 */
 	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `FlxG.cameras.setDrawsDefault()` instead")
 	public static var defaultCameras(get, set):Array<FlxCamera>;
@@ -67,7 +69,10 @@ class FlxCamera extends FlxBasic
 	 * This is the non-deprecated list that the public `defaultCameras` proxies. Allows flixel classes
 	 * to use it without warning.
 	 */
-	@:allow(flixel)
+	@:allow(flixel.FlxBasic.get_cameras)
+	@:allow(flixel.FlxBasic.get_camera)
+	@:allow(flixel.system.frontEnds.CameraFrontEnd)
+	@:allow(flixel.group.FlxTypedGroup.draw)
 	static var _defaultCameras:Array<FlxCamera>;
 
 	/**

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -20,7 +20,6 @@ import flixel.system.FlxAssets.FlxShader;
 import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
-import flixel.util.FlxSignal;
 import flixel.util.FlxSpriteUtil;
 import openfl.display.BlendMode;
 import openfl.filters.BitmapFilter;

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -52,8 +52,10 @@ class FlxCamera extends FlxBasic
 
 	/**
 	 * Which cameras a `FlxBasic` uses to be drawn on when nothing else has been specified.
-	 * By default, this is just a reference to `FlxG.cameras.list` / all cameras, but it can be very useful to change.
+	 * Set to `null` to use all cameras where `camera.isDefault == true`.
 	 * This may be temporarily modified during a `draw` call.
+	 *
+	 * Note: starting 4.8.2 this is `null` by default instead of `FlxG.cameras.list`
 	 */
 	public static var defaultCameras:Array<FlxCamera>;
 
@@ -220,6 +222,13 @@ class FlxCamera extends FlxBasic
 	 * Indicates how far the camera is zoomed in.
 	 */
 	public var zoom(default, set):Float;
+
+	/**
+	 * Whether sprites use this object by default.
+	 * Set this to false when adding additional cameras meant to display specific sprites
+	 * @since 4.8.2
+	 */
+	public var isDefault:Bool = true;
 
 	/**
 	 * Difference between native size of camera and zoomed size, divided in half

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -59,7 +59,7 @@ class FlxCamera extends FlxBasic
 	 * or`FlxG.cameras.setDefaultDrawTarget` .
 	 * @see FlxG.cameras.setDefaultDrawTarget
 	 */
-	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `FlxG.cameras.setDrawsDefault()` instead")
+	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `FlxG.cameras.setDefaultDrawTarget` instead")
 	public static var defaultCameras(get, set):Array<FlxCamera>;
 	
 	/**

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -51,9 +51,8 @@ class FlxCamera extends FlxBasic
 	public static var defaultZoom:Float;
 
 	/**
-	 * Which cameras a `FlxBasic` uses to be drawn on when nothing else has been specified.
-	 * By default, this is just a reference to `FlxG.cameras.defaults` / all default cameras.
-	 * This may be temporarily modified during a `draw` call.
+	 * Used behind-the-scenes during the draw phase so that members use the same default
+	 * cameras as their parent.
 	 * 
 	 * Prior to 4.8.2 it was useful to change this value, but that feature is deprecated.
 	 * Instead use `FlxG.cameras.setDrawsDefault`.
@@ -62,7 +61,10 @@ class FlxCamera extends FlxBasic
 	public static var defaultCameras(get, set):Array<FlxCamera>;
 	
 	/**
-	 * The non-deprecated list of cameras that defaultCamera proxies. Allows flixel classes
+	 * Used behind-the-scenes during the draw phase so that members use the same default
+	 * cameras as their parent.
+	 * 
+	 * This is the non-deprecated list that the public `defaultCameras` proxies. Allows flixel classes
 	 * to use it without warning.
 	 */
 	@:allow(flixel)

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -56,10 +56,18 @@ class FlxCamera extends FlxBasic
 	 * By default, this is just a reference to `FlxG.cameras.defaults` / all default cameras.
 	 * This may be temporarily modified during a `draw` call.
 	 * 
-	 * Prior to 4.8.2 it was useful to change this value, but that is no longer recommended.
-	 * Instead use the `isDefualt` property on the FlxCamera.
+	 * Prior to 4.8.2 it was useful to change this value, but that feature is deprecated.
+	 * Instead use the `isDefualt` property on `FlxCamera` instances.
 	 */
-	public static var defaultCameras:Array<FlxCamera>;
+	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `myFlxCamera.isDefault` instead")
+	public static var defaultCameras(get, set):Array<FlxCamera>;
+	
+	/**
+	 * The non-deprecated list of cameras that defaultCamera proxies. Allows flixel classes
+	 * to use it without warning.
+	 */
+	@:allow(flixel)
+	static var _defaultCameras:Array<FlxCamera>;
 
 	/**
 	 * The X position of this camera's display. `zoom` does NOT affect this number.
@@ -1906,6 +1914,16 @@ class FlxCamera extends FlxBasic
 		viewOffsetY = 0.5 * height * (scaleY - initialZoom) / scaleY;
 		viewOffsetHeight = height - viewOffsetY;
 		viewHeight = height - 2 * viewOffsetY;
+	}
+	
+	static inline function get_defaultCameras():Array<FlxCamera>
+	{
+		return _defaultCameras;
+	}
+	
+	static inline function set_defaultCameras(value:Array<FlxCamera>):Array<FlxCamera>
+	{
+		return _defaultCameras = value;
 	}
 }
 

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -59,7 +59,7 @@ class FlxCamera extends FlxBasic
 	 * Prior to 4.8.2 it was useful to change this value, but that feature is deprecated.
 	 * Instead use the `isDefualt` property on `FlxCamera` instances.
 	 */
-	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `myFlxCamera.isDefault` instead")
+	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `FlxG.cameras.setDrawsDefault()` instead")
 	public static var defaultCameras(get, set):Array<FlxCamera>;
 	
 	/**
@@ -233,19 +233,6 @@ class FlxCamera extends FlxBasic
 	 */
 	public var zoom(default, set):Float;
 
-	/**
-	 * Whether sprites render to this camera by default.
-	 * Set this to false when adding additional cameras meant to display specific sprites
-	 * @since 4.8.2
-	 */
-	public var isDefault(default, set):Bool = true;
-
-	/**
-	 * Dispatches whenever isDefault is changed.
-	 * @since 4.8.2
-	 */
-	public var isDefaultChange(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();
-	
 	/**
 	 * Difference between native size of camera and zoomed size, divided in half
 	 * Needed to do occlusion of objects when zoom != initialZoom
@@ -1035,7 +1022,6 @@ class FlxCamera extends FlxBasic
 		scroll = FlxDestroyUtil.put(scroll);
 		targetOffset = FlxDestroyUtil.put(targetOffset);
 		deadzone = FlxDestroyUtil.put(deadzone);
-		isDefaultChange = null;
 
 		target = null;
 		flashSprite = null;
@@ -1892,14 +1878,6 @@ class FlxCamera extends FlxBasic
 			flashSprite.visible = visible;
 		}
 		return this.visible = visible;
-	}
-	
-	function set_isDefault(value:Bool):Bool
-	{
-		this.isDefault = value;
-		isDefaultChange.dispatch(this);
-		
-		return this.isDefault;
 	}
 
 	inline function calcOffsetX():Void

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1886,13 +1886,12 @@ class FlxCamera extends FlxBasic
 		return this.visible = visible;
 	}
 	
-	function set_isDefault(isDefault:Bool):Bool
+	function set_isDefault(value:Bool):Bool
 	{
-		if (isDefault != this.isDefault)
-		{
-			isDefaultChange.dispatch(this);
-		}
-		return this.isDefault = isDefault;
+		this.isDefault = value
+		isDefaultChange.dispatch(this);
+		
+		return this.isDefault;
 	}
 
 	inline function calcOffsetX():Void

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -20,6 +20,7 @@ import flixel.system.FlxAssets.FlxShader;
 import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import flixel.util.FlxSignal;
 import flixel.util.FlxSpriteUtil;
 import openfl.display.BlendMode;
 import openfl.filters.BitmapFilter;
@@ -52,10 +53,10 @@ class FlxCamera extends FlxBasic
 
 	/**
 	 * Which cameras a `FlxBasic` uses to be drawn on when nothing else has been specified.
-	 * Set to `null` to use all cameras where `camera.isDefault == true`.
+	 * By default, this is just a reference to `FlxG.cameras.defaults` / all default cameras.
 	 * This may be temporarily modified during a `draw` call.
-	 *
-	 * Note: starting 4.8.2 this is `null` by default instead of `FlxG.cameras.list`
+	 * 
+	 * Prior to 4.8.2 it was useful to change this value, but that is no longer recommended.
 	 */
 	public static var defaultCameras:Array<FlxCamera>;
 
@@ -228,8 +229,14 @@ class FlxCamera extends FlxBasic
 	 * Set this to false when adding additional cameras meant to display specific sprites
 	 * @since 4.8.2
 	 */
-	public var isDefault:Bool = true;
+	public var isDefault(default, set):Bool = true;
 
+	/**
+	 * Dispatches whenever isDefault is changed on a camera
+	 * @since 4.8.2
+	 */
+	public var isDefaultChange(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();
+	
 	/**
 	 * Difference between native size of camera and zoomed size, divided in half
 	 * Needed to do occlusion of objects when zoom != initialZoom
@@ -1019,6 +1026,7 @@ class FlxCamera extends FlxBasic
 		scroll = FlxDestroyUtil.put(scroll);
 		targetOffset = FlxDestroyUtil.put(targetOffset);
 		deadzone = FlxDestroyUtil.put(deadzone);
+		isDefaultChange = null;
 
 		target = null;
 		flashSprite = null;
@@ -1875,6 +1883,15 @@ class FlxCamera extends FlxBasic
 			flashSprite.visible = visible;
 		}
 		return this.visible = visible;
+	}
+	
+	function set_isDefault(isDefault:Bool):Bool
+	{
+		if (isDefault != this.isDefault)
+		{
+			isDefaultChange.dispatch(this);
+		}
+		return this.isDefault = isDefault;
 	}
 
 	inline function calcOffsetX():Void

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -57,6 +57,7 @@ class FlxCamera extends FlxBasic
 	 * This may be temporarily modified during a `draw` call.
 	 * 
 	 * Prior to 4.8.2 it was useful to change this value, but that is no longer recommended.
+	 * Instead use the `isDefualt` property on the FlxCamera.
 	 */
 	public static var defaultCameras:Array<FlxCamera>;
 
@@ -232,7 +233,7 @@ class FlxCamera extends FlxBasic
 	public var isDefault(default, set):Bool = true;
 
 	/**
-	 * Dispatches whenever isDefault is changed on a camera
+	 * Dispatches whenever isDefault is changed.
 	 * @since 4.8.2
 	 */
 	public var isDefaultChange(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -57,7 +57,7 @@ class FlxCamera extends FlxBasic
 	 * This may be temporarily modified during a `draw` call.
 	 * 
 	 * Prior to 4.8.2 it was useful to change this value, but that feature is deprecated.
-	 * Instead use the `isDefualt` property on `FlxCamera` instances.
+	 * Instead use `FlxG.cameras.setDrawsDefault`.
 	 */
 	@:deprecated("`FlxCamera.defaultCameras` is deprecated, use `FlxG.cameras.setDrawsDefault()` instead")
 	public static var defaultCameras(get, set):Array<FlxCamera>;

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -861,9 +861,16 @@ class FlxGame extends Sprite
 
 		FlxG.cameras.lock();
 
+		var autoDefaultCameras = FlxCamera.defaultCameras == null;
+		if (autoDefaultCameras)
+			FlxCamera.defaultCameras = FlxG.cameras.getDefaults();
+
 		FlxG.plugins.draw();
 
 		_state.draw();
+
+		if (autoDefaultCameras)
+			FlxCamera.defaultCameras = null;
 
 		if (FlxG.renderTile)
 		{

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -861,17 +861,9 @@ class FlxGame extends Sprite
 
 		FlxG.cameras.lock();
 
-		// if defaultCameras is null, find all cameras set as default
-		var autoDefaultCameras = FlxCamera.defaultCameras == null;
-		if (autoDefaultCameras)
-			FlxCamera.defaultCameras = FlxG.cameras.getDefaults();
-
 		FlxG.plugins.draw();
 
 		_state.draw();
-
-		if (autoDefaultCameras)
-			FlxCamera.defaultCameras = null;
 
 		if (FlxG.renderTile)
 		{

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -861,6 +861,7 @@ class FlxGame extends Sprite
 
 		FlxG.cameras.lock();
 
+		// if defaultCameras is null, find all cameras set as default
 		var autoDefaultCameras = FlxCamera.defaultCameras == null;
 		if (autoDefaultCameras)
 			FlxCamera.defaultCameras = FlxG.cameras.getDefaults();

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -180,10 +180,10 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		var i:Int = 0;
 		var basic:FlxBasic = null;
 		
-		var oldDefaultCameras = FlxCamera.defaultCameras;
+		var oldDefaultCameras = FlxCamera._defaultCameras;
 		if (cameras != null)
 		{
-			FlxCamera.defaultCameras = cameras;
+			FlxCamera._defaultCameras = cameras;
 		}
 		
 		while (i < length)
@@ -196,7 +196,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			}
 		}
 		
-		FlxCamera.defaultCameras = oldDefaultCameras;
+		FlxCamera._defaultCameras = oldDefaultCameras;
 	}
 
 	/**

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -184,9 +184,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		var i:Int = 0;
 		var basic:FlxBasic = null;
-		
-		var oldDefaultCameras = FlxCamera._defaultCameras;
 
+		var oldDefaultCameras = FlxCamera._defaultCameras;
 		if (cameras != null)
 		{
 			FlxCamera._defaultCameras = cameras;
@@ -201,7 +200,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 				basic.draw();
 			}
 		}
-		
+
 		FlxCamera._defaultCameras = oldDefaultCameras;
 	}
 

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -16,7 +16,7 @@ class CameraFrontEnd
 	public var list(default, null):Array<FlxCamera> = [];
 	
 	/**
-	 * Array listing all cameras marked as default, updated every `draw` call.
+	 * Array listing all cameras marked as default, automatically updated when isDefault is changed.
 	 */
 	public var defaults(default, null):Array<FlxCamera> = [];
 

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -109,6 +109,7 @@ class CameraFrontEnd
 	 * @see flixel.FlxBasic.cameras
 	 * @param camera The camera you wish to change.
 	 * @param value  If false, FlxBasics will not render to it unless you add it to their `cameras` list.
+	 * @since 4.9.0
 	 */
 	public function setDefaultDrawTarget(camera:FlxCamera, value:Bool)
 	{

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -140,7 +140,7 @@ class CameraFrontEnd
 
 		FlxG.camera = add(NewCamera);
 		NewCamera.ID = 0;
-		
+
 		FlxCamera._defaultCameras = defaults;
 	}
 

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -57,7 +57,7 @@ class CameraFrontEnd
 		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
 		
 		list.push(NewCamera);
-		NewCamera.isDefaultChange.remove(isDefaultChange);
+		NewCamera.isDefaultChange.add(isDefaultChange);
 		if (NewCamera.isDefault)
 			defaults.push(NewCamera);
 		

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -12,6 +12,7 @@ class CameraFrontEnd
 	/**
 	 * An array listing FlxCamera objects that are used to draw stuff.
 	 * By default flixel creates one camera the size of the screen.
+	 * Do not edit directly, use `add` and `remove` instead.
 	 */
 	public var list(default, null):Array<FlxCamera> = [];
 	
@@ -107,7 +108,7 @@ class CameraFrontEnd
 	 * @param camera		The camera you wish to change
 	 * @param drawsDefault	If false, FlxBasics will not render to it unless you add it to their `cameras` list.
 	 */
-	function setDrawsDefault(camera:FlxCamera, drawsDefault:Bool)
+	public function setDrawsDefault(camera:FlxCamera, drawsDefault:Bool)
 	{
 		if (list.indexOf(camera) == -1)
 		{

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -133,7 +133,7 @@ class CameraFrontEnd
 		FlxG.camera = add(NewCamera);
 		NewCamera.ID = 0;
 		
-		FlxCamera.defaultCameras = defaults;
+		FlxCamera._defaultCameras = defaults;
 	}
 
 	/**
@@ -189,7 +189,7 @@ class CameraFrontEnd
 	@:allow(flixel.FlxG)
 	function new()
 	{
-		FlxCamera.defaultCameras = defaults;
+		FlxCamera._defaultCameras = defaults;
 	}
 
 	/**

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -16,9 +16,9 @@ class CameraFrontEnd
 	public var list(default, null):Array<FlxCamera> = [];
 	
 	/**
-	 * Array listing all cameras marked as default, updated every `draw` call
+	 * Array listing all cameras marked as default, updated every `draw` call.
 	 */
-	var defaults:Array<FlxCamera> = [];
+	public var defaults(default, null):Array<FlxCamera> = [];
 
 	/**
 	 * The current (global, applies to all cameras) bgColor.
@@ -57,6 +57,7 @@ class CameraFrontEnd
 		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
 		
 		list.push(NewCamera);
+		NewCamera.isDefaultChange.remove(isDefaultChange);
 		if (NewCamera.isDefault)
 			defaults.push(NewCamera);
 		
@@ -79,6 +80,7 @@ class CameraFrontEnd
 			FlxG.game.removeChild(Camera.flashSprite);
 			list.splice(index, 1);
 			defaults.remove(Camera);
+			Camera.isDefaultChange.remove(isDefaultChange);
 		}
 		else
 		{
@@ -99,6 +101,20 @@ class CameraFrontEnd
 
 		cameraRemoved.dispatch(Camera);
 	}
+	
+	/**
+	 * Adds or removes a camera from the `defaults` array depending on the value of 
+	 * @param camera 
+	 */
+	function isDefaultChange(camera:FlxCamera)
+	{
+		var index = defaults.indexOf(camera);
+		
+		if (camera.isDefault && index == -1)
+			defaults.push(camera);
+		else if (!camera.isDefault)
+			defaults.splice(index, 1);
+	}
 
 	/**
 	 * Dumps all the current cameras and resets to just one camera.
@@ -117,7 +133,7 @@ class CameraFrontEnd
 		FlxG.camera = add(NewCamera);
 		NewCamera.ID = 0;
 		
-		FlxCamera.defaultCameras = null;
+		FlxCamera.defaultCameras = defaults;
 	}
 
 	/**
@@ -173,6 +189,7 @@ class CameraFrontEnd
 	@:allow(flixel.FlxG)
 	function new()
 	{
+		FlxCamera.defaultCameras = defaults;
 	}
 
 	/**
@@ -275,21 +292,6 @@ class CameraFrontEnd
 				camera.update(elapsed);
 			}
 		}
-	}
-	
-	/**
-	 * Finds all cameras where `isDefault == true` adds returns the Array.
-	 */
-	@:allow(flixel.FlxGame)
-	function getDefaults():Array<FlxCamera>
-	{
-		defaults.resize(0);
-		for (camera in list)
-		{
-			if (camera.isDefault)
-				defaults.push(camera);
-		}
-		return defaults;
 	}
 	
 	/**

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -19,7 +19,8 @@ class CameraFrontEnd
 	public var list(default, null):Array<FlxCamera> = [];
 	
 	/**
-	 * Array listing all cameras marked as default, `FlxBasics` with no `cameras` set will render to them.
+	 * Array listing all cameras marked as default draw targets, `FlxBasics` with no
+	 *`cameras` set will render to them.
 	 */
 	var defaults:Array<FlxCamera> = [];
 
@@ -53,8 +54,10 @@ class CameraFrontEnd
 	 * Handy for PiP, split-screen, etc.
 	 *
 	 * @param	NewCamera         The camera you want to add.
-	 * @param	DefaultDrawTarget If false, FlxBasics will not render to it unless you add it to their `cameras` list.
+	 * @param	DefaultDrawTarget Whether to add the camera to the list of default draw targets. If false, 
+	 *                            `FlxBasics` will not render to it unless you add it to their `cameras` list.
 	 * @return	This FlxCamera instance.
+	 * @see flixel.FlxBasic.cameras
 	 */
 	public function add<T:FlxCamera>(NewCamera:T, DefaultDrawTarget:Bool = true):T
 	{
@@ -105,10 +108,12 @@ class CameraFrontEnd
 	}
 	
 	/**
-	 * If set to true, `FlxBasics` render to the specified camera if the `FlxBasic` has a null `cameras` value.
+	 * If set to true, the camera is listed as a default draw target, meaning `FlxBasics`
+	 * render to the specified camera if the `FlxBasic` has a null `cameras` value.
 	 * @see flixel.FlxBasic.cameras
 	 * @param camera The camera you wish to change.
 	 * @param value  If false, FlxBasics will not render to it unless you add it to their `cameras` list.
+	 * @see flixel.FlxBasic.cameras
 	 * @since 4.9.0
 	 */
 	public function setDefaultDrawTarget(camera:FlxCamera, value:Bool)

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -14,6 +14,11 @@ class CameraFrontEnd
 	 * By default flixel creates one camera the size of the screen.
 	 */
 	public var list(default, null):Array<FlxCamera> = [];
+	
+	/**
+	 * Array listing all cameras marked as default, updated every `draw` call
+	 */
+	var defaults:Array<FlxCamera> = [];
 
 	/**
 	 * The current (global, applies to all cameras) bgColor.
@@ -50,8 +55,12 @@ class CameraFrontEnd
 	public function add<T:FlxCamera>(NewCamera:T):T
 	{
 		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
-		FlxG.cameras.list.push(NewCamera);
-		NewCamera.ID = FlxG.cameras.list.length - 1;
+		
+		list.push(NewCamera);
+		if (NewCamera.isDefault)
+			defaults.push(NewCamera);
+		
+		NewCamera.ID = list.length - 1;
 		cameraAdded.dispatch(NewCamera);
 		return NewCamera;
 	}
@@ -69,6 +78,7 @@ class CameraFrontEnd
 		{
 			FlxG.game.removeChild(Camera.flashSprite);
 			list.splice(index, 1);
+			defaults.remove(Camera);
 		}
 		else
 		{
@@ -106,8 +116,8 @@ class CameraFrontEnd
 
 		FlxG.camera = add(NewCamera);
 		NewCamera.ID = 0;
-
-		FlxCamera.defaultCameras = list;
+		
+		FlxCamera.defaultCameras = null;
 	}
 
 	/**
@@ -163,7 +173,6 @@ class CameraFrontEnd
 	@:allow(flixel.FlxG)
 	function new()
 	{
-		FlxCamera.defaultCameras = list;
 	}
 
 	/**
@@ -267,7 +276,22 @@ class CameraFrontEnd
 			}
 		}
 	}
-
+	
+	/**
+	 * Finds all cameras where `isDefault == true` adds returns the Array.
+	 */
+	@:allow(flixel.FlxGame)
+	function getDefaults():Array<FlxCamera>
+	{
+		defaults.resize(0);
+		for (camera in list)
+		{
+			if (camera.isDefault)
+				defaults.push(camera);
+		}
+		return defaults;
+	}
+	
 	/**
 	 * Resizes and moves cameras when the game resizes (onResize signal).
 	 */

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -52,12 +52,12 @@ class CameraFrontEnd
 	/**
 	 * Add a new camera object to the game.
 	 * Handy for PiP, split-screen, etc.
+	 * @see flixel.FlxBasic.cameras
 	 *
 	 * @param	NewCamera         The camera you want to add.
 	 * @param	DefaultDrawTarget Whether to add the camera to the list of default draw targets. If false, 
 	 *                            `FlxBasics` will not render to it unless you add it to their `cameras` list.
 	 * @return	This FlxCamera instance.
-	 * @see flixel.FlxBasic.cameras
 	 */
 	public function add<T:FlxCamera>(NewCamera:T, DefaultDrawTarget:Bool = true):T
 	{
@@ -111,9 +111,9 @@ class CameraFrontEnd
 	 * If set to true, the camera is listed as a default draw target, meaning `FlxBasics`
 	 * render to the specified camera if the `FlxBasic` has a null `cameras` value.
 	 * @see flixel.FlxBasic.cameras
+	 * 
 	 * @param camera The camera you wish to change.
 	 * @param value  If false, FlxBasics will not render to it unless you add it to their `cameras` list.
-	 * @see flixel.FlxBasic.cameras
 	 * @since 4.9.0
 	 */
 	public function setDefaultDrawTarget(camera:FlxCamera, value:Bool)

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -293,7 +293,7 @@ class CameraFrontEnd
 			}
 		}
 	}
-	
+
 	/**
 	 * Resizes and moves cameras when the game resizes (onResize signal).
 	 */

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -7,6 +7,8 @@ import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxSignal.FlxTypedSignal;
 
+using flixel.util.FlxArrayUtil;
+
 class CameraFrontEnd
 {
 	/**
@@ -18,9 +20,8 @@ class CameraFrontEnd
 	
 	/**
 	 * Array listing all cameras marked as default, `FlxBasics` with no `cameras` set will render to them.
-	 * @since 4.8.2
 	 */
-	var defaults(default, null):Array<FlxCamera> = [];
+	var defaults:Array<FlxCamera> = [];
 
 	/**
 	 * The current (global, applies to all cameras) bgColor.
@@ -51,16 +52,16 @@ class CameraFrontEnd
 	 * Add a new camera object to the game.
 	 * Handy for PiP, split-screen, etc.
 	 *
-	 * @param	NewCamera		The camera you want to add.
-	 * @param	DrawsDefault	If false, FlxBasics will not render to it unless you add it to their `cameras` list.
+	 * @param	NewCamera         The camera you want to add.
+	 * @param	DefaultDrawTarget If false, FlxBasics will not render to it unless you add it to their `cameras` list.
 	 * @return	This FlxCamera instance.
 	 */
-	public function add<T:FlxCamera>(NewCamera:T, DrawsDefault:Bool = true):T
+	public function add<T:FlxCamera>(NewCamera:T, DefaultDrawTarget:Bool = true):T
 	{
 		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
 		
 		list.push(NewCamera);
-		if (DrawsDefault)
+		if (DefaultDrawTarget)
 			defaults.push(NewCamera);
 		
 		NewCamera.ID = list.length - 1;
@@ -104,23 +105,24 @@ class CameraFrontEnd
 	}
 	
 	/**
-	 * Changes whether the specified camera draws FlxBasics 
-	 * @param camera		The camera you wish to change
-	 * @param drawsDefault	If false, FlxBasics will not render to it unless you add it to their `cameras` list.
+	 * If set to true, `FlxBasics` render to the specified camera if the `FlxBasic` has a null `cameras` value.
+	 * @see flixel.FlxBasic.cameras
+	 * @param camera The camera you wish to change.
+	 * @param value  If false, FlxBasics will not render to it unless you add it to their `cameras` list.
 	 */
-	public function setDrawsDefault(camera:FlxCamera, drawsDefault:Bool)
+	public function setDefaultDrawTarget(camera:FlxCamera, value:Bool)
 	{
-		if (list.indexOf(camera) == -1)
+		if (!list.contains(camera))
 		{
-			FlxG.log.warn("FlxG.cameras.setDrawsDefault(): The specified camera is not a part of the game.");
+			FlxG.log.warn("FlxG.cameras.setDefaultDrawTarget(): The specified camera is not a part of the game.");
 			return;
 		}
 		
 		var index = defaults.indexOf(camera);
 		
-		if (drawsDefault && index == -1)
+		if (value && index == -1)
 			defaults.push(camera);
-		else if (!drawsDefault)
+		else if (!value)
 			defaults.splice(index, 1);
 	}
 

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -16,9 +16,10 @@ class CameraFrontEnd
 	public var list(default, null):Array<FlxCamera> = [];
 	
 	/**
-	 * Array listing all cameras marked as default, automatically updated when isDefault is changed.
+	 * Array listing all cameras marked as default, `FlxBasics` with no `cameras` set will render to them.
+	 * @since 4.8.2
 	 */
-	public var defaults(default, null):Array<FlxCamera> = [];
+	var defaults(default, null):Array<FlxCamera> = [];
 
 	/**
 	 * The current (global, applies to all cameras) bgColor.
@@ -49,16 +50,16 @@ class CameraFrontEnd
 	 * Add a new camera object to the game.
 	 * Handy for PiP, split-screen, etc.
 	 *
-	 * @param	NewCamera	The camera you want to add.
+	 * @param	NewCamera		The camera you want to add.
+	 * @param	DrawsDefault	If false, FlxBasics will not render to it unless you add it to their `cameras` list.
 	 * @return	This FlxCamera instance.
 	 */
-	public function add<T:FlxCamera>(NewCamera:T):T
+	public function add<T:FlxCamera>(NewCamera:T, DrawsDefault:Bool = true):T
 	{
 		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
 		
 		list.push(NewCamera);
-		NewCamera.isDefaultChange.add(isDefaultChange);
-		if (NewCamera.isDefault)
+		if (DrawsDefault)
 			defaults.push(NewCamera);
 		
 		NewCamera.ID = list.length - 1;
@@ -80,7 +81,6 @@ class CameraFrontEnd
 			FlxG.game.removeChild(Camera.flashSprite);
 			list.splice(index, 1);
 			defaults.remove(Camera);
-			Camera.isDefaultChange.remove(isDefaultChange);
 		}
 		else
 		{
@@ -103,16 +103,23 @@ class CameraFrontEnd
 	}
 	
 	/**
-	 * Adds or removes a camera from the `defaults` array depending on the value of 
-	 * @param camera 
+	 * Changes whether the specified camera draws FlxBasics 
+	 * @param camera		The camera you wish to change
+	 * @param drawsDefault	If false, FlxBasics will not render to it unless you add it to their `cameras` list.
 	 */
-	function isDefaultChange(camera:FlxCamera)
+	function setDrawsDefault(camera:FlxCamera, drawsDefault:Bool)
 	{
+		if (list.indexOf(camera) == -1)
+		{
+			FlxG.log.warn("FlxG.cameras.setDrawsDefault(): The specified camera is not a part of the game.");
+			return;
+		}
+		
 		var index = defaults.indexOf(camera);
 		
-		if (camera.isDefault && index == -1)
+		if (drawsDefault && index == -1)
 			defaults.push(camera);
-		else if (!camera.isDefault)
+		else if (!drawsDefault)
 			defaults.splice(index, 1);
 	}
 

--- a/tests/unit/src/flixel/FlxCameraTest.hx
+++ b/tests/unit/src/flixel/FlxCameraTest.hx
@@ -32,12 +32,14 @@ class FlxCameraTest extends FlxTest
 	function testDefaultLength():Void
 	{
 		Assert.areEqual(1, FlxG.cameras.list.length);
+		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 
 	@Test
 	function testDefaultCameras():Void
 	{
+		@:privateAccess
 		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
@@ -47,6 +49,7 @@ class FlxCameraTest extends FlxTest
 		FlxCamera.defaultCameras = [FlxG.camera];
 		switchState(new FlxState());
 
+		@:privateAccess
 		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
@@ -55,26 +58,30 @@ class FlxCameraTest extends FlxTest
 	{
 		FlxG.cameras.add(camera);
 		Assert.areEqual(2, FlxG.cameras.list.length);
+		@:privateAccess
 		Assert.areEqual(2, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.remove(camera);
 		Assert.areEqual(1, FlxG.cameras.list.length);
+		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 
 	@Test // #2296
 	function testIsDefaultCamera():Void
 	{
-		camera.isDefault = false;
-		FlxG.cameras.add(camera);
+		FlxG.cameras.add(camera, false);
 		Assert.areEqual(2, FlxG.cameras.list.length);
+		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 
-		camera.isDefault = true;
+		FlxG.cameras.setDrawsDefault(camera, true);
+		@:privateAccess
 		Assert.areEqual(2, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.remove(camera);
 		Assert.areEqual(1, FlxG.cameras.list.length);
+		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 

--- a/tests/unit/src/flixel/FlxCameraTest.hx
+++ b/tests/unit/src/flixel/FlxCameraTest.hx
@@ -70,7 +70,7 @@ class FlxCameraTest extends FlxTest
 		Assert.areEqual(2, FlxG.cameras.list.length);
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 
-		FlxG.cameras.setDrawsDefault(camera, true);
+		FlxG.cameras.setDefaultDrawTarget(camera, true);
 		Assert.areEqual(2, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.remove(camera);

--- a/tests/unit/src/flixel/FlxCameraTest.hx
+++ b/tests/unit/src/flixel/FlxCameraTest.hx
@@ -3,6 +3,7 @@ package flixel;
 import flixel.util.FlxColor;
 import massive.munit.Assert;
 
+@:access(flixel.system.frontEnds.CameraFrontEnd)
 class FlxCameraTest extends FlxTest
 {
 	var camera:FlxCamera;
@@ -32,14 +33,12 @@ class FlxCameraTest extends FlxTest
 	function testDefaultLength():Void
 	{
 		Assert.areEqual(1, FlxG.cameras.list.length);
-		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 
 	@Test
 	function testDefaultCameras():Void
 	{
-		@:privateAccess
 		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
@@ -49,7 +48,6 @@ class FlxCameraTest extends FlxTest
 		FlxCamera.defaultCameras = [FlxG.camera];
 		switchState(new FlxState());
 
-		@:privateAccess
 		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
@@ -58,12 +56,10 @@ class FlxCameraTest extends FlxTest
 	{
 		FlxG.cameras.add(camera);
 		Assert.areEqual(2, FlxG.cameras.list.length);
-		@:privateAccess
 		Assert.areEqual(2, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.remove(camera);
 		Assert.areEqual(1, FlxG.cameras.list.length);
-		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 
@@ -72,16 +68,13 @@ class FlxCameraTest extends FlxTest
 	{
 		FlxG.cameras.add(camera, false);
 		Assert.areEqual(2, FlxG.cameras.list.length);
-		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.setDrawsDefault(camera, true);
-		@:privateAccess
 		Assert.areEqual(2, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.remove(camera);
 		Assert.areEqual(1, FlxG.cameras.list.length);
-		@:privateAccess
 		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 

--- a/tests/unit/src/flixel/FlxCameraTest.hx
+++ b/tests/unit/src/flixel/FlxCameraTest.hx
@@ -32,12 +32,13 @@ class FlxCameraTest extends FlxTest
 	function testDefaultLength():Void
 	{
 		Assert.areEqual(1, FlxG.cameras.list.length);
+		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 
 	@Test
 	function testDefaultCameras():Void
 	{
-		Assert.areEqual(FlxG.cameras.list, FlxCamera.defaultCameras);
+		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
 	@Test
@@ -46,7 +47,7 @@ class FlxCameraTest extends FlxTest
 		FlxCamera.defaultCameras = [FlxG.camera];
 		switchState(new FlxState());
 
-		Assert.areEqual(FlxG.cameras.list, FlxCamera.defaultCameras);
+		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
 	@Test
@@ -54,9 +55,27 @@ class FlxCameraTest extends FlxTest
 	{
 		FlxG.cameras.add(camera);
 		Assert.areEqual(2, FlxG.cameras.list.length);
+		Assert.areEqual(2, FlxG.cameras.defaults.length);
 
 		FlxG.cameras.remove(camera);
 		Assert.areEqual(1, FlxG.cameras.list.length);
+		Assert.areEqual(1, FlxG.cameras.defaults.length);
+	}
+
+	@Test // #2296
+	function testIsDefaultCamera():Void
+	{
+		camera.isDefault = false;
+		FlxG.cameras.add(camera);
+		Assert.areEqual(2, FlxG.cameras.list.length);
+		Assert.areEqual(1, FlxG.cameras.defaults.length);
+
+		camera.isDefault = true;
+		Assert.areEqual(2, FlxG.cameras.defaults.length);
+
+		FlxG.cameras.remove(camera);
+		Assert.areEqual(1, FlxG.cameras.list.length);
+		Assert.areEqual(1, FlxG.cameras.defaults.length);
 	}
 
 	@Test // #1515


### PR DESCRIPTION
### Problem
Often times, when I add a second camera, my intention is either:
A. To have both cameras draw everything if certain portions of the screen (i.e.: splitscreen).
B. To have the new camera draw one set of things, often a specific FlxGroup, and everything else render on the original camera.

Scenario A is pretty straightforward however B is not. It usually involves setting `FlxCamera.defaultCameras = [cameraA]` and just kinda hoping that no other parts of my code are doing anything crazy with multiple cameras. Not to mention setting `FlxCamera.defaultCameras` during a `draw` phase could have unintended side effects (or just not work at all).

### Solution
Give `CameraFrontEnd` methods to set and unset which cameras are "default" drawers. default drawing cameras will act as though it was listed in `defaultCameras` at the start of the draw phase. This way you can add new cameras without worrying about stomping on other code involving cameras

### Backwards Compatibility
The old way should still work but documentation will be updated to discourage its use and inform them of the new property

### Info
This went through a few iterations, previously I was checking/validating the default Array every draw cycle. but it seems important to update the list right away because `FlxCamera.defaultCameras` can be accessed at any time via `myCamera.cameras` since `set_camera` returns  `FlxCamera.defaultCameras` when `_cameras` is null.

Edit: even more iterations!

## Examples

Currently, when you want to add a camera that only displays a specific thing, this is how you do it.
```hx
menuCamera = new FlxCamera();
FlxG.cameras.add(menuCamera);
menu.camera = [menuCamera];
// only draw the main camera by default
// Note: assumes menuCamera was the only camera added
FlxCamera.defaultCameras = [FlxG.camera];
```
Or you could try to account for other camera-related code with:
```hx
menuCamera = new FlxCamera();
FlxG.cameras.add(menuCamera);
menu.camera = [menuCamera];
if (FlxCamera.defaultCameras == FlxG.cameras.list)
{
    FlxCamera.defaultCameras = FlxCamera.defaultCameras.concat();
    FlxCamera.defaultCameras.remove(menuCamera);
}
```

New way:
```hx
menuCamera = new FlxCamera();
FlxG.cameras.add(menuCamera, false);
menu.camera = [menuCamera];
```

and to have the above but also do something like split-screen, you would need to do something like this:
```hx
p1Cam = FlxG.camera;
p1Cam.width = 0.5 * FlxG.width;
p2Cam = new FlxCamera(p1Cam.width, 0, p1Cam.width);
FlxG.cameras.add(p2Cam);
if (FlxCamera.defaultCameras.indexOf(p2Cam) == -1)
{
    // defaultCameras is not set to FlxG.cameras.list
    FlxCamera.defaultCameras.add(p2Cam);
}
```

New way:
```hx
p1Cam = FlxG.camera;
p1Cam.width = 0.5 * FlxG.width;
p2Cam = new FlxCamera(p1Cam.width, 0, p1Cam.width);
FlxG.cameras.add(p2Cam);
```
