### PR TITLE
raise minimum haxe version to 4.2.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        haxe-version: ["4.0.5", stable, nightly]
+        haxe-version: ["4.2.5", stable, nightly]
         target: [html5, hl, neko, flash, cpp]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -470,7 +470,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		{
 			basic = members[i++]; // we use basic as FlxBasic for performance reasons
 
-			if (basic != null && !basic.exists && (ObjectClass == null || basic is ObjectClass))
+			if (basic != null && !basic.exists && (ObjectClass == null || Std.isOfType(basic, ObjectClass)))
 			{
 				if (Force && Type.getClassName(Type.getClass(basic)) != Type.getClassName(ObjectClass))
 				{
@@ -849,7 +849,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 						group.forEachOfType(ObjectClass, cast Function, Recurse);
 				}
 
-				if (basic is ObjectClass)
+				if (Std.isOfType(basic, ObjectClass))
 					Function(cast basic);
 			}
 		}

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -7,11 +7,6 @@ import flixel.util.FlxArrayUtil;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSignal.FlxTypedSignal;
 import flixel.util.FlxSort;
-#if (haxe_ver >= 4.2)
-import Std.isOfType;
-#else
-import Std.is as isOfType;
-#end
 
 typedef FlxGroup = FlxTypedGroup<FlxBasic>;
 
@@ -475,7 +470,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		{
 			basic = members[i++]; // we use basic as FlxBasic for performance reasons
 
-			if (basic != null && !basic.exists && (ObjectClass == null || isOfType(basic, ObjectClass)))
+			if (basic != null && !basic.exists && (ObjectClass == null || basic is ObjectClass))
 			{
 				if (Force && Type.getClassName(Type.getClass(basic)) != Type.getClassName(ObjectClass))
 				{
@@ -854,7 +849,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 						group.forEachOfType(ObjectClass, cast Function, Recurse);
 				}
 
-				if (isOfType(basic, ObjectClass))
+				if (basic is ObjectClass)
 					Function(cast basic);
 			}
 		}

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -23,11 +23,6 @@ import flixel.util.FlxSpriteUtil;
 #if !(FLX_NATIVE_CURSOR && FLX_MOUSE)
 import flash.display.Bitmap;
 #end
-#if (haxe_ver >= 4.2)
-import Std.isOfType;
-#else
-import Std.is as isOfType;
-#end
 
 /**
  * Adds a new functionality to Flixel debugger that allows any object
@@ -347,7 +342,7 @@ class Interaction extends Window
 	public function getTool(className:Class<Tool>):Tool
 	{
 		for (tool in _tools)
-			if (isOfType(tool, className))
+			if (tool is className)
 				return tool;
 		return null;
 	}

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -342,7 +342,7 @@ class Interaction extends Window
 	public function getTool(className:Class<Tool>):Tool
 	{
 		for (tool in _tools)
-			if (tool is className)
+			if (Std.isOfType(tool, className))
 				return tool;
 		return null;
 	}

--- a/flixel/system/debug/watch/Tracker.hx
+++ b/flixel/system/debug/watch/Tracker.hx
@@ -31,11 +31,6 @@ import flixel.animation.FlxAnimationController;
 import flixel.input.touch.FlxTouch;
 #end
 #end
-#if (haxe_ver >= 4.2)
-import Std.isOfType;
-#else
-import Std.is as isOfType;
-#end
 import flixel.util.FlxStringUtil;
 
 class Tracker extends Watch
@@ -70,7 +65,7 @@ class Tracker extends Watch
 
 		var lastMatchingProfile:TrackerProfile = null;
 		for (profile in profiles)
-			if (isOfType(Object, profile.objectClass) || Object == profile.objectClass)
+			if (Object is profile.objectClass || Object == profile.objectClass)
 				lastMatchingProfile = profile;
 
 		return lastMatchingProfile;

--- a/flixel/system/debug/watch/Tracker.hx
+++ b/flixel/system/debug/watch/Tracker.hx
@@ -65,7 +65,7 @@ class Tracker extends Watch
 
 		var lastMatchingProfile:TrackerProfile = null;
 		for (profile in profiles)
-			if (Object is profile.objectClass || Object == profile.objectClass)
+			if (Std.isOfType(Object, profile.objectClass) || Object == profile.objectClass)
 				lastMatchingProfile = profile;
 
 		return lastMatchingProfile;

--- a/flixel/system/frontEnds/PluginFrontEnd.hx
+++ b/flixel/system/frontEnds/PluginFrontEnd.hx
@@ -5,11 +5,6 @@ import flixel.input.mouse.FlxMouseEventManager;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxStringUtil;
 import flixel.util.FlxTimer;
-#if (haxe_ver >= 4.2)
-import Std.isOfType;
-#else
-import Std.is as isOfType;
-#end
 
 /**
  * Accessed via `FlxG.plugins`.
@@ -54,7 +49,7 @@ class PluginFrontEnd
 	{
 		for (plugin in list)
 		{
-			if (isOfType(plugin, ClassType))
+			if (plugin is ClassType)
 			{
 				return cast plugin;
 			}
@@ -101,7 +96,7 @@ class PluginFrontEnd
 
 		while (i >= 0)
 		{
-			if (isOfType(list[i], ClassType))
+			if (list[i] is ClassType)
 			{
 				list.splice(i, 1);
 				results = true;

--- a/flixel/system/frontEnds/PluginFrontEnd.hx
+++ b/flixel/system/frontEnds/PluginFrontEnd.hx
@@ -49,7 +49,7 @@ class PluginFrontEnd
 	{
 		for (plugin in list)
 		{
-			if (plugin is ClassType)
+			if (Std.isOfType(plugin, ClassType))
 			{
 				return cast plugin;
 			}
@@ -96,7 +96,7 @@ class PluginFrontEnd
 
 		while (i >= 0)
 		{
-			if (list[i] is ClassType)
+			if (Std.isOfType(list[i], ClassType))
 			{
 				list.splice(i, 1);
 				results = true;

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -75,8 +75,8 @@ class FlxDefines
 
 	static function checkDependencyCompatibility()
 	{
-		#if (haxe_ver < "4.0.5")
-		abortVersion("Haxe", "4.0.5 or newer", "haxe_ver", (macro null).pos);
+		#if (haxe < version("4.2.5"))
+		abortVersion("Haxe", "4.2.5 or newer", "haxe_ver", (macro null).pos);
 		#end
 
 		#if !nme

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -16,7 +16,7 @@ import openfl.display.BitmapData;
 
 using StringTools;
 
-class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
+abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 {
 	/**
 	 * Set this flag to use one of the 16-tile binary auto-tile algorithms (OFF, AUTO, or ALT).
@@ -110,42 +110,19 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Virtual methods, must be implemented in each renderers
 	 */
