### PR TITLE
Possible fix for drawing tiled sprites with FlxStrip

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -587,17 +587,24 @@ class FlxCamera extends FlxBasic
 			&& _headTriangles.antialiasing == smoothing
 			&& _headTriangles.colored == isColored
 			&& _headTriangles.blending == blendInt
+			#if !flash
 			&& _headTriangles.hasColorOffsets == hasColorOffsets
-            && _headTriangles.shader == shader)
+            && _headTriangles.shader == shader
+			#end
+			)
 		{
 			return _headTriangles;
 		}
 
+		#if !flash
 		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
+		#else
+		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend);
+		#end
 	}
 
 	@:noCompletion
-	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
+	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode #if !flash , ?hasColorOffsets:Bool, ?shader:FlxShader #end):FlxDrawTrianglesItem
 	{
 		var itemToReturn:FlxDrawTrianglesItem = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
@@ -618,8 +625,10 @@ class FlxCamera extends FlxBasic
 		itemToReturn.antialiasing = smoothing;
 		itemToReturn.colored = isColored;
 		itemToReturn.blending = blendInt;
+		#if !flash
 		itemToReturn.hasColorOffsets = hasColorOffsets;
         itemToReturn.shader = shader;
+		#end
 
 		itemToReturn.nextTyped = _headTriangles;
 		_headTriangles = itemToReturn;
@@ -760,7 +769,7 @@ class FlxCamera extends FlxBasic
 	}
 
 	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>,
-			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false, ?transform:ColorTransform, ?shader:FlxShader):Void
+			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false #if !flash , ?transform:ColorTransform, ?shader:FlxShader #end):Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -838,12 +847,17 @@ class FlxCamera extends FlxBasic
 		else
 		{
 			_bounds.set(0, 0, width, height);
-			var isColored:Bool = (transform != null && transform.hasRGBMultipliers());
+			var isColored:Bool = (colors != null && colors.length != 0);
+
+			#if !flash
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
-			
-			isColored = isColored || (colors != null && colors.length != 0);
+			isColored = isColored || (transform != null && transform.hasRGBMultipliers());
 			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
 			drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds, transform);
+			#else
+			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend);
+			drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds);
+			#end
 		}
 	}
 

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -589,7 +589,7 @@ class FlxCamera extends FlxBasic
 			&& _headTriangles.blending == blendInt
 			#if !flash
 			&& _headTriangles.hasColorOffsets == hasColorOffsets
-            && _headTriangles.shader == shader
+			&& _headTriangles.shader == shader
 			#end
 			)
 		{
@@ -623,7 +623,7 @@ class FlxCamera extends FlxBasic
 		itemToReturn.blending = blendInt;
 		#if !flash
 		itemToReturn.hasColorOffsets = hasColorOffsets;
-        itemToReturn.shader = shader;
+		itemToReturn.shader = shader;
 		#end
 
 		itemToReturn.nextTyped = _headTriangles;

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -596,15 +596,11 @@ class FlxCamera extends FlxBasic
 			return _headTriangles;
 		}
 
-		#if !flash
 		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
-		#else
-		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend);
-		#end
 	}
 
 	@:noCompletion
-	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode #if !flash , ?hasColorOffsets:Bool, ?shader:FlxShader #end):FlxDrawTrianglesItem
+	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
 	{
 		var itemToReturn:FlxDrawTrianglesItem = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
@@ -769,7 +765,7 @@ class FlxCamera extends FlxBasic
 	}
 
 	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>,
