### PR TITLE
Fix get_embedded() in FlxText

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -626,7 +626,7 @@ class FlxText extends FlxSprite
 
 	inline function get_embedded():Bool
 	{
-		return textField.embedFonts = true;
+		return textField.embedFonts;
 	}
 
 	inline function get_systemFont():String


### PR DESCRIPTION
I noticed this while looking through FlxText, instead of just returning the text field's `embedFonts` value, it sets it to `true` first, essentially making it always return `true`. I'm guessing this is a mistake, so I made this pull request which fixes it.