### PR TITLE
Added custom loop point to FlxAnimation

### DIFF
--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -44,6 +44,12 @@ class FlxAnimation extends FlxBaseAnimation
 	public var looped(default, null):Bool = true;
 
 	/**
+	 * The custom loop point for this animation.
+	 * This allows you to skip the first few frames of an animation when looping.
+	 */
+	public var loopPoint:Int = 0;
+
+	/**
 	 * Whether or not this animation is being played backwards.
 	 */
 	public var reversed(default, null):Bool = false;
@@ -191,7 +197,7 @@ class FlxAnimation extends FlxBaseAnimation
 			_frameTimer -= delay;
 			if (reversed)
 			{
-				if (looped && curFrame == 0)
+				if (looped && curFrame == loopPoint)
 					curFrame = numFrames - 1;
 				else
 					curFrame--;
@@ -199,7 +205,7 @@ class FlxAnimation extends FlxBaseAnimation
 			else
 			{
 				if (looped && curFrame == numFrames - 1)
-					curFrame = 0;
+					curFrame = loopPoint;
 				else
 					curFrame++;
 			}


### PR DESCRIPTION
This simple change adds the ability to set a custom loop point on an FlxAnimation.

This allows you to conveniently perform behaviors such as having a "lead-in" to a looping animation.

For example, if you have a 5-frame animation, and you set `loopPoint` to 3, the frames you see will be:

`1-2-3-4-5~3-4-5~3-4-5~3-4-5~3-4-5`