### PR TITLE
Update FlxPoint pivotRadians to proper order of operations

### DIFF
--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -7,31 +7,31 @@ import openfl.geom.Point;
 
 /**
  * 2-dimensional point class
- * 
+ *
  * ## Pooling
  * To avoid creating new instances, unnecessarily, used points can be
  * for later use. Rather than creating a new instance directly, call
  * `FlxPoint.get(x, y)` and it will retrieve a point from the pool, if
  * one exists, otherwise it will create a new instance. Similarly, when
  * you're done using a point, call `myPoint.put()` to place it back.
- * 
+ *
  * You can disable point pooling entirely with `FLX_NO_POINT_POOL`.
- * 
+ *
  * ## Weak points
  * Weak points are points meant for a singular use, rather than calling
  * `put` on every point you `get`, you can create a weak point, and have
  * it placed back once used. All `FlxPoint` methods and Flixel utilities
  * automatically call `putWeak()` on every point passed in.
- * 
+ *
  * In the following example, a weak point is created, and passed into
  * `p.degreesTo` where `putWeak` is called on it, putting it back in the pool.
  *
  * ```haxe
  * var angle = p.degreesTo(FlxPoint.weak(FlxG.mouse.x, FlxG.mouse.y));
  * ```
- * 
+ *
  * ## Overloaded Operators
- * 
+ *
  * - `A += B` adds the value of `B` to `A`
  * - `A -= B` subtracts the value of `B` from `A`
  * - `A *= k` scales `A` by float `k` in both x and y components
@@ -43,7 +43,7 @@ import openfl.geom.Point;
  *
  * Note: that these operators get points from the pool, but do not put
  * points back in the pool, unless they are weak.
- * 
+ *
  * Example: 4 total points are created, but only 3 are put into the pool
  * ```haxe
  * var a = FlxPoint.get(1, 1);
@@ -53,7 +53,7 @@ import openfl.geom.Point;
  * b.put();
  * c.put();
  * ```
- * 
+ *
  * To put all 4 back, it should look like this:
  * ```haxe
  * var a = FlxPoint.get(1, 1);
@@ -65,11 +65,11 @@ import openfl.geom.Point;
  * c.put();
  * d.put();
  * ```
- * 
+ *
  * Otherwise, the remainging points will become garbage, adding to the
  * heap, potentially triggering a garbage collection when you don't want.
  */
-@:forward abstract FlxPoint(FlxBasePoint) to FlxBasePoint from FlxBasePoint 
+@:forward abstract FlxPoint(FlxBasePoint) to FlxBasePoint from FlxBasePoint
 {
 	public static inline var EPSILON:Float = 0.0000001;
 	public static inline var EPSILON_SQUARED:Float = EPSILON * EPSILON;
@@ -142,7 +142,7 @@ import openfl.geom.Point;
 		return result;
 	}
 
-	
+
 	/**
 	 * Operator that divides a point by float, returning a new point.
 	 */
@@ -185,7 +185,7 @@ import openfl.geom.Point;
 		return a.scale(b);
 	}
 
-	
+
 	/**
 	 * Operator that adds two points, returning a new point.
 	 */
@@ -586,7 +586,7 @@ import openfl.geom.Point;
 	}
 
 	/**
-	 * Rotates this point clockwise in 2D space around another point by the given radians.
+	 * Rotates this point counter-clockwise in 2D space around another point by the given radians.
 	 * Note: To rotate a point around 0,0 you can use `p.radians += angle`
 	 * @since 5.0.0
 	 *
@@ -596,7 +596,7 @@ import openfl.geom.Point;
 	 */
 	public function pivotRadians(pivot:FlxPoint, radians:Float):FlxPoint
 	{
-		_point1.copyFrom(pivot).subtractPoint(this);
+		_point1.copyFrom(this).subtractPoint(pivot);
 		_point1.radians += radians;
 		set(_point1.x + pivot.x, _point1.y + pivot.y);
 		pivot.putWeak();
@@ -604,7 +604,7 @@ import openfl.geom.Point;
 	}
 
 	/**
-	 * Rotates this point clockwise in 2D space around another point by the given degrees.
+	 * Rotates this point counter-clockwise in 2D space around another point by the given degrees.
 	 * Note: To rotate a point around 0,0 you can use `p.degrees += angle`
 	 * @since 5.0.0
 	 *
@@ -684,16 +684,16 @@ import openfl.geom.Point;
 	}
 
 	/** DEPRECATED
-	 * 
+	 *
 	 * Calculates the angle between this and another point. 0 degrees points straight up.
-	 * 
+	 *
 	 * Note: Every other flixel function treats straight right as 0 degrees.
-	 * 
+	 *
 	 * Also Note: The result is very innacurate.
 	 *
 	 * @param   point   The other point.
 	 * @return  The angle in degrees, between -180 and 180.
-	 * 
+	 *
 	 * @see [Flixel 5.0.0 Migration guide](https://github.com/HaxeFlixel/flixel/wiki/Flixel-5.0.0-Migration-guide)
 	 */
 	@:deprecated("angleBetween is deprecated, use degreesTo instead")
