### PR TITLE
Apply include/excludes on files not directories

### DIFF
--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -106,7 +106,7 @@ private class FileReference
 			name = value.split("/").pop();
 
 		// replace some forbidden names to underscores, since variables cannot have these symbols.
-		name = name.split("-").join("_").split(".").join("__");
+		name = name.split("-").join("_").split(" ").join("_").split(".").join("__");
 		if (!valid.match(name)) // #1796
 		{
 			Context.warning('Invalid name: $name for file: $value', Context.currentPos());

--- a/flixel/system/macros/FlxAssetPaths.hx
+++ b/flixel/system/macros/FlxAssetPaths.hx
@@ -36,16 +36,16 @@ class FlxAssetPaths
 		{
 			var path = resolvedPath + name;
 
-			if (include != null && !include.match(path))
-				continue;
-
-			if (exclude != null && exclude.match(path))
-				continue;
-
 			if (!FileSystem.isDirectory(path))
 			{
 				// ignore invisible files
 				if (name.startsWith("."))
+					continue;
+
+				if (include != null && !include.match(path))
+					continue;
+
+				if (exclude != null && exclude.match(path))
 					continue;
 
 				var reference = FileReference.fromPath(path, rename);


### PR DESCRIPTION
AssetPaths was excluding directories that didn't match the include paths, meaning nearly all files would be excluded if an include string was given. 