### PR TITLE
add hasAny and correct isTouching

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1177,7 +1177,7 @@ class FlxObject extends FlxBasic
 	 */
 	public inline function isTouching(direction:FlxDirectionFlags):Bool
 	{
-		return touching.has(direction);
+		return touching.hasAny(direction);
 	}
 
 	/**
@@ -1189,7 +1189,7 @@ class FlxObject extends FlxBasic
 	 */
 	public inline function justTouched(direction:FlxDirectionFlags):Bool
 	{
-		return touching.has(direction) && !wasTouching.has(direction);
+		return touching.hasAny(direction) && !wasTouching.hasAny(direction);
 	}
 
 	/**

--- a/flixel/util/FlxDirectionFlags.hx
+++ b/flixel/util/FlxDirectionFlags.hx
@@ -66,11 +66,19 @@ import flixel.math.FlxAngle;
 	}
 
 	/**
-	 * Returns true if this contains all of the supplied flags.
+	 * Returns true if this contains **all** of the supplied flags.
 	 */
 	public inline function has(dir:FlxDirectionFlags):Bool
 	{
 		return this & dir == dir;
+	}
+
+	/**
+	 * Returns true if this contains **any** of the supplied flags.
+	 */
+	public inline function hasAny(dir:FlxDirectionFlags):Bool
+	{
+		return this & dir > 0;
 	}
 
 	/**


### PR DESCRIPTION
When `FlxDirectionFlags` were added, `FlxObject.isTouching` was inadvertently changed so that it required **all** flags rather than **any** of the flags. this corrects that.

Also adds `FlxDirectionFlags.hasAny(...)`