### PR TITLE
Remove references to FlxObject direction flag constants

### DIFF
--- a/flixel/math/FlxAngle.hx
+++ b/flixel/math/FlxAngle.hx
@@ -5,6 +5,7 @@ import haxe.macro.Expr;
 #if !macro
 import flixel.FlxObject;
 import flixel.FlxSprite;
+import flixel.util.FlxDirectionFlags;
 #if FLX_TOUCH
 import flixel.input.touch.FlxTouch;
 #end
@@ -204,18 +205,18 @@ class FlxAngle
 	 * @param	AsDegrees		If you need the value in degrees instead of radians, set to true
 	 * @return	The angle (in radians unless AsDegrees is true)
 	 */
-	public static function angleFromFacing(FacingBitmask:Int, AsDegrees:Bool = false):Float
+	public static function angleFromFacing(Facing:FlxDirectionFlags, AsDegrees:Bool = false):Float
 	{
-		var degrees = switch (FacingBitmask)
+		var degrees = switch (Facing)
 		{
-			case FlxObject.LEFT: 180;
-			case FlxObject.RIGHT: 0;
-			case FlxObject.UP: -90;
-			case FlxObject.DOWN: 90;
-			case f if (f == FlxObject.UP | FlxObject.LEFT): -135;
-			case f if (f == FlxObject.UP | FlxObject.RIGHT): -45;
-			case f if (f == FlxObject.DOWN | FlxObject.LEFT): 135;
-			case f if (f == FlxObject.DOWN | FlxObject.RIGHT): 45;
+			case LEFT: 180;
+			case RIGHT: 0;
+			case UP: -90;
+			case DOWN: 90;
+			case f if (f == UP | LEFT): -135;
+			case f if (f == UP | RIGHT): -45;
+			case f if (f == DOWN | LEFT): 135;
+			case f if (f == DOWN | RIGHT): 45;
 			default: 0;
 		}
 		return AsDegrees ? degrees : asRadians(degrees);

--- a/flixel/system/FlxQuadTree.hx
+++ b/flixel/system/FlxQuadTree.hx
@@ -426,7 +426,7 @@ class FlxQuadTree extends FlxRect
 					else
 					{
 						_object = cast basic;
-						if (_object.exists && _object.allowCollisions != FlxObject.NONE)
+						if (_object.exists && _object.allowCollisions != NONE)
 						{
 							_objectLeftEdge = _object.x;
 							_objectTopEdge = _object.y;
@@ -441,7 +441,7 @@ class FlxQuadTree extends FlxRect
 		else
 		{
 			_object = cast ObjectOrGroup;
-			if (_object.exists && _object.allowCollisions != FlxObject.NONE)
+			if (_object.exists && _object.allowCollisions != NONE)
 			{
 				_objectLeftEdge = _object.x;
 				_objectTopEdge = _object.y;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -204,7 +204,7 @@ class FlxText extends FlxSprite
 		textField.sharpness = 100;
 		textField.height = (Text.length <= 0) ? 1 : 10;
 
-		allowCollisions = FlxObject.NONE;
+		allowCollisions = NONE;
 		moves = false;
 
 		drawFrame();

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -7,7 +7,6 @@ import flash.text.TextFieldAutoSize;
 import flash.text.TextFormat;
 import flash.text.TextFormatAlign;
 import flixel.FlxG;
-import flixel.FlxObject;
 import flixel.FlxSprite;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.atlas.FlxAtlas;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -883,7 +883,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 		while (i < mapSize)
 		{
-			if (_tileObjects[_data[i]].allowCollisions != FlxObject.NONE)
+			if (_tileObjects[_data[i]].allowCollisions != NONE)
 			{
 				distances[i] = -2;
 			}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -345,7 +345,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		length += _startingIndex;
 
 		for (i in 0...length)
-			_tileObjects[i] = new FlxTile(this, i, _tileWidth, _tileHeight, (i >= _drawIndex), (i >= _collideIndex) ? allowCollisions : FlxObject.NONE);
+			_tileObjects[i] = new FlxTile(this, i, _tileWidth, _tileHeight, (i >= _drawIndex), (i >= _collideIndex) ? allowCollisions : NONE);
 
 		// Create debug tiles for rendering bounding boxes on demand
 		#if FLX_DEBUG
@@ -475,7 +475,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 				{
 					rect.x = _helperPoint.x + (columnIndex % widthInTiles) * rectWidth;
 					rect.y = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * rectHeight;
-					drawDebugBoundingBox(Camera.debugLayer.graphics, rect, tile.allowCollisions, tile.allowCollisions != FlxObject.ANY);
+					drawDebugBoundingBox(Camera.debugLayer.graphics, rect, tile.allowCollisions, tile.allowCollisions != ANY);
 				}
 
 				columnIndex++;
@@ -671,7 +671,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 					&& ((Object.y + Object.height) > tile.y)
 					&& (Object.y < (tile.y + tile.height));
 
-				if (tile.allowCollisions != FlxObject.NONE)
+				if (tile.allowCollisions != NONE)
 				{
 					if (Callback != null)
 					{
@@ -694,7 +694,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 						tile.callbackFunction(tile, Object);
 					}
 
-					if (tile.allowCollisions != FlxObject.NONE)
+					if (tile.allowCollisions != NONE)
 						results = true;
 				}
 
@@ -834,7 +834,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			tileX = Math.floor(curX / _scaledTileWidth);
 			tileY = Math.floor(curY / _scaledTileHeight);
 
-			if (_tileObjects[_data[tileY * widthInTiles + tileX]].allowCollisions != FlxObject.NONE)
+			if (_tileObjects[_data[tileY * widthInTiles + tileX]].allowCollisions != NONE)
 			{
 				// Some basic helper stuff
 				tileX *= Std.int(_scaledTileWidth);

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -3,8 +3,9 @@ package flixel;
 import flash.display.BitmapData;
 import flixel.graphics.FlxGraphic;
 import flixel.math.FlxPoint;
-import flixel.tile.FlxTilemap;
 import flixel.math.FlxMath;
+import flixel.tile.FlxTilemap;
+import flixel.util.FlxDirectionFlags;
 import massive.munit.Assert;
 
 class FlxObjectTest extends FlxTest
@@ -92,33 +93,37 @@ class FlxObjectTest extends FlxTest
 	}
 
 	@Test
-	@Ignore("Failing on Travis right now for some reason")
+	// @Ignore("Failing on Travis right now for some reason")
 	function testUpdateTouchingFlagsHorizontal():Void
 	{
-		var object1 = new FlxObject(0, 0, 10, 10);
-		var object2 = new FlxObject(20, 2, 10, 6);
+		var object1 = new FlxObject(5, 0, 10, 10);
+		var object2 = new FlxObject(20, 0, 10, 10);
+		object1.velocity.set(10, 0);
 		FlxG.state.add(object1);
 		FlxG.state.add(object2);
-		object1.velocity.set(20, 0);
-		step(20);
+		step(60);
 		Assert.isTrue(FlxG.overlap(object1, object2, null, FlxObject.updateTouchingFlags));
-		Assert.areEqual(FlxObject.RIGHT, object1.touching);
-		Assert.areEqual(FlxObject.LEFT, object2.touching);
+		Assert.isTrue (object1.touching.has(RIGHT));
+		Assert.isTrue (object2.touching.has(LEFT));
+		Assert.isFalse(object1.touching.has(DOWN));
+		Assert.isFalse(object2.touching.has(UP));
 	}
 
 	@Test // #1556
-	@Ignore("Failing on Travis right now for some reason")
+	// @Ignore("Failing on Travis right now for some reason")
 	function testUpdateTouchingFlagsVertical():Void
 	{
-		var object1 = new FlxObject(0, 0, 10, 10);
-		var object2 = new FlxObject(2, 20, 10, 6);
+		var object1 = new FlxObject(0, 5, 10, 10);
+		var object2 = new FlxObject(0, 20, 10, 10);
+		object1.velocity.set(0, 10);
 		FlxG.state.add(object1);
 		FlxG.state.add(object2);
-		object1.velocity.set(0, 20);
-		step(20);
+		step(60);
 		Assert.isTrue(FlxG.overlap(object1, object2, null, FlxObject.updateTouchingFlags));
-		Assert.areEqual(FlxObject.DOWN, object1.touching);
-		Assert.areEqual(FlxObject.UP, object2.touching);
+		Assert.isTrue (object1.touching.has(DOWN));
+		Assert.isTrue (object2.touching.has(UP));
+		Assert.isFalse(object1.touching.has(RIGHT));
+		Assert.isFalse(object2.touching.has(LEFT));
 	}
 
 	@Test // #1556
@@ -132,8 +137,8 @@ class FlxObjectTest extends FlxTest
 		object1.velocity.set(0, 20);
 		step(20);
 		Assert.isFalse(FlxG.overlap(object1, object2, null, FlxObject.updateTouchingFlags));
-		Assert.areEqual(FlxObject.NONE, object1.touching);
-		Assert.areEqual(FlxObject.NONE, object2.touching);
+		Assert.areEqual(FlxDirectionFlags.NONE, object1.touching);
+		Assert.areEqual(FlxDirectionFlags.NONE, object2.touching);
 	}
 
 	@Test


### PR DESCRIPTION
I still think it's too early to deprecate them, but no need for them in other flixel classes