### PR TITLE
Update iOS asset paths

### DIFF
--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -38,7 +38,7 @@ class FlxAssetPaths
 			?rename:String->String):Array<FileReference>
 	{
 		var fileReferences:Array<FileReference> = [];
-		var resolvedPath = #if (ios || tvos) Context.resolvePath(directory) #else directory #end;
+		var resolvedPath = #if (ios || tvos) "../assets/" + directory #else directory #end;
 		var directoryInfo = FileSystem.readDirectory(resolvedPath);
 		for (name in directoryInfo)
 		{

--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -38,7 +38,7 @@ class FlxAssetPaths
 			?rename:String->String):Array<FileReference>
 	{
 		var fileReferences:Array<FileReference> = [];
-		var resolvedPath = #if (ios || tvos) "../assets/" + directory #else directory #end;
+		var resolvedPath = #if (ios || tvos) Context.resolvePath(directory) #else directory #end;
 		var directoryInfo = FileSystem.readDirectory(resolvedPath);
 		for (name in directoryInfo)
 		{


### PR DESCRIPTION
Adds the direct path for iOS assets - building now works as expected. Resolves problems found in #2233 