### PR TITLE
Fixing `FlxBitmapText.cutLines()`

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -756,6 +756,11 @@ class FlxBitmapText extends FlxSprite
 					subLine = subLine.addChar(charCode);
 					subLineWidth += charWidth;
 				}
+				
+				if (subLineWidth > 0)
+				{
+					newLines.push(subLine.toString());
+				}
 
 				c++;
 			}


### PR DESCRIPTION
In `FlxBitmapText` when `autoSize` is `false` it will use `wordWrap` by default.
If `wordWrap` is false, it will use `cutLines` to cut (truncate) lines that are too long.
However, if the string in the field is smaller than the maximum width of the field, `cutLines` ends up truncating the entire string, which causes a crash when the `textHeight` or `textWidth` is computed in order to display the `FlxBitmapText`
This should fix that issue.