### PR TITLE
prevent crash when destroying sprites in a anim callback

### DIFF
--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -217,6 +217,11 @@ class FlxAnimation extends FlxBaseAnimation
 				else
 					curFrame++;
 			}
+			
+			// prevents null ref when the sprite is destroyed on finishCallback (#2782)
+			if (finished)
+				break;
+			
 			curFrameDuration = getCurrentFrameDuration();
 		}
 	}


### PR DESCRIPTION
fixes #2782

The following example will crash without this fix
```hx

import flixel.FlxG;
import flixel.FlxSprite;

class AnimCallbackTestState extends flixel.FlxState
{
    override function create()
    {
        var sprite:FlxSprite = new FlxSprite().makeGraphic(100, 100);
        sprite.animation.add("anim", [0, 0, 0, 0], 4, false);
        add(sprite);
        
        // insert animation code here
        sprite.animation.finishCallback = function(anim:String)
        {
            sprite.destroy();
        }
        
        sprite.animation.play('anim');
    }
}
```

The issue is that `parent` is referenced internally after the finishCallback is fired. Specifically the callback fired in set_curFrame from [FlxAnimation.hx#L218](https://github.com/HaxeFlixel/flixel/blob/dev/flixel/animation/FlxAnimation.hx#L218) and parent is referenced in [FlxAnimation.hx#L220](https://github.com/HaxeFlixel/flixel/blob/dev/flixel/animation/FlxAnimation.hx#L220)