### PR TITLE
Fix showcase link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Haxelib License](https://badgen.net/haxelib/license/flixel)](LICENSE.md)
 [![Patreon](https://img.shields.io/badge/donate-patreon-blue.svg)](https://www.patreon.com/haxeflixel) 
 
-[![](images/showcase.png)](http://www.haxeflixel.com/showcase)
+[![](images/showcase.png)](https://haxeflixel.com/showcase)
 
 ## Links
 


### PR DESCRIPTION
## Description
I've noticed that a click on the showcase resulted in a `DNS_PROBE_FINISHED_NXDOMAIN`.
I have adjusted the link to match the other link formats and it should work now.