### PR TITLE
Add debugImmovable to FlxObject

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -772,6 +772,11 @@ class FlxObject extends FlxBasic
 	 * when `FlxG.debugger.drawDebug` is `true`.
 	 */
 	public var ignoreDrawDebug:Bool = false;
+
+	/**
+	 * Whether this sprite can be moved with the interaction tool in the debugger.
+	 */
+	public var debugImmovable:Bool = false;
 	#end
 
 	/**

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -564,7 +564,8 @@ class Interaction extends Window
 			var group = FlxTypedGroup.resolveGroup(member);
 			if (group != null)
 				findItemsWithinArea(items, group.members, area);
-			else if ((member is FlxSprite) && area.overlaps(cast(member, FlxSprite).getHitbox()))
+			else if ((member is FlxSprite) && area.overlaps(cast(member, FlxSprite).getHitbox()) 
+				&& !cast(member, FlxSprite).debugImmovable)
 				items.push(cast member);
 		}
 	}

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -565,7 +565,7 @@ class Interaction extends Window
 			if (group != null)
 				findItemsWithinArea(items, group.members, area);
 			else if ((member is FlxSprite) && area.overlaps(cast(member, FlxSprite).getHitbox()) 
-				&& !cast(member, FlxSprite).debugImmovable)
+				#if FLX_DEBUG && !cast(member, FlxSprite).debugImmovable #end)
 				items.push(cast member);
 		}
 	}


### PR DESCRIPTION
When positioning some sprites with the Interaction tool in the debugger, some unwanted ones can be selected if they're overlapping making it quite annoying to try and get the right sprite.

A hack to prevent this is something like running this in `update()`:
```haxe
FlxG.game.debugger.interaction.selectedItems.remove(sprite);
```

This PR makes this simpler by adding a `debugImmovable` property to `FlxObject` and not pushing the object to the selectedItems if it's immovable.