### PR TITLE
Fill the remaining pixels of a FlxGradient with the last colour picked

### DIFF
--- a/flixel/util/FlxGradient.hx
+++ b/flixel/util/FlxGradient.hx
@@ -140,6 +140,10 @@ class FlxGradient
 			sM.scale(tempBitmap.scaleX, tempBitmap.scaleY);
 
 			data.draw(tempBitmap, sM);
+
+			// The scaled bitmap might not have filled the data. Fill the remaining pixels with the last color.
+			var remainingRect = new openfl.geom.Rectangle(0, tempBitmap.height, width, height - tempBitmap.height);
+			data.fillRect(remainingRect, colors[colors.length - 1]);
 		}
 
 		return data;


### PR DESCRIPTION
Because the height is dividing by the chunk size and rounding down to an integer it may not end up being the correct height when scaled back up.

With the follow line of code the sprite isn't the full height of the game (640x480) :
```haxe
FlxGradient.createGradientFlxSprite(FlxG.width, FlxG.height, [FlxColor.BLUE, FlxColor.RED], 121)
```
![image](https://user-images.githubusercontent.com/42767280/127752094-ab0135b6-981b-45c3-ad13-11fc29e2d95b.png)

My change will fill the rest with the last colour picked in the array. It wont be the same size as the other chunks but it's better for it to be smaller that just not shown.
![image](https://user-images.githubusercontent.com/42767280/127752081-385fa403-fb48-462f-8231-71594384e4ee.png)