### PR TITLE
prevent frame padding before tilegraphic is loaded

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -312,6 +312,11 @@ class FlxGraphic implements IFlxDestroyable
 	public var isDumped(default, null):Bool = false;
 
 	/**
+	 * Whether the `BitmapData` of this graphic object has been loaded or not.
+	 */
+	public var isLoaded(get, never):Bool;
+
+	/**
 	 * Whether the `BitmapData` of this graphic object can be dumped for decreased memory usage,
 	 * but may cause some issues (when you need direct access to pixels of this graphic.
 	 * If the graphic is dumped then you should call `undump()` and have total access to pixels.
@@ -578,6 +583,11 @@ class FlxGraphic implements IFlxDestroyable
 			return FlxGraphic.getBitmap(newBitmap, unique);
 
 		return null;
+	}
+	
+	inline function get_isLoaded()
+	{
+		return bitmap != null && !bitmap.rect.isEmpty();
 	}
 
 	inline function get_canBeDumped():Bool

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -35,42 +35,63 @@ import Std.is as isOfType;
 using flixel.util.FlxColorTransformUtil;
 
 #if html5
+/**
+ * BitmapData loaded via @:bitmap is loaded asynchronously, this allows us to apply frame
+ * padding to the bitmap once it's loaded rather
+ */
+private interface IEmbeddedBitmapData
+{
+	var onLoad:()->Void;
+}
+
 @:keep @:bitmap("assets/images/tile/autotiles.png")
 private class RawGraphicAuto extends BitmapData {}
-class GraphicAuto extends RawGraphicAuto
+class GraphicAuto extends RawGraphicAuto implements IEmbeddedBitmapData
 {
-	public function new (width = 128, height = 8, transparent = true, fillRGBA = 0xFFffffff, ?onLoad:Dynamic)
+	static inline var WIDTH = 128;
+	static inline var HEIGHT = 8;
+
+	public var onLoad:()->Void;
+	public function new ()
 	{
-		super(width, height, transparent, fillRGBA, onLoad);
+		super(WIDTH, HEIGHT, true, 0xFFffffff, (_)-> if (onLoad != null) onLoad());
 		// Set properties because `@:bitmap` constructors ignore width/height
-		this.width = width;
-		this.height = height;
+		this.width = WIDTH;
+		this.height = HEIGHT;
 	}
 }
 
 @:keep @:bitmap("assets/images/tile/autotiles_alt.png")
 private class RawGraphicAutoAlt extends BitmapData {}
-class GraphicAutoAlt extends RawGraphicAutoAlt
+class GraphicAutoAlt extends RawGraphicAutoAlt implements IEmbeddedBitmapData
 {
-	public function new (width = 128, height = 8, transparent = true, fillRGBA = 0xFFffffff, ?onLoad:Dynamic)
+	static inline var WIDTH = 128;
+	static inline var HEIGHT = 8;
+
+	public var onLoad:()->Void;
+	public function new ()
 	{
-		super(width, height, transparent, fillRGBA, onLoad);
-		// Set again because `@:bitmap` constructors ignore width/height
-		this.width = width;
-		this.height = height;
+		super(WIDTH, HEIGHT, true, 0xFFffffff, (_)-> if (onLoad != null) onLoad());
+		// Set properties because `@:bitmap` constructors ignore width/height
+		this.width = WIDTH;
+		this.height = HEIGHT;
 	}
 }
 
 @:keep @:bitmap("assets/images/tile/autotiles_full.png")
 private class RawGraphicAutoFull extends BitmapData {}
-class GraphicAutoFull extends RawGraphicAutoFull
+class GraphicAutoFull extends RawGraphicAutoFull implements IEmbeddedBitmapData
 {
-	public function new (width = 256, height = 48, transparent = true, fillRGBA = 0xFFffffff, ?onLoad:Dynamic)
+	static inline var WIDTH = 256;
+	static inline var HEIGHT = 48;
+
+	public var onLoad:()->Void;
+	public function new ()
 	{
-		super(width, height, transparent, fillRGBA, onLoad);
-		// Set again because `@:bitmap` constructors ignore width/height
-		this.width = width;
-		this.height = height;
+		super(WIDTH, HEIGHT, true, 0xFFffffff, (_)-> if (onLoad != null) onLoad());
+		// Set properties because `@:bitmap` constructors ignore width/height
+		this.width = WIDTH;
+		this.height = HEIGHT;
 	}
 }
 #else
@@ -351,10 +372,30 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		this.tileWidth = tileWidth;
 		this.tileHeight = tileHeight;
 
-		if (defaultFramePadding > 0)
+		if (defaultFramePadding > 0 && graph.isLoaded)
 			frames = padTileFrames(tileWidth, tileHeight, graph, defaultFramePadding);
 		else
+		{
+			#if html5
+			/* if Using tile graphics like GraphicAuto or others defined above, they will not
+			 * load immediately. Track their loading and apply frame padding after.
+			**/
+			if (!graph.isLoaded && isOfType(graph.bitmap, IEmbeddedBitmapData))
+			{
+				var futureBitmap:IEmbeddedBitmapData = cast graph.bitmap;
+				futureBitmap.onLoad = function()
+				{
+					frames = padTileFrames(tileWidth, tileHeight, graph, defaultFramePadding);
+				}
+			}
+			else if (defaultFramePadding > 0 && !graph.isLoaded)
+			{
+				FlxG.log.warn('defaultFramePadding not applied to "${graph.key}" because it is loading asynchronously.'
+					+ "using `@:bitmap` assets on html5 is not recommended");
+			}
+			#end
 			frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(tileWidth, tileHeight));
+		}
 	}
 
 	function padTileFrames(tileWidth:Int, tileHeight:Int, graphic:FlxGraphic, padding:Int)


### PR DESCRIPTION
This fixes a bug introduced by #2581. Where frame padding was applied before the bitmap was loaded. this is a pretty hacky fix, but FlxGraphic.fromClass is almost never used so w/e