### PR TITLE
Overload operators of FlxVector abstract.

### DIFF
--- a/flixel/math/FlxVector.hx
+++ b/flixel/math/FlxVector.hx
@@ -45,7 +45,7 @@ import openfl.geom.Point;
 
 	@:noCompletion
 	@:op(A + B)
-	static inline function addPointNew(lhs:FlxVector, rhs:FlxVector):FlxVector
+	static inline function sumVectorsOp(lhs:FlxVector, rhs:FlxVector):FlxVector
 	{
 		var result = weak(lhs.x, lhs.y).addPoint(rhs);
 		lhs.putWeak();
@@ -54,7 +54,7 @@ import openfl.geom.Point;
 
 	@:noCompletion
 	@:op(A - B)
-	static inline function subtractPointNew(lhs:FlxVector, rhs:FlxVector):FlxVector
+	static inline function subtractVectorsOp(lhs:FlxVector, rhs:FlxVector):FlxVector
 	{
 		var result = weak(lhs.x, lhs.y).subtractPoint(rhs);
 		lhs.putWeak();
@@ -63,7 +63,7 @@ import openfl.geom.Point;
 
 	@:noCompletion
 	@:op(A * B) @:commutative
-	static inline function scalePointNew(lhs:FlxVector, rhs:Float):FlxVector
+	static inline function scaleVectorOp(lhs:FlxVector, rhs:Float):FlxVector
 	{
 		var result = weak(lhs.x, lhs.y).scale(rhs);
 		lhs.putWeak();
@@ -71,7 +71,7 @@ import openfl.geom.Point;
 	}
 
 	@:noCompletion
-	@:op(-A) static inline function negatePointNew(lhs:FlxVector):FlxVector
+	@:op(-A) static inline function negateVectorOp(lhs:FlxVector):FlxVector
 	{
 		var result = weak(lhs.x, lhs.y).negate();
 		lhs.putWeak();

--- a/flixel/math/FlxVector.hx
+++ b/flixel/math/FlxVector.hx
@@ -43,6 +43,17 @@ import openfl.geom.Point;
 		return FlxPoint.weak(x, y);
 	}
 
+	/**
+	 * Internal function that implements binary `+` operator on `FlxVector` instances.
+	 * 
+	 * Use it like this: `var vC = vA + vB`.
+	 * 
+	 * NOTE: any `weak` vector operand will be released to the pool.
+	 * 
+	 * @param	lhs		first vector
+	 * @param	rhs		second vector
+	 * @return	new *weak* `FlxVector` that is sum of `lhs` and `rhs` vectors
+	 */
 	@:noCompletion
 	@:op(A + B)
 	static inline function sumVectorsOp(lhs:FlxVector, rhs:FlxVector):FlxVector
@@ -52,6 +63,18 @@ import openfl.geom.Point;
 		return result;
 	}
 
+	/**
+	 * Internal function that implements binary `-` operator on `FlxVector` instances.
+	 * 
+	 * Use it like this: `var vC = vA - vB`.
+	 * 
+	 * NOTE: any `weak` vector operand will be released to the pool.
+	 * 
+	 * @param	lhs		first vector
+	 * @param	rhs		second vector
+	 * @return	new *weak* `FlxVector` that is result of subtraction `rhs` vector
+	 * from `lhs` vector
+	 */
 	@:noCompletion
 	@:op(A - B)
 	static inline function subtractVectorsOp(lhs:FlxVector, rhs:FlxVector):FlxVector
@@ -61,6 +84,18 @@ import openfl.geom.Point;
 		return result;
 	}
 
+	/**
+	 * Internal function that implements binary `*` operator on `FlxVector` instances.
+	 * 
+	 * Use it like this: `var vC = vA * k`.
+	 * 
+	 * NOTE: any `weak` vector operand will be released to the pool.
+	 * 
+	 * @param	lhs		vector
+	 * @param	rhs		scale coefficient
+	 * @return	new *weak* `FlxVector` that is result of scaling `lhs` vector
+	 * with `rhs` coefficient
+	 */
 	@:noCompletion
 	@:op(A * B) @:commutative
 	static inline function scaleVectorOp(lhs:FlxVector, rhs:Float):FlxVector
