### PR TITLE
Add the "FLX_SUPPRESS_ICON" define

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
 
-	<icon path="assets/images/logo/HaxeFlixel.svg" unless="SUPPRESS_FLIXEL_ICON" />
+	<icon path="assets/images/logo/HaxeFlixel.svg" unless="FLX_SUPPRESS_ICON" />
 	
 	<section unless="unit-test">
 		<assets path="assets/sounds" rename="flixel/sounds" include="*.mp3" if="web || air" embed="true" />

--- a/include.xml
+++ b/include.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
 
-	<icon path="assets/images/logo/HaxeFlixel.svg" />
+	<icon path="assets/images/logo/HaxeFlixel.svg" unless="SUPPRESS_FLIXEL_ICON" />
 	
 	<section unless="unit-test">
 		<assets path="assets/sounds" rename="flixel/sounds" include="*.mp3" if="web || air" embed="true" />


### PR DESCRIPTION
This resolves an issue I have been experiencing, in which my project (which utilizes HXP for project configuration rather than XML) is having its icons be overridden by the one provided by the HaxeFlixel library.

The solution may be instead to resolve the underlying issue, see haxelime/lime#1508