### PR TITLE
Add new pressure and isPen fields for pen input

### DIFF
--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -26,12 +26,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	/**
 	 * A value between 0.0 and 1.0 indicating force of the contact with the device. If the device does not support detecting the pressure, the value is 1.0.
 	 */
-	public var pressure(get, never):Float;
-
-	/**
-	 * Returns `true` if the touch event is caused by a stylus/pen device, rather than a finger touch.
-	 */
-	public var isPen(get, never):Bool;
+	public var pressure(get, null):Float;
 
 	public var justReleased(get, never):Bool;
 	public var released(get, never):Bool;
@@ -40,8 +35,6 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 
 	var input:FlxInput<Int>;
 	var flashPoint = new Point();
-	var _pressure:Float;
-	var _isPen:Bool;
 
 	public var justPressedPosition(default, null) = FlxPoint.get();
 	public var justPressedTimeInTicks(default, null):Int = -1;
@@ -50,7 +43,6 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	{
 		input = null;
 		justPressedPosition = FlxDestroyUtil.put(justPressedPosition);
-		_pressure = null;
 		flashPoint = null;
 	}
 
@@ -62,11 +54,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		setXY(x, y);
 		input.ID = pointID;
 		input.reset();
-		setPressure(pressure);
-		if (pressure > 0)
-			setIsPen(true);
-		else
-			setIsPen(false);
+		this.pressure = pressure;
 	}
 
 	/**
@@ -75,17 +63,13 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	 * @param	PointID		touchPointID of the touch
 	 * @param	pressure	A value between 0.0 and 1.0 indicating force of the contact with the device. If the device does not support detecting the pressure, the value is 1.0.
 	 */
-	function new(x:Int = 0, y:Int = 0, pointID:Int = 0, pressure:Float = 1.0)
+	function new(x:Int = 0, y:Int = 0, pointID:Int = 0, pressure:Float = 0)
 	{
 		super();
 
 		input = new FlxInput(pointID);
 		setXY(x, y);
-		setPressure(pressure);
-		if (pressure > 0)
-			setIsPen(true);
-		else
-			setIsPen(false);
+		this.pressure = pressure;
 	}
 
 	/**
@@ -122,11 +106,6 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		setGlobalScreenPositionUnsafe(flashPoint.x, flashPoint.y);
 	}
 
-	function setPressure(pressure:Float)
-	{
-		_pressure = pressure;
-	}
-
 	/**
 	 * Workaround for browsers treating non-pen touches as 0 pressure.
 	 * 
@@ -138,20 +117,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	 */
 	inline function get_pressure():Float
 	{
-		if (isPen && _pressure > 0)
-			return _pressure;
-		else
-			return 1;
-	}
-
-	function setIsPen(pen:Bool)
-	{
-		_isPen = pen;
-	}
-
-	inline function get_isPen():Bool
-	{
-		return _isPen;
+		return pressure;
 	}
 
 	inline function get_touchPointID():Int

--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -26,7 +26,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	/**
 	 * A value between 0.0 and 1.0 indicating force of the contact with the device. If the device does not support detecting the pressure, the value is 1.0.
 	 */
-	public var pressure(get, null):Float;
+	public var pressure(default, null):Float;
 
 	public var justReleased(get, never):Bool;
 	public var released(get, never):Bool;
@@ -104,20 +104,6 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		flashPoint = FlxG.game.globalToLocal(flashPoint);
 
 		setGlobalScreenPositionUnsafe(flashPoint.x, flashPoint.y);
-	}
-
-	/**
-	 * Workaround for browsers treating non-pen touches as 0 pressure.
-	 * 
-	 * If the touch starts off with pressure > 0, it's very likely to be a pen input,
-	 * but it's easier to deal with pressure for regular touches if it's assumed to be 1.0
-	 * as OpenFL claims it should be (possibly a bug?).
-	 *
-	 * If it's a pen, supply regular pressure value.
-	 */
-	inline function get_pressure():Float
-	{
-		return pressure;
 	}
 
 	inline function get_touchPointID():Int

