### PR TITLE
Fix reversed animations not finishing

### DIFF
--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -251,7 +251,7 @@ class FlxAnimation extends FlxBaseAnimation
 
 		if (tempFrame >= 0)
 		{
-			if (!looped && frame > maxFrameIndex)
+			if (!looped && tempFrame > maxFrameIndex)
 			{
 				finished = true;
 				curFrame = reversed ? 0 : maxFrameIndex;


### PR DESCRIPTION
I noticed reversed animations didn't call the animation finish callback. This fixes that by checking `tempFrame` instead of `frame`.