### PR TITLE
prevent references to camera.camera

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -2033,6 +2033,22 @@ class FlxCamera extends FlxBasic
 		viewMarginY = 0.5 * height * (scaleY - initialZoom) / scaleY;
 	}
 	
+	@:deprecated("don't reference camera.camera")
+	@:noCompletion
+	override function get_camera():FlxCamera throw "don't reference camera.camera";
+	
+	@:deprecated("don't reference camera.camera")
+	@:noCompletion
+	override function set_camera(value:FlxCamera):FlxCamera throw "don't reference camera.camera";
+	
+	@:deprecated("don't reference camera.cameras")
+	@:noCompletion
+	override function get_cameras():Array<FlxCamera> throw "don't reference camera.cameras";
+	
+	@:deprecated("don't reference camera.cameras")
+	@:noCompletion
+	override function set_cameras(value:Array<FlxCamera>):Array<FlxCamera> throw "don't reference camera.cameras";
+	
 	static inline function get_defaultCameras():Array<FlxCamera>
 	{
 		return _defaultCameras;

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -2033,22 +2033,6 @@ class FlxCamera extends FlxBasic
 		viewMarginY = 0.5 * height * (scaleY - initialZoom) / scaleY;
 	}
 	
-	@:deprecated("don't reference camera.camera")
-	@:noCompletion
-	override function get_camera():FlxCamera throw "don't reference camera.camera";
-	
-	@:deprecated("don't reference camera.camera")
-	@:noCompletion
-	override function set_camera(value:FlxCamera):FlxCamera throw "don't reference camera.camera";
-	
-	@:deprecated("don't reference camera.cameras")
-	@:noCompletion
-	override function get_cameras():Array<FlxCamera> throw "don't reference camera.cameras";
-	
-	@:deprecated("don't reference camera.cameras")
-	@:noCompletion
-	override function set_cameras(value:Array<FlxCamera>):Array<FlxCamera> throw "don't reference camera.cameras";
-	
 	static inline function get_defaultCameras():Array<FlxCamera>
 	{
 		return _defaultCameras;
@@ -2150,6 +2134,26 @@ class FlxCamera extends FlxBasic
 	{
 		return viewMarginBottom;
 	}
+	
+	/**
+	 * Do not use the following fields! They only exists because FlxCamera extends FlxBasic,
+	 * we're hiding them because they've only caused confusion.
+	 */
+	@:deprecated("don't reference camera.camera")
+	@:noCompletion
+	override function get_camera():FlxCamera throw "don't reference camera.camera";
+	
+	@:deprecated("don't reference camera.camera")
+	@:noCompletion
+	override function set_camera(value:FlxCamera):FlxCamera throw "don't reference camera.camera";
+	
+	@:deprecated("don't reference camera.cameras")
+	@:noCompletion
+	override function get_cameras():Array<FlxCamera> throw "don't reference camera.cameras";
+	
+	@:deprecated("don't reference camera.cameras")
+	@:noCompletion
+	override function set_cameras(value:Array<FlxCamera>):Array<FlxCamera> throw "don't reference camera.cameras";
 	
 }
 


### PR DESCRIPTION
follow-up to #2731, should prevent future issues where people try to reference camera **inside** FlxCamera