### PR TITLE
Added new compile defines: FLX_NO_ERROR_SOUND and FLX_NO_ERROR_CONSOLE

### DIFF
--- a/flixel/system/debug/log/LogStyle.hx
+++ b/flixel/system/debug/log/LogStyle.hx
@@ -60,8 +60,8 @@ class LogStyle
 		bold = Bold;
 		italic = Italic;
 		underlined = Underlined;
-		errorSound = ErrorSound;
-		openConsole = OpenConsole;
+		errorSound = #if FLX_NO_ERROR_SOUND null #else ErrorSound #end;
+		openConsole = #if FLX_NO_ERROR_CONSOLE false #else OpenConsole #end;
 		callbackFunction = CallbackFunction;
 	}
 }

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -27,6 +27,8 @@ private enum UserDefines
 	/* Simplifies FlxPoint but can increase GC frequency */
 	FLX_NO_POINT_POOL;
 	FLX_NO_PITCH;
+	FLX_NO_ERROR_SOUND;
+	FLX_NO_ERROR_CONSOLE;
 }
 
 /**


### PR DESCRIPTION
Added two new compile defines:

* `FLX_NO_ERROR_SOUND` disables any sounds which play when a warning or error is logged.
* `FLX_NO_ERROR_CONSOLE` disables the behavior where the console automatically opens when a warning or error is logged.

These are useful in the even that a developer wants to compile a debug build, but does not want to be annoyed by regular beeping of the console. This allows them to temporarily disable the beeps by adding compile defines to their project file.