### PR TITLE
Invalid Save chars

### DIFF
--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -56,7 +56,8 @@ class LogFrontEnd
 	public function advanced(Data:Dynamic, ?Style:LogStyle, FireOnce:Bool = false):Void
 	{
 		#if FLX_DEBUG
-		if (FlxG.game.debugger == null)
+		// Check null game since `FlxG.save.bind` may be called before `new FlxGame`
+		if (FlxG.game == null || FlxG.game.debugger == null)
 		{
 			_standardTraceFunction(Data);
 			return;

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -56,7 +56,7 @@ import openfl.net.SharedObjectFlushStatus;
 class FlxSave implements IFlxDestroyable
 {
 	
-	static var invalidChars = ~/[ ~%&\\;:"',<>?#]+/;
+	static var invalidChars = ~/[ ~%&\\;:"',<>?#]+/g;
 	
 	/**
 	 * Checks for `~%&\;:"',<>?#` or space characters


### PR DESCRIPTION
Fixes #2776 

The previous code only replaced the first invalid character, now it replaces all invalid characters.

This also checks for a null FlxGame before logging to prevent a null crash when calling `FlxG.save.bind` before `new FlxGame`