### PR TITLE
Enable GLSL 3.00 migration

### DIFF
--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -24,7 +24,7 @@ class FlxGraphicsShader extends GraphicsShader
 				openfl_ColorOffsetv = colorOffset / 255.0;
 				openfl_ColorMultiplierv = colorMultiplier;
 			}
-		}")
+		}", true)
 	@:glFragmentHeader("
 		uniform bool hasTransform;
 		uniform bool hasColorTransform;
@@ -63,7 +63,7 @@ class FlxGraphicsShader extends GraphicsShader
 			}
 			return vec4(0.0, 0.0, 0.0, 0.0);
 		}
-	")
+	", true)
 	@:glFragmentSource("
 		#pragma header
 		


### PR DESCRIPTION
Without modifying the fragment header and vertex source to replace deprecated keywords, specifying `300 es` or higher as your GLSL version (possible with openfl/openfl#2577) will break. This pull request tells the ShaderMacro to perform this replacement.

This change should be non-breaking even if it is merged before 2577, due to how annotations are read.