### PR TITLE
Apply scaling to checkPixelPerfectOverlap()

### DIFF
--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -710,7 +710,7 @@ class FlxMouseEventManager extends FlxBasic
 	{
 		if (Sprite.angle != 0)
 		{
-			var pivot = FlxPoint.weak(Sprite.x + Sprite.origin.x - Sprite.offset.x, Sprite.y + Sprite.origin.y - Sprite.offset.y);
+			var pivot = FlxPoint.weak((Sprite.x + Sprite.origin.x - Sprite.offset.x) * Sprite.scale.x, (Sprite.y + Sprite.origin.y - Sprite.offset.y) * Sprite.scale.y);
 			Point.rotate(pivot, -Sprite.angle);
 		}
 		return Sprite.pixelsOverlapPoint(Point, 0x01, Camera);


### PR DESCRIPTION
Noticed an issue with scaling and this class, thought I might try to add a fix to it.