### PR TITLE
Fix `firstPressed` functions in FlxGamepad

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -449,7 +449,11 @@ class FlxGamepad implements IFlxDestroyable
 	 */
 	public inline function firstPressedID():FlxGamepadInputID
 	{
-		return mapping.getID(firstPressedRawID());
+		var id = firstPressedRawID();
+		if (id < 0)
+			return id;
+
+		return mapping.getID(id);
 	}
 
 	/**
@@ -460,7 +464,7 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		for (button in buttons)
 		{
-			if (button != null && button.released)
+			if (button != null && button.pressed)
 			{
 				return button.ID;
 			}
@@ -474,7 +478,11 @@ class FlxGamepad implements IFlxDestroyable
 	 */
 	public inline function firstJustPressedID():FlxGamepadInputID
 	{
-		return mapping.getID(firstJustPressedRawID());
+		var id = firstJustPressedRawID();
+		if (id < 0)
+			return id;
+
+		return mapping.getID(id);
 	}
 
 	/**
@@ -499,7 +507,11 @@ class FlxGamepad implements IFlxDestroyable
 	 */
 	public inline function firstJustReleasedID():FlxGamepadInputID
 	{
-		return mapping.getID(firstJustReleasedRawID());
+		var id = firstJustReleasedRawID();
+		if (id < 0)
+			return id;
+
+		return mapping.getID(id);
 	}
 
 	/**


### PR DESCRIPTION
* `firstPressedRawID` now returns the first button that's pressed instead of the first button that's released
* `firstPressedID`, `firstJustPressedID` and `firstJustReleasedID` now properly return `NONE` on XInput and Logitech controllers (before, if no buttons were detected, it would return `GUIDE` as opposed to `NONE`)