@@ -70,6 +105,16 @@ import openfl.geom.Point;
 		return result;
 	}
 
+	/**
+	 * Internal function that implements unary `-` operator on `FlxVector` instances.
+	 * 
+	 * Use it like this: `var vC = -vA`.
+	 * 
+	 * NOTE: any `weak` vector operand will be released to the pool.
+	 * 
+	 * @param	lhs		vector
+	 * @return	new *weak* `FlxVector` that is result of negation `lhs` vector
+	 */
 	@:noCompletion
 	@:op(-A) static inline function negateVectorOp(lhs:FlxVector):FlxVector
 	{
@@ -78,6 +123,18 @@ import openfl.geom.Point;
 		return result;
 	}
 
+	/**
+	 * Internal function that implements binary `*` operator on `FlxVector` instances
+	 * as dot product operation (do not confuse it with scaling operation).
+	 * 
+	 * Use it like this: `var dot = vA * vB`.
+	 * 
+	 * NOTE: any `weak` vector operand will be released to the pool.
+	 * 
+	 * @param	lhs		first vector
+	 * @param	rhs		second vector
+	 * @return	dot product of `lhs` and `rhs` vectors 
+	 */
 	@:noCompletion
 	@:op(A * B)
 	static inline function dotProductOp(lhs:FlxVector, rhs:FlxVector):Float
@@ -171,7 +228,10 @@ import openfl.geom.Point;
 
 	/**
 	 * Adds the coordinates of another point to the coordinates of this point.
-	 *
+	 * 
+	 * NOTE: You can do this operation with `+=` operator, i.e.
+	 * `vA += vB` is the same as `vA.addPoint(vB)`.
+	 * 
 	 * @param	point	The point to add to this point
 	 * @return	This point.
 	 */
@@ -195,7 +255,10 @@ import openfl.geom.Point;
 
 	/**
 	 * Subtracts the coordinates of another point from the coordinates of this point.
-	 *
+	 * 
+	 * NOTE: You can do this operation with `-=` operator, i.e.
+	 * `vA -= vB` is the same as `vA.subtractPoint(vB)`.
+	 * 
 	 * @param	point	The point to subtract from this point
 	 * @return	This point.
 	 */
@@ -207,7 +270,10 @@ import openfl.geom.Point;
 
 	/**
 	 * Scale this vector.
-	 *
+	 * 
+	 * NOTE: You can do this operation with `*=` operator, i.e.
+	 * `V *= k` is the same as `V.scale(k)`.
+	 * 
 	 * @param	k - scale coefficient
 	 * @return	scaled vector
 	 */

--- a/flixel/math/FlxVector.hx
+++ b/flixel/math/FlxVector.hx
@@ -44,17 +44,38 @@ import openfl.geom.Point;
 	}
 
 	@:noCompletion
-	@:op(A == B)
-	public static inline function checkEquality(lhs:FlxVector, rhs:FlxVector):Bool
+	@:op(A + B)
+	static inline function addPointNew(lhs:FlxVector, rhs:FlxVector):FlxVector
 	{
-		return lhs.equals(rhs);
+		var result = weak(lhs.x, lhs.y).addPoint(rhs);
+		lhs.putWeak();
+		return result;
 	}
 
 	@:noCompletion
-	@:op(A != B)
-	public static inline function notEqual(lhs:FlxVector, rhs:FlxVector):Bool
+	@:op(A - B)
+	static inline function subtractPointNew(lhs:FlxVector, rhs:FlxVector):FlxVector
 	{
-		return !(lhs == rhs);
+		var result = weak(lhs.x, lhs.y).subtractPoint(rhs);
+		lhs.putWeak();
+		return result;
+	}
+
+	@:noCompletion
+	@:op(A * B) @:commutative
+	static inline function scalePointNew(lhs:FlxVector, rhs:Float):FlxVector
+	{
+		var result = weak(lhs.x, lhs.y).scale(rhs);
+		lhs.putWeak();
+		return result;
+	}
+
+	@:noCompletion
+	@:op(-A) static inline function negatePointNew(lhs:FlxVector):FlxVector
+	{
+		var result = weak(lhs.x, lhs.y).negate();
+		lhs.putWeak();
+		return result;
 	}
 
 	// Without these delegates we have to say `this.x` everywhere.
