### PR TITLE
Trigger re-draw when FlxText.text is set to empty string

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -869,7 +869,7 @@ class FlxText extends FlxSprite
 			}
 		}
 
-		if (textField != null && textField.text != null && textField.text.length >= 0)
+		if (textField != null && textField.text != null)
 		{
 			// Now that we've cleared a buffer, we need to actually render the text to it
 			copyTextFormat(_defaultFormat, _formatAdjusted);

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -869,7 +869,7 @@ class FlxText extends FlxSprite
 			}
 		}
 
-		if (textField != null && textField.text != null && textField.text.length > 0)
+		if (textField != null && textField.text != null && textField.text.length >= 0)
 		{
 			// Now that we've cleared a buffer, we need to actually render the text to it
 			copyTextFormat(_defaultFormat, _formatAdjusted);


### PR DESCRIPTION
Fixes #2845
When FlxText is initialized to a non-empty string and then flxtext.text is set to "" (empty string), it does not clear the text and the old text is still visible (which only seems to happen if `fieldWidth` is set to a non-zero value and only happens on html5 targets somehow). This pr should cause `drawTextFieldTo` to be called even when text is empty, which will update and clear the text correctly.