-	function updateTile(index:Int):Void
-	{
-		throw "updateTile must be implemented";
-	}
+	abstract function updateTile(index:Int):Void;
 
-	function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
-	{
-		throw "cacheGraphics must be implemented";
-	}
+	abstract function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void;
 
-	function initTileObjects():Void
-	{
-		throw "initTileObjects must be implemented";
-	}
+	abstract function initTileObjects():Void;
 
-	function updateMap():Void
-	{
-		throw "updateMap must be implemented";
-	}
+	abstract function updateMap():Void;
 
-	function computeDimensions():Void
-	{
-		throw "computeDimensions must be implemented";
-	}
+	abstract function computeDimensions():Void;
 
-	public function getTileIndexByCoords(coord:FlxPoint):Int
-	{
-		throw "getTileIndexByCoords must be implemented";
-		return 0;
-	}
+	abstract public function getTileIndexByCoords(coord:FlxPoint):Int;
 
-	public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
-	{
-		throw "getTileCoordsByIndex must be implemented";
-		return null;
-	}
+	abstract public function getTileCoordsByIndex(index:Int, midpoint:Bool = true):FlxPoint;
 
 	/**
 	 * Shoots a ray from the start point to the end point.
@@ -159,11 +136,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	public function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool
-	{
-		throw "ray must be implemented";
-		return false;
-	}
+	abstract public function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool;
 
 	/**
 	 * Shoots a ray from the start point to the end point.
@@ -179,11 +152,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	public function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
-	{
-		throw "rayStep must be implemented?";
-		return false;
-	}
+	abstract public function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool;
 
 	/**
 	 * Calculates at which point where the given line, from start to end, first enters the tilemap.
@@ -230,16 +199,9 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		return calcRayEntry(end, start, result);
 	}
 
-	public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
-	{
-		throw "overlapsWithCallback must be implemented";
-		return false;
-	}
+	abstract public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false, ?position:FlxPoint):Bool;
 
-	public function setDirty(dirty:Bool = true):Void
-	{
-		throw "setDirty must be implemented";
-	}
+	abstract public function setDirty(dirty:Bool = true):Void;
 
 	function new()
 	{

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -16,7 +16,7 @@ import openfl.display.BitmapData;
 
 using StringTools;
 
-abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
+class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 {
 	/**
 	 * Set this flag to use one of the 16-tile binary auto-tile algorithms (OFF, AUTO, or ALT).
@@ -110,19 +110,42 @@ abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Virtual methods, must be implemented in each renderers
 	 */
