### PR TITLE
Update documentation on scale modes.

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -172,7 +172,9 @@ class FlxG
 	public static var height(default, null):Int;
 
 	/**
-	 * The scale mode the game should use - available policies are found in `flixel.system.scaleModes`.
+	 * The scale mode the game should use.
+	 * HaxeFlixel includes several available scale modes, which are located in `flixel.system.scaleModes`.
+	 * However, you may also create a class which extends `BaseScaleMode`, and override its behavior according to your needs.
 	 */
 	public static var scaleMode(default, set):BaseScaleMode = new RatioScaleMode();
 

--- a/flixel/system/scaleModes/BaseScaleMode.hx
+++ b/flixel/system/scaleModes/BaseScaleMode.hx
@@ -5,6 +5,12 @@ import flixel.math.FlxPoint;
 import flixel.util.FlxHorizontalAlign;
 import flixel.util.FlxVerticalAlign;
 
+/**
+ * The base class from which all other scale modes extend from.
+ * You can implement your own scale mode by extending this class and overriding the appropriate methods.
+ * 
+ * The default behavior of `BaseScaleMode` matches that of `FillScaleMode`.
+ */
 class BaseScaleMode
 {
 	public var deviceSize(default, null):FlxPoint;

--- a/flixel/system/scaleModes/FillScaleMode.hx
+++ b/flixel/system/scaleModes/FillScaleMode.hx
@@ -2,6 +2,12 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
+/**
+ * `FillScaleMode` is a scaling mode which stretches and squashes the game to exactly fit the provided window.
+ * This may result in the graphics of your game being distorted if the user resizes their game window.
+ * 
+ * To enable it in your project, use `FlxG.scaleMode = new FillScaleMode();`.
+ */
 class FillScaleMode extends BaseScaleMode
 {
 	override function updateGamePosition():Void

--- a/flixel/system/scaleModes/FixedScaleAdjustSizeScaleMode.hx
+++ b/flixel/system/scaleModes/FixedScaleAdjustSizeScaleMode.hx
@@ -2,6 +2,17 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
+/**
+ * `FixedScaleAdjustSizeScaleMode` is a scaling mode which maintains the game's scene at a fixed size.
+ * This will clip off the edges of the scene for dimensions which are too small.
+ * However, unlike `FixedScaleMode`, this mode will extend the width of the current scene to match the window scale.
+ * The result is that objects that would be offscreen on smaller window sizes will be visible in larger ones.
+ * 
+ * Note that compared with `StageSizeScaleMode`, this scale mode aligns with the center of the game's screen,
+ * so the coordinates 0,0 may not be located at the top left of your game window.
+ * 
+ * To enable it in your project, use `FlxG.scaleMode = new FixedScaleAdjustSizeScaleMode();`.
+ */
 class FixedScaleAdjustSizeScaleMode extends BaseScaleMode
 {
 	var fixedWidth:Bool = false;

--- a/flixel/system/scaleModes/FixedScaleMode.hx
+++ b/flixel/system/scaleModes/FixedScaleMode.hx
@@ -2,6 +2,13 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
+/**
+ * `FixedScaleMode` is a scaling mode which maintains the game's scene at a fixed size.
+ * This will clip off the edges of the scene for dimensions which are too small,
+ * and leave black margins on the sides for dimensions which are too large.
+ * 
+ * To enable it in your project, use `FlxG.scaleMode = new FixedScaleMode();`.
+ */
 class FixedScaleMode extends BaseScaleMode
 {
 	override function updateGameSize(Width:Int, Height:Int):Void

--- a/flixel/system/scaleModes/PixelPerfectScaleMode.hx
+++ b/flixel/system/scaleModes/PixelPerfectScaleMode.hx
@@ -3,8 +3,15 @@ package flixel.system.scaleModes;
 import flixel.FlxG;
 
 /**
- * A scale mode which scales up the game to the highest integer factor it can,
- * maintains the aspect ratio, and windowboxes the game if necessary.
+ * `PixelPerfectScaleMode` is a scaling mode which maintains the game's aspect ratio.
+ * When you shrink or grow the window, the width and height of the game will adjust,
+ * either scaling the game or adding black bars as needed.
+ * 
+ * However, it will only scale the game by integer factors, to maintain pixel perfect rendering.
+ * This may cause the game window to be windowboxed on all sides, scaling the game up only when there is
+ * enough room to exactly double the render scale.
+ * 
+ * To enable it in your project, use `FlxG.scaleMode = new PixelPerfectScaleMode();`.
  */
 class PixelPerfectScaleMode extends BaseScaleMode
 {

--- a/flixel/system/scaleModes/RatioScaleMode.hx
+++ b/flixel/system/scaleModes/RatioScaleMode.hx
@@ -2,6 +2,13 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
+/**
+ * `RatioScaleMode` is a scaling mode which maintains the game's aspect ratio.
+ * When you shrink or grow the window, the width and height of the game will adjust,
+ * either scaling the game or adding black bars as needed.
+ *
+ * This is the default scaling mode used by HaxeFlixel.
+ */
 class RatioScaleMode extends BaseScaleMode
 {
 	var fillScreen:Bool;

--- a/flixel/system/scaleModes/RelativeScaleMode.hx
+++ b/flixel/system/scaleModes/RelativeScaleMode.hx
@@ -2,6 +2,16 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
+/**
+ * `RelativeScaleMode` is a scaling mode which stretches and squashes the game to exactly fit the provided window.
+ * It acts similar to the `FillScaleMode`, however there is one major difference.
+ * `RelativeScaleMode` takes two parameters, which represent the width scale and height scale.
+ * 
+ * For example, `RelativeScaleMode(1, 0.5)` will cause the game to take up 100% of the window width,
+ * but only 50% of the window height, filling in the remaining space with a black margin.
+ * 
+ * To enable it in your project, use `FlxG.scaleMode = new RelativeScaleMode();`.
+ */
 class RelativeScaleMode extends BaseScaleMode
 {
 	var _widthScale:Float;

--- a/flixel/system/scaleModes/StageSizeScaleMode.hx
+++ b/flixel/system/scaleModes/StageSizeScaleMode.hx
@@ -2,6 +2,17 @@ package flixel.system.scaleModes;
 
 import flixel.FlxG;
 
+/**
+ * `StageSizeScaleMode` is a scaling mode which maintains the game's scene at a fixed size.
+ * This will clip off the edges of the scene for dimensions which are too small.
+ * However, unlike `FixedScaleMode`, this mode will extend the width of the current scene to match the window scale.
+ * The result is that objects that would be offscreen on smaller window sizes will be visible in larger ones.
+ * 
+ * Note that compared with `FixedScaleAdjustSizeScaleMode`, this scale mode aligns with the top left of the game's screen.
+ * The coordinates 0,0 are always located at the top left of your game window.
+ * 
+ * To enable it in your project, use `FlxG.scaleMode = new StageSizeScaleMode();`.
+ */
 class StageSizeScaleMode extends BaseScaleMode
 {
 	override public function onMeasure(Width:Int, Height:Int):Void


### PR DESCRIPTION
I was looking into what the available options for scale modes were, and found that the [documentation was noticeably blank](https://api.haxeflixel.com/flixel/system/scaleModes/FillScaleMode.html). This left me guessing as to the intended behavior of each mode.

I eventually ended up creating a simple test bench project that would allow me to change the scale mode easily, created a succinct description of the behavior each policy displayed, and added them to the HaxeDocs for the relevant source files (which I presume is where the API reference page pulls from, please correct me if I am wrong on this).