### PR TITLE
Align FlxText between all targets

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -871,6 +871,12 @@ class FlxText extends FlxSprite
 
 			return;
 		}
+		#elseif !web
+		// Fix to render desktop and mobile text in the same visual location as web
+		_matrix.translate(-1, -1); // left and up
+		graphic.draw(textField, _matrix);
+		_matrix.translate(1, 1); // return to center
+		return;
 		#end
 
 		graphic.draw(textField, _matrix);

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -57,7 +57,7 @@ class FlxButton extends FlxTypedButton<FlxText>
 		super(X, Y, OnClick);
 
 		for (point in labelOffsets)
-			point.set(point.x - 1, point.y + 3);
+			point.set(point.x, point.y + 3);
 
 		initLabel(Text);
 	}


### PR DESCRIPTION
The desktop and mobile versions of FlxText do not render in the same visual location as web, instead rendering +1 x/y from the origin. See here for discussion:  https://github.com/HaxeFlixel/flixel/discussions/2528

Separately, the code for centering text on a button has always used (x - 1, y +3), even as far back as 2013. Changes to text (possibly through OpenFL) have improved centering and no longer need the (x - 1), which currently causes it to render off-center.