-			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false #if !flash , ?transform:ColorTransform, ?shader:FlxShader #end):Void
+			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false, ?transform:ColorTransform, ?shader:FlxShader):Void
 	{
 		if (FlxG.renderBlit)
 		{

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -577,7 +577,7 @@ class FlxCamera extends FlxBasic
 	}
 
 	@:noCompletion
-	public function startTrianglesBatch(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
+	public function startTrianglesBatch(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?repeat:Bool = false, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
 	{
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
 
@@ -590,17 +590,18 @@ class FlxCamera extends FlxBasic
 			#if !flash
 			&& _headTriangles.hasColorOffsets == hasColorOffsets
 			&& _headTriangles.shader == shader
+			&& _headTriangles.repeat == repeat
 			#end
 			)
 		{
 			return _headTriangles;
 		}
 
-		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
+		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend, repeat, hasColorOffsets, shader);
 	}
 
 	@:noCompletion
-	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
+	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?repeat:Bool = false, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
 	{
 		var itemToReturn:FlxDrawTrianglesItem = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
@@ -624,6 +625,7 @@ class FlxCamera extends FlxBasic
 		#if !flash
 		itemToReturn.hasColorOffsets = hasColorOffsets;
 		itemToReturn.shader = shader;
+		itemToReturn.repeat = repeat;
 		#end
 
 		itemToReturn.nextTyped = _headTriangles;
@@ -848,7 +850,7 @@ class FlxCamera extends FlxBasic
 			#if !flash
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
 			isColored = isColored || (transform != null && transform.hasRGBMultipliers());
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
+			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend, repeat, hasColorOffsets, shader);
 			drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds, transform);
 			#else
 			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend);

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -45,10 +45,9 @@ private typedef FlxDrawItem = #if FLX_DRAW_QUADS flixel.graphics.tile.FlxDrawQua
 class FlxCamera extends FlxBasic
 {
 	/**
-	 * While you can alter the zoom of each camera after the fact,
-	 * this variable determines what value the camera will start at when created.
+	 * Any `FlxCamera` with a zoom of 0 (the default value) will have this zoom value.
 	 */
-	public static var defaultZoom:Float;
+	public static var defaultZoom:Float = 1.0;
 
 	/**
 	 * Used behind-the-scenes during the draw phase so that members use the same default

--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -56,7 +56,11 @@ class FlxStrip extends FlxSprite
 				continue;
 
 			getScreenPosition(_point, camera).subtractPoint(offset);
+			#if !flash
 			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing, colorTransform, shader);
+			#else
+			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing);
+			#end
 		}
 	}
 }

--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -56,7 +56,7 @@ class FlxStrip extends FlxSprite
 				continue;
 
 			getScreenPosition(_point, camera).subtractPoint(offset);
-			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing);
+			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing, colorTransform, shader);
 		}
 	}
 }

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -6,8 +6,10 @@ import flixel.graphics.tile.FlxDrawBaseItem.FlxDrawItemType;
 import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
+import flixel.system.FlxAssets.FlxShader;
 import flixel.util.FlxColor;
 import openfl.display.Graphics;
+import openfl.display.ShaderParameter;
 import openfl.display.TriangleCulling;
 import openfl.geom.ColorTransform;
 
@@ -20,6 +22,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 {
 	static var point:FlxPoint = FlxPoint.get();
 	static var rect:FlxRect = FlxRect.get();
+
+    public var shader:FlxShader;
+	var alphas:Array<Float>;
+    var colorMultipliers:Array<Float>;
+	var colorOffsets:Array<Float>;
 
 	public var vertices:DrawData<Float> = new DrawData<Float>();
 	public var indices:DrawData<Int> = new DrawData<Int>();
@@ -36,6 +43,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	{
 		super();
 		type = FlxDrawItemType.TRIANGLES;
+		alphas = [];
 	}
 
 	override public function render(camera:FlxCamera):Void
@@ -46,7 +54,25 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		if (numTriangles <= 0)
 			return;
 
-		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
+        var shader = shader != null ? shader : graphics.shader;
+		shader.bitmap.input = graphics.bitmap;
+		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
+		shader.alpha.value = alphas;
+
+        if (colored || hasColorOffsets)
+        {
+            shader.colorMultiplier.value = colorMultipliers;
+            shader.colorOffset.value = colorOffsets;
+        }
+
+        setParameterValue(shader.hasTransform, true);
+		setParameterValue(shader.hasColorTransform, colored || hasColorOffsets);
+
+		#if (openfl > "8.7.0")
+		camera.canvas.graphics.overrideBlendMode(blend);
+		#end
+		camera.canvas.graphics.beginShaderFill(shader);
+
 		#if !openfl_legacy
 		camera.canvas.graphics.drawTriangles(vertices, indices, uvtData, TriangleCulling.NONE);
 		#else
@@ -76,6 +102,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		verticesPosition = 0;
 		indicesPosition = 0;
 		colorsPosition = 0;
+		alphas.splice(0, alphas.length);
+        if (colorMultipliers != null)
+			colorMultipliers.splice(0, colorMultipliers.length);
+		if (colorOffsets != null)
+			colorOffsets.splice(0, colorOffsets.length);
 	}
 
 	override public function dispose():Void
@@ -87,10 +118,13 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		uvtData = null;
 		colors = null;
 		bounds = null;
+		alphas = null;
+        colorMultipliers = null;
+		colorOffsets = null;
 	}
 
 	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>, ?position:FlxPoint,
-			?cameraBounds:FlxRect):Void
+			?cameraBounds:FlxRect, ?transform:ColorTransform):Void
 	{
 		if (position == null)
 			position = point.set();
@@ -164,7 +198,58 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 		position.putWeak();
 		cameraBounds.putWeak();
+
+        for (_ in 0...numVertices)
+        {
+			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
+			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
+			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
+        }
+
+        if (colored || hasColorOffsets)
+        {
+            if (colorMultipliers == null)
+                colorMultipliers = [];
+
+            if (colorOffsets == null)
+                colorOffsets = [];
+
+            for (_ in 0...numVertices)
+            {
+				if(transform != null)
+				{
+					colorMultipliers.push(transform.redMultiplier);
+					colorMultipliers.push(transform.greenMultiplier);
+					colorMultipliers.push(transform.blueMultiplier);
+
+					colorOffsets.push(transform.redOffset);
+					colorOffsets.push(transform.greenOffset);
+					colorOffsets.push(transform.blueOffset);
+					colorOffsets.push(transform.alphaOffset);
+				}
+				else
+				{
+					colorMultipliers.push(1);
+					colorMultipliers.push(1);
+					colorMultipliers.push(1);
+	
+					colorOffsets.push(0);
+					colorOffsets.push(0);
+					colorOffsets.push(0);
+					colorOffsets.push(0);
+				}
+
+                colorMultipliers.push(1);
+            }
+        }
 	}
+
+    inline function setParameterValue(parameter:ShaderParameter<Bool>, value:Bool):Void
+    {
+        if (parameter.value == null)
+            parameter.value = [];
+        parameter.value[0] = value;
+    }
 
 	public static inline function inflateBounds(bounds:FlxRect, x:Float, y:Float):FlxRect
 	{

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -28,6 +28,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	var alphas:Array<Float>;
     var colorMultipliers:Array<Float>;
 	var colorOffsets:Array<Float>;
+	public var repeat:Bool;
 	#end
 
 	public var vertices:DrawData<Float> = new DrawData<Float>();
@@ -62,6 +63,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
         var shader = shader != null ? shader : graphics.shader;
 		shader.bitmap.input = graphics.bitmap;
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
+		shader.bitmap.wrap = (repeat) ? REPEAT : CLAMP;
 		shader.alpha.value = alphas;
 
         if (colored || hasColorOffsets)
@@ -76,7 +78,12 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		#if (openfl > "8.7.0")
 		camera.canvas.graphics.overrideBlendMode(blend);
 		#end
-		camera.canvas.graphics.beginShaderFill(shader);
+		if(!repeat && shader != null)
+		{
+			camera.canvas.graphics.beginShaderFill(shader);
+		}
+		else
+			camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
 		#else
 		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
 		#end

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -23,10 +23,12 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	static var point:FlxPoint = FlxPoint.get();
 	static var rect:FlxRect = FlxRect.get();
 
+	#if !flash
     public var shader:FlxShader;
 	var alphas:Array<Float>;
     var colorMultipliers:Array<Float>;
 	var colorOffsets:Array<Float>;
+	#end
 
 	public var vertices:DrawData<Float> = new DrawData<Float>();
 	public var indices:DrawData<Int> = new DrawData<Int>();
@@ -43,7 +45,9 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	{
 		super();
 		type = FlxDrawItemType.TRIANGLES;
+		#if !flash
 		alphas = [];
+		#end
 	}
 
 	override public function render(camera:FlxCamera):Void
@@ -54,6 +58,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		if (numTriangles <= 0)
 			return;
 
+		#if !flash
         var shader = shader != null ? shader : graphics.shader;
 		shader.bitmap.input = graphics.bitmap;
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
@@ -72,6 +77,9 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		camera.canvas.graphics.overrideBlendMode(blend);
 		#end
 		camera.canvas.graphics.beginShaderFill(shader);
+		#else
+		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
+		#end
 
 		#if !openfl_legacy
 		camera.canvas.graphics.drawTriangles(vertices, indices, uvtData, TriangleCulling.NONE);
@@ -102,11 +110,13 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		verticesPosition = 0;
 		indicesPosition = 0;
 		colorsPosition = 0;
+		#if !flash
 		alphas.splice(0, alphas.length);
         if (colorMultipliers != null)
 			colorMultipliers.splice(0, colorMultipliers.length);
 		if (colorOffsets != null)
 			colorOffsets.splice(0, colorOffsets.length);
+		#end
 	}
 
 	override public function dispose():Void
@@ -118,13 +128,15 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		uvtData = null;
 		colors = null;
 		bounds = null;
+		#if !flash
 		alphas = null;
         colorMultipliers = null;
 		colorOffsets = null;
+		#end
 	}
 
 	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>, ?position:FlxPoint,
-			?cameraBounds:FlxRect, ?transform:ColorTransform):Void
+			?cameraBounds:FlxRect #if !flash , ?transform:ColorTransform #end):Void
 	{
 		if (position == null)
 			position = point.set();
@@ -199,6 +211,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		position.putWeak();
 		cameraBounds.putWeak();
 
+		#if !flash
         for (_ in 0...numVertices)
         {
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
@@ -242,6 +255,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
                 colorMultipliers.push(1);
             }
         }
+		#end
 	}
 
     inline function setParameterValue(parameter:ShaderParameter<Bool>, value:Bool):Void


### PR DESCRIPTION
This adds a field called 'repeat' into `FlxDrawTrianglesItem`, which will allow for tiling the bitmap used when rendering using drawTriangles. This should fix #2694 as whenever `flxstripobject.repeat` is set to true, it will use `beginBitmapFill` to perform rendering, as opposed to `beginShaderFill`. However this will also disable shaders if the repeat field is set to true and only allow shaders when it is set to false.