### PR TITLE
allow for mp3/ogg/wav in getSound

### DIFF
--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -255,7 +255,7 @@ class FlxAssets
 
 	public static function getSound(id:String):Sound
 	{
-		if (id.endsWith(".mp3") && id.endsWith(".ogg") && id.endsWith(".wav"))
+		if (!id.endsWith(".mp3") && !id.endsWith(".ogg") && !id.endsWith(".wav"))
 			id += "." + defaultSoundExtension;
 
 		return Assets.getSound(id);

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -52,7 +52,7 @@ class FlxAssets
 	 * `FlxAssets.getSound` which are not common. Currently set to ".ogg" on non-flash targets
 	 * for backwards compatibility reasons.
 	 */
-	public static var defaultSoundExtension = #if flash ".mp3" #else ".ogg" #end;
+	public static var defaultSoundExtension = #if flash "mp3" #else "ogg" #end;
 	
 	#if (macro || doc_gen)
 	/**
@@ -256,7 +256,7 @@ class FlxAssets
 	public static function getSound(id:String):Sound
 	{
 		if (id.endsWith(".mp3") && id.endsWith(".ogg") && id.endsWith(".wav"))
-			id += defaultSoundExtension;
+			id += "." + defaultSoundExtension;
 
 		return Assets.getSound(id);
 	}

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -253,6 +253,13 @@ class FlxAssets
 		return null;
 	}
 
+	/**
+	 * Loads an OpenFL sound asset from the given asset id. If an extension not provided the 
+	 * `defaultSoundExtension` is used (defaults to "ogg" on non-flash targets).
+	 * 
+	 * @param   id  The asset id of the local sound file.
+	 * @return  The sound file.
+	 */
 	public static function getSound(id:String):Sound
 	{
 		if (!id.endsWith(".mp3") && !id.endsWith(".ogg") && !id.endsWith(".wav"))

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -16,6 +16,8 @@ import flixel.util.typeLimit.OneOfTwo;
 import openfl.Assets;
 import openfl.utils.ByteArray;
 
+using StringTools;
+
 @:keep @:bitmap("assets/images/logo/logo.png")
 class GraphicLogo extends BitmapData {}
 
@@ -45,6 +47,13 @@ typedef FlxShader =
 
 class FlxAssets
 {
+	/**
+	 * The default sound format to be assumed when unspecified, only affects calls to
+	 * `FlxAssets.getSound` which are not common. Currently set to ".ogg" on non-flash targets
+	 * for backwards compatibility reasons.
+	 */
+	public static var defaultSoundExtension = #if flash ".mp3" #else ".ogg" #end;
+	
 	#if (macro || doc_gen)
 	/**
 	 * Reads files from a directory relative to this project and generates `public static inline`
@@ -244,15 +253,12 @@ class FlxAssets
 		return null;
 	}
 
-	public static inline function getSound(id:String):Sound
+	public static function getSound(id:String):Sound
 	{
-		var extension = "";
-		#if flash
-		extension = ".mp3";
-		#else
-		extension = ".ogg";
-		#end
-		return Assets.getSound(id + extension);
+		if (id.endsWith(".mp3") && id.endsWith(".ogg") && id.endsWith(".wav"))
+			id += defaultSoundExtension;
+
+		return Assets.getSound(id);
 	}
 
 	public static function getVirtualInputFrames():FlxAtlasFrames


### PR DESCRIPTION
This allows "system" sounds to be any format. `FlxAsset.getSound()`, while barely used, controls many internal sounds such as the volume noise and "error noises". previously these needed to be ogg files, since mp3 wasn't available in FOSS for a while. Now you can specify the format in these path strings. Additionally, you can set `FlxAssets.defaultSoundExtension = "mp3"`

Relavant to #2699