### PR TITLE
better warnings for invalid width/height args

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -480,38 +480,42 @@ class FlxSprite extends FlxObject
 	 * HaxeFlixel copies the previous reference onto the `pixels` field instead
 	 * of creating another copy of the image data, to save memory.
 	 *
-	 * @param   Graphic    The image you want to use.
-	 * @param   Animated   Whether the `Graphic` parameter is a single sprite or a row / grid of sprites.
-	 * @param   Width      Specify the width of your sprite
-	 *                     (helps figure out what to do with non-square sprites or sprite sheets).
-	 * @param   Height     Specify the height of your sprite
-	 *                     (helps figure out what to do with non-square sprites or sprite sheets).
-	 * @param   Unique     Whether the graphic should be a unique instance in the graphics cache.
-	 *                     Set this to `true` if you want to modify the `pixels` field without changing
-	 *                     the `pixels` of other sprites with the same `BitmapData`.
-	 * @param   Key        Set this parameter if you're loading `BitmapData`.
+	 * @param   graphic      The image you want to use.
+	 * @param   animated     Whether the `Graphic` parameter is a single sprite or a row / grid of sprites.
+	 * @param   frameWidth   Specify the width of your sprite
+	 *                       (helps figure out what to do with non-square sprites or sprite sheets).
+	 * @param   frameHeight  Specify the height of your sprite
+	 *                       (helps figure out what to do with non-square sprites or sprite sheets).
+	 * @param   unique       Whether the graphic should be a unique instance in the graphics cache.
+	 *                       Set this to `true` if you want to modify the `pixels` field without changing
+	 *                       the `pixels` of other sprites with the same `BitmapData`.
+	 * @param   key          Set this parameter if you're loading `BitmapData`.
 	 * @return  This `FlxSprite` instance (nice for chaining stuff together, if you're into that).
 	 */
-	public function loadGraphic(Graphic:FlxGraphicAsset, Animated:Bool = false, Width:Int = 0, Height:Int = 0, Unique:Bool = false, ?Key:String):FlxSprite
+	public function loadGraphic(graphic:FlxGraphicAsset, animated = false, frameWidth = 0, frameHeight = 0, unique = false, ?key:String):FlxSprite
 	{
-		var graph:FlxGraphic = FlxG.bitmap.add(Graphic, Unique, Key);
+		var graph:FlxGraphic = FlxG.bitmap.add(graphic, unique, key);
 		if (graph == null)
 			return this;
 
-		if (Width == 0)
+		if (frameWidth == 0)
 		{
-			Width = Animated ? graph.height : graph.width;
-			Width = (Width > graph.width) ? graph.width : Width;
+			frameWidth = animated ? graph.height : graph.width;
+			frameWidth = (frameWidth > graph.width) ? graph.width : frameWidth;
 		}
+		else if (frameWidth > graph.width)
+			FlxG.log.warn('frameWidth:$frameWidth is larger than the graphic\'s width:${graph.width}');
 
-		if (Height == 0)
+		if (frameHeight == 0)
 		{
-			Height = Animated ? Width : graph.height;
-			Height = (Height > graph.height) ? graph.height : Height;
+			frameHeight = animated ? frameWidth : graph.height;
+			frameHeight = (frameHeight > graph.height) ? graph.height : frameHeight;
 		}
+		else if (frameHeight > graph.height)
+			FlxG.log.warn('frameHeight:$frameHeight is larger than the graphic\'s height:${graph.height}');
 
-		if (Animated)
-			frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(Width, Height));
+		if (animated)
+			frames = FlxTileFrames.fromGraphic(graph, FlxPoint.get(frameWidth, frameHeight));
 		else
 			frames = graph.imageFrame;
 

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -42,6 +42,13 @@ class FlxAnimationController implements IFlxDestroyable
 	 * The total number of frames in this image.
 	 * WARNING: assumes each row in the sprite sheet is full!
 	 */
+	public var numFrames(get, never):Int;
+
+	/**
+	 * The total number of frames in this image.
+	 * WARNING: assumes each row in the sprite sheet is full!
+	 */
+	@:deprecated("frames is deprecated, use numFrames")
 	public var frames(get, never):Int;
 
 	/**
@@ -174,40 +181,49 @@ class FlxAnimationController implements IFlxDestroyable
 	/**
 	 * Adds a new animation to the sprite.
 	 *
-	 * @param   Name        What this animation should be called (e.g. `"run"`).
-	 * @param   Frames      An array of indices indicating what frames to play in what order (e.g. `[0, 1, 2]`).
-	 * @param   FrameRate   The speed in frames per second that the animation should play at (e.g. `40` fps).
-	 * @param   Looped      Whether or not the animation is looped or just plays once.
-	 * @param   FlipX       Whether the frames should be flipped horizontally.
-	 * @param   FlipY       Whether the frames should be flipped vertically.
+	 * @param   name        What this animation should be called (e.g. `"run"`).
+	 * @param   frames      An array of indices indicating what frames to play in what order (e.g. `[0, 1, 2]`).
+	 * @param   frameRate   The speed in frames per second that the animation should play at (e.g. `40` fps).
+	 * @param   looped      Whether or not the animation is looped or just plays once.
+	 * @param   flipX       Whether the frames should be flipped horizontally.
+	 * @param   flipY       Whether the frames should be flipped vertically.
 	 */
-	public function add(Name:String, Frames:Array<Int>, FrameRate:Float = 30, Looped:Bool = true, FlipX:Bool = false, FlipY:Bool = false):Void
+	public function add(name:String, frames:Array<Int>, frameRate = 30.0, looped = true, flipX = false, flipY = false):Void
 	{
+		if (numFrames == 0)
+			FlxG.log.warn('Could not create animation: $name, this sprite has no frames');
+		
 		// Check _animations frames
-		var framesToAdd:Array<Int> = Frames;
-		var numFrames:Int = framesToAdd.length - 1;
-		var i:Int = numFrames;
-		while (i >= 0)
+		var framesToAdd:Array<Int> = frames;
+		var hasInvalidFrames = false;
+		var i = framesToAdd.length;
+		while (i-- >= 0)
 		{
-			if (framesToAdd[i] >= frames)
+			final frame = framesToAdd[i];
+			if (frame >= numFrames)
 			{
+				// log if frames are excluded
+				hasInvalidFrames = true;
+				
 				// Splicing original Frames array could lead to unexpected results
 				// So we are cloning it (only once) and will use its copy
-				if (framesToAdd == Frames)
-				{
-					framesToAdd = Frames.copy();
-				}
+				if (framesToAdd == frames)
+					framesToAdd = frames.copy();
 
 				framesToAdd.splice(i, 1);
 			}
-			i--;
 		}
-
+		
 		if (framesToAdd.length > 0)
 		{
-			var anim = new FlxAnimation(this, Name, framesToAdd, FrameRate, Looped, FlipX, FlipY);
-			_animations.set(Name, anim);
+			var anim = new FlxAnimation(this, name, framesToAdd, frameRate, looped, flipX, flipY);
+			_animations.set(name, anim);
+			
+			if (hasInvalidFrames)
+				FlxG.log.warn('Could not add frames above ${numFrames - 1} to animation: $name');
 		}
+		else
+			FlxG.log.warn('Could not create animation: $name, no valid frames were given');
 	}
 
 	/**
@@ -242,19 +258,20 @@ class FlxAnimationController implements IFlxDestroyable
 			FlxG.log.warn("No animation called \"" + Name + "\"");
 			return;
 		}
+		
+		var hasInvalidFrames = false;
 
 		// Check _animations frames
-		var numFrames:Int = Frames.length - 1;
-		var i:Int = numFrames;
-		while (i >= 0)
+		for (frame in Frames)
 		{
-			if (Frames[numFrames - i] < frames)
-			{
-				// add to existing animation, forward to backward
-				anim.frames.push(Frames[numFrames - i]);
-			}
-			i--;
+			if (frame < numFrames)
+				anim.frames.push(frame);
+			else
+				hasInvalidFrames = true;
 		}
+		
+		if (hasInvalidFrames)
+			FlxG.log.warn('Could not append frames above ${numFrames - 1} to animation: $Name');
 	}
 
 	/**
@@ -425,20 +442,16 @@ class FlxAnimationController implements IFlxDestroyable
 	 * to find `"file05.png"`, allowing 99 frames per animation.
 	 * Returns the found frame or `-1` on failure.
 	 */
-	function findSpriteFrame(Prefix:String, Index:Int, Postfix:String):Int
+	function findSpriteFrame(prefix:String, index:Int, postfix:String):Int
 	{
-		var numFrames:Int = frames;
-		var flxFrames:Array<FlxFrame> = _sprite.frames.frames;
-		for (i in 0...numFrames)
+		for (i=>frame in _sprite.frames.frames)
 		{
-			var name:String = flxFrames[i].name;
-			if (StringTools.startsWith(name, Prefix) && StringTools.endsWith(name, Postfix))
+			final name = frame.name;
+			if (StringTools.startsWith(name, prefix) && StringTools.endsWith(name, postfix))
 			{
-				var index:Null<Int> = Std.parseInt(name.substring(Prefix.length, name.length - Postfix.length));
-				if (index != null && index == Index)
-				{
+				final frameIndex:Null<Int> = Std.parseInt(name.substring(prefix.length, name.length - postfix.length));
+				if (frameIndex == index)
 					return i;
-				}
 			}
 		}
 
@@ -639,7 +652,7 @@ class FlxAnimationController implements IFlxDestroyable
 			_curAnim.stop();
 			_curAnim = null;
 		}
-		frameIndex = FlxG.random.int(0, frames - 1);
+		frameIndex = FlxG.random.int(0, numFrames - 1);
 	}
 
 	inline function fireCallback():Void
