### PR TITLE
Adding option for Split Sound Tray

### DIFF
--- a/flixel/input/keyboard/FlxKey.hx
+++ b/flixel/input/keyboard/FlxKey.hx
@@ -106,6 +106,7 @@ abstract FlxKey(Int) from Int to Int
 	var NUMPADPLUS = 107;
 	var NUMPADPERIOD = 110;
 	var NUMPADMULTIPLY = 106;
+	var NUMPADDIVIDE = 111;
 
 	@:from
 	public static inline function fromString(s:String)

--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -590,7 +590,7 @@ class FlxSound extends FlxBasic
 	function updateTransform():Void
 	{
 		_transform.volume = #if FLX_SOUND_SYSTEM (FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume * #end
-			(group != null ? group.volume : 1) * _volume * _volumeAdjust;
+			(group != null ? (group.muted ? 0 : group.volume) : 1) * _volume * _volumeAdjust;
 
 		if (_channel != null)
 			_channel.soundTransform = _transform;

--- a/flixel/system/FlxSoundGroup.hx
+++ b/flixel/system/FlxSoundGroup.hx
@@ -1,5 +1,7 @@
 package flixel.system;
 
+import flixel.math.FlxMath;
+
 /**
  * A way of grouping sounds for things such as collective volume control
  */
@@ -9,6 +11,11 @@ class FlxSoundGroup
 	 * The sounds in this group
 	 */
 	public var sounds:Array<FlxSound> = [];
+
+	/**
+	 * Whether or not this group's sounds are muted.
+	 */
+	public var muted:Bool = false;
 
 	/**
 	 * The volume of this group
@@ -21,7 +28,7 @@ class FlxSoundGroup
 	 */
 	public function new(volume:Float = 1)
 	{
-		this.volume = volume;
+		this.volume = FlxMath.bound(volume, 0, 1);
 	}
 
 	/**
@@ -77,7 +84,7 @@ class FlxSoundGroup
 
 	function set_volume(volume:Float):Float
 	{
-		this.volume = volume;
+		this.volume = FlxMath.bound(volume, 0, 1);
 		for (sound in sounds)
 		{
 			sound.updateTransform();

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -4,11 +4,11 @@ package flixel.system.frontEnds;
 import flash.media.Sound;
 import flixel.FlxG;
 import flixel.group.FlxGroup.FlxTypedGroup;
-import flixel.system.FlxAssets.FlxSoundAsset;
-import flixel.system.FlxSoundGroup;
-import flixel.system.FlxSound;
-import flixel.math.FlxMath;
 import flixel.input.keyboard.FlxKey;
+import flixel.math.FlxMath;
+import flixel.system.FlxAssets.FlxSoundAsset;
+import flixel.system.FlxSound;
+import flixel.system.FlxSoundGroup;
 import openfl.Assets;
 #if (openfl >= "8.0.0")
 import openfl.utils.AssetType;
@@ -32,28 +32,88 @@ class SoundFrontEnd
 
 	/**
 	 * Set this hook to get a callback whenever the volume changes.
-	 * Function should take the form myVolumeHandler(volume:Float).
+	 * Function should take the form myVolumeHandler(volume:Float, WhichVolume:Int). 
+	 * Where `WhichVolume` will show which volume was changed:
+	 * 1 = Master, 2 = Sound, 3 = Music.
 	 */
-	public var volumeHandler:Float->Void;
+	public var volumeHandler:Float->Int->Void;
 
 	#if FLX_KEYBOARD
 	/**
-	 * The key codes used to increase volume (see FlxG.keys for the keys available).
+	 * The key codes used to increase Master volume (see FlxG.keys for the keys available).
 	 * Default keys: + (and numpad +). Set to null to deactivate.
 	 */
-	public var volumeUpKeys:Array<FlxKey> = [PLUS, NUMPADPLUS];
+	public var masterVolumeUpKeys:Array<FlxKey> = [PLUS, NUMPADPLUS];
 
 	/**
-	 * The keys to decrease volume (see FlxG.keys for the keys available).
+	 * The keys to decrease Master volume (see FlxG.keys for the keys available).
 	 * Default keys: - (and numpad -). Set to null to deactivate.
 	 */
-	public var volumeDownKeys:Array<FlxKey> = [MINUS, NUMPADMINUS];
+	public var masterVolumeDownKeys:Array<FlxKey> = [MINUS, NUMPADMINUS];
 
 	/**
-	 * The keys used to mute / unmute the game (see FlxG.keys for the keys available).
+	 * The keys used to mute / unmute the Master volume (see FlxG.keys for the keys available).
 	 * Default keys: 0 (and numpad 0). Set to null to deactivate.
 	 */
-	public var muteKeys:Array<FlxKey> = [ZERO, NUMPADZERO];
+	public var masterMuteKeys:Array<FlxKey> = [ZERO, NUMPADZERO];
+
+	/**
+	 * The key modifiers to use for Master volume
+	 * Default key: SHIFT. Set to null to deactivate
+	 */
+	public var masterModifier:Array<FlxKey> = [SHIFT];
+
+	/**
+	 * The key codes used to increase Sound volume (see FlxG.keys for the keys available).
+	 * Default keys: + (and numpad +). Set to null to deactivate.
+	 */
+	public var soundVolumeUpKeys:Array<FlxKey> = [PLUS, NUMPADPLUS];
+
+	/**
+	 * The keys to decrease Sound volume (see FlxG.keys for the keys available).
+	 * Default keys: - (and numpad -). Set to null to deactivate.
+	 */
+	public var soundVolumeDownKeys:Array<FlxKey> = [MINUS, NUMPADMINUS];
+
+	/**
+	 * The keys used to mute / unmute the Sound volume (see FlxG.keys for the keys available).
+	 * Default keys: 0 (and numpad 0). Set to null to deactivate.
+	 */
+	public var soundMuteKeys:Array<FlxKey> = [ZERO, NUMPADZERO];
+
+	/**
+	 * The key modifier to use for Master volume
+	 * Default: deactivated. Set to a key like SHIFT or CONTROL to activate
+	 */
+	public var soundModifier:Array<FlxKey> = null;
+
+	/**
+	 * The key codes used to increase Music volume (see FlxG.keys for the keys available).
+	 * Default keys: PAGEUP (and numpad 9). Set to null to deactivate.
+	 */
+	public var musicVolumeUpKeys:Array<FlxKey> = [NUMPADMULTIPLY];
+
+	/**
+	 * The keys to decrease Music volume (see FlxG.keys for the keys available).
+	 * Default keys: PAGEDOWN (and numpad 3). Set to null to deactivate.
+	 */
+	public var musicVolumeDownKeys:Array<FlxKey> = [NUMPADDIVIDE];
+
+	/**
+	 * The keys used to mute / unmute the Music volume (see FlxG.keys for the keys available).
+	 * Default keys: DELETE (and numpad Period). Set to null to deactivate.
+	 */
+	public var musicMuteKeys:Array<FlxKey> = [DELETE, NUMPADPERIOD];
+
+	/**
+	 * The key modifier to use for Sound volume
+	 * Default: deactivated. Set to a key like SHIFT or CONTROL to activate
+	 */
+	public var musicModifier:Array<FlxKey> = null;
+
+	public static inline var VOL_MASTER:Int = 0;
+	public static inline var VOL_SOUND:Int = 1;
+	public static inline var VOL_MUSIC:Int = 2;
 	#end
 
 	/**
@@ -217,8 +277,8 @@ class SoundFrontEnd
 	 * @param	OnComplete		Called when the sound finished playing
 	 * @return	A FlxSound object.
 	 */
-	public function play(EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup,
-			AutoDestroy:Bool = true, ?OnComplete:Void->Void):FlxSound
+	public function play(EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup, AutoDestroy:Bool = true,
+			?OnComplete:Void->Void):FlxSound
 	{
 		if ((EmbeddedSound is String))
 		{
@@ -242,8 +302,8 @@ class SoundFrontEnd
 	 * @param	OnLoad			Called when the sound finished loading.
 	 * @return	A FlxSound object.
 	 */
-	public function stream(URL:String, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup,
-			AutoDestroy:Bool = true, ?OnComplete:Void->Void, ?OnLoad:Void->Void):FlxSound
+	public function stream(URL:String, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup, AutoDestroy:Bool = true, ?OnComplete:Void->Void,
+			?OnLoad:Void->Void):FlxSound
 	{
 		return load(null, Volume, Looped, Group, AutoDestroy, true, URL, OnComplete, OnLoad);
 	}
@@ -318,37 +378,60 @@ class SoundFrontEnd
 	/**
 	 * Toggles muted, also activating the sound tray.
 	 */
-	public function toggleMuted():Void
+	public function toggleMuted(WhichVolume:Int = VOL_MASTER):Void
 	{
-		muted = !muted;
+		switch (WhichVolume)
+		{
+			case VOL_MASTER:
+				defaultSoundGroup.muted = defaultSoundGroup.muted = muted = !muted;
+
+			case VOL_SOUND:
+				defaultSoundGroup.muted = !defaultSoundGroup.muted;
+
+			case VOL_MUSIC:
+				defaultSoundGroup.muted = !defaultMusicGroup.muted;
+		}
 
 		if (volumeHandler != null)
 		{
-			volumeHandler(muted ? 0 : volume);
+			volumeHandler(muted ? 0 : volume, WhichVolume);
 		}
 
-		showSoundTray();
+		showSoundTray(WhichVolume == VOL_MUSIC);
 	}
 
 	/**
 	 * Changes the volume by a certain amount, also activating the sound tray.
 	 */
-	public function changeVolume(Amount:Float):Void
+	public function changeVolume(Amount:Float, WhichVolume:Int = VOL_MASTER):Void
 	{
-		muted = false;
-		volume += Amount;
-		showSoundTray();
+		switch (WhichVolume)
+		{
+			case VOL_MASTER:
+				muted = false;
+				volume += Amount;
+
+			case VOL_SOUND:
+				defaultSoundGroup.muted = false;
+				defaultSoundGroup.volume += Amount;
+
+			case VOL_MUSIC:
+				defaultMusicGroup.muted = false;
+				defaultMusicGroup.volume += Amount;
+		}
+
+		showSoundTray(WhichVolume == VOL_MUSIC);
 	}
 
 	/**
 	 * Shows the sound tray if it is enabled.
 	 */
-	public function showSoundTray():Void
+	public function showSoundTray(Silent:Bool = false):Void
 	{
 		#if FLX_SOUND_TRAY
 		if (FlxG.game.soundTray != null && soundTrayEnabled)
 		{
-			FlxG.game.soundTray.show();
+			FlxG.game.soundTray.show(Silent);
 		}
 		#end
 	}
@@ -371,12 +454,33 @@ class SoundFrontEnd
 			list.update(elapsed);
 
 		#if FLX_KEYBOARD
-		if (FlxG.keys.anyJustReleased(muteKeys))
+		#if FLX_SPLIT_SOUND_TRAY
+		if (FlxG.keys.anyJustReleased(masterMuteKeys) && (masterModifier == null || FlxG.keys.anyPressed(masterModifier)))
+			toggleMuted(VOL_MASTER);
+		else if (FlxG.keys.anyJustReleased(masterVolumeUpKeys) && (masterModifier == null || FlxG.keys.anyPressed(masterModifier)))
+			changeVolume(0.1, VOL_MASTER);
+		else if (FlxG.keys.anyJustReleased(masterVolumeDownKeys) && (masterModifier == null || FlxG.keys.anyPressed(masterModifier)))
+			changeVolume(-0.1, VOL_MASTER);
+		else if (FlxG.keys.anyJustReleased(soundMuteKeys) && (soundModifier == null || FlxG.keys.anyPressed(soundModifier)))
+			toggleMuted(VOL_SOUND);
+		else if (FlxG.keys.anyJustReleased(soundVolumeUpKeys) && (soundModifier == null || FlxG.keys.anyPressed(soundModifier)))
+			changeVolume(0.1, VOL_SOUND);
+		else if (FlxG.keys.anyJustReleased(soundVolumeDownKeys) && (soundModifier == null || FlxG.keys.anyPressed(soundModifier)))
+			changeVolume(-0.1, VOL_SOUND);
+		else if (FlxG.keys.anyJustReleased(musicMuteKeys) && (soundModifier == null || FlxG.keys.anyPressed(soundModifier)))
+			toggleMuted(VOL_MUSIC);
+		else if (FlxG.keys.anyJustReleased(musicVolumeUpKeys) && (soundModifier == null || FlxG.keys.anyPressed(soundModifier)))
+			changeVolume(0.1, VOL_MUSIC);
+		else if (FlxG.keys.anyJustReleased(musicVolumeDownKeys) && (soundModifier == null || FlxG.keys.anyPressed(soundModifier)))
+			changeVolume(-0.1, VOL_MUSIC);
+		#else
+		if (FlxG.keys.anyJustReleased(masterMuteKeys))
 			toggleMuted();
-		else if (FlxG.keys.anyJustReleased(volumeUpKeys))
+		else if (FlxG.keys.anyJustReleased(masterVolumeUpKeys))
 			changeVolume(0.1);
-		else if (FlxG.keys.anyJustReleased(volumeDownKeys))
+		else if (FlxG.keys.anyJustReleased(masterVolumeDownKeys))
 			changeVolume(-0.1);
+		#end
 		#end
 	}
 
@@ -428,6 +532,28 @@ class SoundFrontEnd
 		{
 			muted = FlxG.save.data.mute;
 		}
+
+		#if FLX_SPLIT_SOUND_TRAY
+		if (FlxG.save.data.soundvolume != null)
+		{
+			defaultSoundGroup.volume = FlxG.save.data.soundvolume;
+		}
+
+		if (FlxG.save.data.soundmute != null)
+		{
+			defaultSoundGroup.muted = FlxG.save.data.soundmute;
+		}
+
+		if (FlxG.save.data.musicvolume != null)
+		{
+			defaultMusicGroup.volume = FlxG.save.data.musicvolume;
+		}
+
+		if (FlxG.save.data.musicmute != null)
+		{
+			defaultMusicGroup.muted = FlxG.save.data.musicmute;
+		}
+		#end
 	}
 
 	function set_volume(Volume:Float):Float
@@ -437,7 +563,7 @@ class SoundFrontEnd
 		if (volumeHandler != null)
 		{
 			var param:Float = muted ? 0 : Volume;
-			volumeHandler(param);
+			volumeHandler(param, VOL_MASTER);
 		}
 		return volume = Volume;
 	}

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -20,6 +20,7 @@ private enum UserDefines
 	FLX_NO_DEBUG;
 	FLX_RECORD;
 	FLX_UNIT_TEST;