-	abstract function updateTile(index:Int):Void;
+	function updateTile(index:Int):Void
+	{
+		throw "updateTile must be implemented";
+	}
 
-	abstract function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void;
+	function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
+	{
+		throw "cacheGraphics must be implemented";
+	}
 
-	abstract function initTileObjects():Void;
+	function initTileObjects():Void
+	{
+		throw "initTileObjects must be implemented";
+	}
 
-	abstract function updateMap():Void;
+	function updateMap():Void
+	{
+		throw "updateMap must be implemented";
+	}
 
-	abstract function computeDimensions():Void;
+	function computeDimensions():Void
+	{
+		throw "computeDimensions must be implemented";
+	}
 
-	abstract public function getTileIndexByCoords(coord:FlxPoint):Int;
+	public function getTileIndexByCoords(coord:FlxPoint):Int
+	{
+		throw "getTileIndexByCoords must be implemented";
+		return 0;
+	}
 
-	abstract public function getTileCoordsByIndex(index:Int, midpoint:Bool = true):FlxPoint;
+	public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
+	{
+		throw "getTileCoordsByIndex must be implemented";
+		return null;
+	}
 
 	/**
 	 * Shoots a ray from the start point to the end point.
@@ -136,7 +159,11 @@ abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	abstract public function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool;
+	public function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool
+	{
+		throw "ray must be implemented";
+		return false;
+	}
 
 	/**
 	 * Shoots a ray from the start point to the end point.
@@ -152,7 +179,11 @@ abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	abstract public function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool;
+	public function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
+	{
+		throw "rayStep must be implemented?";
+		return false;
+	}
 
 	/**
 	 * Calculates at which point where the given line, from start to end, first enters the tilemap.
@@ -199,9 +230,16 @@ abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		return calcRayEntry(end, start, result);
 	}
 
-	abstract public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false, ?position:FlxPoint):Bool;
+	public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
+	{
+		throw "overlapsWithCallback must be implemented";
+		return false;
+	}
 
-	abstract public function setDirty(dirty:Bool = true):Void;
+	public function setDirty(dirty:Bool = true):Void
+	{
+		throw "setDirty must be implemented";
+	}
 
 	function new()
 	{

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -26,11 +26,6 @@ import flixel.util.FlxDirectionFlags;
 import flixel.util.FlxSpriteUtil;
 import openfl.display.BlendMode;
 import openfl.geom.ColorTransform;
-#if (haxe_ver >= 4.2)
-import Std.isOfType;
-#else
-import Std.is as isOfType;
-#end
 
 using flixel.util.FlxColorTransformUtil;
 
@@ -382,7 +377,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 			/* if Using tile graphics like GraphicAuto or others defined above, they will not
 			 * load immediately. Track their loading and apply frame padding after.
 			**/
