### PR TITLE
Allow per-frame durations on FlxFramesCollection

### DIFF
--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -70,14 +70,13 @@ class FlxAnimationController implements IFlxDestroyable
 	/**
 	 * Internal, stores all the animation that were added to this sprite.
 	 */
-	var _animations(default, null):Map<String, FlxAnimation>;
+	var _animations(default, null) = new Map<String, FlxAnimation>();
 
 	var _prerotated:FlxPrerotatedAnimation;
 
-	public function new(Sprite:FlxSprite)
+	public function new(sprite:FlxSprite)
 	{
-		_sprite = Sprite;
-		_animations = new Map<String, FlxAnimation>();
+		_sprite = sprite;
 	}
 
 	public function update(elapsed:Float):Void
@@ -136,6 +135,12 @@ class FlxAnimationController implements IFlxDestroyable
 		_animations = null;
 		callback = null;
 		_sprite = null;
+	}
+
+	@:allow(flixel.animation.FlxAnimation)
+	function getFrameDuration(index:Int)
+	{
+		return _sprite.frames.frames[index].duration;
 	}
 
 	function clearPrerotated():Void
@@ -443,29 +448,30 @@ class FlxAnimationController implements IFlxDestroyable
 	/**
 	 * Adds a new animation to the sprite.
 	 *
-	 * @param   Name        What this animation should be called (e.g. `"run"`).
-	 * @param   Prefix      Common beginning of image names in atlas (e.g. `"tiles-"`).
-	 * @param   FrameRate   The speed in frames per second that the animation should play at (e.g. `40` fps).
-	 * @param   Looped      Whether or not the animation is looped or just plays once.
-	 * @param   FlipX       Whether the frames should be flipped horizontally.
-	 * @param   FlipY       Whether the frames should be flipped vertically.
+	 * @param   name        What this animation should be called (e.g. `"run"`).
+	 * @param   prefix      Common beginning of image names in atlas (e.g. `"tiles-"`).
+	 * @param   frameRate   The animation speed in frames per second.
+	 *                      Note: individual frames have their own duration, which overides this value.
+	 * @param   looped      Whether or not the animation is looped or just plays once.
+	 * @param   flipX       Whether the frames should be flipped horizontally.
+	 * @param   flipY       Whether the frames should be flipped vertically.
 	 */
