### PR TITLE
Fix VarTween still updating properties on cancel() during onUpdate

### DIFF
--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -56,8 +56,9 @@ class VarTween extends FlxTween
 
 			super.update(elapsed);
 
-			for (info in _propertyInfos)
-				Reflect.setProperty(info.object, info.field, info.startValue + info.range * scale);
+			if(active)
+				for (info in _propertyInfos)
+					Reflect.setProperty(info.object, info.field, info.startValue + info.range * scale);
 		}
 	}
 

--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -56,7 +56,7 @@ class VarTween extends FlxTween
 
 			super.update(elapsed);
 
-			if(active)
+			if (active)
 				for (info in _propertyInfos)
 					Reflect.setProperty(info.object, info.field, info.startValue + info.range * scale);
 		}


### PR DESCRIPTION
If tween has `cancel` called during `onUpdate` it will still try to apply properties and cause an error.