### PR TITLE
call members' kill/revive when called on sprite groups

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -694,32 +694,21 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	override function set_x(Value:Float):Float
 	{
 		if (exists && x != Value)
-		{
-			var offset:Float = Value - x;
-			transformChildren(xTransform, offset);
-		}
-
+			transformChildren(xTransform, Value - x);// offset
 		return x = Value;
 	}
 
 	override function set_y(Value:Float):Float
 	{
 		if (exists && y != Value)
-		{
-			var offset:Float = Value - y;
-			transformChildren(yTransform, offset);
-		}
-
+			transformChildren(yTransform, Value - y);// offset
 		return y = Value;
 	}
 
 	override function set_angle(Value:Float):Float
 	{
 		if (exists && angle != Value)
-		{
-			var offset:Float = Value - angle;
-			transformChildren(angleTransform, offset);
-		}
+			transformChildren(angleTransform, Value - angle);// offset
 		return angle = Value;
 	}
 

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -555,23 +555,25 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	override public function revive():Void
 	{
 		_skipTransformChildren = true;
-		super.revive();
+		super.revive(); // calls set_exists and set_alive
 		_skipTransformChildren = false;
 		group.revive();
 	}
 
 	override public function reset(X:Float, Y:Float):Void
 	{
-		revive();
-		setPosition(X, Y);
-
 		for (sprite in _sprites)
 		{
 			if (sprite != null)
-			{
-				sprite.reset(X, Y);
-			}
+				sprite.reset(sprite.x + X - x, sprite.y + Y - y);
 		}
+		
+		// prevent any transformations on children, mainly from setter overrides
+		_skipTransformChildren = true;
+		super.revive();
+		x = X;
+		y = Y;
+		_skipTransformChildren = false;
 	}
 
 	/**

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -543,7 +543,9 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	override public function kill():Void
 	{
+		_skipTransformChildren = true;
 		super.kill();
+		_skipTransformChildren = false;
 		group.kill();
 	}
 
@@ -552,7 +554,9 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	override public function revive():Void
 	{
+		_skipTransformChildren = true;
 		super.revive();
+		_skipTransformChildren = false;
 		group.revive();
 	}
 
@@ -601,7 +605,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	@:generic
 	public function transformChildren<V>(Function:T->V->Void, Value:V):Void
 	{
-		if (group == null)
+		if (_skipTransformChildren || group == null)
 			return;
 
 		for (sprite in _sprites)
@@ -620,7 +624,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	@:generic
 	public function multiTransformChildren<V>(FunctionArray:Array<T->V->Void>, ValueArray:Array<V>):Void
 	{
-		if (group == null)
+		if (_skipTransformChildren || group == null)
 			return;
 
 		var numProps:Int = FunctionArray.length;
@@ -687,7 +691,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	override function set_x(Value:Float):Float
 	{
-		if (!_skipTransformChildren && exists && x != Value)
+		if (exists && x != Value)
 		{
 			var offset:Float = Value - x;
 			transformChildren(xTransform, offset);
@@ -698,7 +702,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	override function set_y(Value:Float):Float
 	{
-		if (!_skipTransformChildren && exists && y != Value)
+		if (exists && y != Value)
 		{
 			var offset:Float = Value - y;
 			transformChildren(yTransform, offset);

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -570,9 +570,16 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		
 		// prevent any transformations on children, mainly from setter overrides
 		_skipTransformChildren = true;
-		super.revive();
+		
+		// recreate super.reset() but call super.revive instead of revive
+		touching = NONE;
+		wasTouching = NONE;
 		x = X;
 		y = Y;
+		// last.set(x, y); // null on sprite groups
+		velocity.set();
+		super.revive();
+		
 		_skipTransformChildren = false;
 	}
 

--- a/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
@@ -94,16 +94,29 @@ class FlxSpriteGroupTest extends FlxTest
 	 */
 	function testKillRevive2306()
 	{
-		var member = new Member();
-		Assert.isFalse(member.killed);
-		Assert.isFalse(member.revived);
-		group.add(member);
+		var member1 = new Member();
+		group.add(member1);
+		Assert.isFalse(member1.killed);
+		Assert.isFalse(member1.revived);
+		
+		var member2 = new Member();
+		Assert.isFalse(member1.killed);
+		Assert.isFalse(member1.revived);
+		group.add(member2);
+		
+		member2.exists = false;
 		group.kill();
-		Assert.isTrue(member.killed);
-		Assert.isFalse(member.revived);
+		Assert.isTrue(member1.killed);
+		Assert.isFalse(member1.revived);
+		Assert.isFalse(member2.killed);
+		Assert.isFalse(member2.revived);
+		
+		member2.exists = true;
 		group.revive();
-		Assert.isTrue(member.killed);
-		Assert.isTrue(member.revived);
+		Assert.isTrue(member1.killed);
+		Assert.isTrue(member1.revived);
+		Assert.isFalse(member2.killed);
+		Assert.isFalse(member2.revived);
 		return group;
 	}
 }

--- a/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
@@ -86,4 +86,42 @@ class FlxSpriteGroupTest extends FlxTest
 		group.alpha = 1;
 		Assert.areEqual(1, group.members[0].alpha);
 	}
+	
+	@Test
+	/** #2306
+	 * Make sure members' kill() and revive() are actually called,
+	 * rather than just checking their exists/alive values.
+	 */
+	function testKillRevive2306()
+	{
+		var member = new Member();
+		Assert.isFalse(member.killed);
+		Assert.isFalse(member.revived);
+		group.add(member);
+		group.kill();
+		Assert.isTrue(member.killed);
+		Assert.isFalse(member.revived);
+		group.revive();
+		Assert.isTrue(member.killed);
+		Assert.isTrue(member.revived);
+		return group;
+	}
+}
+
+class Member extends FlxSprite
+{
+	public var killed = false;
+	public var revived = false;
+	
+	override function kill()
+	{
+		killed = true;
+		super.kill();
+	}
+	
+	override function revive()
+	{
+		revived = true;
+		super.revive();
+	}
 }

--- a/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
@@ -87,6 +87,24 @@ class FlxSpriteGroupTest extends FlxTest
 		Assert.areEqual(1, group.members[0].alpha);
 	}
 	
+	@Test // #2306
+	function testReset()
+	{
+		for (i in 0...group.length)
+		{
+			var member = group.members[i];
+			member.x = i * 5;
+		}
+		
+		group.reset(10, 0);
+		
+		for (i in 0...group.length)
+		{
+			var member = group.members[i];
+			FlxAssert.areNear(group.x + i * 5, member.x);
+		}
+	}
+	
 	@Test
 	/** #2306
 	 * Make sure members' kill() and revive() are actually called,


### PR DESCRIPTION
fixes #2306 
FlxGroups weren't calling kill() and revive on it's members, but it appeared as though it was, because it was setting alive and exists on each of them individually.

I also changed reset(). Before it would move everything over uniformly, and then reset every sprite to the same x,y. Now it resets everything to a new uniformly moved position.