### PR TITLE
Mention color in docs for FlxBitmapFont.fromMonospace

### DIFF
--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -469,6 +469,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	 * Loads a monospaced bitmap font.
 	 *
 	 * @param   source    Source image for this font.
+	 *                    Use white pixels if you intend to change the color.
 	 * @param   letters   The characters used in the font set, in display order.
 	 *                    You can use the `TEXT_SET` constants for common font set arrangements.
 	 * @param   charSiz   The size of each character in the font set.


### PR DESCRIPTION
This makes it a little more clear that if you're loading a FlxBitmapFont from a monospace font file that you wish to change the color of, ensure the pixels are white. This allows the textColor property to work as expected. If the pixels happen to be black, the textColor changes won't be visible.

## Some Context

This took me a bit of debugging to figure out, but I was loading this monospace font:
![mono](https://user-images.githubusercontent.com/928367/134521776-2a49868e-1992-4f2b-893c-ea591084fb93.png)
Setting `bitmapText.textColor = FlxColor.WHITE` with `bitmapText.useTextColor = true` wasn't working. When I looked [at the FlxBitmapText demo code](https://github.com/HaxeFlixel/flixel-demos/blob/master/UserInterface/FlxBitmapText/source/PlayState.hx), I realized the font pixels were white. 🤯 So I changed my font above to:
![mono](https://user-images.githubusercontent.com/928367/134522204-b8e10b8b-8f25-496e-b1f9-361a58adec00.png)
and every works now! (There's an image there on light bgs, I swear! 😂 )

I figured specifying this in the docs for the image param might help others trying to do the same.
