### PR TITLE
Add default antialiasing option to FlxSprite

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -129,9 +129,10 @@ using flixel.util.FlxColorTransformUtil;
 class FlxSprite extends FlxObject
 {
 	/**
-	 * The default value for `antialiasing` across all `FlxSprite`s.
+	 * The default value for `antialiasing` across all `FlxSprites`,
+	 * defaults to `false`.
 	 */
-	public static var defaultAntialiasing:Bool = true;
+	public static var defaultAntialiasing:Bool = false;
 	
 	/**
 	 * Class that handles adding and playing animations on this sprite.

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -129,6 +129,11 @@ using flixel.util.FlxColorTransformUtil;
 class FlxSprite extends FlxObject
 {
 	/**
+	 * The default value for `antialiasing` across all `FlxSprite`s.
+	 */
+	public static var defaultAntialiasing:Bool = true;
+	
+	/**
 	 * Class that handles adding and playing animations on this sprite.
 	 * @see https://snippets.haxeflixel.com/sprites/animation/
 	 */
@@ -371,6 +376,7 @@ class FlxSprite extends FlxObject
 		super(X, Y);
 
 		useFramePixels = FlxG.renderBlit;
+		antialiasing = defaultAntialiasing;
 		if (SimpleGraphic != null)
 			loadGraphic(SimpleGraphic);
 	}


### PR DESCRIPTION
For performance reasons games might include an antialiasing option in their settings menu. But implementing an antialiasing option, especially in a project that's nearing completion is tedious because you'd have to change the antialiasing value for every sprite.

This PR adds a `defaultAntialiasing` option to FlxSprite, which sets its antialiasing value upon creation to `defaultAntialiasing`.

So instead of changing every sprite's value manually, you could simply do
```haxe
FlxSprite.defaultAntialiasing = true;
```
and it would automatically set `antialiasing` to `true` on every sprite upon creation.
