### PR TITLE
FlxBar.hx - pixelPerfectRender fix

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -833,6 +833,12 @@ class FlxBar extends FlxSprite
 			{
 				x = parent.x + positionOffset.x;
 				y = parent.y + positionOffset.y;
+
+				if (isPixelPerfectRender(camera)) 
+				{
+					x = Math.floor(x);
+					y = Math.floor(y);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fix a small issue in FlxBar.hx where if pixelPerfectRender is being used, the top and bottom bars would sometimes appear misaligned.

Note: this fixes the issue while the state the FlxBar is in is the current, active state. If a transparent SubState is opened above the state, the misalignment reappears for some reason...