### PR TITLE
fix issues with ray()

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -955,20 +955,30 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 
 	function checkColumn(x:Int, startY:Int, endY:Int):Int
 	{
-		if (startY > endY)
-			return checkColumn(x, endY, startY);
-		
 		if (startY < 0)
 			startY = 0;
+		
+		if (endY < 0)
+			endY = 0;
+		
+		if (startY > heightInTiles - 1)
+			startY = heightInTiles - 1;
 		
 		if (endY > heightInTiles - 1)
 			endY = heightInTiles - 1;
 		
-		for (y in startY...endY + 1)
+		var y = startY;
+		final step = startY <= endY ? 1 : -1;
+		while (true)
 		{
 			var index = y * widthInTiles + x;
 			if (getTileCollisions(getTileByIndex(index)) != NONE)
 				return index;
+			
+			if (y == endY)
+				break;
+			
+			y += step;
 		}
 		
 		return -1;


### PR DESCRIPTION
Fixes issues like this. the reason for this issue was that checkColumn was always checking tiles from top to bottom.
<img width="614" alt="Screen Shot 2022-10-05 at 12 44 27 AM" src="https://user-images.githubusercontent.com/2609513/193989707-e5a399b8-16af-495d-bd1e-f1080676ace6.png">
