### PR TITLE
large FlxGroup changes

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -934,7 +934,7 @@ class FlxObject extends FlxBasic
 		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
 		{
-			return FlxTypedGroup.overlaps(overlapsCallback.bind(_, 0, 0, inScreenSpace, camera), group);
+			return group.any(overlapsCallback.bind(_, 0, 0, inScreenSpace, camera));
 		}
 
 		if (objectOrGroup.flixelType == TILEMAP)
@@ -993,7 +993,7 @@ class FlxObject extends FlxBasic
 		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
 		{
-			return FlxTypedGroup.overlaps(overlapsAtCallback.bind(_, x, y, inScreenSpace, camera), group);
+			return group.any(overlapsAtCallback.bind(_, x, y, inScreenSpace, camera));
 		}
 
 		if (objectOrGroup.flixelType == TILEMAP)

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -934,7 +934,7 @@ class FlxObject extends FlxBasic
 		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
 		{
-			return FlxTypedGroup.overlaps(overlapsCallback, group, 0, 0, inScreenSpace, camera);
+			return FlxTypedGroup.overlaps(overlapsCallback.bind(_, 0, 0, inScreenSpace, camera), group);
 		}
 
 		if (objectOrGroup.flixelType == TILEMAP)
@@ -993,7 +993,7 @@ class FlxObject extends FlxBasic
 		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
 		{
-			return FlxTypedGroup.overlaps(overlapsAtCallback, group, x, y, inScreenSpace, camera);
+			return FlxTypedGroup.overlaps(overlapsAtCallback.bind(_, x, y, inScreenSpace, camera), group);
 		}
 
 		if (objectOrGroup.flixelType == TILEMAP)

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -661,6 +661,14 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	}
 
 	/**
+	 * Iterates through every member and index.
+	 */
+	public inline function keyValueIterator()
+	{
+		return members.keyValueIterator();
+	}
+
+	/**
 	 * Applies a function to all members.
 	 *
 	 * @param   func     A function that modifies one element at a time.

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -408,7 +408,117 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	{
 		members.sort(func.bind(order));
 	}
-
+	
+	/**
+	 * Searches for, and returns the first member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function getFirst(func:T->Bool):Null<T>
+	{
+		var result:T = null;
+		for (basic in members)
+		{
+			if (basic != null && func(basic))
+			{
+				result = basic;
+				break;
+			}
+		}
+		return result;
+	}
+	
+	/**
+	 * Searches for, and returns the last member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function getLast(func:T->Bool):Null<T>
+	{
+		var result:T = null;
+		var i = members.length;
+		while (i-- > 0)
+		{
+			final basic = members[i];
+			if (basic != null && func(basic))
+			{
+				result = basic;
+				break;
+			}
+		}
+		return result;
+	}
+	
+	/**
+	 * Searches for, and returns the index of the first member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function getFirstIndex(func:T->Bool):Int
+	{
+		var result = -1;
+		for (i=>basic in members)
+		{
+			if (basic != null && func(basic))
+			{
+				result = i;
+				break;
+			}
+		}
+		return result;
+	}
+	
+	/**
+	 * Searches for, and returns the index of the last member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function getLastIndex(func:T->Bool):Int
+	{
+		var result = -1;
+		var i = members.length;
+		while (i-- > 0)
+		{
+			final basic = members[i];
+			if (basic != null && func(basic))
+			{
+				result = i;
+				break;
+			}
+		}
+		return result;
+	}
+	
+	/**
+	 * Tests whether any member satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function any(func:T->Bool):Bool
+	{
+		for (basic in members)
+		{
+			if (basic != null && func(basic))
+				return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Tests whether every member satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function every(func:T->Bool):Bool
+	{
+		for (basic in members)
+		{
+			if (basic != null && !func(basic))
+				return false;
+		}
+		return true;
+	}
+	
 	/**
 	 * Call this function to retrieve the first object with `exists == false` in the group.
 	 * This is handy for recycling in general, e.g. respawning enemies.
@@ -454,13 +564,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 */
 	public function getFirstExisting():Null<T>
 	{
-		for (basic in members)
-		{
-			if (basic != null && basic.exists)
-				return basic;
-		}
-
-		return null;
+		return inline getFirst((basic)->basic.exists);
 	}
 
 	/**
@@ -471,13 +575,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 */
 	public function getFirstAlive():Null<T>
 	{
-		for (basic in members)
-		{
-			if (basic != null && basic.exists && basic.alive)
-				return basic;
-		}
-
-		return null;
+		return inline getFirst((basic)->basic.exists && basic.alive);
 	}
 
 	/**
@@ -488,15 +586,9 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 */
 	public function getFirstDead():Null<T>
 	{
-		for (basic in members)
-		{
-			if (basic != null && !basic.alive)
-				return basic;
-		}
-
-		return null;
+		return inline getFirst((basic)->!basic.alive);
 	}
