### PR TITLE
Added `toTitleCase` & `slugify` functions to `FlxStringUtil`

### DIFF
--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -649,10 +649,10 @@ class FlxStringUtil
 	}
 	
 	/**
-	 * Returns a slugified string
+	 * Returns an Underscored, or "slugified" string
 	 * Example: `"A Tale of Two Cities, Part II"` becomes `"a_tale_of_two_cities__part_ii"`
 	 */
-	public static function slugify(str:String):String 
+	public static function toUnderscoreCase(str:String):String 
 	{
 		var regex = ~/[^a-z0-9]+/g;
 		return regex.replace(str.toLowerCase(), '_');

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -647,6 +647,38 @@ class FlxStringUtil
 	{
 		return s == null || s.length == 0;
 	}
+	
+	/**
+	 * Returns a slugified string
+	 * Example: `"A Tale of Two Cities, Part II"` becomes `"a_tale_of_two_cities__part_ii"`
+	 */
+	public static function slugify(str:String):String 
+	{
+		var regex = ~/[^a-z0-9]+/g;
+		return regex.replace(str.toLowerCase(), '_');
+	}
+	
+	/**
+	 * Returns a string formatted to 'Title Case'. 
+	 * Example: `"a tale of two cities, pt ii" returns `"A Tale of Two Cities, Part II"`
+	 */
+	public static function toTitleCase(str:String):String 
+	{
+		var exempt:Array<String> = ["a", "an", "the", "at", "by", "for", "in", "of", "on", "to", "up", "and", "as", "but", "or", "nor"];
+		var roman = ~/^(?=[MDCLXVI])M*(C[MD]|D?C*)(X[CL]|L?X*)(I[XV]|V?I*)$/i;
+		var words:Array<String> = str.toLowerCase().split(" ");
+		
+		for (i in 0...words.length) 
+		{
+			if (roman.match(words[i]))
+				words[i] = words[i].toUpperCase();
+			else if (i == 0 || exempt.indexOf(words[i]) == -1)
+				words[i] = words[i].charAt(0).toUpperCase() + words[i].substr(1);
+		}
+
+		return words.join(" ");
+		
+	}
 }
 
 class LabelValuePair implements IFlxDestroyable


### PR DESCRIPTION
Added a couple of simple helper functions to `FlxStringUtil`:
`toTitleCase` will turn something like `"a tale of two cities, pt ii"` into: `"A Tale of Two Cities, Part II"`
and `slugify` which will turn a string into a 'slug': Example: `"A Tale of Two Cities, Part II"` becomes `"a_tale_of_two_cities__part_ii"`