### PR TITLE
onUpHandler() should change the status to highlight

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -514,7 +514,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	 */
 	function onUpHandler():Void
 	{
-		status = FlxButton.NORMAL;
+		status = FlxButton.HIGHLIGHT;
 		input.release();
 		currentInput = null;
 		// Order matters here, because onUp.fire() could cause a state change and destroy this object.


### PR DESCRIPTION
Having the button status return to "normal" instead of "highlight" after releasing a button press was causing the onOver.sound to play, since the status would immediately change from "normal" to "highlight". I'm not sure if there was a reason for doing it this way; I didn't notice any side effects after a quick test.