### PR TITLE
Fix chaining for screenCenter()

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1211,7 +1211,7 @@ class FlxObject extends FlxBasic
 	 * @param   axes   On what axes to center the object (e.g. `X`, `Y`, `XY`) - default is both. 
 	 * @return  This FlxObject for chaining
 	 */
-	public inline function screenCenter(axes:FlxAxes = XY):FlxObject
+	public inline function screenCenter<T:FlxObject>(axes:FlxAxes = XY):T
 	{
 		if (axes.x)
 			x = (FlxG.width - width) / 2;
@@ -1219,7 +1219,7 @@ class FlxObject extends FlxBasic
 		if (axes.y)
 			y = (FlxG.height - height) / 2;
 
-		return this;
+		return cast this;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes chaining for `screenCenter` function in `FlxObject`.
Currently you cannot really chain FlxSprites or whatever with `screenCenter` since it returns `FlxObject`, not the extended class.
Example:
```haxe  
var sprite:FlxSprite = new FlxSprite().screenCenter(); //is not allowed
var sprite:FlxSprite = cast new FlxSprite().screenCenter(); //is allowed
```