### PR TITLE
remove @:nocompletion on FlxSubState._parentState

### DIFF
--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -30,7 +30,6 @@ class FlxSubState extends FlxState
 	/**
 	 * Helper var for `close()` so `closeSubState()` can be called on the parent.
 	 */
-	@:noCompletion
 	@:allow(flixel.FlxState.resetSubState)
 	var _parentState:FlxState;
 


### PR DESCRIPTION
It seems like this was added by mistake, when Gama addied it to most private vars of this class.

it was even used in a FlxDemo: https://github.com/HaxeFlixel/flixel-demos/blob/dev/Features/SubState/source/SubState.hx#L55