### PR TITLE
Cancel grandchild tweens

### DIFF
--- a/flixel/tweens/misc/VarTween.hx
+++ b/flixel/tweens/misc/VarTween.hx
@@ -116,6 +116,9 @@ class VarTween extends FlxTween
 
 	override function isTweenOf(object:Dynamic, ?field:String):Bool
 	{
+		if (object == _object && field == null)
+			return true;
+		
 		for (property in _propertyInfos)
 		{
 			if (object == property.object && (field == property.field || field == null))

--- a/tests/unit/src/flixel/FlxCameraTest.hx
+++ b/tests/unit/src/flixel/FlxCameraTest.hx
@@ -39,16 +39,19 @@ class FlxCameraTest extends FlxTest
 	@Test
 	function testDefaultCameras():Void
 	{
-		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
+		@:privateAccess
+		Assert.areEqual(FlxG.cameras.defaults, FlxCamera._defaultCameras);
 	}
 
 	@Test
 	function testDefaultCamerasStateSwitch():Void
 	{
-		FlxCamera.defaultCameras = [FlxG.camera];
+		@:privateAccess
+		FlxCamera._defaultCameras = [FlxG.camera];
 		switchState(new FlxState());
 
-		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
+		@:privateAccess
+		Assert.areEqual(FlxG.cameras.defaults, FlxCamera._defaultCameras);
 	}
 
 	@Test

--- a/tests/unit/src/flixel/FlxCameraTest.hx
+++ b/tests/unit/src/flixel/FlxCameraTest.hx
@@ -39,19 +39,16 @@ class FlxCameraTest extends FlxTest
 	@Test
 	function testDefaultCameras():Void
 	{
-		@:privateAccess
-		Assert.areEqual(FlxG.cameras.defaults, FlxCamera._defaultCameras);
+		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
 	@Test
 	function testDefaultCamerasStateSwitch():Void
 	{
-		@:privateAccess
-		FlxCamera._defaultCameras = [FlxG.camera];
+		FlxCamera.defaultCameras = [FlxG.camera];
 		switchState(new FlxState());
 
-		@:privateAccess
-		Assert.areEqual(FlxG.cameras.defaults, FlxCamera._defaultCameras);
+		Assert.areEqual(FlxG.cameras.defaults, FlxCamera.defaultCameras);
 	}
 
 	@Test

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -249,15 +249,29 @@ class FlxTweenTest extends FlxTest
 		Assert.isTrue(tween2a.finished);
 		Assert.isFalse(tween2b.finished);
 		
-		var foo3 = {a: {f:0}, b: {f:0}, c: {f:0}};
+		var foo3 = {a: {f:0}, b: {f:0}, c: {f:0}, d: {f:0}};
 		var tween3a = FlxTween.tween(foo3, {"a.f": 1}, 0.1);
 		var tween3b = FlxTween.tween(foo3, {"b.f": 1}, 0.1);
 		var tween3c = FlxTween.tween(foo3, {"c.f": 1}, 0.1);
+		var tween3d = FlxTween.tween(foo3.d, {"f": 1}, 0.1);
+		// cancel call matches tween call
 		FlxTween.cancelTweensOf(foo3, ["a.f"]);
-		FlxTween.cancelTweensOf(foo3.b, ["f"]);
 		Assert.isTrue(tween3a.finished);
+		Assert.isFalse(tween3b.finished);
+		Assert.isFalse(tween3c.finished);
+		Assert.isFalse(tween3d.finished);
+		// cancel called on child property, with grandchild field
+		FlxTween.cancelTweensOf(foo3.b);
 		Assert.isTrue(tween3b.finished);
 		Assert.isFalse(tween3c.finished);
+		Assert.isFalse(tween3d.finished);
+		// cancel grandchild tweens when cancel target matches tween target
+		FlxTween.cancelTweensOf(foo3);
+		Assert.isTrue(tween3c.finished);
+		Assert.isFalse(tween3d.finished);// doesn't cancel all grandchildren
+		// cancel called on parent property, with dotted grandchild field
+		FlxTween.cancelTweensOf(foo3, ["d.f"]);
+		Assert.isTrue(tween3d.finished);
 	}
 
 	@Test // #2273

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -261,7 +261,7 @@ class FlxTweenTest extends FlxTest
 		Assert.isFalse(tween3c.finished);
 		Assert.isFalse(tween3d.finished);
 		// cancel called on child property, with grandchild field
-		FlxTween.cancelTweensOf(foo3.b);
+		FlxTween.cancelTweensOf(foo3.b, ["f"]);
 		Assert.isTrue(tween3b.finished);
 		Assert.isFalse(tween3c.finished);
 		Assert.isFalse(tween3d.finished);


### PR DESCRIPTION
```hx
FlxTween.tween(camera, {'scroll.y': 500}, 1.0);
```
The tween above can already be cancelled, via:
```hx
FlxTween.cancelTweensOf(camera.scroll);
```
but because the camera is the actual tween target, it should also be cancelled with:
```hx
FlxTween.cancelTweensOf(camera);
```

Whereas `tween(camera.scroll, {y: 500}, 1.0)` is not a tween on camera, so it must be cancelled with `cancelTweensOf(camera.scroll)` or `cancelTweensOf(camera, ['scroll.y'])`.