### PR TITLE
add deprecated FlxPath for 4.11 migrator

### DIFF
--- a/flixel/util/FlxPath.hx
+++ b/flixel/util/FlxPath.hx
@@ -1,0 +1,7 @@
+package flixel.util;
+
+/** 
+ * DEPRECATED - FlxPath was moved to the `flixel.path` package. Update your imports.
+ */
+@:deprecated("FlxPath was moved to the package: `flixel.path`")
+typedef FlxPath = flixel.path.FlxPath;


### PR DESCRIPTION
Adding back `flixel.util.FlxPath`, with a deprecation warning