### PR TITLE
Prevent hashlink segfaults on linux

### DIFF
--- a/flixel/input/FlxBaseKeyList.hx
+++ b/flixel/input/FlxBaseKeyList.hx
@@ -22,7 +22,7 @@ class FlxBaseKeyList
 
 	inline function check(keyCode:Int):Bool
 	{
-		return keyManager.checkStatus(keyCode, status);
+		return keyManager.checkStatusUnsafe(keyCode, status);
 	}
 
 	function get_ANY():Bool

--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -150,35 +150,58 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	 */
 	public function checkStatus(KeyCode:Key, Status:FlxInputState):Bool
 	{
-		return switch (KeyCode)
+		/*
+		Note: switch(KeyCode) { case ANY: } causes seg faults with
+		hashlink on linux. This should use ifs, until it is fixed.
+		See: https://github.com/HaxeFlixel/flixel/issues/2318
+		*/
+		
+		if (KeyCode == FlxKey.ANY)
 		{
-			case FlxKey.ANY:
-				switch (Status)
-				{
-					case PRESSED: pressed.ANY;
-					case JUST_PRESSED: justPressed.ANY;
-					case RELEASED: released.ANY;
-					case JUST_RELEASED: justReleased.ANY;
-				}
-			case FlxKey.NONE:
-				switch (Status)
-				{
-					case PRESSED: pressed.NONE;
-					case JUST_PRESSED: justPressed.NONE;
-					case RELEASED: released.NONE;
-					case JUST_RELEASED: justReleased.NONE;
-				}
-			default:
-				var key = getKey(KeyCode);
-				if (key == null)
-				{
-					#if debug
-					throw 'Invalid key code: $KeyCode.';
-					#end
-					return false;
-				}
-				return key.hasState(Status);
+			return switch (Status)
+			{
+				case PRESSED: pressed.ANY;
+				case JUST_PRESSED: justPressed.ANY;
+				case RELEASED: released.ANY;
+				case JUST_RELEASED: justReleased.ANY;
+			}
 		}
+		
+		if (KeyCode == FlxKey.NONE)
+		{
+			return switch (Status)
+			{
+				case PRESSED: pressed.NONE;
+				case JUST_PRESSED: justPressed.NONE;
+				case RELEASED: released.NONE;
+				case JUST_RELEASED: justReleased.NONE;
+			}
+		}
+		
+		if (_keyListMap.exists(KeyCode))
+		{
+			return checkStatusUnsafe(KeyCode, Status);
+		}
+		
+		#if debug
+		throw 'Invalid key code: $KeyCode.';
+		#end
+		return false;
+	}
+
+	/**
+	 * Check the status of a single of key.
+	 * Throws errors on ANY, NONE or invalid keys.
+	 * Use `checkStatus`, for most cases.
+	 * 
+	 * @param KeyCode KeyCode to be checked.
+	 * @param Status  The key state to check for.
+	 * @return Whether the provided key has the specified status.
+	 */
+	@:allow(flixel.input.FlxBaseKeyList)
+	inline function checkStatusUnsafe(KeyCode:Key, Status:FlxInputState)
+	{
+		return getKey(KeyCode).hasState(Status);
 	}
 
 	/**

--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -199,7 +199,7 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	 * @return Whether the provided key has the specified status.
 	 */
 	@:allow(flixel.input.FlxBaseKeyList)
-	inline function checkStatusUnsafe(KeyCode:Key, Status:FlxInputState)
+	function checkStatusUnsafe(KeyCode:Key, Status:FlxInputState)
 	{
 		return getKey(KeyCode).hasState(Status);
 	}

--- a/flixel/input/keyboard/FlxKey.hx
+++ b/flixel/input/keyboard/FlxKey.hx
@@ -11,8 +11,8 @@ abstract FlxKey(Int) from Int to Int
 	public static var fromStringMap(default, null):Map<String, FlxKey> = FlxMacroUtil.buildMap("flixel.input.keyboard.FlxKey");
 	public static var toStringMap(default, null):Map<FlxKey, String> = FlxMacroUtil.buildMap("flixel.input.keyboard.FlxKey", true);
 	// Key Indicies
-	var ANY = 254;
-	var NONE = 255;
+	var ANY = -2;
+	var NONE = -1;
 	var A = 65;
 	var B = 66;
 	var C = 67;

--- a/flixel/input/keyboard/FlxKey.hx
+++ b/flixel/input/keyboard/FlxKey.hx
@@ -11,8 +11,8 @@ abstract FlxKey(Int) from Int to Int
 	public static var fromStringMap(default, null):Map<String, FlxKey> = FlxMacroUtil.buildMap("flixel.input.keyboard.FlxKey");
 	public static var toStringMap(default, null):Map<FlxKey, String> = FlxMacroUtil.buildMap("flixel.input.keyboard.FlxKey", true);
 	// Key Indicies
-	var ANY = -2;
-	var NONE = -1;
+	var ANY = 254;
+	var NONE = 255;
 	var A = 65;
 	var B = 66;
 	var C = 67;

--- a/tests/unit/src/flixel/input/keyboard/FlxKeyTest.hx
+++ b/tests/unit/src/flixel/input/keyboard/FlxKeyTest.hx
@@ -1,0 +1,21 @@
+package flixel.input.keyboard;
+
+import massive.munit.Assert;
+
+class FlxKeyTest extends FlxTest
+{
+	@Before
+	function before() {}
+	
+	@Test
+	function testNone():Void
+	{
+		Assert.isTrue(FlxG.keys.pressed.NONE);
+	}
+	
+	@Test
+	function testAny():Void
+	{
+		Assert.isFalse(FlxG.keys.pressed.ANY);
+	}
+}


### PR DESCRIPTION
This is to address the issue - https://github.com/HaxeFlixel/flixel/issues/2318

It doesn't fix the underlying issue (apparently something in hashlink) but the changes here would mean flixel can run on linux unchanged.

I've been running flixel with hashlink on linux for a long time with the changes in this PR and have not seen issues. I had a look through OpenFL and Lime key codes to be sure nothing else was using 254 or 255 already.

Aside from anecdotal personal use I have made a test flixel program here to ensure the FlxKey still works with the changes - https://github.com/jobf/flxkey-smoketest

I've tested with the following and it's working as expected.

- linux
- hashlink (on linux)
- html5 (on linux)
- html5 (on windows)

Ideally if someone can help test the following, that would be great. Currently compiling on windows is not working here but if I get it working I will update.

- windows
- mac
- hashlink (on mac)
- html5 (on mac)