### PR TITLE
Implement RGB/RGBA detection to `FlxColor.fromString`

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -392,6 +392,17 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	}
 
 	/**
+	 * Return a String representation of the color in the format rgba(R, G, B, A)
+	 *
+	 * @param Alpha Whether to include the alpha value in the RGB string
+	 * @return	A string in the format rgba(R, G, B, A)
+	 */
+	public inline function toRGBString(Alpha:Bool = false):String
+	{
+		return (Alpha ? "rgba" : "rgb") + '($red, $green, $blue' + (Alpha ? ', $alpha' : "") + ")";
+	}
+
+	/**
 	 * Return a String representation of the color in the format #RRGGBB
 	 *
 	 * @return	A string of length 7 in the format #RRGGBB

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -381,7 +381,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	/**
 	 * Return a String representation of the color in the format 0xAARRGGBB
 	 *
-	 * @param Alpha Whether to include the alpha value in the hes string
+	 * @param Alpha Whether to include the alpha value in the hex string
 	 * @param Prefix Whether to include "0x" prefix at start of string
 	 * @return	A string of length 10 in the format 0xAARRGGBB
 	 */

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -82,8 +82,8 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 */
 	public var lightness(get, set):Float;
 
-	static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
-	static var RGB_REGEX = ~/^rgba?\s*\((\s*\d{1,3}\s*,?){3,4}\)/i;
+	static var HEX_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
+	static var RGB_REGEX = ~/^rgba?\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,?\s*(\d{1,3})?\s*\)/i;
 
 	/**
 	 * Create a color from the least significant four bytes of an Int
@@ -194,9 +194,9 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var result:Null<FlxColor> = null;
 		str = StringTools.trim(str);
 
-		if (COLOR_REGEX.match(str))
+		if (HEX_REGEX.match(str))
 		{
-			var hexColor:String = "0x" + COLOR_REGEX.matched(2);
+			var hexColor:String = "0x" + HEX_REGEX.matched(2);
 			result = new FlxColor(Std.parseInt(hexColor));
 			if (hexColor.length == 8)
 			{
@@ -205,11 +205,8 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		}
 		else if (RGB_REGEX.match(str))
 		{
-			var splittedColors = [
-				for (strNum in str.remove("rgba").remove("rgb").remove("(").remove(")").split(","))
-					Std.parseInt(strNum)
-			];
-			result = fromRGB(splittedColors[0], splittedColors[1], splittedColors[2], splittedColors[3] == null ? 255 : splittedColors[3]);
+			result = fromRGB(Std.parseInt(RGB_REGEX.matched(1)), Std.parseInt(RGB_REGEX.matched(2)), Std.parseInt(RGB_REGEX.matched(3)),
+				RGB_REGEX.matched(4) == null ? 255 : Std.parseInt(RGB_REGEX.matched(4)));
 		}
 		else
 		{

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -379,7 +379,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	}
 
 	/**
-	 * Return a String representation of the color in the format
+	 * Return a String representation of the color in the format 0xAARRGGBB
 	 *
 	 * @param Alpha Whether to include the alpha value in the hes string
 	 * @param Prefix Whether to include "0x" prefix at start of string

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -83,7 +83,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public var lightness(get, set):Float;
 
 	static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
-	static var RGB_REGEX = ~/^rgb\s*\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)/i;
+	static var RGB_REGEX = ~/^rgb\s*\((\s*\d{1,3}\s*,?){3,4}\)/i;
 
 	/**
 	 * Create a color from the least significant four bytes of an Int
@@ -208,7 +208,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 				for (strNum in str.remove("rgb").remove("(").remove(")").split(","))
 					Std.parseInt(strNum)
 			];
-			result = FlxColor.fromRGB(splittedColors[0], splittedColors[1], splittedColors[2]);
+			result = fromRGB(splittedColors[0], splittedColors[1], splittedColors[2], splittedColors[3]);
 		}
 		else
 		{

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -3,6 +3,8 @@ package flixel.util;
 import flixel.math.FlxMath;
 import flixel.system.macros.FlxMacroUtil;
 
+using flixel.util.FlxStringUtil;
+
 /**
  * Class representing a color, based on Int. Provides a variety of methods for creating and converting colors.
  *
@@ -81,6 +83,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public var lightness(get, set):Float;
 
 	static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
+	static var RGB_REGEX = ~/^rgb\s*\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)/i;
 
 	/**
 	 * Create a color from the least significant four bytes of an Int
@@ -180,6 +183,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * - `#3F000011`   -> `0x3F000011`
 	 * - `GRAY`        -> `0xFF808080`
 	 * - `blue`        -> `0xFF0000FF`
+	 * - `rgb(184, 76, 217)`  -> `0xFFB84CD9`
 	 *
 	 * @param	str 	The string to be parsed
 	 * @return	A `FlxColor` or `null` if the `String` couldn't be parsed
@@ -197,6 +201,14 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 			{
 				result.alphaFloat = 1;
 			}
+		}
+		else if (RGB_REGEX.match(str))
+		{
+			var splittedColors = [
+				for (strNum in str.remove("rgb").remove("(").remove(")").split(","))
+					Std.parseInt(strNum)
+			];
+			result = FlxColor.fromRGB(splittedColors[0], splittedColors[1], splittedColors[2]);
 		}
 		else
 		{

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -83,7 +83,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public var lightness(get, set):Float;
 
 	static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
-	static var RGB_REGEX = ~/^rgb\s*\((\s*\d{1,3}\s*,?){3,4}\)/i;
+	static var RGB_REGEX = ~/^rgba?\s*\((\s*\d{1,3}\s*,?){3,4}\)/i;
 
 	/**
 	 * Create a color from the least significant four bytes of an Int
@@ -184,6 +184,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * - `GRAY`        -> `0xFF808080`
 	 * - `blue`        -> `0xFF0000FF`
 	 * - `rgb(184, 76, 217)`  -> `0xFFB84CD9`
+	 * - `rgba(184, 76, 217, 127)`  -> `0x7FB84CD9`
 	 *
 	 * @param	str 	The string to be parsed
 	 * @return	A `FlxColor` or `null` if the `String` couldn't be parsed

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -209,7 +209,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 				for (strNum in str.remove("rgb").remove("(").remove(")").split(","))
 					Std.parseInt(strNum)
 			];
-			result = fromRGB(splittedColors[0], splittedColors[1], splittedColors[2], splittedColors[3]);
+			result = fromRGB(splittedColors[0], splittedColors[1], splittedColors[2], splittedColors[3] == null ? 255 : splittedColors[3]);
 		}
 		else
 		{

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -206,7 +206,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		else if (RGB_REGEX.match(str))
 		{
 			var splittedColors = [
-				for (strNum in str.remove("rgb").remove("(").remove(")").split(","))
+				for (strNum in str.remove("rgba").remove("rgb").remove("(").remove(")").split(","))
 					Std.parseInt(strNum)
 			];
 			result = fromRGB(splittedColors[0], splittedColors[1], splittedColors[2], splittedColors[3] == null ? 255 : splittedColors[3]);


### PR DESCRIPTION
Convert strings like `rgb(184, 76, 217)` to a FlxColor using fromString. (case-insensitive & ignores white spaces)

Examples:
- `rgb(184, 76, 12)`
- ` rgb  ( 123, 21,0 )`
- `rgb ( 32 , 56 , 63 , 127 )` 
- `rgba(32,56,63,0)` 


```haxe
~/^rgb\s*\((\s*\d{1,3}\s*,?){3,4}\)/i
```