-	public function addByPrefix(Name:String, Prefix:String, FrameRate:Int = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
+	public function addByPrefix(name:String, prefix:String, frameRate = 30, looped = true, flipX = false, flipY = false):Void
 	{
 		if (_sprite.frames != null)
 		{
 			var animFrames:Array<FlxFrame> = new Array<FlxFrame>();
-			findByPrefix(animFrames, Prefix); // adds valid frames to animFrames
+			findByPrefix(animFrames, prefix); // adds valid frames to animFrames
 
 			if (animFrames.length > 0)
 			{
 				var frameIndices:Array<Int> = new Array<Int>();
-				byPrefixHelper(frameIndices, animFrames, Prefix); // finds frames and appends them to the blank array
+				byPrefixHelper(frameIndices, animFrames, prefix); // finds frames and appends them to the blank array
 
 				if (frameIndices.length > 0)
 				{
-					var anim:FlxAnimation = new FlxAnimation(this, Name, frameIndices, FrameRate, Looped, FlipX, FlipY);
-					_animations.set(Name, anim);
+					var anim:FlxAnimation = new FlxAnimation(this, name, frameIndices, frameRate, looped, flipX, flipY);
+					_animations.set(name, anim);
 				}
 			}
 		}
@@ -478,27 +484,27 @@ class FlxAnimationController implements IFlxDestroyable
 	 * Frames are sorted numerically while ignoring postfixes (e.g. `".png"`, `".gif"`).
 	 * The animation must already exist in order to append frames to it.
 	 *
-	 * @param   Name     What the existing animation is called (e.g. `"run"`).
-	 * @param   Prefix   Common beginning of image names in atlas (e.g. `"tiles-"`)
+	 * @param   name     What the existing animation is called (e.g. `"run"`).
+	 * @param   prefix   Common beginning of image names in atlas (e.g. `"tiles-"`)
 	 */
-	public function appendByPrefix(Name:String, Prefix:String):Void
+	public function appendByPrefix(name:String, prefix:String):Void
 	{
-		var anim:FlxAnimation = _animations.get(Name);
+		var anim:FlxAnimation = _animations.get(name);
 		if (anim == null)
 		{
-			FlxG.log.warn("No animation called \"" + Name + "\"");
+			FlxG.log.warn("No animation called \"" + name + "\"");
 			return;
 		}
 
 		if (_sprite.frames != null)
 		{
 			var animFrames:Array<FlxFrame> = new Array<FlxFrame>();
-			findByPrefix(animFrames, Prefix); // adds valid frames to animFrames
+			findByPrefix(animFrames, prefix); // adds valid frames to animFrames
 
 			if (animFrames.length > 0)
 			{
 				// finds frames and appends them to the existing array
-				byPrefixHelper(anim.frames, animFrames, Prefix);
+				byPrefixHelper(anim.frames, animFrames, prefix);
 			}
 		}
 	}
@@ -617,9 +623,9 @@ class FlxAnimationController implements IFlxDestroyable
 	/**
 	 * Gets the FlxAnimation object with the specified name.
 	 */
-	public inline function getByName(Name:String):FlxAnimation
+	public inline function getByName(name:String):FlxAnimation
 	{
-		return _animations.get(Name);
+		return _animations.get(name);
 	}
 
 	/**
@@ -779,7 +785,7 @@ class FlxAnimationController implements IFlxDestroyable
 	public function getAnimationList():Array<FlxAnimation>
 	{
 		var animList:Array<FlxAnimation> = [];
-		
+
 		for (anims in _animations)
 		{
 			animList.push(anims);
@@ -839,26 +845,26 @@ class FlxAnimationController implements IFlxDestroyable
 		return _curAnim;
 	}
 
-	inline function set_curAnim(Anim:FlxAnimation):FlxAnimation
+	inline function set_curAnim(anim:FlxAnimation):FlxAnimation
 	{
-		if (Anim != _curAnim)
+		if (anim != _curAnim)
 		{
 			if (_curAnim != null)
 			{
 				_curAnim.stop();
 			}
 
-			if (Anim != null)
+			if (anim != null)
 			{
-				Anim.play();
+				anim.play();
 			}
 		}
-		return _curAnim = Anim;
+		return _curAnim = anim;
 	}
 
 	inline function get_paused():Bool
 	{
-		var paused:Bool = false;
+		var paused = false;
 		if (_curAnim != null)
 		{
 			paused = _curAnim.paused;
@@ -866,11 +872,11 @@ class FlxAnimationController implements IFlxDestroyable
 		return paused;
 	}
 
-	inline function set_paused(Value:Bool):Bool
+	inline function set_paused(value:Bool):Bool
 	{
 		if (_curAnim != null)
 		{
-			if (Value)
+			if (value)
 			{
 				_curAnim.pause();
 			}
@@ -879,12 +885,12 @@ class FlxAnimationController implements IFlxDestroyable
 				_curAnim.resume();
 			}
 		}
-		return Value;
+		return value;
 	}
 
 	function get_finished():Bool
 	{
-		var finished:Bool = true;
+		var finished = true;
 		if (_curAnim != null)
 		{
 			finished = _curAnim.finished;
@@ -892,13 +898,13 @@ class FlxAnimationController implements IFlxDestroyable
 		return finished;
 	}
 
-	inline function set_finished(Value:Bool):Bool
+	inline function set_finished(value:Bool):Bool
 	{
-		if (Value && _curAnim != null)
+		if (value && _curAnim != null)
 		{
 			_curAnim.finish();
 		}
-		return Value;
+		return value;
 	}
 
 	inline function get_frames():Int
@@ -912,8 +918,8 @@ class FlxAnimationController implements IFlxDestroyable
 	 * @param   Frame   `FlxFrame` to find
 	 * @return  position of specified `FlxFrame` object.
 	 */
-	public inline function getFrameIndex(Frame:FlxFrame):Int
+	public inline function getFrameIndex(frame:FlxFrame):Int
 	{
-		return _sprite.frames.frames.indexOf(Frame);
+		return _sprite.frames.frames.indexOf(frame);
 	}
 }

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -24,6 +24,21 @@ class FlxAtlasFrames extends FlxFramesCollection
 	}
 
 	/**
+	 * Parsing method for Aseprite atlases.
+	 *
+	 * @param   source        The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
+	 * @param   description   Contents of JSON file with atlas description.
+	 *                        You can get it with `Assets.getText(path/to/description.json)`.
+	 *                        Or you can just a pass path to the JSON file in the assets directory.
+	 *                        You can also directly pass in the parsed object.
+	 * @return  Newly created `FlxAtlasFrames` collection.
+	 */
+	public static inline function fromAseprite(source:FlxGraphicAsset, description:FlxTexturePackerSource):FlxAtlasFrames
+	{
+		return fromTexturePackerJson(source, description);
+	}
+
+	/**
 	 * Parsing method for TexturePacker atlases in JSON format.
 	 *
 	 * @param   source        The image source (can be `FlxGraphic`, `String`, or `BitmapData`).

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -24,20 +24,21 @@ class FlxAtlasFrames extends FlxFramesCollection
 	}
 
 	/**
-	 * Parsing method for Aseprite atlases.
+	 * Parsing method for atlases generated from Aseprite's JSON export options. Note that Aseprite
+	 * and Texture Packer use the same JSON format, however this method honors frames' `duration`
+	 * whereas `fromTexturePackerJson` ignores it by default (for backwrds compatibility reasons).
 	 *
-	 * @param   source               The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
-	 * @param   description          Contents of JSON file with atlas description.
-	 *                               You can get it with `Assets.getText(path/to/description.json)`.
-	 *                               Or you can just a pass path to the JSON file in the assets directory.
-	 *                               You can also directly pass in the parsed object.
-	 * @param   ignoreFrameDuration  If false, any frame durations defined in the json will override the
-	 *                               frameRate set in you `FlxAnimationController`.
+	 * @param   source       The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
+	 * @param   description  Contents of JSON file with atlas description.
+	 *                       You can get it with `Assets.getText(path/to/description.json)`.
+	 *                       Or you can just a pass path to the JSON file in the assets directory.
+	 *                       You can also directly pass in the parsed object.
 	 * @return  Newly created `FlxAtlasFrames` collection.
+	 * @see [Exporting texture atlases with Aseprite](https://www.aseprite.org/docs/sprite-sheet/#texture-atlases)
 	 */
