### PR TITLE
honor FlxSprite.defaultAntiAliasing in FlxTilemap

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -131,6 +131,7 @@ class FlxSprite extends FlxObject
 	/**
 	 * The default value for `antialiasing` across all `FlxSprites`,
 	 * defaults to `false`.
+	 * @since 5.0.0
 	 */
 	public static var defaultAntialiasing:Bool = false;
 	
@@ -157,7 +158,7 @@ class FlxSprite extends FlxObject
 	/**
 	 * Controls whether the object is smoothed when rotated, affects performance.
 	 */
-	public var antialiasing(default, set):Bool = false;
+	public var antialiasing(default, set):Bool = defaultAntialiasing;
 
 	/**
 	 * Set this flag to true to force the sprite to update during the `draw()` call.
@@ -378,7 +379,6 @@ class FlxSprite extends FlxObject
 		super(X, Y);
 
 		useFramePixels = FlxG.renderBlit;
-		antialiasing = defaultAntialiasing;
 		if (SimpleGraphic != null)
 			loadGraphic(SimpleGraphic);
 	}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -135,8 +135,10 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	/**
 	 * Controls whether the object is smoothed when rotated, affects performance.
 	 * @since 4.1.0
+	 * 
+	 * @see FlxSprite.defaultAntialiasing
 	 */
-	public var antialiasing(default, set):Bool = false;
+	public var antialiasing(default, set):Bool = FlxSprite.defaultAntialiasing;
 
 	/**
 	 * Use to offset the drawing position of the tilemap,


### PR DESCRIPTION
FlxTilemap checks FlxSprite.defaultAntiAliasing for the default value