### PR TITLE
easy xml/json types

### DIFF
--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -158,23 +158,23 @@ class FlxBitmapFont extends FlxFramesCollection
 	/**
 	 * Loads font data in AngelCode's format.
 	 *
-	 * @param   Source   Font image source.
-	 * @param   Data     Font data.
+	 * @param   source  Font image source.
+	 * @param   data    Font data.
 	 * @return  Generated bitmap font object.
 	 */
-	public static function fromAngelCode(Source:FlxBitmapFontGraphicAsset, Data:FlxAngelCodeSource):FlxBitmapFont
+	public static function fromAngelCode(source:FlxBitmapFontGraphicAsset, data:FlxAngelCodeSource):FlxBitmapFont
 	{
 		var graphic:FlxGraphic = null;
 		var frame:FlxFrame = null;
 
-		if ((Source is FlxFrame))
+		if ((source is FlxFrame))
 		{
-			frame = cast Source;
+			frame = cast source;
 			graphic = frame.parent;
 		}
 		else
 		{
-			graphic = FlxG.bitmap.add(cast Source);
+			graphic = FlxG.bitmap.add(cast source);
 			frame = graphic.imageFrame.frame;
 		}
 
@@ -182,30 +182,9 @@ class FlxBitmapFont extends FlxFramesCollection
 		if (font != null)
 			return font;
 
-		var fontData:Xml = null;
-
-		if (Data != null)
-		{
-			if ((Data is Xml))
-			{
-				fontData = cast Data;
-			}
-			else // Data is String
-			{
-				var data:String = Std.string(Data);
-
-				if (Assets.exists(data))
-				{
-					data = Assets.getText(data);
-				}
-
-				fontData = Xml.parse(data);
-			}
-		}
-
 		font = new FlxBitmapFont(frame);
 
-		var fast:Access = new Access(fontData.firstElement());
+		final fast = new Access(data.getXml().firstElement());
 
 		// how much to move the cursor when going to the next line.
 		font.lineHeight = Std.parseInt(fast.node.common.att.lineHeight);

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -15,6 +15,8 @@ import flixel.util.typeLimit.OneOfThree;
 import flixel.util.typeLimit.OneOfTwo;
 import openfl.Assets;
 import openfl.utils.ByteArray;
+import haxe.xml.Access;
+import haxe.Json;
 
 using StringTools;
 
@@ -27,13 +29,67 @@ class GraphicVirtualInput extends BitmapData {}
 @:file("assets/images/ui/virtual-input.txt")
 class VirtualInputData extends #if (lime_legacy || nme) ByteArray #else ByteArrayData #end {}
 
-typedef FlxAngelCodeSource = OneOfTwo<Xml, String>;
-typedef FlxTexturePackerSource = OneOfTwo<String, TexturePackerObject>;
+typedef FlxAngelCodeSource = FlxXmlAsset;
+typedef FlxTexturePackerSource = FlxJsonAsset<TexturePackerObject>;
 typedef FlxSoundAsset = OneOfThree<String, Sound, Class<Sound>>;
 typedef FlxGraphicAsset = OneOfThree<FlxGraphic, BitmapData, String>;
 typedef FlxGraphicSource = OneOfThree<BitmapData, Class<Dynamic>, String>;
 typedef FlxTilemapGraphicAsset = OneOfFour<FlxFramesCollection, FlxGraphic, BitmapData, String>;
 typedef FlxBitmapFontGraphicAsset = OneOfFour<FlxFrame, FlxGraphic, BitmapData, String>;
+
+abstract FlxXmlAsset(OneOfTwo<Xml, String>) from Xml from String
+{
+	public function getXml()
+	{
+		if ((this is String))
+		{
+			final str:String = cast this;
+			if (Assets.exists(str))
+				return fromPath(str);
+			
+			return fromXmlString(str);
+		}
+		
+		return cast (this, Xml);
+	}
+	
+	static inline function fromPath<T>(path:String):Xml
+	{
+		return fromXmlString(Assets.getText(path));
+	}
+	
+	static inline function fromXmlString<T>(data:String):Xml
+	{
+		return Xml.parse(data);
+	}
+}
+
+abstract FlxJsonAsset<T>(OneOfTwo<T, String>) from T from String
+{
+	public function getData():T
+	{
+		if ((this is String))
+		{
+			final str:String = cast this;
+			if (Assets.exists(str))
+				return fromPath(str);
+			
+			return fromDataString(str);
+		}
+		
+		return cast this;
+	}
+	
+	static inline function fromPath<T>(path:String):T
+	{
+		return fromDataString(Assets.getText(path));
+	}
+	
+	static inline function fromDataString<T>(data:String):T
+	{
+		return cast Json.parse(data);
+	}
+}
 
 typedef FlxShader =
 	#if (openfl_legacy || nme)

--- a/tests/unit/src/flixel/graphics/frames/FlxAtlasFramesTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/FlxAtlasFramesTest.hx
@@ -7,15 +7,24 @@ import massive.munit.Assert;
 class FlxAtlasFramesTest extends FlxTest
 {
 	var bmd:BitmapData;
-	var hashJson:String;
-	var atlasHash:FlxAtlasFrames;
+	var json:String;
+	var xml:String;
+	var atlasJson:FlxAtlasFrames;
+	var atlasXml:FlxAtlasFrames;
 
 	@Before
 	function before()
 	{
 		bmd = new BitmapData(1, 1);
-		hashJson = '{"frames":{"alien.png":{"frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},"medium.png":{"frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},"ship.png":{"frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},"small.png":{"frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}}}';
-		atlasHash = FlxAtlasFrames.fromTexturePackerJson(bmd, hashJson);
+		json = '{"frames":{"alien.png":{"frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},"medium.png":{"frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},"ship.png":{"frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},"small.png":{"frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}}}';
+		atlasJson = FlxAtlasFrames.fromTexturePackerJson(new BitmapData(1, 1), json);
+		xml = '<TextureAtlas>
+  <SubTexture name="hey0001" x="471" y="528" width="394" height="416" frameX="-0" frameY="-0" frameWidth="414" frameHeight="418" />
+  <SubTexture name="hey0002" x="471" y="528" width="394" height="416" frameX="-0" frameY="-0" frameWidth="414" frameHeight="418" />
+  <SubTexture name="hey0003" x="1887" y="514" width="413" height="410" frameX="-0" frameY="-8" frameWidth="414" frameHeight="418" />
+  <SubTexture name="hey0004" x="1887" y="514" width="413" height="410" frameX="-0" frameY="-8" frameWidth="414" frameHeight="418" />
+</TextureAtlas>';
+		atlasXml = FlxAtlasFrames.fromSparrow(new BitmapData(1, 1), xml);
 	}
 
 	@Test
@@ -24,11 +33,12 @@ class FlxAtlasFramesTest extends FlxTest
 		var arrJson = '{"frames":[{"filename":"alien.png","frame":{"x":2,"y":2,"w":46,"h":16},"rotated":false,"trimmed":true,"spriteSourceSize":{"x":1,"y":0,"w":46,"h":16},"sourceSize":{"w":48,"h":16},"pivot":{"x":0.5,"y":0.5}},{"filename":"medium.png","frame":{"x":2,"y":20,"w":32,"h":32},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":32,"h":32},"sourceSize":{"w":32,"h":32},"pivot":{"x":0.5,"y":0.5}},{"filename":"ship.png","frame":{"x":36,"y":38,"w":12,"h":8},"rotated":true,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":12,"h":8},"sourceSize":{"w":12,"h":8},"pivot":{"x":0.5,"y":0.5}},{"filename":"small.png","frame":{"x":36,"y":20,"w":16,"h":16},"rotated":false,"trimmed":false,"spriteSourceSize":{"x":0,"y":0,"w":16,"h":16},"sourceSize":{"w":16,"h":16},"pivot":{"x":0.5,"y":0.5}}]}';
 		var atlasArray = FlxAtlasFrames.fromTexturePackerJson(bmd, arrJson);
 
-		Assert.areEqual(atlasArray.numFrames, atlasHash.numFrames);
+		Assert.areEqual(atlasArray.numFrames, atlasJson.numFrames);
+		Assert.areEqual(atlasJson.numFrames, 4);
 
 		for (frameArr in atlasArray.frames)
 		{
-			var hashArr = atlasHash.framesHash.get(frameArr.name);
+			var hashArr = atlasJson.framesHash.get(frameArr.name);
 			Assert.areEqual(frameArr.name, hashArr.name);
 			Assert.isTrue(frameArr.sourceSize.equals(hashArr.sourceSize));
 		}
@@ -37,14 +47,46 @@ class FlxAtlasFramesTest extends FlxTest
 	@Test
 	function testTexturePackerJsonObject()
 	{
-		var parsed = Json.parse(hashJson);
-		var atlasHash2 = FlxAtlasFrames.fromTexturePackerJson(bmd, parsed);
+		final parsed = Json.parse(json);
+		final atlas2 = FlxAtlasFrames.fromTexturePackerJson(bmd, parsed);
 
-		Assert.areEqual(atlasHash.numFrames, atlasHash2.numFrames);
+		Assert.areEqual(atlasJson.numFrames, atlas2.numFrames);
+		Assert.areEqual(atlas2.numFrames, 4);
 
-		for (frame in atlasHash.frames)
+		for (frame in atlasJson.frames)
 		{
-			var frame2 = atlasHash2.framesHash.get(frame.name);
+			final frame2 = atlas2.framesHash.get(frame.name);
+			Assert.isTrue(frame.sourceSize.equals(frame2.sourceSize));
+		}
+	}
+
+	@Test
+	function testSparrowObject()
+	{
+		final parsed = Xml.parse(xml);
+		final atlas2 = FlxAtlasFrames.fromSparrow(bmd, parsed);
+
+		Assert.areEqual(atlasXml.numFrames, atlas2.numFrames);
+		Assert.areEqual(atlas2.numFrames, 4);
+
+		for (frame in atlasXml.frames)
+		{
+			final frame2 = atlas2.framesHash.get(frame.name);
+			Assert.isTrue(frame.sourceSize.equals(frame2.sourceSize));
+		}
+	}
+
+	@Test
+	function testSparrowXml()
+	{
+		final atlas2 = FlxAtlasFrames.fromSparrow(bmd, xml);
+
+		Assert.areEqual(atlasXml.numFrames, atlas2.numFrames);
+		Assert.areEqual(atlas2.numFrames, 4);
+
+		for (frame in atlasXml.frames)
+		{
+			final frame2 = atlas2.framesHash.get(frame.name);
 			Assert.isTrue(frame.sourceSize.equals(frame2.sourceSize));
 		}
 	}


### PR DESCRIPTION
just an easy way to accept various args with OneOfTwo without having to convert them all to the final type for each method that uses the type as an arg

`FlxXmlAsset`: takes the following and converts to an `Xml` with `getXml()`
- a string path to an xml asset
- a xml string
- an Xml object

`FlxJsonAsset<T>`: takes the following and coverts to typedef `T` with `getData()`. 
- a string path to an json asset
- a json string
- a T instance