@@ -945,7 +945,7 @@ import openfl.geom.Point;
 	 * @param   length   The length to set the point
 	 * @param   radians  The angle to set the point, in radians
 	 * @return  The rotated point
-	 * 
+	 *
 	 * @since 4.10.0
 	 */
 	public function setPolarRadians(length:Float, radians:Float):FlxPoint
@@ -961,7 +961,7 @@ import openfl.geom.Point;
 	 * @param   length  The length to set the point
 	 * @param   degrees The angle to set the point, in degrees
 	 * @return  The rotated point
-	 * 
+	 *
 	 * @since 4.10.0
 	 */
 	public inline function setPolarDegrees(length:Float, degrees:Float):FlxPoint
@@ -1425,7 +1425,7 @@ import openfl.geom.Point;
 
 /**
  * The base class of FlxPoint, just use FlxPoint instead.
- * 
+ *
  * Note to contributors: don't worry about adding functionality to the base class.
  * it's all mostly inlined anyway so there's no runtime definitions for
  * reflection or anything.

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -573,10 +573,10 @@ import openfl.geom.Point;
 	}
 
 	/**
-	 * Rotates this point counter-clockwise in 2D space around another point by the given degrees.
+	 * Rotates this point clockwise in 2D space around another point by the given degrees.
 	 *
 	 * @param   pivot    The pivot you want to rotate this point around
-	 * @param   degrees  Rotate the point by this many degrees counter-clockwise.
+	 * @param   degrees  Rotate the point by this many degrees clockwise.
 	 * @return  A FlxPoint containing the coordinates of the rotated point.
 	 */
 	@:deprecated("rotate is deprecated, use pivotDegrees")
@@ -586,12 +586,12 @@ import openfl.geom.Point;
 	}
 
 	/**
-	 * Rotates this point counter-clockwise in 2D space around another point by the given radians.
+	 * Rotates this point clockwise in 2D space around another point by the given radians.
 	 * Note: To rotate a point around 0,0 you can use `p.radians += angle`
 	 * @since 5.0.0
 	 *
 	 * @param   pivot    The pivot you want to rotate this point around
-	 * @param   radians  Rotate the point by this many radians counter-clockwise.
+	 * @param   radians  Rotate the point by this many radians clockwise.
 	 * @return  A FlxPoint containing the coordinates of the rotated point.
 	 */
 	public function pivotRadians(pivot:FlxPoint, radians:Float):FlxPoint
