### PR TITLE
add startOutro, deprecate switchTo

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -368,8 +368,18 @@ class FlxG
 	 */
 	public static inline function switchState(nextState:FlxState):Void
 	{
-		if (state.switchTo(nextState))
-			game._requestedState = nextState;
+		final stateOnCall = FlxG.state;
+		// Use reflection to avoid deprecation warning on switchTo
+		if (Reflect.field(state, 'switchTo')(nextState))
+		{
+			state.startOutro(function()
+			{
+				if (FlxG.state == stateOnCall)
+					game._requestedState = nextState;
+				else
+					FlxG.log.warn("`onOutroComplete` was called after the state was switched. This will be ignored");
+			});
+		}
 	}
 
 	/**

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -10,6 +10,8 @@ import flixel.util.FlxSignal.FlxTypedSignal;
  * It is for all intents and purpose a fancy `FlxGroup`. And really, it's not even that fancy.
  */
 @:keepSub // workaround for HaxeFoundation/haxe#3749
+@:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("switchTo", "switchTo is deprecated, use startOutro"))
+// show deprecation warning when `switchTo` is overriden in dereived classes
 class FlxState extends FlxGroup
 {
 	/**
@@ -171,9 +173,24 @@ class FlxState extends FlxGroup
 	 *
 	 * Useful for customizing state switches, e.g. for transition effects.
 	 */
+	@:deprecated("switchTo is deprecated, use startOutro")
 	public function switchTo(nextState:FlxState):Bool
 	{
 		return true;
+	}
+	
+	/**
+	 * Called from `FlxG.switchState()`, when `onOutroComplete` is called, the actual state
+	 * switching will happen.
+	 * 
+	 * Note: Calling `super.startOutro(onOutroComplete)` will call `onOutroComplete`.
+	 * 
+	 * @param   onOutroComplete  Called when the outro is complete.
+	 * @since 5.3.0
+	 */
+	public function startOutro(onOutroComplete:()->Void)
+	{
+		onOutroComplete();
 	}
 
 	/**

--- a/flixel/system/macros/FlxMacroUtil.hx
+++ b/flixel/system/macros/FlxMacroUtil.hx
@@ -53,4 +53,27 @@ class FlxMacroUtil
 
 		return macro $a{finalExpr};
 	}
+	
+	public static macro function deprecateOverride(fieldName:String, ?msg:String):Array<Field>
+	{
+		var fields = Context.getBuildFields();
+		var pos:Position = null;
+		for (field in fields)
+		{
+			if (field.name == fieldName)
+			{
+				pos = field.pos;
+				break;
+			}
+		}
+		
+		if (pos != null)
+		{
+			if (msg == null)
+				msg = '$fieldName is deprecated';
+			
+			Context.warning(msg, pos);
+		}
+		return null;
+	}
 }

--- a/tests/unit/src/flixel/FlxStateTest.hx
+++ b/tests/unit/src/flixel/FlxStateTest.hx
@@ -1,6 +1,7 @@
 package flixel;
 
 import massive.munit.Assert;
+import flixel.util.FlxTimer;
 
 class FlxStateTest extends FlxTest
 {
@@ -47,13 +48,38 @@ class FlxStateTest extends FlxTest
 		resetState();
 		Assert.areEqual(finalState, FlxG.state);
 	}
+	
+	@Test
+	function testOutro()
+	{
+		var outroState = new OutroState();
+		
+		FlxG.switchState(outroState);
+		step();
+		Assert.areEqual(outroState, FlxG.state);
+		
+		FlxG.switchState(new FlxState());
+		step();
+		Assert.areEqual(outroState, FlxG.state);
+		step();
+		Assert.areNotEqual(outroState, FlxG.state);
+		
+	}
 }
 
 class FinalState extends FlxState
 {
-	override public function switchTo(nextState:FlxState):Bool
+	override function switchTo(nextState:FlxState):Bool
 	{
 		return false;
+	}
+}
+
+class OutroState extends FlxState
+{
+	override function startOutro(onOutroComplete:()->Void)
+	{
+		new FlxTimer().start(0, (_)->onOutroComplete());
 	}
 }
 


### PR DESCRIPTION
related to #2565

adds `startOutro` which is called from `FlxG.switchState` with a callback that - when called - triggers the actual switching. `switchTo` is now deprecated because it doesn't work with the [proposed changes for Flixel 6.0.0](https://github.com/HaxeFlixel/flixel/issues/2541)

It's worth noting that this new system doesn't allow states to prevent switches, by evaluating the next state instance, but based on the name "switchTo" and how `switchTo` is currently used I don't think that was ever a desired feature, but rather a side-effect to how it was implemented, if devs want to use this kind of state flow control they can make some proprietary system for handling that.

## The Old Way
when `FlxG.switchState` is called, switchTo is called, a fade to black is started, after which stateSwitch is called again and it will actually switch states.
```hx
package states;

import flixel.text.FlxBitmapText;
import flixel.FlxState;
import flixel.FlxG;

class StateOutroTestState extends FlxState
{
    var switchingStates:Bool = false;
    
    override function create()
    {
        super.create();
        
        final text = new FlxBitmapText("StateOutroTestState");
        text.scale.scale(4);
        text.updateHitbox();
        // show in random position so it's clear that a state switch happened
        text.x = FlxG.random.float(0, FlxG.width - text.width);
        text.y = FlxG.random.float(0, FlxG.height - text.height);
        add(text);
    }
    
    override function update(elapsed)
    {
        super.update(elapsed);
        
        if (FlxG.keys.justReleased.SPACE && switchingStates == false)
        {
            // prevents switch state calls while already playing the outro
            switchingStates = true;
            FlxG.switchState(new StateOutroTestState());
        }
    }
    
    // --- --- --- --- --- --- ---  The Important Part   --- --- --- --- --- --- --- //
    var outroComplete = false;
    override function switchTo(nextState:FlxState):Bool
    {
        if (outroComplete)
            return true;
        
        camera.fade(function ()
        {
            outroComplete = true;
            FlxG.switchState(nextState);
        });
        return false;
    }
    // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- //
}
```

Note: This way still works perfectly fine but overriding `switchTo` in a class that derives from `FlxState` will show the warning: "switchTo is deprecated, use startOutro".

## The New Way
In this way, startOutro simply passes the complete callback into the fade

```hx
package states;

import flixel.text.FlxBitmapText;
import flixel.FlxState;
import flixel.FlxG;

class StateOutroTestState extends FlxState
{
    var switchingStates:Bool = false;
    
    override function create()
    {
        super.create();
        
        final text = new FlxBitmapText("StateOutroTestState");
        text.scale.scale(4);
        text.updateHitbox();
        // show in random position so it's clear that a state switch happened
        text.x = FlxG.random.float(0, FlxG.width - text.width);
        text.y = FlxG.random.float(0, FlxG.height - text.height);
        add(text);
    }
    
    override function update(elapsed)
    {
        super.update(elapsed);
        
        if (FlxG.keys.justReleased.SPACE && switchingStates == false)
        {
            // prevents switch state calls while already playing the outro
            switchingStates = true;
            FlxG.switchState(new StateOutroTestState());
        }
    }
    
    // --- --- --- --- --- --- ---  The Important Part   --- --- --- --- --- --- --- //
    override function startOutro(onOutroComplete:()->Void)
    {
        camera.fade(onOutroComplete);
    }
    // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- //
}
```
Pretty sexy, if I do say so, myself.