+	FLX_SPLIT_SOUND_TRAY;
 	/* additional rendering define */
 	FLX_RENDER_TRIANGLE;
 }

--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -1,10 +1,10 @@
 package flixel.system.ui;
 
 #if FLX_SOUND_SYSTEM
+import flash.Lib;
 import flash.display.Bitmap;
 import flash.display.BitmapData;
 import flash.display.Sprite;
-import flash.Lib;
 import flash.text.TextField;
 import flash.text.TextFormat;
 import flash.text.TextFormatAlign;
@@ -36,10 +36,18 @@ class FlxSoundTray extends Sprite
 	 */
 	var _bars:Array<Bitmap>;
 
+	#if FLX_SPLIT_SOUND_TRAY
+	var _soundBars:Array<Bitmap>;
+
+	var _musicBars:Array<Bitmap>;
+	#end
+
 	/**
 	 * How wide the sound tray background is.
 	 */
 	var _width:Int = 80;
+
+	var _height:Int = 30;
 
 	var _defaultScale:Float = 2.0;
 
@@ -54,13 +62,58 @@ class FlxSoundTray extends Sprite
 		visible = false;
 		scaleX = _defaultScale;
 		scaleY = _defaultScale;
-		var tmp:Bitmap = new Bitmap(new BitmapData(_width, 30, true, 0x7F000000));
+
+		#if FLX_SPLIT_SOUND_TRAY
+		var orientation:String = 'H';
+		if (Lib.current.stage.stageWidth > ((_width * 3) + 10) * _defaultScale)
+		{
+			// HORIZONTAL
+			_width = (_width * 3) + 10;
+		}
+		else
+		{
+			// VERTICAL
+			orientation = 'V';
+			_height = 90;
+		}
+		#end
+
+		var tmp:Bitmap = new Bitmap(new BitmapData(_width, _height, true, 0x7F000000));
 		screenCenter();
 		addChild(tmp);
 
