### PR TITLE
Specify a negative icon priority.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
 
-	<icon path="assets/images/logo/HaxeFlixel.svg" />
+	<icon path="assets/images/logo/HaxeFlixel.svg" priority="-10" />
 	
 	<section unless="unit-test">
 		<assets path="assets/sounds" rename="flixel/sounds" include="*.mp3" if="web || air" embed="true" />


### PR DESCRIPTION
This will make it easy for other libraries to override the Flixel's default icon, even with an inconvenient include order. Same with end users; any icons they set will take precedence, even if they set them before `<haxelib name="flixel" />`.

At the time of this writing, this is a development-only feature. Lime versions 7.9.0 and under will simply ignore the `priority` attribute.

Supersedes #2466.