@@ -604,7 +604,7 @@ import openfl.geom.Point;
 	}
 
 	/**
-	 * Rotates this point counter-clockwise in 2D space around another point by the given degrees.
+	 * Rotates this point clockwise in 2D space around another point by the given degrees.
 	 * Note: To rotate a point around 0,0 you can use `p.degrees += angle`
 	 * @since 5.0.0
 	 *

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -7,31 +7,31 @@ import openfl.geom.Point;
 
 /**
  * 2-dimensional point class
- *
+ * 
  * ## Pooling
  * To avoid creating new instances, unnecessarily, used points can be
  * for later use. Rather than creating a new instance directly, call
  * `FlxPoint.get(x, y)` and it will retrieve a point from the pool, if
  * one exists, otherwise it will create a new instance. Similarly, when
  * you're done using a point, call `myPoint.put()` to place it back.
- *
+ * 
  * You can disable point pooling entirely with `FLX_NO_POINT_POOL`.
- *
+ * 
  * ## Weak points
  * Weak points are points meant for a singular use, rather than calling
  * `put` on every point you `get`, you can create a weak point, and have
  * it placed back once used. All `FlxPoint` methods and Flixel utilities
  * automatically call `putWeak()` on every point passed in.
- *
+ * 
  * In the following example, a weak point is created, and passed into
  * `p.degreesTo` where `putWeak` is called on it, putting it back in the pool.
  *
  * ```haxe
  * var angle = p.degreesTo(FlxPoint.weak(FlxG.mouse.x, FlxG.mouse.y));
  * ```
- *
+ * 
  * ## Overloaded Operators
- *
+ * 
  * - `A += B` adds the value of `B` to `A`
  * - `A -= B` subtracts the value of `B` from `A`
  * - `A *= k` scales `A` by float `k` in both x and y components
@@ -43,7 +43,7 @@ import openfl.geom.Point;
  *
  * Note: that these operators get points from the pool, but do not put
  * points back in the pool, unless they are weak.
- *
+ * 
  * Example: 4 total points are created, but only 3 are put into the pool
  * ```haxe
  * var a = FlxPoint.get(1, 1);
@@ -53,7 +53,7 @@ import openfl.geom.Point;
  * b.put();
  * c.put();
  * ```
- *
+ * 
  * To put all 4 back, it should look like this:
  * ```haxe
  * var a = FlxPoint.get(1, 1);
@@ -65,11 +65,11 @@ import openfl.geom.Point;
  * c.put();
  * d.put();
  * ```
- *
+ * 
  * Otherwise, the remainging points will become garbage, adding to the
  * heap, potentially triggering a garbage collection when you don't want.
  */
-@:forward abstract FlxPoint(FlxBasePoint) to FlxBasePoint from FlxBasePoint
+@:forward abstract FlxPoint(FlxBasePoint) to FlxBasePoint from FlxBasePoint 
 {
 	public static inline var EPSILON:Float = 0.0000001;
 	public static inline var EPSILON_SQUARED:Float = EPSILON * EPSILON;
@@ -142,7 +142,7 @@ import openfl.geom.Point;
 		return result;
 	}
 
-
+	
 	/**
 	 * Operator that divides a point by float, returning a new point.
 	 */
@@ -185,7 +185,7 @@ import openfl.geom.Point;
 		return a.scale(b);
 	}
 
-
+	
 	/**
 	 * Operator that adds two points, returning a new point.
 	 */
@@ -573,10 +573,10 @@ import openfl.geom.Point;
 	}
 
 	/**
-	 * Rotates this point clockwise in 2D space around another point by the given degrees.
+	 * Rotates this point counter-clockwise in 2D space around another point by the given degrees.
 	 *
 	 * @param   pivot    The pivot you want to rotate this point around
-	 * @param   degrees  Rotate the point by this many degrees clockwise.
+	 * @param   degrees  Rotate the point by this many degrees counter-clockwise.
 	 * @return  A FlxPoint containing the coordinates of the rotated point.
 	 */
 	@:deprecated("rotate is deprecated, use pivotDegrees")
@@ -591,7 +591,7 @@ import openfl.geom.Point;
 	 * @since 5.0.0
 	 *
 	 * @param   pivot    The pivot you want to rotate this point around
-	 * @param   radians  Rotate the point by this many radians clockwise.
+	 * @param   radians  Rotate the point by this many radians counter-clockwise.
 	 * @return  A FlxPoint containing the coordinates of the rotated point.
 	 */
 	public function pivotRadians(pivot:FlxPoint, radians:Float):FlxPoint
@@ -684,16 +684,16 @@ import openfl.geom.Point;
 	}
 
 	/** DEPRECATED
-	 *
+	 * 
 	 * Calculates the angle between this and another point. 0 degrees points straight up.
-	 *
+	 * 
 	 * Note: Every other flixel function treats straight right as 0 degrees.
-	 *
+	 * 
 	 * Also Note: The result is very innacurate.
 	 *
 	 * @param   point   The other point.
 	 * @return  The angle in degrees, between -180 and 180.
-	 *
+	 * 
 	 * @see [Flixel 5.0.0 Migration guide](https://github.com/HaxeFlixel/flixel/wiki/Flixel-5.0.0-Migration-guide)
 	 */
 	@:deprecated("angleBetween is deprecated, use degreesTo instead")
