### PR TITLE
Add `FlxTween.shake` for sprite shaking.

### DIFF
--- a/flixel/tweens/FlxTween.hx
+++ b/flixel/tweens/FlxTween.hx
@@ -1,5 +1,7 @@
 package flixel.tweens;
 
+import flixel.tweens.misc.ShakeTween;
+import flixel.util.FlxAxes;
 import flixel.FlxG;
 import flixel.FlxObject;
 import flixel.FlxSprite;
@@ -128,6 +130,26 @@ class FlxTween implements IFlxDestroyable
 	public static function num(FromValue:Float, ToValue:Float, Duration:Float = 1, ?Options:TweenOptions, ?TweenFunction:Float->Void):NumTween
 	{
 		return globalManager.num(FromValue, ToValue, Duration, Options, TweenFunction);
+	}
+
+	/**
+	 * A simple shake effect for FlxSprite. Shorthand for creating a ShakeTween, starting it and adding it to the TweenManager.
+	 *
+	 * ```haxe
+	 * FlxTween.shake(Sprite, 0.1, 2, FlxAxes.XY, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: ONESHOT });
+	 * ```
+	 * 
+	 * @param	Sprite       Sprite to shake.
+	 * @param   Intensity    Percentage representing the maximum distance
+	 *                       that the sprite can move while shaking.
+	 * @param   Duration     The length in seconds that the shaking effect should last.
+	 * @param   Axes         On what axes to shake. Default value is `FlxAxes.XY` / both.
+	 * @param	Options      A structure with tween options.
+	 * @return The added ShakeTween object.
+	 */
+	public static function shake(Sprite:FlxSprite, Intensity:Float = 0.05, Duration:Float = 1, ?Axes:FlxAxes, ?Options:TweenOptions):ShakeTween
+	{
+		return globalManager.shake(Sprite, Intensity, Duration, Axes, Options);
 	}
 
 	/**
@@ -854,6 +876,27 @@ class FlxTweenManager extends FlxBasic
 	{
 		var tween = new NumTween(Options, this);
 		tween.tween(FromValue, ToValue, Duration, TweenFunction);
+		return add(tween);
+	}
+
+	/**
+	 * A simple shake effect for FlxSprite. Shorthand for creating a ShakeTween, starting it and adding it to the TweenManager.
+	 *
+	 * ```haxe
+	 * FlxTween.shake(Sprite, 0.1, 2, FlxAxes.XY, { ease: easeFunction, onStart: onStart, onUpdate: onUpdate, onComplete: onComplete, type: ONESHOT });
+	 * ```
+	 * 
+	 * @param	Sprite       Sprite to shake.
+	 * @param   Intensity    Percentage representing the maximum distance
+	 *                       that the sprite can move while shaking.
+	 * @param   Duration     The length in seconds that the shaking effect should last.
+	 * @param   Axes         On what axes to shake. Default value is `FlxAxes.XY` / both.
+	 * @param	Options      A structure with tween options.
+	 */
+	public function shake(Sprite:FlxSprite, Intensity:Float = 0.05, Duration:Float = 1, ?Axes:FlxAxes = XY, ?Options:TweenOptions):ShakeTween
+	{
+		var tween = new ShakeTween(Options, this);
+		tween.tween(Sprite, Intensity, Duration, Axes);
 		return add(tween);
 	}
 

--- a/flixel/tweens/misc/ShakeTween.hx
+++ b/flixel/tweens/misc/ShakeTween.hx
@@ -24,9 +24,9 @@ class ShakeTween extends FlxTween
 	var sprite:FlxSprite;
 
 	/**
-	 * Defines the initial position of the sprite at the beginning of the shake effect.
+	 * Defines the initial offset of the sprite at the beginning of the shake effect.
 	 */
