### PR TITLE
turn FlxG.sound.loadSavedPrefs() into a public function

### DIFF
--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -417,7 +417,7 @@ class SoundFrontEnd
 	/**
 	 * Loads saved sound preferences if they exist.
 	 */
-	function loadSavedPrefs():Void
+	public function loadSavedPrefs():Void
 	{
 		if (FlxG.save.data.volume != null)
 		{


### PR DESCRIPTION
Just lets you easily call `FlxG.sound.loadSavedPrefs()` from anywhere in code when needed.

If you rebind FlxG.save's, and use the FlxG.save.data for your own purpose, adjusting the sound tray volume will save to your newly binded file. This means that when FlxGame and all the SoundFrontEnd stuff is normally initialized, your last "saved" volume settings will NOT be set properly, because loadSavedPrefs() will only be called once during initalization, and the saves will be binded to "flixel" instead of your new FlxSave binds that has the actual sound save data with it. Allowing loadSavedPrefs() would be very handy