### PR TITLE
Fix Garbage Memory in FlxText

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -795,7 +795,7 @@ class FlxText extends FlxSprite
 			newHeight = oldHeight;
 		}
 
-		if (oldWidth != newWidth || oldHeight != newHeight)
+		if (oldWidth != Std.int(newWidth) || oldHeight != Std.int(newHeight))
 		{
 			// Need to generate a new buffer to store the text graphic
 			height = newHeight;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -785,9 +785,9 @@ class FlxText extends FlxSprite
 			oldHeight = graphic.height;
 		}
 
-		var newWidth:Float = textField.width;
+		var newWidth:Int = Math.ceil(textField.width);
 		// Account for gutter
-		var newHeight:Float = textField.textHeight + VERTICAL_GUTTER;
+		var newHeight:Int = Math.ceil(textField.textHeight) + VERTICAL_GUTTER;
 
 		// prevent text height from shrinking on flash if text == ""
 		if (textField.textHeight == 0)
@@ -795,16 +795,16 @@ class FlxText extends FlxSprite
 			newHeight = oldHeight;
 		}
 
-		if (oldWidth != Std.int(newWidth) || oldHeight != Std.int(newHeight))
+		if (oldWidth != newWidth || oldHeight != newHeight)
 		{
 			// Need to generate a new buffer to store the text graphic
 			height = newHeight;
 			var key:String = FlxG.bitmap.getUniqueKey("text");
-			makeGraphic(Std.int(newWidth), Std.int(newHeight), FlxColor.TRANSPARENT, false, key);
+			makeGraphic(newWidth, newHeight, FlxColor.TRANSPARENT, false, key);
 
 			if (_hasBorderAlpha)
 				_borderPixels = graphic.bitmap.clone();
-			frameHeight = Std.int(height);
+			frameHeight = newHeight;
 			textField.height = height * 1.2;
 			_flashRect.x = 0;
 			_flashRect.y = 0;


### PR DESCRIPTION
There has been a bug in FlxText where updating the text takes up more memory due to it having to regenerate the bitmap, this was actually due to a bad condition check against an Int and a Float.

This has been tested and has no noticeable visual changes.