-	public static inline function fromAseprite(source:FlxGraphicAsset, description:FlxTexturePackerSource, ignoreFrameDuration = false):FlxAtlasFrames
+	public static inline function fromAseprite(source:FlxGraphicAsset, description:FlxAsepriteJsonAsset):FlxAtlasFrames
 	{
-		return fromTexturePackerJson(source, description, !ignoreFrameDuration);
+		return fromTexturePackerJson(source, description, true);
 	}
 
 	/**
@@ -48,11 +49,11 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 *                            You can get it with `Assets.getText(path/to/description.json)`.
 	 *                            Or you can just a pass path to the JSON file in the assets directory.
 	 *                            You can also directly pass in the parsed object.
-	 * @param   useFrameDuration  If true, any frame durations defined in the json will override the
+	 * @param   useFrameDuration  If true, any frame durations defined in the JSON will override the
 	 *                            frameRate set in you `FlxAnimationController`.
 	 * @return  Newly created `FlxAtlasFrames` collection.
 	 */
-	public static function fromTexturePackerJson(source:FlxGraphicAsset, description:FlxTexturePackerSource, useFrameDuration = false):FlxAtlasFrames
+	public static function fromTexturePackerJson(source:FlxGraphicAsset, description:FlxTexturePackerJsonAsset, useFrameDuration = false):FlxAtlasFrames
 	{
 		var graphic:FlxGraphic = FlxG.bitmap.add(source, false);
 		if (graphic == null)

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -26,11 +26,13 @@ class FlxAtlasFrames extends FlxFramesCollection
 	/**
 	 * Parsing method for Aseprite atlases.
 	 *
-	 * @param   source        The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
-	 * @param   description   Contents of JSON file with atlas description.
-	 *                        You can get it with `Assets.getText(path/to/description.json)`.
-	 *                        Or you can just a pass path to the JSON file in the assets directory.
-	 *                        You can also directly pass in the parsed object.
+	 * @param   source               The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
+	 * @param   description          Contents of JSON file with atlas description.
+	 *                               You can get it with `Assets.getText(path/to/description.json)`.
+	 *                               Or you can just a pass path to the JSON file in the assets directory.
+	 *                               You can also directly pass in the parsed object.
+	 * @param   ignoreFrameDuration  If false, any frame durations defined in the json will override the
+	 *                               frameRate set in you `FlxAnimationController`.
 	 * @return  Newly created `FlxAtlasFrames` collection.
 	 */
 	public static inline function fromAseprite(source:FlxGraphicAsset, description:FlxTexturePackerSource, ignoreFrameDuration = false):FlxAtlasFrames
@@ -41,11 +43,13 @@ class FlxAtlasFrames extends FlxFramesCollection
 	/**
 	 * Parsing method for TexturePacker atlases in JSON format.
 	 *
-	 * @param   source        The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
-	 * @param   description   Contents of JSON file with atlas description.
-	 *                        You can get it with `Assets.getText(path/to/description.json)`.
-	 *                        Or you can just a pass path to the JSON file in the assets directory.
-	 *                        You can also directly pass in the parsed object.
+	 * @param   source            The image source (can be `FlxGraphic`, `String`, or `BitmapData`).
+	 * @param   description       Contents of JSON file with atlas description.
+	 *                            You can get it with `Assets.getText(path/to/description.json)`.
+	 *                            Or you can just a pass path to the JSON file in the assets directory.
+	 *                            You can also directly pass in the parsed object.
+	 * @param   useFrameDuration  If true, any frame durations defined in the json will override the
+	 *                            frameRate set in you `FlxAnimationController`.
 	 * @return  Newly created `FlxAtlasFrames` collection.
 	 */
 	public static function fromTexturePackerJson(source:FlxGraphicAsset, description:FlxTexturePackerSource, useFrameDuration = false):FlxAtlasFrames

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -113,7 +113,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		final sourceSize = FlxPoint.get(frameData.sourceSize.w, frameData.sourceSize.h);
 		final offset = FlxPoint.get(frameData.spriteSourceSize.x, frameData.spriteSourceSize.y);
 		final duration = (useFrameDuration && frameData.duration != null) ? frameData.duration / 1000 : 0;
-		frames.addAtlasFrame(frameRect, sourceSize, offset, frameName, angle, duration);
+		frames.addAtlasFrame(frameRect, sourceSize, offset, frameName, angle, false, false, duration);
 	}
 
 	/**

--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -9,8 +9,7 @@ import flixel.graphics.frames.FlxFrame.FlxFrameAngle;
 import flixel.graphics.frames.FlxFramesCollection.FlxFrameCollectionType;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
-import flixel.system.FlxAssets.FlxAngelCodeSource;
-import flixel.system.FlxAssets.FlxBitmapFontGraphicAsset;
+import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import openfl.Assets;
 import haxe.xml.Access;
@@ -162,7 +161,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	 * @param   data    Font data.
 	 * @return  Generated bitmap font object.
 	 */
