### PR TITLE
callCenterOrigin bool in FlxSprite.updateHitbox()

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -711,14 +711,17 @@ class FlxSprite extends FlxObject
 
 	/**
 	 * Updates the sprite's hitbox (`width`, `height`, `offset`) according to the current `scale`.
-	 * Also calls `centerOrigin()`.
+	 * Also calls `centerOrigin()` when callCenterOrigin is true.
 	 */
-	public function updateHitbox():Void
+	public function updateHitbox(callCenterOrigin:Bool = true):Void
 	{
 		width = Math.abs(scale.x) * frameWidth;
 		height = Math.abs(scale.y) * frameHeight;
 		offset.set(-0.5 * (width - frameWidth), -0.5 * (height - frameHeight));
-		centerOrigin();
+		if(callCenterOrigin)
+		{
+			centerOrigin();
+		}
 	}
 
 	/**


### PR DESCRIPTION
A project I've been working on has been having issues with updateHitbox causing animated sprites to be heavily displaced from their intended positions, and I've figured out that this is why. Simply adds a boolean variable in updateHitbox() that allows you to disable it calling centerOrigin() (Enabled by default for backwards compatibility). If there are any problems with this, let me know.