### PR TITLE
Fix findMinY() and findMaxY() misconception

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -906,7 +906,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	public function findMinY()
 	{
-		return length == 0 ? x : findMinYHelper();
+		return length == 0 ? y : findMinYHelper();
 	}
 	
 	function findMinYHelper()
@@ -937,7 +937,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	public function findMaxY()
 	{
-		return length == 0 ? x : findMaxYHelper();
+		return length == 0 ? y : findMaxYHelper();
 	}
 	
 	function findMaxYHelper()


### PR DESCRIPTION
Both findMinY() and findMaxY() return X when both variables declare it'll return a Y value when the sprite's length is 0?