### PR TITLE
add flxAxes static constructors

### DIFF
--- a/flixel/util/FlxAxes.hx
+++ b/flixel/util/FlxAxes.hx
@@ -36,4 +36,32 @@ enum abstract FlxAxes(Int)
 	{
 		return self == Y || self == XY;
 	}
+	
+	public function toString():String
+	{
+		return switch self
+		{
+			case X: "x";
+			case Y: "y";
+			case XY: "xy";
+			case NONE: "none";
+		}
+	}
+	
+	public static function fromBools(x:Bool, y:Bool):FlxAxes
+	{
+		return cast (x ? (cast X:Int) : 0) | (y ? (cast Y:Int) : 0);
+	}
+	
+	public static function fromString(axes:String):FlxAxes
+	{
+		return switch axes.toLowerCase()
+		{
+			case "x": X;
+			case "y": Y;
+			case "xy" | "yx" | "both": XY;
+			case "none" | "" | null : NONE;
+			default : throw "Invalid axes value: " + axes;
+		}
+	}
 }


### PR DESCRIPTION
Adds `axes.toString()`, `FlxAxes.fromString("xy")` and `FlxAxes.fromBools(xAxis, yAxis)`