@@ -724,9 +737,9 @@ class FlxAnimationController implements IFlxDestroyable
 
 	function set_frameIndex(Frame:Int):Int
 	{
-		if (_sprite.frames != null && frames > 0)
+		if (_sprite.frames != null && numFrames > 0)
 		{
-			Frame = Frame % frames;
+			Frame = Frame % numFrames;
 			_sprite.frame = _sprite.frames.frames[Frame];
 			frameIndex = Frame;
 			fireCallback();
@@ -908,6 +921,11 @@ class FlxAnimationController implements IFlxDestroyable
 	}
 
 	inline function get_frames():Int
+	{
+		return _sprite.numFrames;
+	}
+
+	inline function get_numFrames():Int
 	{
 		return _sprite.numFrames;
 	}

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -256,7 +256,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	function setupAnimation(animationName:String, frameIndex:Int):Void
 	{
 		// make sure the animation doesn't contain an invalid frame
-		frameIndex = Std.int(Math.min(frameIndex, animation.frames - 1));
+		frameIndex = Std.int(Math.min(frameIndex, animation.numFrames - 1));
 		animation.add(animationName, [frameIndex]);
 	}
 


### PR DESCRIPTION
## Previously

- if someone passes invalid width/height args into loadGraphic, it may not create any frames, even if the height is off by one and it wont log a warning.
- If they call `animation.add` with frame indices higher than the sprite's total number of frames, it won't add those frames and it wont log a warning.
- If they call `animation.add` with no valid frame indices, it won't create the animation, and it won't log a warning.
- If they try to play an animation that doesn't exists it **would** log: `No animation called "$name"`

This caused issued where people with incorrect width/height args would get warnings when trying to play anims, and they have no idea why.

## Now 
- It will log a warning when the desired frameHeight/frameWidth is too big
- It will log a warning when an animation is given an invalid frame
- It will log a warning when they try to make an animation with no valid frames

Example:
```hx
import flixel.FlxSprite;
import openfl.display.BitmapData;

class InvalidFrameSizeTestState extends flixel.FlxState
{
	override function create()
	{
		super.create();
		
		final size = 100;
		
		// works fine
		testLoadGraphic(size * 12, size, size, size);
		
		
		/* Warnings:
		 * frameHeight:100 is larger than the graphic's height:99
		 * Could not create animation: a, this sprite has no frames
		 * Could not create animation: b, this sprite has no frames
		 * Could not create animation: c, this sprite has no frames
		 * No animation called "a"
		 * No animation called "b"
		 * No animation called "c"
		 */
		testLoadGraphic(size * 12, size - 1, size, size);
		
		/* Warnings:
		 * Could not add frames above 5 to animation: b
		 * Could not create animation: c, no valid frames were given
		 * No animation called "c"
		 */
		testLoadGraphic(size * 6, size, size, size);
		
	}
	
	function testLoadGraphic(bitmapWidth:Int, bitmapHeight:Int, frameWidth:Int, frameHeight:Int)
	{
		final bmd = new BitmapData(bitmapWidth, bitmapHeight, false);
		final sprite = new FlxSprite();
		sprite.loadGraphic(bmd, true, frameWidth, frameHeight);
		sprite.animation.add("a", [ 0,  1,  2,  3]);
		sprite.animation.add("b", [ 4,  5,  6,  7]);
		sprite.animation.add("c", [ 8,  9, 10, 11]);
		
		sprite.animation.play("a");
		sprite.animation.play("b");
		sprite.animation.play("c");
	}
}
```