### PR TITLE
Fix FLX_PITCH not properly defined on older versions of lime

### DIFF
--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -143,10 +143,12 @@ class FlxDefines
 
 		if (!defined(FLX_NO_SOUND_SYSTEM) && !defined(FLX_NO_SOUND_TRAY))
 			define(FLX_SOUND_TRAY);
-		
-		if (defined(FLX_NO_SOUND_SYSTEM) #if openfl_legacy || !defined("sys") #elseif (lime >= "8.0.0") || defined("flash") #end)
+		#if (openfl_legacy || lime >= "8.0.0")
+		if (defined(FLX_NO_SOUND_SYSTEM) || #if openfl_legacy !defined("sys") #else defined("flash") #end)
 			define(FLX_NO_PITCH);
-			
+		#else
+		define(FLX_NO_PITCH);
+		#end
 		if (!defined(FLX_NO_PITCH))
 			define(FLX_PITCH);
 		


### PR DESCRIPTION

Fixes #2677 