### PR TITLE
log error instead of throwing

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -818,13 +818,22 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		{
 			range = 1;
 		}
+		
+		final maxIndex = _tileObjects.length;
+		final end = tile + range;
+		if (maxIndex == 0)
+		{
+			final rangeDisplay = range == 1 ? 'tile $tile' : 'tiles $tile-${end-1}';
+			FlxG.log.error('Cannot setTileProperties of $rangeDisplay when tilemap does not contain any tiles.'
+				+ ' This may be due to an invalid graphic.');
+			return;
+		}
 
-		var end = tile + range;
-
-		var maxIndex = _tileObjects.length;
 		if (end > maxIndex)
 		{
-			throw 'Index $end exceeds the maximum tile index of $maxIndex. Please verify the Tile ($tile) and Range ($range) parameters.';
+			final rangeDisplay = range == 1 ? 'tile $tile' : 'tiles $tile-${end-1}';
+			FlxG.log.error('Cannot setTileProperties of $rangeDisplay when there are only $end tiles.');
+			return;
 		}
 
 		for (i in tile...end)

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -347,6 +347,19 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_checkBufferChanges = true;
 	}
 
+	override function setTileProperties(tile:Int, allowCollisions = ANY, ?callback:FlxObject->FlxObject->Void, ?callbackFilter:Class<FlxObject>, range = 1):Void
+	{
+		final end = tile + range;
+		final maxIndex = _tileObjects.length;
+		if (end > maxIndex)
+		{
+			FlxG.log.error('Index $end exceeds the maximum tile index of $maxIndex. Please verify the Tile ($tile) and Range ($range) parameters.');
+			return;
+		}
+		
+		super.setTileProperties(tile, allowCollisions, callback, callbackFilter, range);
+	}
+
 	override function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		if ((tileGraphic is FlxFramesCollection))

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -347,19 +347,6 @@ class FlxTilemap extends FlxBaseTilemap<FlxTile>
 		_checkBufferChanges = true;
 	}
 
-	override function setTileProperties(tile:Int, allowCollisions = ANY, ?callback:FlxObject->FlxObject->Void, ?callbackFilter:Class<FlxObject>, range = 1):Void
-	{
-		final end = tile + range;
-		final maxIndex = _tileObjects.length;
-		if (end > maxIndex)
-		{
-			FlxG.log.error('Index $end exceeds the maximum tile index of $maxIndex. Please verify the Tile ($tile) and Range ($range) parameters.');
-			return;
-		}
-		
-		super.setTileProperties(tile, allowCollisions, callback, callbackFilter, range);
-	}
-
 	override function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		if ((tileGraphic is FlxFramesCollection))


### PR DESCRIPTION
Downgrades errors in setTileProperties from a throw to `FlxG.log.error`. A problem here is usually a symptom of another issue, like an invalid asset. Throwing here hides the root error