### PR TITLE
Small implementations for HaxeFlixel

### DIFF
--- a/flixel/math/FlxMatrix.hx
+++ b/flixel/math/FlxMatrix.hx
@@ -18,17 +18,19 @@ class FlxMatrix extends Matrix
 	 */
 	public inline function rotateWithTrig(cos:Float, sin:Float):FlxMatrix
 	{
-		var a1:Float = a * cos - b * sin;
+		var temp1:Float;
+
+		temp1 = a * cos - b * sin;
 		b = a * sin + b * cos;
-		a = a1;
+		a = temp1;
 
-		var c1:Float = c * cos - d * sin;
+		temp1 = c * cos - d * sin;
 		d = c * sin + d * cos;
-		c = c1;
+		c = temp1;
 
-		var tx1:Float = tx * cos - ty * sin;
+		temp1 = tx * cos - ty * sin;
 		ty = tx * sin + ty * cos;
-		tx = tx1;
+		tx = temp1;
 
 		return this;
 	}

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -752,6 +752,11 @@ class FlxText extends FlxSprite
 		return super.get_height();
 	}
 
+	override function set_width(value:Float):Float {
+		fieldWidth = value;
+		return super.set_width(value);
+	}
+
 	override function updateColorTransform():Void
 	{
 		if (colorTransform == null)


### PR DESCRIPTION
The minor fix is to make the width for FlxText change the field width, too. When you decrease the regular width, the text won't be offset to the right.