### PR TITLE
Added a swap function to FlxArrayUtil

### DIFF
--- a/flixel/util/FlxArrayUtil.hx
+++ b/flixel/util/FlxArrayUtil.hx
@@ -83,6 +83,25 @@ class FlxArrayUtil
 	}
 
 	/**
+	 * Swaps two elements of an array, which are located at indices `index1` and `index2`
+	 * @param array The array whose elements need to be swapped
+	 * @param index1 The index of one of the elements to be swapped
+	 * @param index2 The index of the other element to be swapped
+	 * @return The array
+	 */
+	@:generic
+	public static inline function swap<T>(array:Array<T>, index1:Int, index2:Int):Array<T>
+	{
+		if(index1 >= 0 && index1 < array.length && index2 >= 0 && index2 < array.length)
+		{
+			var temp = array[index1];
+			array[index1] = array[index2];
+			array[index2] = temp;
+		}
+		return array;
+	}
+
+	/**
 	 * Clears an array structure, but leaves the object data untouched
 	 * Useful for cleaning up temporary references to data you want to preserve.
 	 * WARNING: Can lead to memory leaks.


### PR DESCRIPTION
This pr adds a simple swap function to FlxArrayUtil, which should be useful for re-ordering sprites like this:

https://user-images.githubusercontent.com/83609901/204037478-fb613af5-a993-4e0d-b972-f37689a16bc3.mp4

The code:
```haxe
package;

import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;
import flixel.text.FlxText;
import flixel.util.FlxArrayUtil;
import flixel.util.FlxColor;

class PlayState extends FlxState
{
	var card1:FlxSprite;
	var card2:FlxSprite;
	var helpText:FlxText;

	override public function create()
	{
		super.create();
		card1 = new FlxSprite().makeGraphic(100, 100, FlxColor.RED);
		card1.screenCenter();
		card1.x -= 20;

		card2 = new FlxSprite().makeGraphic(100, 100, FlxColor.YELLOW);
		card2.screenCenter();
		card2.x += 20;
		card2.y += 20;

		helpText = new FlxText(0, FlxG.height - 20, 0, 'Press ENTER to toggle which card is at the front');
		helpText.setFormat(null, 12, FlxColor.BLACK);
		helpText.screenCenter(X);
		add(helpText);

		FlxG.camera.bgColor = FlxColor.WHITE;
		add(card1);
		add(card2);
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);
		if (FlxG.keys.justPressed.ENTER)
		{
			FlxArrayUtil.swap(members, members.indexOf(card1), members.indexOf(card2));
		}
	}
}
```
