### PR TITLE
Add hxformat.json to published Flixel release

### DIFF
--- a/release.bat
+++ b/release.bat
@@ -1,1 +1,1 @@
-7z a -tzip -i!assets -i!flixel -i!images -i!CHANGELOG.md -i!LICENSE.md -i!README.md -i!include.xml -i!haxelib.json -i!run.n flixel.zip
+7z a -tzip -i!assets -i!flixel -i!images -i!CHANGELOG.md -i!LICENSE.md -i!README.md -i!include.xml -i!hxformat.json -i!haxelib.json -i!run.n flixel.zip

--- a/release.sh
+++ b/release.sh
@@ -1,2 +1,2 @@
 # Same as release.bat but for unix
-7z a -tzip -i!assets -i!flixel -i!images -i!CHANGELOG.md -i!LICENSE.md -i!README.md -i!include.xml -i!haxelib.json -i!run.n flixel.zip
+7z a -tzip -i!assets -i!flixel -i!images -i!CHANGELOG.md -i!LICENSE.md -i!README.md -i!include.xml -i!hxformat.json -i!haxelib.json -i!run.n flixel.zip


### PR DESCRIPTION
Sometimes I need to do some tests with Flixel code, and if my project has different formatter rules it affects Flixel formatting. This pr fixes this (Lime, for example, publishes its formatter rules too).