### PR TITLE
sceenCenter Readibility

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1067,7 +1067,7 @@ class FlxObject extends FlxBasic
 	 * @param   axes   On what axes to center the object (e.g. `X`, `Y`, `XY`) - default is both. 
 	 * @return  This FlxObject for chaining
 	 */
-	public function screenCenter(axes:FlxAxes = XY):FlxObject
+	public inline function screenCenter(axes:FlxAxes = XY):FlxObject
 	{
 		if (axes.match(X | XY))
 			x = (FlxG.width - width) / 2;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1069,10 +1069,10 @@ class FlxObject extends FlxBasic
 	 */
 	public function screenCenter(axes:FlxAxes = XY):FlxObject
 	{
-		if (axes.match(X | XY))
+		if (axes != FlxAxes.Y) // X or XY
 			x = (FlxG.width - width) / 2;
 
-		if (axes.match(Y | XY))
+		if (axes != FlxAxes.X) // Y or XY
 			y = (FlxG.height - height) / 2;
 
 		return this;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1064,18 +1064,16 @@ class FlxObject extends FlxBasic
 	/**
 	 * Centers this `FlxObject` on the screen, either by the x axis, y axis, or both.
 	 *
-	 * @param   axes   On what axes to center the object - default is `FlxAxes.XY` / both.
+	 * @param   axes   On what axes to center the object (e.g. `X`, `Y`, `XY`) - default is both. 
 	 * @return  This FlxObject for chaining
 	 */
-	public function screenCenter(?axes:FlxAxes):FlxObject
+	public function screenCenter(axes:FlxAxes = XY):FlxObject
 	{
-		if (axes == null)
-			axes = FlxAxes.XY;
+		if (axes.match(X | XY))
+			x = (FlxG.width - width) / 2;
 
-		if (axes != FlxAxes.Y)
-			x = (FlxG.width / 2) - (width / 2);
-		if (axes != FlxAxes.X)
-			y = (FlxG.height / 2) - (height / 2);
+		if (axes.match(Y | XY))
+			y = (FlxG.height - height) / 2;
 
 		return this;
 	}

--- a/flixel/util/FlxAxes.hx
+++ b/flixel/util/FlxAxes.hx
@@ -1,8 +1,18 @@
 package flixel.util;
 
+#if (haxe >= "4")
 enum FlxAxes
 {
 	X;
 	Y;
 	XY;
 }
+#else
+// Use abstract in 3.4.7 to allow default arguments
+@:enum abstract FlxAxes(Int)
+{
+	var X = 1;
+	var Y = 2;
+	var XY = 3;
+}
+#end

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -246,6 +246,31 @@ class FlxObjectTest extends FlxTest
 		assertOnScreen(0, FlxG.height - 1);
 		assertNotOnScreen(0, FlxG.height);
 	}
+	
+	@Test
+	function testScreenCenter()
+	{
+		var center = FlxPoint.get((FlxG.width - object1.width) / 2, (FlxG.height - object1.height) / 2);
+		var offCenter = center.copyTo().add(1000, 1000);
+		
+		object1.setPosition(offCenter.x, offCenter.y);
+		object1.screenCenter(X);
+		Assert.areEqual(object1.x, center.x);
+		Assert.areEqual(object1.y, offCenter.y);
+
+		object1.setPosition(offCenter.x, offCenter.y);
+		object1.screenCenter(Y);
+		Assert.areEqual(object1.x, offCenter.x);
+		Assert.areEqual(object1.y, center.y);
+
+		object1.setPosition(offCenter.x, offCenter.y);
+		object1.screenCenter(XY);
+		Assert.areEqual(object1.x, center.x);
+		Assert.areEqual(object1.y, center.y);
+		
+		offCenter.put();
+		center.put();
+	}
 }
 
 class CollisionState extends FlxState

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -267,6 +267,11 @@ class FlxObjectTest extends FlxTest
 		object1.screenCenter(XY);
 		Assert.areEqual(object1.x, center.x);
 		Assert.areEqual(object1.y, center.y);
+
+		object1.setPosition(offCenter.x, offCenter.y);
+		object1.screenCenter();
+		Assert.areEqual(object1.x, center.x);
+		Assert.areEqual(object1.y, center.y);
 		
 		offCenter.put();
 		center.put();


### PR DESCRIPTION
Someone in the discord was really confused by this. Not sure why it takes Null<FlxAxes> when it could default to XY and be more easily understood. The test was added because why not.

this will break existing code where a null literal or a Nullable FlxAxes were passed in, but I'm fine disallowing that.