### PR TITLE
Simplify and cleanup in small areas

### DIFF
--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -129,7 +129,6 @@ class FlxAnimation extends FlxBaseAnimation
 		if (!Force && !finished && reversed == Reversed)
 		{
 			paused = false;
-			finished = false;
 			return;
 		}
 

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -515,7 +515,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var chroma = Brightness * Saturation;
 		var match = Brightness - chroma;
-		return setHSChromaMatch(Hue, Saturation, chroma, match, Alpha);
+		return setHueChromaMatch(Hue, chroma, match, Alpha);
 	}
 
 	/**
@@ -531,13 +531,13 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var chroma = (1 - Math.abs(2 * Lightness - 1)) * Saturation;
 		var match = Lightness - chroma / 2;
-		return setHSChromaMatch(Hue, Saturation, chroma, match, Alpha);
+		return setHueChromaMatch(Hue, chroma, match, Alpha);
 	}
 
 	/**
 	 * Private utility function to perform common operations between setHSB and setHSL
 	 */
-	inline function setHSChromaMatch(Hue:Float, Saturation:Float, Chroma:Float, Match:Float, Alpha:Float):FlxColor
+	inline function setHueChromaMatch(Hue:Float, Chroma:Float, Match:Float, Alpha:Float):FlxColor
 	{
 		Hue %= 360;
 		var hueD = Hue / 60;

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -730,7 +730,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var hue:Float = 0;
 		if (hueRad != 0)
 		{
-			hue = 180 / Math.PI * Math.atan2(Math.sqrt(3) * (greenFloat - blueFloat), 2 * redFloat - greenFloat - blueFloat);
+			hue = 180 / Math.PI * hueRad;
 		}
 
 		return hue < 0 ? hue + 360 : hue;


### PR DESCRIPTION
This isn't the most important PR since it doesn't really fix anything or improve performance by much, but I found a few cases where code could be simplified a tiny bit.

Each commit explains what changed and why but essentially:
1. ```haxe
   if (!Force && !finished && reversed == Reversed)
   {
       paused = false;
       finished = false; // finished is already false due to if condition
       return;
   }
   ```
2. ```haxe
   function get_hue():Float
   {
       var hueRad = Math.atan2(Math.sqrt(3) * (greenFloat - blueFloat), 2 * redFloat - greenFloat - blueFloat);
       var hue:Float = 0;
       if (hueRad != 0)
       {
           // The Math.atan2 part of below is already calculated by hueRad
           hue = 180 / Math.PI * Math.atan2(Math.sqrt(3) * (greenFloat - blueFloat), 2 * redFloat - greenFloat - blueFloat);
           hue = 180 / Math.PI * hueRad;
       }

       return hue < 0 ? hue + 360 : hue;
   }
   ```
3. in `FlxColor.setHSChromaMatch()`, the saturation field isn't used and could be removed. (I decided to rename it `setHueChromaMatch()` but the name doesn't really matter)