### PR TITLE
Save overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `WatchFrontEnd`: added `FlxG.watch.addFunction` ([#2500](https://github.com/HaxeFlixel/flixel/pull/2500))
 - `FlxPoint`: added binary operators `+`, `-`, `+=`, `-=`, `*`, and `*=` ([#2557](https://github.com/HaxeFlixel/flixel/pull/2557))
 - `FlxColor`: added `rgb` getter and setter ([#2555](https://github.com/HaxeFlixel/flixel/pull/2555))
-- `FlxSave`: added `migrateDataFrom` ([#2566](https://github.com/HaxeFlixel/flixel/pull/2566))
+- `FlxSave`: added `migrateDataFrom`, `status` and `isBound` ([#2566](https://github.com/HaxeFlixel/flixel/pull/2566))
 
 #### Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `WatchFrontEnd`: added `FlxG.watch.addFunction` ([#2500](https://github.com/HaxeFlixel/flixel/pull/2500))
 - `FlxPoint`: added binary operators `+`, `-`, `+=`, `-=`, `*`, and `*=` ([#2557](https://github.com/HaxeFlixel/flixel/pull/2557))
 - `FlxColor`: added `rgb` getter and setter ([#2555](https://github.com/HaxeFlixel/flixel/pull/2555))
+- `FlxSave`: added `migrateDataFrom` ([#2566](https://github.com/HaxeFlixel/flixel/pull/2566))
 
 #### Bugfixes:
 
@@ -35,6 +36,7 @@
 - `FlxTilemap`: Renamed `ray` to `rayStep` added new `ray` with no `resolution` arg ([#2480](https://github.com/HaxeFlixel/flixel/pull/2480))
 - `FlxPath`: move to `flixel.path.FlxPath` ([#2480](https://github.com/HaxeFlixel/flixel/pull/2480))
 - `FlxPoint/FlxVector`: moved all `FlxVector` fields and methods into `FlxPoint` ([#2557](https://github.com/HaxeFlixel/flixel/pull/2557))
+- `FlxSave`: changed the default save name and path to unique values based on Project.xml metadata ([#2566](https://github.com/HaxeFlixel/flixel/pull/2566))
 
 4.11.0 (January 26, 2022)
 ------------------------------

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -49,8 +49,8 @@ import flixel.input.FlxAccelerometer;
 import flixel.input.FlxSwipe;
 #end
 #if FLX_POST_PROCESS
-import openfl.display.OpenGLView;
 import flixel.util.FlxDestroyUtil;
+import openfl.display.OpenGLView;
 
 using flixel.util.FlxArrayUtil;
 #end
@@ -609,7 +609,7 @@ class FlxG
 		#if FLX_ACCELEROMETER
 		accelerometer = new FlxAccelerometer();
 		#end
-		save.bind("flixel");
+		initSave();
 
 		plugins = new PluginFrontEnd();
 		vcr = new VCRFrontEnd();
@@ -661,6 +661,25 @@ class FlxG
 		renderTile = renderMethod == DRAW_TILES;
 
 		FlxObject.defaultPixelPerfectPosition = renderBlit;
+	}
+
+	static function initSave()
+	{
+		var meta = stage.application.meta;
+		var company = meta["company"];
+		if (company == null || company == "")
+			company = "HaxeFlixel";
+
+		var project = meta["file"];
+
+		// replace invalid characters with hyphens
+		var invalidChars = ~/[ ~%&\\;:"',<>?#]/;
+		company = invalidChars.split(company).join("-");
+		project = invalidChars.split(project).join("-");
+
+		// Create a save based on project metadata (since 5.0.0).
+		// look for the pre 5.0 save and convert it if it exists
+		save.bindAndMigrate(company, project, "flixel");
 	}
 
 	/**

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -609,6 +609,7 @@ class FlxG
 		#if FLX_ACCELEROMETER
 		accelerometer = new FlxAccelerometer();
 		#end
+
 		initSave();
 
 		plugins = new PluginFrontEnd();
@@ -672,6 +673,8 @@ class FlxG
 
 		var project = meta["file"];
 
+		trace('bind($company, $project)');
+
 		// replace invalid characters with hyphens
 		var invalidChars = ~/[ ~%&\\;:"',<>?#]/;
 		company = invalidChars.split(company).join("-");
@@ -679,7 +682,12 @@ class FlxG
 
 		// Create a save based on project metadata (since 5.0.0).
 		// look for the pre 5.0 save and convert it if it exists
+		#if flash
+		save.bind('$company-$project');
+		// save.bindAndMigrate('$company-$project', null, "flixel");
+		#else
 		save.bindAndMigrate(company, project, "flixel");
+		#end
 	}
 
 	/**

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -666,28 +666,34 @@ class FlxG
 
 	static function initSave()
 	{
+		// Don't init if the FlxG.save.bind was manually called before the FlxGame was created
+		if (save.isBound)
+			return;
+
+		// Use Project.xml data to determine save id
 		var meta = stage.application.meta;
-		var company = meta["company"];
-		if (company == null || company == "")
-			company = "HaxeFlixel";
-
-		var project = meta["file"];
-
-		trace('bind($company, $project)');
+		var name = meta["file"];
+		var path:String = null;
 
 		// replace invalid characters with hyphens
 		var invalidChars = ~/[ ~%&\\;:"',<>?#]/;
-		company = invalidChars.split(company).join("-");
-		project = invalidChars.split(project).join("-");
+		name = invalidChars.split(name).join("-");
+
+		#if !flash
+		// On most browsers using the full URL path often causes a new save path to be created
+		// every time a new version of the game is updated. Especially on portals like Newgrounds.
+		// just set the path to your company name, to ensure a unique storage id.
+		path = meta["company"];
+		if (path == null || path == "")
+			path = "HaxeFlixel";
+		else
+			path = invalidChars.split(path).join("-");
+		#end
 
 		// Create a save based on project metadata (since 5.0.0).
-		// look for the pre 5.0 save and convert it if it exists
-		#if flash
-		save.bind('$company-$project');
-		// save.bindAndMigrate('$company-$project', null, "flixel");
-		#else
-		save.bindAndMigrate(company, project, "flixel");
-		#end
+		// look for the pre 5.0 save and convert it if it exists.
+		save.bind(name, path);
+		save.migrateDataFrom("flixel");
 	}
 
 	/**

--- a/flixel/system/debug/Window.hx
+++ b/flixel/system/debug/Window.hx
@@ -261,7 +261,7 @@ class Window extends Sprite
 	{
 		visible = Value;
 
-		if (!_closable)
+		if (!_closable && FlxG.save.isBound)
 		{
 			FlxG.save.data.windowSettings[_id] = visible;
 			FlxG.save.flush();
@@ -286,6 +286,9 @@ class Window extends Sprite
 
 	function loadSaveData():Void
 	{
+		if (!FlxG.save.isBound)
+			return;
+
 		if (FlxG.save.data.windowSettings == null)
 		{
 			var maxWindows = 10; // arbitrary

--- a/flixel/system/debug/console/ConsoleHistory.hx
+++ b/flixel/system/debug/console/ConsoleHistory.hx
@@ -12,15 +12,22 @@ class ConsoleHistory
 
 	public function new()
 	{
-		if (FlxG.save.data.history != null)
+		if (FlxG.save.isBound)
 		{
-			commands = FlxG.save.data.history;
-			index = commands.length;
+			if (FlxG.save.data.history != null)
+			{
+				commands = FlxG.save.data.history;
+				index = commands.length;
+			}
+			else
+			{
+				commands = [];
+				FlxG.save.data.history = commands;
+			}
 		}
 		else
 		{
 			commands = [];
-			FlxG.save.data.history = commands;
 		}
 	}
 
@@ -44,7 +51,8 @@ class ConsoleHistory
 		if (isEmpty || getPreviousCommand() != command)
 		{
 			commands.push(command);
-			FlxG.save.flush();
+			if (FlxG.save.isBound)
+				FlxG.save.flush();
 
 			if (commands.length > MAX_LENGTH)
 				commands.shift();

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -1,15 +1,15 @@
 package flixel.system.frontEnds;
 
 #if FLX_SOUND_SYSTEM
-import flash.media.Sound;
 import flixel.FlxG;
 import flixel.group.FlxGroup.FlxTypedGroup;
-import flixel.system.FlxAssets.FlxSoundAsset;
-import flixel.system.FlxSoundGroup;
-import flixel.system.FlxSound;
-import flixel.math.FlxMath;
 import flixel.input.keyboard.FlxKey;
+import flixel.math.FlxMath;
+import flixel.system.FlxAssets.FlxSoundAsset;
+import flixel.system.FlxSound;
+import flixel.system.FlxSoundGroup;
 import openfl.Assets;
+import openfl.media.Sound;
 #if (openfl >= "8.0.0")
 import openfl.utils.AssetType;
 #end
@@ -85,12 +85,12 @@ class SoundFrontEnd
 	/**
 	 * Set up and play a looping background soundtrack.
 	 *
-	 * @param	Music		The sound file you want to loop in the background.
-	 * @param	Volume		How loud the sound should be, from 0 to 1.
-	 * @param	Looped		Whether to loop this music.
-	 * @param	Group		The group to add this sound to.
+	 * @param   embeddedMusic  The sound file you want to loop in the background.
+	 * @param   volume         How loud the sound should be, from 0 to 1.
+	 * @param   looped         Whether to loop this music.
+	 * @param   group          The group to add this sound to.
 	 */
-	public function playMusic(Music:FlxSoundAsset, Volume:Float = 1, Looped:Bool = true, ?Group:FlxSoundGroup):Void
+	public function playMusic(embeddedMusic:FlxSoundAsset, volume = 1.0, looped = true, ?group:FlxSoundGroup):Void
 	{
 		if (music == null)
 		{
@@ -101,32 +101,32 @@ class SoundFrontEnd
 			music.stop();
 		}
 
-		music.loadEmbedded(Music, Looped);
-		music.volume = Volume;
+		music.loadEmbedded(embeddedMusic, looped);
+		music.volume = volume;
 		music.persist = true;
-		music.group = (Group == null) ? defaultMusicGroup : Group;
+		music.group = (group == null) ? defaultMusicGroup : group;
 		music.play();
 	}
 
 	/**
 	 * Creates a new FlxSound object.
 	 *
-	 * @param	EmbeddedSound	The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
-	 * @param	Volume			How loud to play it (0 to 1).
-	 * @param	Looped			Whether to loop this sound.
-	 * @param	Group			The group to add this sound to.
-	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.
-	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param	AutoPlay		Whether to play the sound.
-	 * @param	URL				Load a sound from an external web resource instead.  Only used if EmbeddedSound = null.
-	 * @param	OnComplete		Called when the sound finished playing.
-	 * @param	OnLoad			Called when the sound finished loading.  Called immediately for succesfully loaded embedded sounds.
-	 * @return	A FlxSound object.
+	 * @param   embeddedSound   The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
+	 * @param   volume          How loud to play it (0 to 1).
+	 * @param   looped          Whether to loop this sound.
+	 * @param   group           The group to add this sound to.
+	 * @param   autoDestroy     Whether to destroy this sound when it finishes playing.
+	 *                          Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param   autoPlay        Whether to play the sound.
+	 * @param   url             Load a sound from an external web resource instead.  Only used if EmbeddedSound = null.
+	 * @param   onComplete      Called when the sound finished playing.
+	 * @param   onLoad          Called when the sound finished loading.  Called immediately for succesfully loaded embedded sounds.
+	 * @return  A FlxSound object.
 	 */
-	public function load(?EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup, AutoDestroy:Bool = false,
-			AutoPlay:Bool = false, ?URL:String, ?OnComplete:Void->Void, ?OnLoad:Void->Void):FlxSound
+	public function load(?embeddedSound:FlxSoundAsset, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?url:String,
+			?onComplete:Void->Void, ?onLoad:Void->Void):FlxSound
 	{
-		if ((EmbeddedSound == null) && (URL == null))
+		if ((embeddedSound == null) && (url == null))
 		{
 			FlxG.log.warn("FlxG.sound.load() requires either\nan embedded sound or a URL to work.");
 			return null;
@@ -134,46 +134,46 @@ class SoundFrontEnd
 
 		var sound:FlxSound = list.recycle(FlxSound);
 
-		if (EmbeddedSound != null)
+		if (embeddedSound != null)
 		{
-			sound.loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
-			loadHelper(sound, Volume, Group, AutoPlay);
+			sound.loadEmbedded(embeddedSound, looped, autoDestroy, onComplete);
+			loadHelper(sound, volume, group, autoPlay);
 			// Call OnlLoad() because the sound already loaded
-			if (OnLoad != null && sound._sound != null)
-				OnLoad();
+			if (onLoad != null && sound._sound != null)
+				onLoad();
 		}
 		else
 		{
-			var loadCallback = OnLoad;
-			if (AutoPlay)
+			var loadCallback = onLoad;
+			if (autoPlay)
 			{
 				// Auto play the sound when it's done loading
 				loadCallback = function()
 				{
 					sound.play();
 
-					if (OnLoad != null)
-						OnLoad();
+					if (onLoad != null)
+						onLoad();
 				}
 			}
 
-			sound.loadStream(URL, Looped, AutoDestroy, OnComplete, loadCallback);
-			loadHelper(sound, Volume, Group);
+			sound.loadStream(url, looped, autoDestroy, onComplete, loadCallback);
+			loadHelper(sound, volume, group);
 		}
 
 		return sound;
 	}
 
-	function loadHelper(sound:FlxSound, Volume:Float, Group:FlxSoundGroup, AutoPlay:Bool = false):FlxSound
+	function loadHelper(sound:FlxSound, volume:Float, group:FlxSoundGroup, autoPlay = false):FlxSound
 	{
-		sound.volume = Volume;
+		sound.volume = volume;
 
-		if (AutoPlay)
+		if (autoPlay)
 		{
 			sound.play();
 		}
 
-		sound.group = (Group == null) ? defaultSoundGroup : Group;
+		sound.group = (group == null) ? defaultSoundGroup : group;
 		return sound;
 	}
 
@@ -181,15 +181,15 @@ class SoundFrontEnd
 	 * Method for sound caching (especially useful on mobile targets). The game may freeze
 	 * for some time the first time you try to play a sound if you don't use this method.
 	 *
-	 * @param	EmbeddedSound	Name of sound assets specified in your .xml project file
-	 * @return	Cached Sound object
+	 * @param   embeddedSound  Name of sound assets specified in your .xml project file
+	 * @return  Cached Sound object
 	 */
-	public inline function cache(EmbeddedSound:String):Sound
+	public inline function cache(embeddedSound:String):Sound
 	{
 		// load the sound into the OpenFL assets cache
-		if (Assets.exists(EmbeddedSound, AssetType.SOUND) || Assets.exists(EmbeddedSound, AssetType.MUSIC))
-			return Assets.getSound(EmbeddedSound, true);
-		FlxG.log.error('Could not find a Sound asset with an ID of \'$EmbeddedSound\'.');
+		if (Assets.exists(embeddedSound, AssetType.SOUND) || Assets.exists(embeddedSound, AssetType.MUSIC))
+			return Assets.getSound(embeddedSound, true);
+		FlxG.log.error('Could not find a Sound asset with an ID of \'$embeddedSound\'.');
 		return null;
 	}
 
@@ -208,44 +208,43 @@ class SoundFrontEnd
 	/**
 	 * Plays a sound from an embedded sound. Tries to recycle a cached sound first.
 	 *
-	 * @param	EmbeddedSound	The embedded sound resource you want to play.
-	 * @param	Volume			How loud to play it (0 to 1).
-	 * @param	Looped			Whether to loop this sound.
-	 * @param	Group			The group to add this sound to.
-	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.
-	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param	OnComplete		Called when the sound finished playing
-	 * @return	A FlxSound object.
+	 * @param   embeddedSound  The embedded sound resource you want to play.
+	 * @param   volume         How loud to play it (0 to 1).
+	 * @param   looped         Whether to loop this sound.
+	 * @param   group          The group to add this sound to.
+	 * @param   autoDestroy    Whether to destroy this sound when it finishes playing.
+	 *                         Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param   onComplete     Called when the sound finished playing
+	 * @return  A FlxSound object.
 	 */
-	public function play(EmbeddedSound:FlxSoundAsset, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup,
-			AutoDestroy:Bool = true, ?OnComplete:Void->Void):FlxSound
+	public function play(embeddedSound:FlxSoundAsset, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = true, ?onComplete:Void->Void):FlxSound
 	{
-		if ((EmbeddedSound is String))
+		if ((embeddedSound is String))
 		{
-			EmbeddedSound = cache(EmbeddedSound);
+			embeddedSound = cache(embeddedSound);
 		}
-		var sound = list.recycle(FlxSound).loadEmbedded(EmbeddedSound, Looped, AutoDestroy, OnComplete);
-		return loadHelper(sound, Volume, Group, true);
+		var sound = list.recycle(FlxSound).loadEmbedded(embeddedSound, looped, autoDestroy, onComplete);
+		return loadHelper(sound, volume, group, true);
 	}
 
 	/**
 	 * Plays a sound from a URL. Tries to recycle a cached sound first.
 	 * NOTE: Just calls FlxG.sound.load() with AutoPlay == true.
 	 *
-	 * @param	URL				Load a sound from an external web resource instead.
-	 * @param	Volume			How loud to play it (0 to 1).
-	 * @param	Looped			Whether to loop this sound.
-	 * @param	Group			The group to add this sound to.
-	 * @param	AutoDestroy		Whether to destroy this sound when it finishes playing.
-	 * 							Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param	OnComplete		Called when the sound finished playing
-	 * @param	OnLoad			Called when the sound finished loading.
-	 * @return	A FlxSound object.
+	 * @param   url          Load a sound from an external web resource instead.
+	 * @param   volume       How loud to play it (0 to 1).
+	 * @param   looped       Whether to loop this sound.
+	 * @param   group        The group to add this sound to.
+	 * @param   autoDestroy  Whether to destroy this sound when it finishes playing.
+	 *                       Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param   onComplete   Called when the sound finished playing
+	 * @param   onLoad       Called when the sound finished loading.
+	 * @return  A FlxSound object.
 	 */
-	public function stream(URL:String, Volume:Float = 1, Looped:Bool = false, ?Group:FlxSoundGroup,
-			AutoDestroy:Bool = true, ?OnComplete:Void->Void, ?OnLoad:Void->Void):FlxSound
+	public function stream(url:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = true, ?onComplete:Void->Void,
+			?onLoad:Void->Void):FlxSound
 	{
-		return load(null, Volume, Looped, Group, AutoDestroy, true, URL, OnComplete, OnLoad);
+		return load(null, volume, looped, group, autoDestroy, true, url, onComplete, onLoad);
 	}
 
 	/**
@@ -289,11 +288,11 @@ class SoundFrontEnd
 	/**
 	 * Called by FlxGame on state changes to stop and destroy sounds.
 	 *
-	 * @param	ForceDestroy	Kill sounds even if persist is true.
+	 * @param   forceDestroy  Kill sounds even if persist is true.
 	 */
-	public function destroy(ForceDestroy:Bool = false):Void
+	public function destroy(forceDestroy = false):Void
 	{
-		if (music != null && (ForceDestroy || !music.persist))
+		if (music != null && (forceDestroy || !music.persist))
 		{
 			destroySound(music);
 			music = null;
@@ -301,7 +300,7 @@ class SoundFrontEnd
 
 		for (sound in list.members)
 		{
-			if (sound != null && (ForceDestroy || !sound.persist))
+			if (sound != null && (forceDestroy || !sound.persist))
 			{
 				destroySound(sound);
 			}
@@ -419,6 +418,9 @@ class SoundFrontEnd
 	 */
 	function loadSavedPrefs():Void
 	{
+		if (!FlxG.save.isBound)
+			return;
+
 		if (FlxG.save.data.volume != null)
 		{
 			volume = FlxG.save.data.volume;

--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -1,16 +1,16 @@
 package flixel.system.ui;
 
 #if FLX_SOUND_SYSTEM
-import flash.display.Bitmap;
-import flash.display.BitmapData;
-import flash.display.Sprite;
-import flash.Lib;
-import flash.text.TextField;
-import flash.text.TextFormat;
-import flash.text.TextFormatAlign;
 import flixel.FlxG;
 import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
+import openfl.Lib;
+import openfl.display.Bitmap;
+import openfl.display.BitmapData;
+import openfl.display.Sprite;
+import openfl.text.TextField;
+import openfl.text.TextFormat;
+import openfl.text.TextFormatAlign;
 #if flash
 import flash.text.AntiAliasType;
 import flash.text.GridFitType;
@@ -117,9 +117,12 @@ class FlxSoundTray extends Sprite
 				active = false;
 
 				// Save sound preferences
-				FlxG.save.data.mute = FlxG.sound.muted;
-				FlxG.save.data.volume = FlxG.sound.volume;
-				FlxG.save.flush();
+				if (FlxG.save.isBound)
+				{
+					FlxG.save.data.mute = FlxG.sound.muted;
+					FlxG.save.data.volume = FlxG.sound.volume;
+					FlxG.save.flush();
+				}
 			}
 		}
 	}

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -224,6 +224,7 @@ class FlxSave implements IFlxDestroyable
 	{
 		return switch (status)
 		{
+			// can't use the pattern var `name` or it will break in 4.0.5
 			case BOUND(n, _): n;
 			default: null;
 		}
@@ -233,6 +234,7 @@ class FlxSave implements IFlxDestroyable
 	{
 		return switch (status)
 		{
+			// can't use the pattern var `path` or it will break in 4.0.5
 			case BOUND(_, p): p;
 			default: null;
 		}

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -224,7 +224,7 @@ class FlxSave implements IFlxDestroyable
 	{
 		return switch (status)
 		{
-			case BOUND(name, _): name;
+			case BOUND(n, _): n;
 			default: null;
 		}
 	}
@@ -233,7 +233,7 @@ class FlxSave implements IFlxDestroyable
 	{
 		return switch (status)
 		{
-			case BOUND(_, path): path;
+			case BOUND(_, p): p;
 			default: null;
 		}
 	}

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -12,6 +12,12 @@ import openfl.net.SharedObjectFlushStatus;
  * some debugging features.
  * 
  * ## Making your own
+ * You can use a specific save name and path by calling the following,
+ * ```haxe
+ * FlxG.save.bind("myGameName", "myGameStudioName");
+ * ```
+ * It is recommended thatg you do so before creating an instance of FlxGame.
+ * 
  * It is not recommended to make you own instance of `FlxSave`, one is made
  * for you when a FlxGame is created at `FlxG.save`. The default `name` and
  * `path` is specified by your Project.xml's "file" and "company",

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -134,7 +134,8 @@ class FlxSave implements IFlxDestroyable
 					Reflect.setField(data, field, Reflect.field(oldData, field));
 			}
 
-			oldSave.erase();
+			if (eraseSave)
+				oldSave.erase();
 			oldSave.destroy();
 
 			// save changes, if there are any

--- a/tests/unit/src/flixel/util/FlxSaveTest.hx
+++ b/tests/unit/src/flixel/util/FlxSaveTest.hx
@@ -48,30 +48,4 @@ class FlxSaveTest extends FlxTest
 		Assert.isNotNull(save.data);
 		Assert.isNull(save.data.int);
 	}
-
-	@Test
-	function testFlushCallback()
-	{
-		var success = false;
-		save.flush(0, function(s)
-		{
-			success = s;
-		});
-		step();
-
-		Assert.isTrue(success);
-	}
-
-	@Test
-	function testCloseCallback()
-	{
-		var success = false;
-		save.close(0, function(s)
-		{
-			success = s;
-		});
-		step();
-
-		Assert.isTrue(success);
-	}
 }


### PR DESCRIPTION
Fixes #2539

related to #2202 #2502  #2396

## The Main Problem
Flixel creates FlxG.save to store internal things, but people tend to bind their own save, usually with a specified path, for a number of reasons:
- To avoid losing saves when things are moved, or when updating their game on web portals like Newgrounds
- To have a unique save id
- To cross-reference saves across applications
- The tutorials and demos told them to bind and close their own save rather than using FlxG.save.

This causes people to call `FlxG.save.bind("MyGameName", "MyName")` after the initial setup from the default save. meaning changes to sound and window preferences are saved to a new save rather than the one loaded at the start of the game. This has led to many people requesting a way to set the initial save path rather than creating a new one.

## Additional Problems
- FlxSoundTray, ConsoleHistory and Window crash when there is no valid FlxG.save.data available
- FlxSave has a lot of global vars used for a callback system that doesn't even need to exist, as no part of FlxSave is asynchronous (any more).

## Proposed changes
Rather than binding to "flixel" automatically, bind to the game's file name and author data, via Project.xml metadata.  This will prevent url paths from changing with updates and devs will have a simple, known id to cross-reference saves in other games.

For backwards compatibility on games that used the old save id, it will automatically search for the old save id and migrate the data into the new default save location, using the new `FlxG.save.migrateDataFrom("flixel")`.

Alternatively, devs can bind FlxG.save to their own desired name and path, FlxGame will no longer attempt to bind to the default save id if the save is already set up. Existing games that already have custom save bindings can do this for backwards compatibility.

To fix save related crashes from internal utils, they will all first check whether the save is bound, using the new `FlxG.save.isBound` getter.  All callback related args and instance vars have been removed.

## Breaking Changes
- Games expecting the old save id will need to be updated
- Calls to flush with the onComplete specified will now
- Use of FlxSave's old private callback-related vars will cause an error

## What now
- More thorough testing on all targets, might want to check out flixel for Switch
- Consider better names for `isBound` and `FlxSaveStatus.BOUND`
- Find a way to unit test setting a save before instantiating FlxGame