### PR TITLE
add pixelPerfectShake

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -379,7 +379,13 @@ class FlxCamera extends FlxBasic
 	 * Enables or disables the filters set via `setFilters()`.
 	 */
 	public var filtersEnabled:Bool = true;
-
+	
+	/**
+	 * If true, screen shake will be rounded to game pixels. Default's to false for backwards compatibility.
+	 * @since 5.4.0
+	 */
+	public var pixelPerfectShake:Bool = false;
+	
 	/**
 	 * Internal, used in blit render mode in camera's `fill()` method for less garbage creation.
 	 * It represents the size of buffer `BitmapData`
@@ -1317,11 +1323,21 @@ class FlxCamera extends FlxBasic
 			{
 				if (_fxShakeAxes.x)
 				{
-					flashSprite.x += FlxG.random.float(-_fxShakeIntensity * width, _fxShakeIntensity * width) * zoom * FlxG.scaleMode.scale.x;
+					var shakePixels = FlxG.random.float(-1, 1) * _fxShakeIntensity * width;
+					if (pixelPerfectShake)
+						shakePixels = Math.round(shakePixels);
+					
+					flashSprite.x += shakePixels * zoom * FlxG.scaleMode.scale.x;
+					// flashSprite.x += FlxG.random.float(-_fxShakeIntensity * width, _fxShakeIntensity * width) * zoom * FlxG.scaleMode.scale.x;
 				}
 				if (_fxShakeAxes.y)
 				{
-					flashSprite.y += FlxG.random.float(-_fxShakeIntensity * height, _fxShakeIntensity * height) * zoom * FlxG.scaleMode.scale.y;
+					var shakePixels = FlxG.random.float(-1, 1) * _fxShakeIntensity * height;
+					if (pixelPerfectShake)
+						shakePixels = Math.round(shakePixels);
+					
+					flashSprite.y += shakePixels * zoom * FlxG.scaleMode.scale.y;
+					// flashSprite.y += FlxG.random.float(-_fxShakeIntensity * height, _fxShakeIntensity * height) * zoom * FlxG.scaleMode.scale.y;
 				}
 			}
 		}


### PR DESCRIPTION
By default screen shake moves the screen by sub-pixels even when `FlxG.camera.pixelPerfectRender` is true, so this is a backward compatible way to use pixel-perfect shake. which, maybe should be the default in flixel 6.0.0 if it doesn't look bad on average