### PR TITLE
FlxDrawQuadsItem Crash fix

### DIFF
--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -116,6 +116,8 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 			return;
 
 		var shader = shader != null ? shader : graphics.shader;
+		if (shader == null)
+			return;
 		shader.bitmap.input = graphics.bitmap;
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
 		shader.alpha.value = alphas;


### PR DESCRIPTION
Sometimes the shader is null so it can cause a crash but with this it fixes it!