@@ -945,7 +945,7 @@ import openfl.geom.Point;
 	 * @param   length   The length to set the point
 	 * @param   radians  The angle to set the point, in radians
 	 * @return  The rotated point
-	 *
+	 * 
 	 * @since 4.10.0
 	 */
 	public function setPolarRadians(length:Float, radians:Float):FlxPoint
@@ -961,7 +961,7 @@ import openfl.geom.Point;
 	 * @param   length  The length to set the point
 	 * @param   degrees The angle to set the point, in degrees
 	 * @return  The rotated point
-	 *
+	 * 
 	 * @since 4.10.0
 	 */
 	public inline function setPolarDegrees(length:Float, degrees:Float):FlxPoint
@@ -1425,7 +1425,7 @@ import openfl.geom.Point;
 
 /**
  * The base class of FlxPoint, just use FlxPoint instead.
- *
+ * 
  * Note to contributors: don't worry about adding functionality to the base class.
  * it's all mostly inlined anyway so there's no runtime definitions for
  * reflection or anything.

--- a/tests/unit/src/flixel/math/FlxPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxPointTest.hx
@@ -159,11 +159,34 @@ class FlxPointTest extends FlxTest
 		assertPointEquals(point1, 1, 2);
 	}
 
+	@Test
+	function testPivotDegrees() {
+		// Pivot around point in same quadrant
+		point1.set(10, 10);
+		point2.set(5, 5);
+		assertPointNearlyEquals(point1.pivotDegrees(point2, 180), 0, 0);
+
+		// pivot around origin
+		point1.set(1, 10);
+		point2.set();
+		assertPointNearlyEquals(point1.pivotDegrees(point2, 90), -10, 1);
+
+		// pivot around point in different quadrant
+		point1.set(10, 10);
+		point2.set(-1, -1);
+		assertPointNearlyEquals(point1.pivotDegrees(point2, 45), -1, 14.55);
+	}
+
 	function assertPointEquals(p:FlxPoint, x:Float, y:Float, ?msg:String, ?info:PosInfos)
 	{
-		if (msg == null)
-			msg = 'Expected (x: $x | y: $y) but was $p';
-
-		Assert.isTrue(x == p.x && y == p.y, msg, info);
+		assertPointNearlyEquals(p, x, y, 0.0, msg, info);
 	}
+
+	function assertPointNearlyEquals(p:FlxPoint, x:Float, y:Float, tollerance:Float = .01, ?msg:String, ?info:PosInfos)
+		{
+			if (msg == null)
+				msg = 'Expected (x: $x | y: $y) but was $p';
+
+			Assert.isTrue(Math.abs(x - p.x) <= tollerance && Math.abs(y -p.y) <= tollerance, msg, info);
+		}
 }

--- a/tests/unit/src/flixel/math/FlxPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxPointTest.hx
@@ -182,11 +182,11 @@ class FlxPointTest extends FlxTest
 		assertPointNearlyEquals(p, x, y, 0.0, msg, info);
 	}
 
-	function assertPointNearlyEquals(p:FlxPoint, x:Float, y:Float, tollerance:Float = .01, ?msg:String, ?info:PosInfos)
+	function assertPointNearlyEquals(p:FlxPoint, x:Float, y:Float, tolerance:Float = .01, ?msg:String, ?info:PosInfos)
 		{
 			if (msg == null)
 				msg = 'Expected (x: $x | y: $y) but was $p';
 
-			Assert.isTrue(Math.abs(x - p.x) <= tollerance && Math.abs(y -p.y) <= tollerance, msg, info);
+			Assert.isTrue(Math.abs(x - p.x) <= tolerance && Math.abs(y -p.y) <= tolerance, msg, info);
 		}
 }


### PR DESCRIPTION
Updates FlxPoint pivotRadians math which was calculating the rotation point improperly.
Fixes #2698 

Old:
1. subtract `point` from `pivot`
1. apply rotation
1. add `pivot` to result
1. return

New:
1. subtract `pivot` from `point`
1. apply rotation
1. add `pivot` to result
1. return

I also updated the doc comments to specify "Counter-clockwise" as the use of cos and sin functions are counter-clockwise. Comparing behavior to the 4.11.0 branch, this is consistent with the behavior there despite that branch also specifying "clockwise"