-	var initialXY:FlxPoint;
+	var initialOffset:FlxPoint;
 
 	/**
 	 * A simple shake effect for FlxSprite.
@@ -43,27 +43,29 @@ class ShakeTween extends FlxTween
 		sprite = Sprite;
 		duration = Duration;
 		axes = Axes;
-		initialXY = new FlxPoint(Sprite.x, Sprite.y);
+		initialOffset = new FlxPoint(Sprite.offset.x, Sprite.offset.y);
 		start();
 		return this;
 	}
 
-	override function destroy()
+	override function destroy():Void
 	{
 		super.destroy();
-		// Return the sprite to its initial position.
-		sprite.setPosition(initialXY.x, initialXY.y);
+		// Return the sprite to its initial offset.
+		if (sprite != null && !sprite.offset.equals(initialOffset))
+			sprite.offset.set(initialOffset.x, initialOffset.y);
 
 		sprite = null;
+		initialOffset = null;
 	}
 
 	override function update(elapsed:Float)
 	{
 		super.update(elapsed);
 		if (axes != Y)
-			sprite.x = initialXY.x + FlxG.random.float(-intensity * sprite.width, intensity * sprite.width);
+			sprite.offset.x = initialOffset.x + FlxG.random.float(-intensity * sprite.width, intensity * sprite.width);
 		if (axes != X)
-			sprite.y = initialXY.y + FlxG.random.float(-intensity * sprite.height, intensity * sprite.height);
+			sprite.offset.y = initialOffset.y + FlxG.random.float(-intensity * sprite.height, intensity * sprite.height);
 	}
 
 	override function isTweenOf(Object:Dynamic, ?Field:String):Bool

--- a/flixel/tweens/misc/ShakeTween.hx
+++ b/flixel/tweens/misc/ShakeTween.hx
@@ -1,0 +1,73 @@
+package flixel.tweens.misc;
+
+import flixel.math.FlxPoint;
+import flixel.util.FlxAxes;
+
+/**
+ * Shake effect for a FlxSprite
+ */
+class ShakeTween extends FlxTween
+{
+	/**
+	 * Percentage representing the maximum distance that the object can move while shaking.
+	 */
+	var intensity:Float;
+
+	/**
+	 * Defines on what axes to `shake()`. Default value is `XY` / both.
+	 */
+	var axes:FlxAxes;
+
+	/**
+	 * The sprite to shake.
+	 */
+	var sprite:FlxSprite;
+
+	/**
+	 * Defines the initial position of the sprite at the beginning of the shake effect.
+	 */
+	var initialXY:FlxPoint;
+
+	/**
+	 * A simple shake effect for FlxSprite.
+	 *
+	 * @param	Sprite       Sprite to shake.
+	 * @param   Intensity    Percentage representing the maximum distance
+	 *                       that the sprite can move while shaking.
+	 * @param   Duration     The length in seconds that the shaking effect should last.
+	 * @param   Axes         On what axes to shake. Default value is `FlxAxes.XY` / both.
+	 */
+	public function tween(Sprite:FlxSprite, Intensity:Float = 0.05, Duration:Float = 1, Axes:FlxAxes = XY):ShakeTween
+	{
+		intensity = Intensity;
+		sprite = Sprite;
+		duration = Duration;
+		axes = Axes;
+		initialXY = new FlxPoint(Sprite.x, Sprite.y);
+		start();
+		return this;
+	}
+
+	override function destroy()
+	{
+		super.destroy();
+		// Return the sprite to its initial position.
+		sprite.setPosition(initialXY.x, initialXY.y);
+
+		sprite = null;
+	}
+
+	override function update(elapsed:Float)
+	{
+		super.update(elapsed);
+		if (axes != Y)
+			sprite.x = initialXY.x + FlxG.random.float(-intensity * sprite.width, intensity * sprite.width);
+		if (axes != X)
+			sprite.y = initialXY.y + FlxG.random.float(-intensity * sprite.height, intensity * sprite.height);
+	}
+
+	override function isTweenOf(Object:Dynamic, ?Field:String):Bool
+	{
+		return sprite == Object && (Field == null || Field == "shake");
+	}
+}

--- a/tests/unit/src/flixel/tweens/FlxTweenTest.hx
+++ b/tests/unit/src/flixel/tweens/FlxTweenTest.hx
@@ -1,5 +1,6 @@
 package flixel.tweens;
 
+import flixel.math.FlxPoint;
 import flixel.tweens.FlxTween.TweenCallback;
 import flixel.util.FlxTimer;
 import massive.munit.Assert;
@@ -210,6 +211,29 @@ class FlxTweenTest extends FlxTest
 
 			complete[n] = true;
 		};
+	}
+
+	@Test
+	function testCancelShakeTween()
+	{
+		var spriteTest = new FlxSprite();
+		var initialOffset = new FlxPoint(0, 0);
+		var shakeTween = FlxTween.shake(spriteTest, 1, 0.1);
+		step();
+		shakeTween.cancel();
+		Assert.isTrue(shakeTween.finished);
+		Assert.isTrue(spriteTest.offset.equals(initialOffset));
+	}
+
+	@Test
+	function testCompleteShakeTween()
+	{
+		var spriteTest = new FlxSprite();
+		var initialOffset = new FlxPoint(0, 0);
+		var shakeTween = FlxTween.shake(spriteTest, 1, 0.01);
+		step(10);
+		Assert.isTrue(shakeTween.finished);
+		Assert.isTrue(spriteTest.offset.equals(initialOffset));
 	}
 
 	@Test


### PR DESCRIPTION
Implement the same function that exists in `FlxCamera` to be used on an individual `FlxSprite` (and not on the whole screen).
Same as #2548 but now from FlxTween:
```haxe
FlxTween.shake(Sprite, Intensity, Duration, Axes, Options);
```
(I did it based on the tweens that are already made to work the same way)

Here two examples:

https://user-images.githubusercontent.com/20217646/166291048-42ae6f51-4823-4699-adad-52a1f218363d.mp4

https://user-images.githubusercontent.com/20217646/166291051-d01fa635-d48d-4c48-a704-6effac181f83.mp4