@@ -193,7 +214,6 @@ import openfl.geom.Point;
 	 * @param	k - scale coefficient
 	 * @return	scaled vector
 	 */
-	@:op(A * B) @:commutative
 	public inline function scaleNew(k:Float):FlxVector
 	{
 		return clone().scale(k);
@@ -205,7 +225,6 @@ import openfl.geom.Point;
 	 * @param	v	vector to add
 	 * @return	addition result
 	 */
-	@:op(A + B)
 	public inline function addNew(v:FlxVector):FlxVector
 	{
 		return clone().addPoint(v);
@@ -217,7 +236,6 @@ import openfl.geom.Point;
 	 * @param	v	vector to subtract
 	 * @return	subtraction result
 	 */
-	@:op(A - B)
 	public inline function subtractNew(v:FlxVector):FlxVector
 	{
 		return clone().subtractPoint(v);
@@ -540,7 +558,6 @@ import openfl.geom.Point;
 		return this;
 	}
 
-	@:op(-A)
 	public inline function negateNew():FlxVector
 	{
 		return clone().negate();

--- a/flixel/math/FlxVector.hx
+++ b/flixel/math/FlxVector.hx
@@ -43,6 +43,20 @@ import openfl.geom.Point;
 		return FlxPoint.weak(x, y);
 	}
 
+	@:noCompletion
+	@:op(A == B)
+	public static inline function checkEquality(lhs:FlxVector, rhs:FlxVector):Bool
+	{
+		return lhs.equals(rhs);
+	}
+
+	@:noCompletion
+	@:op(A != B)
+	public static inline function notEqual(lhs:FlxVector, rhs:FlxVector):Bool
+	{
+		return !(lhs == rhs);
+	}
+
 	// Without these delegates we have to say `this.x` everywhere.
 	public var x(get, set):Float;
 	public var y(get, set):Float;
@@ -131,6 +145,7 @@ import openfl.geom.Point;
 	 * @param	point	The point to add to this point
 	 * @return	This point.
 	 */
+	@:op(A += B)
 	public inline function addPoint(point:FlxPoint):FlxVector
 	{
 		return this.addPoint(point);
@@ -154,6 +169,7 @@ import openfl.geom.Point;
 	 * @param	point	The point to subtract from this point
 	 * @return	This point.
 	 */
+	@:op(A -= B)
 	public inline function subtractPoint(point:FlxPoint):FlxVector
 	{
 		return this.subtractPoint(point);
@@ -165,6 +181,7 @@ import openfl.geom.Point;
 	 * @param	k - scale coefficient
 	 * @return	scaled vector
 	 */
+	@:op(A *= B)
 	public inline function scale(k:Float):FlxVector
 	{
 		return this.scale(k);
@@ -176,6 +193,7 @@ import openfl.geom.Point;
 	 * @param	k - scale coefficient
 	 * @return	scaled vector
 	 */
+	@:op(A * B) @:commutative
 	public inline function scaleNew(k:Float):FlxVector
 	{
 		return clone().scale(k);
@@ -187,6 +205,7 @@ import openfl.geom.Point;
 	 * @param	v	vector to add
 	 * @return	addition result
 	 */
+	@:op(A + B)
 	public inline function addNew(v:FlxVector):FlxVector
 	{
 		return clone().addPoint(v);
@@ -198,6 +217,7 @@ import openfl.geom.Point;
 	 * @param	v	vector to subtract
 	 * @return	subtraction result
 	 */
+	@:op(A - B)
 	public inline function subtractNew(v:FlxVector):FlxVector
 	{
 		return clone().subtractPoint(v);
@@ -277,6 +297,7 @@ import openfl.geom.Point;
 	 * @param	v	vector to multiply
 	 * @return	dot product of two vectors
 	 */
+	@:op(A * B)
 	public inline function dotProduct(v:FlxVector):Float
 	{
 		var dp = dotProductWeak(v);
@@ -519,6 +540,7 @@ import openfl.geom.Point;
 		return this;
 	}
 
+	@:op(-A)
 	public inline function negateNew():FlxVector
 	{
 		return clone().negate();

--- a/flixel/math/FlxVector.hx
+++ b/flixel/math/FlxVector.hx
@@ -78,6 +78,15 @@ import openfl.geom.Point;
 		return result;
 	}
 
+	@:noCompletion
+	@:op(A * B)
+	static inline function dotProductOp(lhs:FlxVector, rhs:FlxVector):Float
+	{
+		var result = lhs.dotProduct(rhs);
+		lhs.putWeak();
+		return result;
+	}
+
 	// Without these delegates we have to say `this.x` everywhere.
 	public var x(get, set):Float;
 	public var y(get, set):Float;
@@ -315,7 +324,6 @@ import openfl.geom.Point;
 	 * @param	v	vector to multiply
 	 * @return	dot product of two vectors
 	 */
-	@:op(A * B)
 	public inline function dotProduct(v:FlxVector):Float
 	{
 		var dp = dotProductWeak(v);

--- a/tests/unit/src/flixel/math/FlxVectorTest.hx
+++ b/tests/unit/src/flixel/math/FlxVectorTest.hx
@@ -1,6 +1,7 @@
 package flixel.math;
 
 import massive.munit.Assert;
+import flixel.util.FlxPool;
 
 @:access(flixel.math.FlxPoint)
 class FlxVectorTest extends FlxTest
@@ -98,7 +99,6 @@ class FlxVectorTest extends FlxTest
 
 		Assert.isTrue(a._inPool);
 		Assert.isTrue(b._inPool);
-		Assert.isTrue(result._weak);
 	}
 
 	@Test
@@ -119,7 +119,6 @@ class FlxVectorTest extends FlxTest
 
 		Assert.isTrue(a._inPool);
 		Assert.isTrue(b._inPool);
-		Assert.isTrue(result._weak);
 	}
 
 	@Test
@@ -137,7 +136,6 @@ class FlxVectorTest extends FlxTest
 		result = 2 * a;
 
 		Assert.isTrue(a._inPool);
-		Assert.isTrue(result._weak);
 	}
 
 	@Test
@@ -196,6 +194,42 @@ class FlxVectorTest extends FlxTest
 		result = -a;
 
 		Assert.isTrue(a._inPool);
-		Assert.isTrue(result._weak);
+	}
+
+	@Test
+	function testExpressionsReturnWeak(params)
+	{
+		FlxVector.EXPRESSIONS_RETURN_WEAK = false; // this is the default value
+
+		Assert.isFalse((vector + vector)._weak);
+		Assert.isFalse((vector - vector)._weak);
+		Assert.isFalse((vector * 2)._weak);
+		Assert.isFalse((-vector)._weak);
+
+		FlxVector.EXPRESSIONS_RETURN_WEAK = true;
+
+		Assert.isTrue((vector + vector)._weak);
+		Assert.isTrue((vector - vector)._weak);
+		Assert.isTrue((vector * 2)._weak);
+		Assert.isTrue((-vector)._weak);
+
+		FlxVector.EXPRESSIONS_RETURN_WEAK = false;
+	}
+
+	@Test
+	function testIntermediateResultsArePooled()
+	{
+		FlxVector.EXPRESSIONS_RETURN_WEAK = true;
+
+		var pool:FlxPool<FlxPoint> = cast FlxVector.pool;
+		pool.clear();
+
+		// complex expression, which intermediate sum `A + B`
+		// must return to the pool in negate
+		- (vector + vector2);
+
+		Assert.areEqual(1, pool.length);
+
+		FlxVector.EXPRESSIONS_RETURN_WEAK = false;
 	}
 }

--- a/tests/unit/src/flixel/math/FlxVectorTest.hx
+++ b/tests/unit/src/flixel/math/FlxVectorTest.hx
@@ -79,4 +79,96 @@ class FlxVectorTest extends FlxTest
 		var normalized = vector.normalize();
 		Assert.isTrue(normalized.equals(new FlxVector(0, 0)));
 	}
+
+	@Test
+	function testEqualityOperatorOverloading():Void
+	{
+		vector.set(1, 2);
+		vector2.set(1, 2);
+
+		Assert.isTrue(vector == vector2);
+		Assert.isFalse(vector != vector2);
+
+		vector2.set(1.1, 2);
+
+		Assert.isTrue(vector != vector2);
+		Assert.isFalse(vector == vector2);
+	}
+
+	@Test
+	function testAddNewOperatorOverloading()
+	{
+		vector.set(1, 2);
+		vector2.set(3, 5);
+
+		Assert.isTrue((vector + vector2) == new FlxVector(4, 7));
+		Assert.isTrue(vector == new FlxVector(1, 2));
+	}
+
+	@Test
+	function testSubtractNewOperatorOverloading():Void
+	{
+		vector.set(1, 2);
+		vector2.set(3, 5);
+
+		Assert.isTrue((vector - vector2) == new FlxVector(-2, -3));
+		Assert.isTrue(vector == new FlxVector(1, 2));
+	}
+
+	@Test
+	function testScaleNewOperatorOverloading():Void
+	{
+		vector.set(2, 3);
+
+		Assert.isTrue((vector * 3) == new FlxVector(6, 9));
+		Assert.isTrue(vector == new FlxVector(2, 3));
+		Assert.isTrue((3 * vector) == new FlxVector(6, 9));
+	}
+
+	@Test
+	function testScaleOperatorOverloading():Void
+	{
+		vector.set(2, 3);
+
+		Assert.isTrue((vector *= 3) == new FlxVector(6, 9));
+		Assert.isTrue(vector == new FlxVector(6, 9));
+	}
+
+	@Test
+	function testDotProductOperatorOverloading():Void
+	{
+		vector.set(1, 2);
+		vector2.set(2, 3);
+
+		Assert.areEqual(8, vector * vector2);
+	}
+
+	@Test
+	function testAddPointOperatorOverloading():Void
+	{
+		vector.set(1, 2);
+		vector2.set(3, 4);
+
+		Assert.isTrue((vector += vector2) == new FlxVector(4, 6));
+		Assert.isTrue(vector == new FlxVector(4, 6));
+	}
+
+	@Test
+	function testSubtractPointOperatorOverloading():Void
+	{
+		vector.set(1, 2);
+		vector2.set(3, 4);
+
+		Assert.isTrue((vector -= vector2) == new FlxVector(-2, -2));
+		Assert.isTrue(vector == new FlxVector(-2, -2));
+	}
+
+	@Test
+	function testNegateNewOperatorOverloading()
+	{
+		vector.set(-1, -2);
+
+		Assert.isTrue(-vector == new FlxVector(1, 2));
+		Assert.isTrue(vector == new FlxVector(-1, -2));
+	}
 }

--- a/tests/unit/src/flixel/math/FlxVectorTest.hx
+++ b/tests/unit/src/flixel/math/FlxVectorTest.hx
@@ -152,10 +152,14 @@ class FlxVectorTest extends FlxTest
 	@Test
 	function testDotProductOperatorOverloading():Void
 	{
-		vector.set(1, 2);
-		vector2.set(2, 3);
+		var a = FlxVector.weak(1, 2);
+		var b = FlxVector.weak(2, 3);
 
-		Assert.areEqual(8, vector * vector2);
+		var result = a * b;
+
+		Assert.areEqual(8, result);
+		Assert.isTrue(a._inPool);
+		Assert.isTrue(b._inPool);
 	}
 
 	@Test

--- a/tests/unit/src/flixel/math/FlxVectorTest.hx
+++ b/tests/unit/src/flixel/math/FlxVectorTest.hx
@@ -82,7 +82,7 @@ class FlxVectorTest extends FlxTest
 	}
 
 	@Test
-	function testAddPointNew()
+	function testSumVectorsOp()
 	{
 		vector.set(1, 2);
 		vector2.set(3, 5);
@@ -102,7 +102,7 @@ class FlxVectorTest extends FlxTest
 	}
 
 	@Test
-	function testSubtractPointNew():Void
+	function testSubtractVectorsOp():Void
 	{
 		vector.set(1, 2);
 		vector2.set(3, 5);
@@ -123,7 +123,7 @@ class FlxVectorTest extends FlxTest
 	}
 
 	@Test
-	function testScalePointNew():Void
+	function testScaleVectorOp():Void
 	{
 		vector.set(2, 3);
 
@@ -150,7 +150,7 @@ class FlxVectorTest extends FlxTest
 	}
 
 	@Test
-	function testDotProductOperatorOverloading():Void
+	function testDotProductOp():Void
 	{
 		var a = FlxVector.weak(1, 2);
 		var b = FlxVector.weak(2, 3);
@@ -183,7 +183,7 @@ class FlxVectorTest extends FlxTest
 	}
 
 	@Test
-	function testNegatePointNew()
+	function testNegateVectorOp()
 	{
 		vector.set(-1, -2);
 

--- a/tests/unit/src/flixel/math/FlxVectorTest.hx
+++ b/tests/unit/src/flixel/math/FlxVectorTest.hx
@@ -2,6 +2,7 @@ package flixel.math;
 
 import massive.munit.Assert;
 
+@:access(flixel.math.FlxPoint)
 class FlxVectorTest extends FlxTest
 {
 	var vector:FlxVector;
@@ -81,48 +82,62 @@ class FlxVectorTest extends FlxTest
 	}
 
 	@Test
-	function testEqualityOperatorOverloading():Void
-	{
-		vector.set(1, 2);
-		vector2.set(1, 2);
-
-		Assert.isTrue(vector == vector2);
-		Assert.isFalse(vector != vector2);
-
-		vector2.set(1.1, 2);
-
-		Assert.isTrue(vector != vector2);
-		Assert.isFalse(vector == vector2);
-	}
-
-	@Test
-	function testAddNewOperatorOverloading()
+	function testAddPointNew()
 	{
 		vector.set(1, 2);
 		vector2.set(3, 5);
 
-		Assert.isTrue((vector + vector2) == new FlxVector(4, 7));
-		Assert.isTrue(vector == new FlxVector(1, 2));
+		var result = vector + vector2;
+
+		Assert.isTrue(result.equals(FlxVector.weak(4, 7)));
+		Assert.isTrue(vector.equals(FlxVector.weak(1, 2)));
+
+		var a = FlxVector.weak(1, 2);
+		var b = FlxVector.weak(3, 5);
+		result = a + b;
+
+		Assert.isTrue(a._inPool);
+		Assert.isTrue(b._inPool);
+		Assert.isTrue(result._weak);
 	}
 
 	@Test
-	function testSubtractNewOperatorOverloading():Void
+	function testSubtractPointNew():Void
 	{
 		vector.set(1, 2);
 		vector2.set(3, 5);
 
-		Assert.isTrue((vector - vector2) == new FlxVector(-2, -3));
-		Assert.isTrue(vector == new FlxVector(1, 2));
+		var result = vector - vector2;
+
+		Assert.isTrue(result.equals(FlxVector.weak(-2, -3)));
+		Assert.isTrue(vector.equals(FlxVector.weak(1, 2)));
+
+		var a = FlxVector.weak(1, 2);
+		var b = FlxVector.weak(3, 5);
+
+		result = a - b;
+
+		Assert.isTrue(a._inPool);
+		Assert.isTrue(b._inPool);
+		Assert.isTrue(result._weak);
 	}
 
 	@Test
-	function testScaleNewOperatorOverloading():Void
+	function testScalePointNew():Void
 	{
 		vector.set(2, 3);
 
-		Assert.isTrue((vector * 3) == new FlxVector(6, 9));
-		Assert.isTrue(vector == new FlxVector(2, 3));
-		Assert.isTrue((3 * vector) == new FlxVector(6, 9));
+		var result = vector * 3;
+
+		Assert.isTrue(result.equals(FlxVector.weak(6, 9)));
+		Assert.isTrue(vector.equals(FlxVector.weak(2, 3)));
+		Assert.isTrue((3 * vector).equals(FlxVector.weak(6, 9)));
+
+		var a = FlxVector.weak(1, 2);
+		result = 2 * a;
+
+		Assert.isTrue(a._inPool);
+		Assert.isTrue(result._weak);
 	}
 
 	@Test
@@ -130,8 +145,8 @@ class FlxVectorTest extends FlxTest
 	{
 		vector.set(2, 3);
 
-		Assert.isTrue((vector *= 3) == new FlxVector(6, 9));
-		Assert.isTrue(vector == new FlxVector(6, 9));
+		Assert.isTrue((vector *= 3).equals(FlxVector.weak(6, 9)));
+		Assert.isTrue(vector.equals(FlxVector.weak(6, 9)));
 	}
 
 	@Test
@@ -149,8 +164,8 @@ class FlxVectorTest extends FlxTest
 		vector.set(1, 2);
 		vector2.set(3, 4);
 
-		Assert.isTrue((vector += vector2) == new FlxVector(4, 6));
-		Assert.isTrue(vector == new FlxVector(4, 6));
+		Assert.isTrue((vector += vector2).equals(FlxVector.weak(4, 6)));
+		Assert.isTrue(vector.equals(FlxVector.weak(4, 6)));
 	}
 
 	@Test
@@ -159,16 +174,24 @@ class FlxVectorTest extends FlxTest
 		vector.set(1, 2);
 		vector2.set(3, 4);
 
-		Assert.isTrue((vector -= vector2) == new FlxVector(-2, -2));
-		Assert.isTrue(vector == new FlxVector(-2, -2));
+		Assert.isTrue((vector -= vector2).equals(FlxVector.weak(-2, -2)));
+		Assert.isTrue(vector.equals(FlxVector.weak(-2, -2)));
 	}
 
 	@Test
