### PR TITLE
Fixed bug causing focus to be lost when pressing TAB.

### DIFF
--- a/flixel/system/debug/console/Console.hx
+++ b/flixel/system/debug/console/Console.hx
@@ -117,8 +117,10 @@ class Console extends Window
 		// openfl/openfl#1856
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, function(e:KeyboardEvent)
 		{
-			if (FlxG.debugger.visible && FlxG.game.debugger.console.visible && e.keyCode == Keyboard.TAB)
+			if (FlxG.debugger.visible && FlxG.game.debugger.console.visible && e.keyCode == Keyboard.TAB) {
 				FlxG.stage.focus = input;
+			}
+			e.preventDefault();
 		});
 		#end
 		#end

--- a/flixel/system/debug/console/Console.hx
+++ b/flixel/system/debug/console/Console.hx
@@ -117,10 +117,11 @@ class Console extends Window
 		// openfl/openfl#1856
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, function(e:KeyboardEvent)
 		{
-			if (FlxG.debugger.visible && FlxG.game.debugger.console.visible && e.keyCode == Keyboard.TAB) {
+			if (FlxG.debugger.visible && FlxG.game.debugger.console.visible && e.keyCode == Keyboard.TAB)
 				FlxG.stage.focus = input;
-			}
-			e.preventDefault();
+			#if windows
+			if (e.keyCode == Keyboard.TAB) e.preventDefault();
+			#end
 		});
 		#end
 		#end


### PR DESCRIPTION
The associated bug can be reproduced in this way:

- Build any project with FLX_DEBUG enabled.
- While in-game, press `TAB`.

Expected behavior is that nothing should happen in-game (unless something is bound to TAB).

Actual behavior is that the window loses focus and the cursor becomes detached from the window.

The root cause is that the console textbox is being focused by OpenFL even when the debugger is not open.

Tested and with this fix the textbox still focuses when the debugger is OPEN (as expected).