-	public static function fromAngelCode(source:FlxBitmapFontGraphicAsset, data:FlxAngelCodeSource):FlxBitmapFont
+	public static function fromAngelCode(source:FlxBitmapFontGraphicAsset, data:FlxAngelCodeXmlAsset):FlxBitmapFont
 	{
 		var graphic:FlxGraphic = null;
 		var frame:FlxFrame = null;

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -10,8 +10,8 @@ import flixel.math.FlxRect;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxStringUtil;
-import haxe.ds.Vector;
 import haxe.ds.ArraySort;
+import haxe.ds.Vector;
 
 /**
  * Base class for all frame types
@@ -83,6 +83,11 @@ class FlxFrame implements IFlxDestroyable
 	public var offset(default, null):FlxPoint;
 
 	/**
+	 * The duration of this frame in seconds. If 0, the anim controller will decide the duration
+	 */
+	public var duration:Float;
+
+	/**
 	 * The type of this frame.
 	 */
 	public var type:FlxFrameType;
@@ -93,12 +98,13 @@ class FlxFrame implements IFlxDestroyable
 
 	@:allow(flixel.graphics.FlxGraphic)
 	@:allow(flixel.graphics.frames.FlxFramesCollection)
-	function new(parent:FlxGraphic, angle:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false, flipY:Bool = false)
+	function new(parent:FlxGraphic, angle = FlxFrameAngle.ANGLE_0, flipX = false, flipY = false, duration = 0.0)
 	{
 		this.parent = parent;
 		this.angle = angle;
 		this.flipX = flipX;
 		this.flipY = flipY;
+		this.duration = duration;
 
 		type = FlxFrameType.REGULAR;
 

--- a/flixel/graphics/frames/FlxFramesCollection.hx
+++ b/flixel/graphics/frames/FlxFramesCollection.hx
@@ -168,13 +168,13 @@ class FlxFramesCollection implements IFlxDestroyable
 	 * @param   flipY        If packed image should be vertically flipped.
 	 * @return  Newly created and added frame object.
 	 */
-	public function addAtlasFrame(frame:FlxRect, sourceSize:FlxPoint, offset:FlxPoint, ?name:String, angle:FlxFrameAngle = 0, flipX:Bool = false,
-			flipY:Bool = false):FlxFrame
+	public function addAtlasFrame(frame:FlxRect, sourceSize:FlxPoint, offset:FlxPoint, ?name:String, angle:FlxFrameAngle = 0, flipX = false, flipY = false,
+			duration = 0.0):FlxFrame
 	{
 		if (name != null && framesHash.exists(name))
 			return framesHash.get(name);
 
-		var texFrame:FlxFrame = new FlxFrame(parent, angle, flipX, flipY);
+		var texFrame:FlxFrame = new FlxFrame(parent, angle, flipX, flipY, duration);
 		texFrame.name = name;
 		texFrame.sourceSize.set(sourceSize.x, sourceSize.y);
 		texFrame.offset.set(offset.x, offset.y);
@@ -185,7 +185,7 @@ class FlxFramesCollection implements IFlxDestroyable
 
 		return pushFrame(texFrame);
 	}
-	
+
 	/**
 	 * Sets the target frame's offset to the specified values. This mainly exists because certain
 	 * atlas exporters don't give the correct offset. If no frame with the specified name exists,
@@ -204,7 +204,7 @@ class FlxFramesCollection implements IFlxDestroyable
 		else
 			FlxG.log.warn('No frame called $name');
 	}
-	
+
 	/**
 	 * Adjusts the target frame's offset by the specified values. This mainly exists because certain
 	 * atlas exporters don't give the correct offset. If no frame with the specified name exists,
@@ -223,7 +223,7 @@ class FlxFramesCollection implements IFlxDestroyable
 		else
 			FlxG.log.warn('No frame called $name');
 	}
-	
+
 	/**
 	 * Sets all frames with the specified name prefix to the specified offset. This mainly
 	 * exists because certain atlas exporters don't give the correct offset.
@@ -236,13 +236,13 @@ class FlxFramesCollection implements IFlxDestroyable
 	 */
 	public function setFramesOffsetByPrefix(prefix:String, offsetX:Float, offsetY:Float)
 	{
-		for (name=>frame in framesHash)
+		for (name => frame in framesHash)
 		{
 			if (name.indexOf(prefix) == 0)
 				frame.offset.set(offsetX, offsetY);
 		}
 	}
-	
+
 	/**
 	 * Adjusts all frames with the specified name prefix by the specified offset. This mainly
 	 * exists because certain atlas exporters don't give the correct offset.
@@ -255,10 +255,47 @@ class FlxFramesCollection implements IFlxDestroyable
 	 */
 	public function addFramesOffsetByPrefix(prefix:String, offsetX:Float, offsetY:Float)
 	{
-		for (name=>frame in framesHash)
+		for (name => frame in framesHash)
 		{
 			if (name.indexOf(prefix) == 0)
 				frame.offset.add(offsetX, offsetY);
+		}
+	}
+
+	/**
+	 * Sets the target frame's offset to the specified values. This mainly exists because certain
+	 * atlas exporters don't give the correct offset. If no frame with the specified name exists,
+	 * a warning is logged.
+	 * 
+	 * @param   name      The name of the frame.
+	 * @param   duration  The new duration of the frame.
+	 * 
+	 * @since 5.3.0
+	 */
+	public function setFramesDuration(name:String, duration:Float)
+	{
+		if (framesHash.exists(name))
+			framesHash[name].duration = duration;
+		else
+			FlxG.log.warn('No frame called $name');
+	}
+
+	/**
+	 * Sets the target frame's offset to the specified values. This mainly exists because certain
+	 * atlas exporters don't give the correct offset. If no frame with the specified name exists,
+	 * a warning is logged.
+	 * 
+	 * @param   prefix    The prefix used to determine which frames are affected.
+	 * @param   duration  The new duration of the frame.
+	 * 
+	 * @since 5.3.0
+	 */
+	public function setFramesDurationByPrefix(prefix:String, duration:Float)
+	{
+		for (name => frame in framesHash)
+		{
+			if (name.indexOf(prefix) == 0)
+				framesHash[name].duration = duration;
 		}
 	}
 

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -13,10 +13,10 @@ import flixel.graphics.frames.FlxFramesCollection;
 import flixel.util.typeLimit.OneOfFour;
 import flixel.util.typeLimit.OneOfThree;
 import flixel.util.typeLimit.OneOfTwo;
+import haxe.Json;
+import haxe.xml.Access;
 import openfl.Assets;
 import openfl.utils.ByteArray;
-import haxe.xml.Access;
-import haxe.Json;
 
 using StringTools;
 
@@ -29,13 +29,20 @@ class GraphicVirtualInput extends BitmapData {}
 @:file("assets/images/ui/virtual-input.txt")
 class VirtualInputData extends #if (lime_legacy || nme) ByteArray #else ByteArrayData #end {}
 
-typedef FlxAngelCodeSource = FlxXmlAsset;
-typedef FlxTexturePackerSource = FlxJsonAsset<TexturePackerObject>;
+typedef FlxAngelCodeXmlAsset = FlxXmlAsset;
+typedef FlxTexturePackerJsonAsset = FlxJsonAsset<TexturePackerObject>;
+typedef FlxAsepriteJsonAsset = FlxTexturePackerJsonAsset;
 typedef FlxSoundAsset = OneOfThree<String, Sound, Class<Sound>>;
 typedef FlxGraphicAsset = OneOfThree<FlxGraphic, BitmapData, String>;
 typedef FlxGraphicSource = OneOfThree<BitmapData, Class<Dynamic>, String>;
 typedef FlxTilemapGraphicAsset = OneOfFour<FlxFramesCollection, FlxGraphic, BitmapData, String>;
 typedef FlxBitmapFontGraphicAsset = OneOfFour<FlxFrame, FlxGraphic, BitmapData, String>;
+
+@:deprecated("`FlxAngelCodeSource` is deprecated, use `FlxAngelCodeAsset` instead")
+typedef FlxAngelCodeSource = FlxAngelCodeXmlAsset;
+
+@:deprecated("`FlxTexturePackerSource` is deprecated, use `FlxAtlasDataAsset` instead")
+typedef FlxTexturePackerSource = FlxTexturePackerJsonAsset;
 
 abstract FlxXmlAsset(OneOfTwo<Xml, String>) from Xml from String
 {
@@ -46,18 +53,18 @@ abstract FlxXmlAsset(OneOfTwo<Xml, String>) from Xml from String
 			final str:String = cast this;
 			if (Assets.exists(str))
 				return fromPath(str);
-			
+
 			return fromXmlString(str);
 		}
-		
-		return cast (this, Xml);
+
+		return cast(this, Xml);
 	}
-	
+
 	static inline function fromPath<T>(path:String):Xml
 	{
 		return fromXmlString(Assets.getText(path));
 	}
-	
+
 	static inline function fromXmlString<T>(data:String):Xml
 	{
 		return Xml.parse(data);
@@ -73,18 +80,18 @@ abstract FlxJsonAsset<T>(OneOfTwo<T, String>) from T from String
 			final str:String = cast this;
 			if (Assets.exists(str))
 				return fromPath(str);
-			
+
 			return fromDataString(str);
 		}
-		
+
 		return cast this;
 	}
