### PR TITLE
Make FlxG.log.redirectTraces true by default

### DIFF
--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -14,7 +14,7 @@ class LogFrontEnd
 	/**
 	 * Whether everything you trace() is being redirected into the log window.
 	 */
-	public var redirectTraces(default, set):Bool = false;
+	public var redirectTraces(default, set):Bool = true;
 
 	var _standardTraceFunction:Dynamic->?PosInfos->Void;
 
@@ -95,8 +95,6 @@ class LogFrontEnd
 				Style.callbackFunction();
 			}
 		}
-
-		redirectTraces = true;
 		#end
 	}
 
@@ -114,6 +112,7 @@ class LogFrontEnd
 	function new()
 	{
 		_standardTraceFunction = haxe.Log.trace;
+		Log.trace = processTraceData;
 	}
 
 	inline function set_redirectTraces(Redirect:Bool):Bool


### PR DESCRIPTION
When a new user tries out their first hello world, they use `trace` to print the desired message to the console. HaxeFlixel has its own debugger with its own console that can accept `trace` calls, but it isn't enabled by default. The average user would expect to print to the console with the command that actually prints, but first they have to set `FlxG.log.redirectTraces = true` every time. It'd make more sense to just have the ability to use `trace` with the debugger by default, because it saves their traces across whatever platform their testing, and keeps the community from having to answer the same question of how to print to the debugger's console.