### PR TITLE
FlxSound minor typo fix

### DIFF
--- a/flixel/system/FlxSound.hx
+++ b/flixel/system/FlxSound.hx
@@ -64,7 +64,7 @@ class FlxSound extends FlxBasic
 	public var amplitudeLeft(default, null):Float;
 
 	/**
-	 * Just the amplitude of the left stereo channel
+	 * Just the amplitude of the right stereo channel
 	 */
 	public var amplitudeRight(default, null):Float;
 


### PR DESCRIPTION
i saw this tiny issue in the flx sound amplitudeRight description might aswell fix it