+		addText("VOLUME", 0, 16);
+
+		_bars = addBars(10, 14);
+
+		#if FLX_SPLIT_SOUND_TRAY
+		if (orientation == 'H')
+		{
+			addText("SOUND", 80, 16);
+			_soundBars = addBars(90, 14);
+
+			addText("MUSIC", 160, 16);
+			_musicBars = addBars(170, 14);
+		}
+		else
+		{
+			addText("SOUND", 0, 46);
+			_soundBars = addBars(10, 44);
+
+			addText("MUSIC", 0, 76);
+			_musicBars = addBars(10, 74);
+		}
+		#end
+
+		y = -height;
+		visible = false;
+	}
+
+	private function addText(Text:String = "", X:Int = 0, Y:Int = 0):Void
+	{
 		var text:TextField = new TextField();
-		text.width = tmp.width;
-		text.height = tmp.height;
+		text.width = 80;
+		text.height = 30;
 		text.multiline = true;
 		text.wordWrap = true;
 		text.selectable = false;
@@ -75,12 +128,25 @@ class FlxSoundTray extends Sprite
 		dtf.align = TextFormatAlign.CENTER;
 		text.defaultTextFormat = dtf;
 		addChild(text);
-		text.text = "VOLUME";
-		text.y = 16;
+		text.text = Text;
+		text.x = X;
+		text.y = Y;
+	}
 