-
+	
 	/**
 	 * Call this function to find out how many members of the group are not dead.
 	 *
@@ -531,7 +623,6 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		
 		for (basic in members)
 		{
-
 			if (basic != null)
 			{
 				if (count < 0)
@@ -542,100 +633,6 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 
 		return count;
-	}
-	
-	/**
-	 * Searches for, and returns the first member that satisfies the function.
-	 * @param   func  The function that tests the members
-	 * @since 5.4.0
-	 */
-	public function find(func:T->Bool):Null<T>
-	{
-		for (basic in members)
-		{
-			if (basic != null && func(basic))
-				return basic;
-		}
-		return null;
-	}
-	
-	/**
-	 * Searches for, and returns the last member that satisfies the function.
-	 * @param   func  The function that tests the members
-	 * @since 5.4.0
-	 */
-	public function findLast(func:T->Bool):Null<T>
-	{
-		var i = members.length;
-		while (i-- > 0)
-		{
-			final basic = members[i];
-			if (basic != null && func(basic))
-				return basic;
-		}
-		return null;
-	}
-	
-	/**
-	 * Searches for, and returns the index of the first member that satisfies the function.
-	 * @param   func  The function that tests the members
-	 * @since 5.4.0
-	 */
-	public function findIndex(func:T->Bool):Int
-	{
-		for (i=>basic in members)
-		{
-			if (basic != null && func(basic))
-				return i;
-		}
-		return -1;
-	}
-	
-	/**
-	 * Searches for, and returns the index of the last member that satisfies the function.
-	 * @param   func  The function that tests the members
-	 * @since 5.4.0
-	 */
-	public function findLastIndex(func:T->Bool):Int
-	{
-		var i = members.length;
-		while (i-- > 0)
-		{
-			final basic = members[i];
-			if (basic != null && func(basic))
-				return i;
-		}
-		return -1;
-	}
-	
-	/**
-	 * Tests whether any member satisfies the function.
-	 * @param   func  The function that tests the members
-	 * @since 5.4.0
-	 */
-	public function any(func:T->Bool):Bool
-	{
-		for (basic in members)
-		{
-			if (basic != null && func(basic))
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Tests whether every member satisfies the function.
-	 * @param   func  The function that tests the members
-	 * @since 5.4.0
-	 */
-	public function every(func:T->Bool):Bool
-	{
-		for (basic in members)
-		{
-			if (basic != null && !func(basic))
-				return false;
-		}
-		return true;
 	}
 	
 	/**

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -21,23 +21,6 @@ typedef FlxGroup = FlxTypedGroup<FlxBasic>;
  */
 class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 {
-	/**
-	 * Helper for overlap functions in `FlxObject` and `FlxTilemap`.
-	 */
-	@:noCompletion
-	static function overlaps(callback:FlxBasic->Bool, group:FlxTypedGroup<FlxBasic>):Bool
-	{
-		if (group == null)
-			return false;
-		
-		for (basic in group)
-		{
-			if (basic != null && callback(basic))
-				return true;
-		}
-		return false;
-	}
-
 	@:noCompletion
 	static function resolveGroup(basic:FlxBasic):FlxTypedGroup<FlxBasic>
 	{
@@ -570,7 +553,101 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 
 		return count;
 	}
-
+	
+	/**
+	 * Searches for, and returns the first member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function find(func:T->Bool):Null<T>
+	{
+		for (basic in members)
+		{
+			if (basic != null && func(basic))
+				return basic;
+		}
+		return null;
+	}
+	
+	/**
+	 * Searches for, and returns the last member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function findLast(func:T->Bool):Null<T>
+	{
+		var i = members.length;
+		while (i-- > 0)
+		{
+			final basic = members[i];
+			if (basic != null && func(basic))
+				return basic;
+		}
+		return null;
+	}
+	
+	/**
+	 * Searches for, and returns the index of the first member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function findIndex(func:T->Bool):Int
+	{
+		for (i=>basic in members)
+		{
+			if (basic != null && func(basic))
+				return i;
+		}
+		return -1;
+	}
+	
+	/**
+	 * Searches for, and returns the index of the last member that satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function findLastIndex(func:T->Bool):Int
+	{
+		var i = members.length;
+		while (i-- > 0)
+		{
+			final basic = members[i];
+			if (basic != null && func(basic))
+				return i;
+		}
+		return -1;
+	}
+	
+	/**
+	 * Tests whether any member satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function any(func:T->Bool):Bool
+	{
+		for (basic in members)
+		{
+			if (basic != null && func(basic))
+				return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Tests whether every member satisfies the function.
+	 * @param   func  The function that tests the members
+	 * @since 5.4.0
+	 */
+	public function every(func:T->Bool):Bool
+	{
+		for (basic in members)
+		{
+			if (basic != null && !func(basic))
+				return false;
+		}
+		return true;
+	}
+	
 	/**
 	 * Returns a member at random from the group.
 	 *

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -8,6 +8,10 @@ import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSignal.FlxTypedSignal;
 import flixel.util.FlxSort;
 
+/**
+ * An alias for `FlxTypedGroup<FlxBasic>`, meaning any flixel object or basic can be added to a
+ * `FlxGroup`, even another `FlxGroup`.
+ */
 typedef FlxGroup = FlxTypedGroup<FlxBasic>;
 
 /**

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -21,15 +21,14 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 * Helper for overlap functions in `FlxObject` and `FlxTilemap`.
 	 */
 	@:noCompletion
-	static function overlaps(callback:(FlxBasic, Float, Float, Bool, FlxCamera)->Bool, group:FlxTypedGroup<FlxBasic>, x:Float, y:Float, inScreenSpace:Bool,
-			camera:FlxCamera):Bool
+	static function overlaps(callback:FlxBasic->Bool, group:FlxTypedGroup<FlxBasic>):Bool
 	{
 		if (group == null)
 			return false;
 		
 		for (basic in group)
 		{
-			if (basic != null && callback(basic, x, y, inScreenSpace, camera))
+			if (basic != null && callback(basic))
 				return true;
 		}
 		return false;

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -606,30 +606,48 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	}
 
 	/**
-	 * Calls `kill()` on the group's `members` and then on the group itself.
-	 * You can revive this group later via `revive()` after this.
+	 * Calls `kill()` on the group's unkilled `members`. Revive them via `reviveMembers()`.
+	 * @since 5.4.0
 	 */
-	override public function kill():Void
+	public function killMembers():Void
 	{
 		for (basic in members)
 		{
 			if (basic != null && basic.exists)
 				basic.kill();
 		}
+	}
+
+	/**
+	 * Calls `killMembers()` and then kills the group itself.
+	 * Revive this group via `revive()`.
+	 */
+	override public function kill():Void
+	{
+		inline killMembers();
 
 		super.kill();
 	}
 
 	/**
-	 * Calls `revive()` on the group's members and then on the group itself.
+	 * Calls `revive()` on the group's killed members and then on the group itself.
+	 * @since 5.4.0
 	 */
-	override public function revive():Void
+	public function reviveMembers():Void
 	{
 		for (basic in members)
 		{
 			if (basic != null && !basic.exists)
 				basic.revive();
 		}
+	}
+
+	/**
+	 * Calls `reviveMembers()` and then revives the group itself.
+	 */
+	override public function revive():Void
+	{
+		inline reviveMembers();
 
 		super.revive();
 	}

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -16,6 +16,10 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSort;
 
+/**
+ * An alias for `FlxTypedSpriteGroup<FlxSprite>`, meaning any sprite can be added to a
+ * `FlxSpriteGroup`, even another `FlxSpriteGroup`.
+ */
 typedef FlxSpriteGroup = FlxTypedSpriteGroup<FlxSprite>;
 
 /**

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -965,7 +965,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
 		{
-			return FlxTypedGroup.overlaps(tilemapOverlapsCallback, group, 0, 0, inScreenSpace, camera);
+			return FlxTypedGroup.overlaps(tilemapOverlapsCallback.bind(_, 0, 0, inScreenSpace, camera), group);
 		}
 		else if (tilemapOverlapsCallback(objectOrGroup))
 		{
@@ -1004,7 +1004,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
 		{
-			return FlxTypedGroup.overlaps(tilemapOverlapsAtCallback, group, x, y, inScreenSpace, camera);
+			return FlxTypedGroup.overlaps(tilemapOverlapsAtCallback.bind(_, x, y, inScreenSpace, camera), group);
 		}
 		else if (tilemapOverlapsAtCallback(objectOrGroup, x, y, inScreenSpace, camera))
 		{

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -962,16 +962,11 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	@:access(flixel.group.FlxTypedGroup)
 	override public function overlaps(objectOrGroup:FlxBasic, inScreenSpace = false, ?camera:FlxCamera):Bool
 	{
-		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
+		final group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
-		{
-			return FlxTypedGroup.overlaps(tilemapOverlapsCallback.bind(_, 0, 0, inScreenSpace, camera), group);
-		}
-		else if (tilemapOverlapsCallback(objectOrGroup))
-		{
-			return true;
-		}
-		return false;
+			return group.any(tilemapOverlapsCallback.bind(_, 0, 0, inScreenSpace, camera));
+		
+		return tilemapOverlapsCallback(objectOrGroup);
 	}
 
 	inline function tilemapOverlapsCallback(objectOrGroup:FlxBasic, x = 0.0, y = 0.0, inScreenSpace = false, ?camera:FlxCamera):Bool
@@ -1001,17 +996,11 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	@:access(flixel.group.FlxTypedGroup)
 	override public function overlapsAt(x:Float, y:Float, objectOrGroup:FlxBasic, inScreenSpace:Bool = false, ?camera:FlxCamera):Bool
 	{
-		var group = FlxTypedGroup.resolveGroup(objectOrGroup);
+		final group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
-		{
-			return FlxTypedGroup.overlaps(tilemapOverlapsAtCallback.bind(_, x, y, inScreenSpace, camera), group);
-		}
-		else if (tilemapOverlapsAtCallback(objectOrGroup, x, y, inScreenSpace, camera))
-		{
-			return true;
-		}
-
-		return false;
+			return group.any(tilemapOverlapsAtCallback.bind(_, x, y, inScreenSpace, camera));
+		
+		return tilemapOverlapsAtCallback(objectOrGroup, x, y, inScreenSpace, camera);
 	}
 
 	inline function tilemapOverlapsAtCallback(objectOrGroup:FlxBasic, x:Float, y:Float, inScreenSpace:Bool, camera:FlxCamera):Bool

--- a/tests/unit/src/flixel/group/FlxGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxGroupTest.hx
@@ -237,4 +237,77 @@ class FlxGroupTest extends FlxTest
 			Assert.fail("FlxGroupTest#testRemovedSignal has failed.");
 		}
 	}
+	
+	function isKilled(basic:FlxBasic)
+	{
+		return basic.alive == false;
+	}
+	
+	function isAlive(basic:FlxBasic)
+	{
+		return basic.alive;
+	}
+	
+	@Test
+	function testFind()
+	{
+		group.remove(group.members[0]); // make first member null
+		group.members[3].kill(); // desired
+		group.members[6].kill();
+		
+		Assert.areEqual(group.members[3], group.find(isKilled));
+	}
+	
+	@Test
+	function testFindLast()
+	{
+		group.remove(group.members[0]); // make first member null
+		group.members[3].kill();
+		group.members[6].kill(); // desired
+		
+		Assert.areEqual(group.members[6], group.findLast(isKilled));
+	}
+	
+	@Test
+	function testFindIndex()
+	{
+		group.remove(group.members[0]); // make first member null
+		group.members[3].kill(); // desired
+		group.members[6].kill();
+		
+		function isKilled(basic) 
+		{
+			return basic.exists == false;
+		}
+		
+		Assert.areEqual(3, group.findIndex(isKilled));
+	}
+	
+	@Test
+	function testFindLastIndex()
+	{
+		group.remove(group.members[0]); // make first member null
+		group.members[3].kill();
+		group.members[6].kill(); // desired
+		
+		Assert.areEqual(6, group.findLastIndex(isKilled));
+	}
+	
+	@Test
+	function testAny()
+	{
+		group.remove(group.members[0]); // make first member null
+		group.members[3].kill();
+		group.members[6].kill(); // desired
+		
+		Assert.isTrue(group.any(isKilled));
+	}
+	
+	@Test
+	function testEvery()
+	{
+		group.remove(group.members[0]); // make first member null
+		
+		Assert.isTrue(group.every(isAlive));
+	}
 }

--- a/tests/unit/src/flixel/group/FlxGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxGroupTest.hx
@@ -218,7 +218,7 @@ class FlxGroupTest extends FlxTest
 	{
 		group.maxSize = group.length;
 		final copy = group.members.copy();
-		group.forEach((basic)->basic.kill());
+		group.killMembers();
 		for (i in 0...group.length)
 			group.recycle(FlxBasic);
 		FlxAssert.arraysEqual(copy, group.members);
@@ -330,6 +330,17 @@ class FlxGroupTest extends FlxTest
 			Assert.isFalse(each.exists);
 		});
 		group.revive();
+		group.forEach(function(each)
+		{
+			Assert.isTrue(each.exists);
+		});
+		
+		group.killMembers();
+		group.forEach(function(each)
+		{
+			Assert.isFalse(each.exists);
+		});
+		group.reviveMembers();
 		group.forEach(function(each)
 		{
 			Assert.isTrue(each.exists);
@@ -504,5 +515,50 @@ class FlxGroupTest extends FlxTest
 		group.remove(group.members[0]); // make first member null
 		
 		Assert.isTrue(group.every(isAlive));
+	}
+	
+	@Test
+	function testGetFirstNull()
+	{
+		Assert.isTrue(group.length >= 6);
+	}
+	
+	@Test
+	function testGetFirstMisc()
+	{
+		Assert.isTrue(group.length > 6);
+		group.members[0].kill();
+		group.members[1].kill();
+		group.members[2].kill();
+		group.remove(group.members[3]); // make null
+		group.remove(group.members[5]); // make null
+		Assert.areEqual(3, group.getFirstNull());
+		Assert.areEqual(group.members[4], group.getFirstExisting());
+		Assert.areEqual(group.members[4], group.getFirstAlive());
+		Assert.areEqual(group.members[0], group.getFirstDead());
+		Assert.areEqual(group.members[0], group.getFirstAvailable());
+		final nullCount = 2;
+		final deadCount = 3;
+		Assert.areEqual(deadCount, group.countDead());
+		Assert.areEqual(group.length - nullCount - deadCount, group.countLiving());
+	}
+	
+	@Test
+	function testIterator()
+	{
+		var count = 0;
+		for (member in group) // array iterator
+			count++;
+		
+		Assert.areEqual(group.length, count);
+		
+		group.remove(group.members[0]);
+		group.members[1].kill();
+		
+		count = 0;
+		for (i=>member in group) // keyValueIterator
+			count++;
+		
+		Assert.areEqual(group.length, count);
 	}
 }


### PR DESCRIPTION
- Changed a lot of while loops to for loops, this was a relic from the flash days, js haxe will turn them back into for loops but this is more readable
- Move function scoped vars to for loop scoped vars when they are only used in the loop, same reason as above
- Add `killMembers` and `reviveMembers` and `keyValueIterator`
- Add new searching utils `getFirst`, `getLast`, `getFirstIndex`, `getLastIndex`, `any` and `every`
- Use inlined `getFirst` for all other, similar search utils
- Replace `getFirstNull`'s loop with a simple indexOf check
- add unit tests for new and changed FlxGroup features