### PR TITLE
add x, y and text args to FlxBitmapText

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -199,11 +199,14 @@ class FlxBitmapText extends FlxSprite
 	 * Warning: The default font may work incorrectly on HTML5
 	 * and is utterly unreliable on Brave Browser with shields up.
 	 * 
-	 * @param 	font	Optional parameter for component's font prop
+	 * @param   x     The initial X position of the text.
+	 * @param   y     The initial Y position of the text.
+	 * @param   text  The text to display.
+	 * @param   font  Optional parameter for component's font prop
 	 */
-	public function new(?font:FlxBitmapFont)
+	public function new(?x = 0.0, ?y = 0.0, ?text:String, ?font:FlxBitmapFont)
 	{
-		super();
+		super(x, y);
 
 		width = fieldWidth = 2;
 		alpha = 1;
@@ -223,6 +226,8 @@ class FlxBitmapText extends FlxSprite
 			textDrawData = [];
 			borderDrawData = [];
 		}
+		
+		this.text = text;
 	}
 
 	/**

--- a/tests/unit/src/flixel/text/FlxBitmapTextTest.hx
+++ b/tests/unit/src/flixel/text/FlxBitmapTextTest.hx
@@ -1,5 +1,8 @@
 package flixel.text;
 
+import flixel.text.FlxBitmapText;
+import flixel.graphics.frames.FlxBitmapFont;
+
 class FlxBitmapTextTest extends FlxTest
 {
 	var text:FlxBitmapText;
@@ -9,5 +12,20 @@ class FlxBitmapTextTest extends FlxTest
 	{
 		text = new FlxBitmapText();
 		destroyable = text;
+	}
+	
+	@Test // #1526 and #2750
+	function testCreateSpriteSkipPosition()
+	{
+		final text1 = new FlxBitmapText("test");
+		final text2 = new FlxBitmapText(FlxBitmapFont.getDefaultFont());
+
+		Assert.areEqual(0, text1.x);
+		Assert.areEqual(0, text1.y);
+		Assert.areEqual(0, text2.x);
+		Assert.areEqual(0, text2.y);
+
+		Assert.isNotNull(text1.text);
+		Assert.areEqual(text1.font, text2.font);
 	}
 }

--- a/tests/unit/src/flixel/text/FlxBitmapTextTest.hx
+++ b/tests/unit/src/flixel/text/FlxBitmapTextTest.hx
@@ -2,6 +2,7 @@ package flixel.text;
 
 import flixel.text.FlxBitmapText;
 import flixel.graphics.frames.FlxBitmapFont;
+import massive.munit.Assert;
 
 class FlxBitmapTextTest extends FlxTest
 {


### PR DESCRIPTION
Copying what FlxSprite's constructor does: `(?x = 0.0, ?y = 0.0)` so that it works in flash, added [a similar test](https://github.com/HaxeFlixel/flixel/blob/dev/tests/unit/src/flixel/FlxSpriteTest.hx#L207-L217) to make sure it worked in flash