### PR TITLE
Account for angle and scale in pixelsOverlapPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@
 
 - Collision: preserve momentum in `FlxG.collide` ([#2422](https://github.com/HaxeFlixel/flixel/pull/2422))
 - Angles: All angle utils treat right as 0 (affects `FlxSwipe` and `FlxPath`) ([#2482](https://github.com/HaxeFlixel/flixel/pull/2482))
-- `FlxAngle`: Deprecated: `getCartesianCoords`, `getPolarCoords`, `angleFromFacing` and `FlxPoint.angleBetween` ([#2482](https://github.com/HaxeFlixel/flixel/pull/2482))
-- `FlxTilemap`: Renamed `ray` to `rayStep` added new `ray` with no `resolution` arg ([#2480](https://github.com/HaxeFlixel/flixel/pull/2480))
+- `FlxAngle`: deprecated: `getCartesianCoords`, `getPolarCoords`, `angleFromFacing` and `FlxPoint.angleBetween` ([#2482](https://github.com/HaxeFlixel/flixel/pull/2482))
+- `FlxTilemap`: renamed `ray` to `rayStep` added new `ray` with no `resolution` arg ([#2480](https://github.com/HaxeFlixel/flixel/pull/2480))
 - `FlxPath`: move to `flixel.path.FlxPath` ([#2480](https://github.com/HaxeFlixel/flixel/pull/2480))
 - `FlxPoint/FlxVector`: moved all `FlxVector` fields and methods into `FlxPoint` ([#2557](https://github.com/HaxeFlixel/flixel/pull/2557))
 - `FlxSave`: changed the default save name and path to unique values based on Project.xml metadata ([#2566](https://github.com/HaxeFlixel/flixel/pull/2566))
+- `FlxSprite`: improved `pixelsOverlapPoint` with scaled or angled sprites ([#2576](https://github.com/HaxeFlixel/flixel/pull/2576))
+	- this also improves `FlxMouseEvents` with the `pixelPerfect` arg enabled
 
 4.11.0 (January 26, 2022)
 ------------------------------

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -689,21 +689,11 @@ class FlxMouseEventManager extends FlxBasic
 	{
 		if (event.pixelPerfect && (event.sprite != null))
 		{
-			return checkPixelPerfectOverlap(point, event.sprite, camera);
+			return event.sprite.pixelsOverlapPoint(point, 0x01, camera);
 		}
 		else
 		{
 			return event.object.overlapsPoint(point, true, camera);
 		}
-	}
-
-	inline function checkPixelPerfectOverlap(point:FlxPoint, sprite:FlxSprite, camera:FlxCamera):Bool
-	{
-		if (sprite.angle != 0)
-		{
-			var pivot = FlxPoint.weak(sprite.x + sprite.origin.x - sprite.offset.x, sprite.y + sprite.origin.y - sprite.offset.y);
-			point.pivotDegrees(pivot, -sprite.angle);
-		}
-		return sprite.pixelsOverlapPoint(point, 0x01, camera);
 	}
 }

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -372,13 +372,30 @@ import openfl.geom.Point;
 	/**
 	 * Scale this point.
 	 *
-	 * @param   k - scale coefficient
+	 * @param   x - scale x coefficient
+	 * @param   y - scale y coefficient, if omitted, x is used
 	 * @return  scaled point
 	 */
-	public inline function scale(k:Float):FlxPoint
+	public inline function scale(x:Float, ?y:Float):FlxPoint
 	{
-		x *= k;
-		y *= k;
+		if (y == null)
+			y = x;
+
+		this.x *= x;
+		this.y *= y;
+		return this;
+	}
+
+	/**
+	 * Scale this point by another point.
+	 *
+	 * @param   point - The x and y scale coefficient
+	 * @return  scaled point
+	 */
+	public inline function scalePoint(point:FlxPoint):FlxPoint
+	{
+		scale(point.x, point.y);
+		point.putWeak();
 		return this;
 	}
 


### PR DESCRIPTION
related to #2511

Added `transformWorldToPixels` and `transformScreenToPixels` to translate from coordinate spaces to the graphic's pixel coordinates.

`pixelsOverlapPoint` is used by `FlxMouseEvent`, I used the [FlxMouseEventManager](https://haxeflixel.com/demos/FlxMouseEventManager/) demo to test this, since it uses  scale and angle, (I also modified the demo to test scrollFactor and offset)