-		var bx:Int = 10;
-		var by:Int = 14;
-		_bars = new Array();
+	/**
+	 * This function creates a group of bars
+	 * @param Group 	Which array these bars belong to
+	 * @param X 		Start X position
+	 * @param Y 		Start Y position
+	 */
+	private function addBars(X:Int = 0, Y:Int = 0):Array<Bitmap>
+	{
+		var bx:Int = X;
+		var by:Int = Y;
+
+		var bars:Array<Bitmap> = [];
+
+		var tmp:Bitmap = null;
 
 		for (i in 0...10)
 		{
@@ -88,13 +154,12 @@ class FlxSoundTray extends Sprite
 			tmp.x = bx;
 			tmp.y = by;
 			addChild(tmp);
-			_bars.push(tmp);
+			bars.push(tmp);
 			bx += 6;
 			by--;
 		}
 
-		y = -height;
-		visible = false;
+		return bars;
 	}
 
 	/**
@@ -119,6 +184,12 @@ class FlxSoundTray extends Sprite
 				// Save sound preferences
 				FlxG.save.data.mute = FlxG.sound.muted;
 				FlxG.save.data.volume = FlxG.sound.volume;
+				#if FLX_SPLIT_SOUND_TRAY
+				FlxG.save.data.soundvolume = FlxG.sound.defaultSoundGroup.volume;
+				FlxG.save.data.soundmute = FlxG.sound.defaultSoundGroup.muted;
+				FlxG.save.data.musicvolume = FlxG.sound.defaultMusicGroup.volume;
+				FlxG.save.data.musicmute = FlxG.sound.defaultMusicGroup.muted;
+				#end
 				FlxG.save.flush();
 			}
 		}
@@ -142,6 +213,7 @@ class FlxSoundTray extends Sprite
 		y = 0;
 		visible = true;
 		active = true;
+
 		var globalVolume:Int = Math.round(FlxG.sound.volume * 10);
 
 		if (FlxG.sound.muted)
@@ -160,6 +232,42 @@ class FlxSoundTray extends Sprite
 				_bars[i].alpha = 0.5;
 			}
 		}
+
+		#if FLX_SPLIT_SOUND_TRAY
+		globalVolume = Math.round(FlxG.sound.defaultSoundGroup.volume * 10);
+
+		if (FlxG.sound.defaultSoundGroup.muted)
+			globalVolume = 0;
+
+		for (i in 0..._soundBars.length)
+		{
+			if (i < globalVolume)
+			{
+				_soundBars[i].alpha = 1;
+			}
+			else
+			{
+				_soundBars[i].alpha = 0.5;
+			}
+		}
+
+		globalVolume = Math.round(FlxG.sound.defaultMusicGroup.volume * 10);
+
+		if (FlxG.sound.defaultMusicGroup.muted)
+			globalVolume = 0;
+
+		for (i in 0..._musicBars.length)
+		{
+			if (i < globalVolume)
+			{
+				_musicBars[i].alpha = 1;
+			}
+			else
+			{
+				_musicBars[i].alpha = 0.5;
+			}
+		}
+		#end
 	}
 
 	public function screenCenter():Void


### PR DESCRIPTION
Set `FLX_SPLIT_SOUND_TRAY` in Project.xml to use.
Seperates controls for Sound, Music & Master Volumes.

Defaults:
* `+` / `-` Sound Up/Down 
* `0` Sound Mute
*  `/` / `*` Music Up/Down 
* `.` Sound Mute
* `SHIFT`+`+` / `SHIFT`+`-` Master Up/Down
* `SHIFT`+`0` Master Mute