### PR TITLE
Added diffX and diffY properties to FlxMouse

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -820,15 +820,17 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		return findMaxXHelper() - findMinXHelper();
 	}
 
+	/**
+	 * Returns the left-most position of the left-most member.
+	 * If there are no members, x is returned.
+	 * 
+	 * @since 5.0.0
+	 */
 	public function findMinX()
 	{
 		return length == 0 ? x : findMinXHelper();
 	}
 	
-	/**
-	 * Returns the left-most position of the left-most member.
-	 * If there are no members, x is returned.
-	 */
 	function findMinXHelper()
 	{
 		var value = Math.POSITIVE_INFINITY;
@@ -852,6 +854,8 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	/**
 	 * Returns the right-most position of the right-most member.
 	 * If there are no members, x is returned.
+	 * 
+	 * @since 5.0.0
 	 */
 	public function findMaxX()
 	{
@@ -897,6 +901,8 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	/**
 	 * Returns the top-most position of the top-most member.
 	 * If there are no members, y is returned.
+	 * 
+	 * @since 5.0.0
 	 */
 	public function findMinY()
 	{
@@ -926,6 +932,8 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	/**
 	 * Returns the top-most position of the top-most member.
 	 * If there are no members, y is returned.
+	 * 
+	 * @since 5.0.0
 	 */
 	public function findMaxY()
 	{

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -816,25 +816,68 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		if (length == 0)
 			return 0;
+		
+		return findMaxXHelper() - findMinXHelper();
+	}
 
-		var minX:Float = Math.POSITIVE_INFINITY;
-		var maxX:Float = Math.NEGATIVE_INFINITY;
-
+	public function findMinX()
+	{
+		return length == 0 ? x : findMinXHelper();
+	}
+	
+	/**
+	 * Returns the left-most position of the left-most member.
+	 * If there are no members, x is returned.
+	 */
+	function findMinXHelper()
+	{
+		var value = Math.POSITIVE_INFINITY;
 		for (member in _sprites)
 		{
 			if (member == null)
 				continue;
-			var minMemberX:Float = member.x;
-			var maxMemberX:Float = minMemberX + member.width;
-
-			if (maxMemberX > maxX)
-				maxX = maxMemberX;
-			if (minMemberX < minX)
-				minX = minMemberX;
+			
+			var minX:Float;
+			if (member.flixelType == SPRITEGROUP)
+				minX = (cast member:FlxSpriteGroup).findMinX();
+			else
+				minX = member.x;
+			
+			if (minX < value)
+				value = minX;
 		}
-		return maxX - minX;
+		return value;
 	}
-
+	
+	/**
+	 * Returns the right-most position of the right-most member.
+	 * If there are no members, x is returned.
+	 */
+	public function findMaxX()
+	{
+		return length == 0 ? x : findMaxXHelper();
+	}
+	
+	function findMaxXHelper()
+	{
+		var value = Math.NEGATIVE_INFINITY;
+		for (member in _sprites)
+		{
+			if (member == null)
+				continue;
+			
+			var maxX:Float;
+			if (member.flixelType == SPRITEGROUP)
+				maxX = (cast member:FlxSpriteGroup).findMaxX();
+			else
+				maxX = member.x + member.width;
+			
+			if (maxX > value)
+				value = maxX;
+		}
+		return value;
+	}
+	
 	/**
 	 * This functionality isn't supported in SpriteGroup
 	 */
@@ -846,26 +889,67 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	override function get_height():Float
 	{
 		if (length == 0)
-		{
 			return 0;
-		}
-
-		var minY:Float = Math.POSITIVE_INFINITY;
-		var maxY:Float = Math.NEGATIVE_INFINITY;
-
+		
+		return findMaxYHelper() - findMinYHelper();
+	}
+	
+	/**
+	 * Returns the top-most position of the top-most member.
+	 * If there are no members, y is returned.
+	 */
+	public function findMinY()
+	{
+		return length == 0 ? x : findMinYHelper();
+	}
+	
+	function findMinYHelper()
+	{
+		var value = Math.POSITIVE_INFINITY;
 		for (member in _sprites)
 		{
 			if (member == null)
 				continue;
-			var minMemberY:Float = member.y;
-			var maxMemberY:Float = minMemberY + member.height;
-
-			if (maxMemberY > maxY)
-				maxY = maxMemberY;
-			if (minMemberY < minY)
-				minY = minMemberY;
+			
+			var minY:Float;
+			if (member.flixelType == SPRITEGROUP)
+				minY = (cast member:FlxSpriteGroup).findMinY();
+			else
+				minY = member.y;
+			
+			if (minY < value)
+				value = minY;
 		}
-		return maxY - minY;
+		return value;
+	}
+	
+	/**
+	 * Returns the top-most position of the top-most member.
+	 * If there are no members, y is returned.
+	 */
+	public function findMaxY()
+	{
+		return length == 0 ? x : findMaxYHelper();
+	}
+	
+	function findMaxYHelper()
+	{
+		var value = Math.NEGATIVE_INFINITY;
+		for (member in _sprites)
+		{
+			if (member == null)
+				continue;
+			
+			var maxY:Float;
+			if (member.flixelType == SPRITEGROUP)
+				maxY = (cast member:FlxSpriteGroup).findMaxY();
+			else
+				maxY = member.y + member.height;
+			
+			if (maxY > value)
+				value = maxY;
+		}
+		return value;
 	}
 
 	// GROUP FUNCTIONS

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -72,22 +72,22 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	/**
 	 * Distance in pixels the mouse has moved since the last frame in the X direction.
 	 */
-	public var diffX(get, never):Int;
+	public var deltaX(get, never):Int;
 
 	/**
 	 * Distance in pixels the mouse has moved since the last frame in the Y direction.
 	 */
-	public var diffY(get, never):Int;
+	public var deltaY(get, never):Int;
 
 	/**
 	 * Distance in pixels the mouse has moved in screen space since the last frame in the X direction.
 	 */
-	public var diffScreenX(get, never):Int;
+	public var deltaScreenX(get, never):Int;
 
 	/**
 	 * Distance in pixels the mouse has moved in screen space since the last frame in the Y direction.
 	 */
-	public var diffScreenY(get, never):Int;
+	public var deltaScreenY(get, never):Int;
 
 	/**
 	 * Check to see if the left mouse button is currently pressed.
@@ -588,16 +588,16 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	inline function get_justMoved():Bool
 		return _prevX != x || _prevY != y;
 
-	inline function get_diffX():Int
+	inline function get_deltaX():Int
 		return x - _prevX;
 
-	inline function get_diffY():Int
+	inline function get_deltaY():Int
 		return y - _prevY;
 
-	inline function get_diffScreenX():Int
+	inline function get_deltaScreenX():Int
 		return screenX - _prevScreenX;
 
-	inline function get_diffScreenY():Int
+	inline function get_deltaScreenY():Int
 		return screenY - _prevScreenY;
 
 	inline function get_pressed():Bool

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -955,20 +955,30 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 
 	function checkColumn(x:Int, startY:Int, endY:Int):Int
 	{
-		if (startY > endY)
-			return checkColumn(x, endY, startY);
-		
 		if (startY < 0)
 			startY = 0;
+		
+		if (endY < 0)
+			endY = 0;
+		
+		if (startY > heightInTiles - 1)
+			startY = heightInTiles - 1;
 		
 		if (endY > heightInTiles - 1)
 			endY = heightInTiles - 1;
 		
-		for (y in startY...endY + 1)
+		var y = startY;
+		final step = startY <= endY ? 1 : -1;
+		while (true)
 		{
 			var index = y * widthInTiles + x;
 			if (getTileCollisions(getTileByIndex(index)) != NONE)
 				return index;
+			
+			if (y == endY)
+				break;
+			
+			y += step;
 		}
 		
 		return -1;


### PR DESCRIPTION
This function makes it easy to compare how the mouse has moved since the last `update()`. This makes the internal _prevX and _prevY values, previously only used by the `justMoved` property, more useful to the user. 

Behaving somewhat similarly to `wheel`, these properties provide the following:

- `diffX`: The distance the mouse has moved horizontally since the previous update.
- `diffY`: The distance the mouse has moved vertically since the previous update.
- `diffScreenX`: The distance the mouse has moved in screen space horizontally since the previous update.
- `diffScreenY`: The distance the mouse has moved in screen space vertically since the last update.