-			if (!graph.isLoaded && isOfType(graph.bitmap, IEmbeddedBitmapData))
+			if (!graph.isLoaded && Std.isOfType(graph.bitmap, IEmbeddedBitmapData))
 			{
 				var futureBitmap:IEmbeddedBitmapData = cast graph.bitmap;
 				futureBitmap.onLoad = function()
@@ -766,7 +761,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 
 				if (overlapFound)
 				{
-					if (tile.callbackFunction != null && (tile.filter == null || isOfType(object, tile.filter)))
+					if (tile.callbackFunction != null && (tile.filter == null || Std.isOfType(object, tile.filter)))
 					{
 						tile.mapIndex = rowStart + column;
 						tile.callbackFunction(tile, object);

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -347,7 +347,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_checkBufferChanges = true;
 	}
 
-	function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
+	override function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		if ((tileGraphic is FlxFramesCollection))
 		{
@@ -405,7 +405,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		);
 	}
 
-	function initTileObjects():Void
+	override function initTileObjects():Void
 	{
 		if (frames == null)
 			return;
@@ -468,7 +468,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	}
 	#end
 
-	function computeDimensions():Void
+	override function computeDimensions():Void
 	{
 		scaledTileWidth = tileWidth * scale.x;
 		scaledTileHeight = tileHeight * scale.y;
@@ -477,7 +477,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		height = scaledHeight;
 	}
 
-	function updateMap():Void
+	override function updateMap():Void
 	{
 		#if FLX_DEBUG
 		if (FlxG.renderBlit)
@@ -655,7 +655,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 *
 	 * @param   dirty  Whether to flag the tilemap buffers as dirty or not.
 	 */
-	public function setDirty(dirty:Bool = true):Void
+	override public function setDirty(dirty:Bool = true):Void
 	{
 		if (FlxG.renderTile)
 			return;
@@ -676,7 +676,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @param   position            Optional, specify a custom position for the tilemap (useful for overlapsAt()-type functionality).
 	 * @return  Whether there were overlaps, or if a callback was specified, whatever the return value of the callback was.
 	 */
-	public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false,
+	override public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false,
 			?position:FlxPoint):Bool
 	{
 		var results:Bool = false;
@@ -780,7 +780,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		return results;
 	}
 
-	public function getTileIndexByCoords(coord:FlxPoint):Int
+	override public function getTileIndexByCoords(coord:FlxPoint):Int
 	{
 		var localX = coord.x - x;
 		var localY = coord.y - y;
@@ -792,7 +792,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		return Std.int(localY / scaledTileHeight) * widthInTiles + Std.int(localX / scaledTileWidth);
 	}
 
-	public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
+	override public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
 	{
 		var point = FlxPoint.get(x + (index % widthInTiles) * scaledTileWidth, y + Std.int(index / widthInTiles) * scaledTileHeight);
 		if (midpoint)
@@ -873,7 +873,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool
+	override function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool
 	{
 		// trim the line to the parts inside the map
 		final trimmedStart = calcRayEntry(start, end);
@@ -1036,7 +1036,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
+	override function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
 	{
 		var step:Float = scaledTileWidth;
 
@@ -1372,7 +1372,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 *
 	 * @param   index  The index of the tile object in _tileObjects internal array you want to update.
 	 */
-	function updateTile(index:Int):Void
+	override function updateTile(index:Int):Void
 	{
 		var tile:FlxTile = _tileObjects[index];
 		if (tile == null || !tile.visible)

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -347,7 +347,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_checkBufferChanges = true;
 	}
 
-	override function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
+	function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		if ((tileGraphic is FlxFramesCollection))
 		{
@@ -405,7 +405,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		);
 	}
 
-	override function initTileObjects():Void
+	function initTileObjects():Void
 	{
 		if (frames == null)
 			return;
@@ -468,7 +468,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	}
 	#end
 
-	override function computeDimensions():Void
+	function computeDimensions():Void
 	{
 		scaledTileWidth = tileWidth * scale.x;
 		scaledTileHeight = tileHeight * scale.y;
@@ -477,7 +477,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		height = scaledHeight;
 	}
 
-	override function updateMap():Void
+	function updateMap():Void
 	{
 		#if FLX_DEBUG
 		if (FlxG.renderBlit)
@@ -655,7 +655,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 *
 	 * @param   dirty  Whether to flag the tilemap buffers as dirty or not.
 	 */
-	override public function setDirty(dirty:Bool = true):Void
+	public function setDirty(dirty:Bool = true):Void
 	{
 		if (FlxG.renderTile)
 			return;
@@ -676,7 +676,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @param   position            Optional, specify a custom position for the tilemap (useful for overlapsAt()-type functionality).
 	 * @return  Whether there were overlaps, or if a callback was specified, whatever the return value of the callback was.
 	 */
-	override public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false,
+	public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false,
 			?position:FlxPoint):Bool
 	{
 		var results:Bool = false;
@@ -780,7 +780,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		return results;
 	}
 
-	override public function getTileIndexByCoords(coord:FlxPoint):Int
+	public function getTileIndexByCoords(coord:FlxPoint):Int
 	{
 		var localX = coord.x - x;
 		var localY = coord.y - y;
@@ -792,7 +792,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		return Std.int(localY / scaledTileHeight) * widthInTiles + Std.int(localX / scaledTileWidth);
 	}
 
-	override public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
+	public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
 	{
 		var point = FlxPoint.get(x + (index % widthInTiles) * scaledTileWidth, y + Std.int(index / widthInTiles) * scaledTileHeight);
 		if (midpoint)
@@ -873,7 +873,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	override function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool
+	function ray(start:FlxPoint, end:FlxPoint, ?result:FlxPoint):Bool
 	{
 		// trim the line to the parts inside the map
 		final trimmedStart = calcRayEntry(start, end);
@@ -1036,7 +1036,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
-	override function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
+	function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
 	{
 		var step:Float = scaledTileWidth;
 
@@ -1372,7 +1372,7 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 	 *
 	 * @param   index  The index of the tile object in _tileObjects internal array you want to update.
 	 */
-	override function updateTile(index:Int):Void
+	function updateTile(index:Int):Void
 	{
 		var tile:FlxTile = _tileObjects[index];
 		if (tile == null || !tile.visible)


### PR DESCRIPTION
closes #2774

- Throws an error if they try to use a lower version than 4.2.5
- Removes all `import Std.is as isOfType;` lines
- ~~Converts FlxBaseTilemap to an abstract class, related to #2734~~ Try this later