-	
+
 	static inline function fromPath<T>(path:String):T
 	{
 		return fromDataString(Assets.getText(path));
 	}
-	
+
 	static inline function fromDataString<T>(data:String):T
 	{
 		return cast Json.parse(data);
@@ -109,7 +116,7 @@ class FlxAssets
 	 * for backwards compatibility reasons.
 	 */
 	public static var defaultSoundExtension = #if flash "mp3" #else "ogg" #end;
-	
+
 	#if (macro || doc_gen)
 	/**
 	 * Reads files from a directory relative to this project and generates `public static inline`
@@ -163,21 +170,20 @@ class FlxAssets
 	 * @see [Flixel 5.0.0 Migration guide - AssetPaths has less caveats](https://github.com/HaxeFlixel/flixel/wiki/Flixel-5.0.0-Migration-guide#assetpaths-has-less-caveats-2575)
 	 * @see [Haxe Macros: Code completion for everything](http://blog.stroep.nl/2014/01/haxe-macros/)
 	**/
-	public static function buildFileReferences(directory = "assets/", subDirectories = false,
-			?include:Expr, ?exclude:Expr, ?rename:String->Null<String>):Array<Field>
+	public static function buildFileReferences(directory = "assets/", subDirectories = false, ?include:Expr, ?exclude:Expr,
+			?rename:String->Null<String>):Array<Field>
 	{
 		#if doc_gen
 		return [];
 		#else
-		return flixel.system.macros.FlxAssetPaths.buildFileReferences(directory, subDirectories,
-			exprToRegex(include), exprToRegex(exclude), rename);
+		return flixel.system.macros.FlxAssetPaths.buildFileReferences(directory, subDirectories, exprToRegex(include), exprToRegex(exclude), rename);
 		#end
 	}
 
 	#if !doc_gen
 	private static function exprToRegex(expr:Expr):EReg
 	{
-		switch(expr.expr)
+		switch (expr.expr)
 		{
 			case null | EConst(CIdent("null")):
 				return null;
@@ -195,7 +201,6 @@ class FlxAssets
 	}
 	#end
 	#end
-
 	#if (!macro || doc_gen)
 	// fonts
 	public static var FONT_DEFAULT:String = "Nokia Cellphone FC Small";


### PR DESCRIPTION
https://user-images.githubusercontent.com/2609513/224172922-de161af3-4626-4b3d-8eb3-44cd0330269c.mp4

Utilized via `FlxAtlasFrames.fromAseprite`, also added to `fromTexturePackerJson` but disabled by default, for backwards compatibility

this also deprecates FlxFrame's `delay` property for the new `frameDuration` field.