### PR TITLE
Add some missing key codes to FlxKey

### DIFF
--- a/flixel/input/keyboard/FlxKey.hx
+++ b/flixel/input/keyboard/FlxKey.hx
@@ -63,6 +63,8 @@ abstract FlxKey(Int) from Int to Int
 	var RBRACKET = 221;
 	var BACKSLASH = 220;
 	var CAPSLOCK = 20;
+	var SCROLL_LOCK = 145;
+	var NUMLOCK = 144;
 	var SEMICOLON = 186;
 	var QUOTE = 222;
 	var ENTER = 13;
@@ -79,7 +81,10 @@ abstract FlxKey(Int) from Int to Int
 	var LEFT = 37;
 	var RIGHT = 39;
 	var TAB = 9;
+	var START = 15;
+	var MENU = 302;
 	var PRINTSCREEN = 301;
+	var BREAK = 19;
 	var F1 = 112;
 	var F2 = 113;
 	var F3 = 114;
@@ -106,6 +111,7 @@ abstract FlxKey(Int) from Int to Int
 	var NUMPADPLUS = 107;
 	var NUMPADPERIOD = 110;
 	var NUMPADMULTIPLY = 106;
+	var NUMPADSLASH = 111;
 
 	@:from
 	public static inline function fromString(s:String)

--- a/flixel/input/keyboard/FlxKey.hx
+++ b/flixel/input/keyboard/FlxKey.hx
@@ -81,7 +81,7 @@ abstract FlxKey(Int) from Int to Int
 	var LEFT = 37;
 	var RIGHT = 39;
 	var TAB = 9;
-	var START = 15;
+	var WINDOWS = 15;
 	var MENU = 302;
 	var PRINTSCREEN = 301;
 	var BREAK = 19;

--- a/flixel/input/keyboard/FlxKeyList.hx
+++ b/flixel/input/keyboard/FlxKeyList.hx
@@ -348,10 +348,10 @@ class FlxKeyList extends FlxBaseKeyList
 	inline function get_TAB()
 		return check(FlxKey.TAB);
 
-	public var START(get, never):Bool;
+	public var WINDOWS(get, never):Bool;
 
-	inline function get_START()
-		return check(FlxKey.START);
+	inline function get_WINDOWS()
+		return check(FlxKey.WINDOWS);
 
 	public var MENU(get, never):Bool;
 

--- a/flixel/input/keyboard/FlxKeyList.hx
+++ b/flixel/input/keyboard/FlxKeyList.hx
@@ -258,6 +258,16 @@ class FlxKeyList extends FlxBaseKeyList
 	inline function get_CAPSLOCK()
 		return check(FlxKey.CAPSLOCK);
 
+	public var SCROLL_LOCK(get, never):Bool;
+
+	inline function get_SCROLL_LOCK()
+		return check(FlxKey.SCROLL_LOCK);
+
+	public var NUMLOCK(get, never):Bool;
+
+	inline function get_NUMLOCK()
+		return check(FlxKey.NUMLOCK);
+
 	public var SEMICOLON(get, never):Bool;
 
 	inline function get_SEMICOLON()
@@ -338,10 +348,25 @@ class FlxKeyList extends FlxBaseKeyList
 	inline function get_TAB()
 		return check(FlxKey.TAB);
 
+	public var START(get, never):Bool;
+
+	inline function get_START()
+		return check(FlxKey.START);
+
+	public var MENU(get, never):Bool;
+
+	inline function get_MENU()
+		return check(FlxKey.MENU);
+
 	public var PRINTSCREEN(get, never):Bool;
 
 	inline function get_PRINTSCREEN()
 		return check(FlxKey.PRINTSCREEN);
+
+	public var BREAK(get, never):Bool;
+
+	inline function get_BREAK()
+		return check(FlxKey.BREAK);
 
 	public var F1(get, never):Bool;
 
@@ -472,4 +497,9 @@ class FlxKeyList extends FlxBaseKeyList
 
 	inline function get_NUMPADMULTIPLY()
 		return check(FlxKey.NUMPADMULTIPLY);
+
+	public var NUMPADSLASH(get, never):Bool;
+
+	inline function get_NUMPADSLASH()
+		return check(FlxKey.NUMPADSLASH);
 }


### PR DESCRIPTION
I found out that some key codes from my keyboard weren't defined in FlxKey, so I added them. This adds the following keys:
* SCROLL_LOCK
* NUMLOCK
* START (aka Windows key)
* MENU
* BREAK (aka Pause key)
* NUMPADSLASH

Tested on HTML5, HashLink, and Windows; might need more testing on Mac and Linux