-	function testNegateNewOperatorOverloading()
+	function testNegatePointNew()
 	{
 		vector.set(-1, -2);
 
-		Assert.isTrue(-vector == new FlxVector(1, 2));
-		Assert.isTrue(vector == new FlxVector(-1, -2));
+		var result = -vector;
+
+		Assert.isTrue(result.equals(FlxVector.weak(1, 2)));
+		Assert.isTrue(vector.equals(FlxVector.weak(-1, -2)));
+
+		var a = FlxVector.weak(1, 2);
+		result = -a;
+
+		Assert.isTrue(a._inPool);
+		Assert.isTrue(result._weak);
 	}
 }


### PR DESCRIPTION
As it was suggested in #2239.

- [x] A + B: addNew
- [x] A - B: subtractNew
- [x] V * N: scaleNew
- [x] A * B: dotProduct
- [x] A += B: addPoint
- [x] A -= B: subtractPoint
- [x] V *= N: scale
- [x] -A: negateNew
- [x] A == B: equals
- [x] A != B: !equals

Though this

```haxe
Assert.isTrue(vector + vector2 == new FlxVector(4, 7));
Assert.isTrue(vector == new FlxVector(1, 2));
```

looks more nice, than this

```haxe
Assert.isTrue(vector.addNew(vector2).equals(new FlxVector(4, 7)));
Assert.isTrue(vector.equals(new FlxVector(1, 2)));
```

I am not sure about comparison operator:

```haxe
var a = new FlxVector(1, 2);
var b = new FlxVector(1, 2);

trace(a == b);   // `false` now, will be `true` with overloaded comparison
```