--- a/flixel/input/touch/FlxTouchManager.hx
+++ b/flixel/input/touch/FlxTouchManager.hx
@@ -1,8 +1,8 @@
 package flixel.input.touch;
 
 #if FLX_TOUCH
-import flash.events.TouchEvent;
 import flash.Lib;
+import flash.events.TouchEvent;
 import flash.ui.Multitouch;
 import flash.ui.MultitouchInputMode;
 
@@ -178,10 +178,11 @@ class FlxTouchManager implements IFlxInputManager
 		if (touch != null)
 		{
 			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
+			touch.setPressure(FlashEvent.pressure);
 		}
 		else
 		{
-			touch = recycle(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY), FlashEvent.touchPointID);
+			touch = recycle(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY), FlashEvent.touchPointID, FlashEvent.pressure);
 		}
 		touch.input.press();
 	}
@@ -209,6 +210,7 @@ class FlxTouchManager implements IFlxInputManager
 		if (touch != null)
 		{
 			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
+			touch.setPressure(FlashEvent.pressure);
 		}
 	}
 
@@ -233,16 +235,15 @@ class FlxTouchManager implements IFlxInputManager
 	 * @param	PointID		id of the touch
 	 * @return	A recycled touch object
 	 */
-	function recycle(X:Int, Y:Int, PointID:Int):FlxTouch
+	function recycle(X:Int, Y:Int, PointID:Int, pressure:Float):FlxTouch
 	{
 		if (_inactiveTouches.length > 0)
 		{
 			var touch:FlxTouch = _inactiveTouches.pop();
-			touch.recycle(X, Y, PointID);
+			touch.recycle(X, Y, PointID, pressure);
 			return add(touch);
 		}
-
-		return add(new FlxTouch(X, Y, PointID));
+		return add(new FlxTouch(X, Y, PointID, pressure));
 	}
 
 	/**

--- a/flixel/input/touch/FlxTouchManager.hx
+++ b/flixel/input/touch/FlxTouchManager.hx
@@ -178,7 +178,7 @@ class FlxTouchManager implements IFlxInputManager
 		if (touch != null)
 		{
 			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
-			touch.setPressure(FlashEvent.pressure);
+			touch.pressure = FlashEvent.pressure;
 		}
 		else
 		{
@@ -210,7 +210,7 @@ class FlxTouchManager implements IFlxInputManager
 		if (touch != null)
 		{
 			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
-			touch.setPressure(FlashEvent.pressure);
+			touch.pressure = FlashEvent.pressure;
 		}
 	}
 


### PR DESCRIPTION
# What?
This is a PR to add support in HaxeFlixel for pen-specific data, since the data already existed in OpenFL's Touch events and just wasn't being passed on:
* `isPen` is a Bool that indicates whether the touch event is being produced by a pen or not - obviously it's `true` if it is a pen.
* `pressure` is a Float (between `0` and `1.0`) which supplies the pressure data from a pen device.
* * If the device is a regular touch, it supplies `1.0` as the pressure
* * I had to fudge things a bit because browsers seem to recognise regular touch as `0` pressure, whereas I feel that `1.0` as a default feels more sane.

Proposed example usage:
```hx
var maxRadius = 50;
override public function update(elapsed:Float)
{
    super.update(elapsed);
    var _firstTouch = FlxG.touches.getFirst();
    if (_firstTouch != null)
    {
        FlxG.watch.add(_firstTouch, "pressure", "Pen pressure");
        FlxG.watch.add(_firstTouch, "isPen", "Is it a pen?");
        circle.radius = maxRadius * _firstTouch.pressure;
        circle.setPosition(_firstTouch.x - circle.radius, _firstTouch.y - circle.radius);
    }
}
```

I'm not used to dealing with `recycle()` or `destroy()` much, so feel free to change/let me know if I've messed something up there.