### PR TITLE
fix flxBar pixel-perfect rendering

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -842,13 +842,13 @@ class FlxBar extends FlxSprite
 	override public function draw():Void
 	{
 		super.draw();
-
+		
 		if (!FlxG.renderTile)
 			return;
-
+		
 		if (alpha == 0)
 			return;
-
+		
 		if (percent > 0 && _frontFrame.type != FlxFrameType.EMPTY)
 		{
 			for (camera in cameras)
@@ -857,26 +857,30 @@ class FlxBar extends FlxSprite
 				{
 					continue;
 				}
-
-				getScreenPosition(_point, camera).subtractPoint(offset);
-
-				_frontFrame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, flipX, flipY);
+				
+				_frontFrame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY());
 				_matrix.translate(-origin.x, -origin.y);
 				_matrix.scale(scale.x, scale.y);
-
+				
 				// rotate matrix if sprite's graphic isn't prerotated
-				if (angle != 0)
+				if (bakedRotationAngle <= 0)
 				{
-					_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+					updateTrig();
+					
+					if (angle != 0)
+						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 				}
-
+				
+				getScreenPosition(_point, camera).subtractPoint(offset);
 				_point.add(origin.x, origin.y);
+				_matrix.translate(_point.x, _point.y);
+				
 				if (isPixelPerfectRender(camera))
 				{
-					_point.floor();
+					_matrix.tx = Math.floor(_matrix.tx);
+					_matrix.ty = Math.floor(_matrix.ty);
 				}
-
-				_matrix.translate(_point.x, _point.y);
+				
 				camera.drawPixels(_frontFrame, _matrix, colorTransform, blend, antialiasing, shader);
 			}
 		}


### PR DESCRIPTION
closes #2849

FlxBar.draw was using what seems to be an old copy of FlxSprite.draw, where the position was rounded to the nearest pixel, but origin, was not. and since FlxBar's defualt height is 5, origin was - by default - 2.5. this caused the front bar to be half a pixel off in most cases

here is my test case:
```hx
package states;

import flixel.FlxG;
import flixel.group.FlxGroup;
import flixel.ui.FlxBar;
import flixel.util.FlxCollision;

class PixelPerfectRenderTestState2849 extends flixel.FlxState
{
    var bar:Bar;
    var walls:FlxGroup;
    override function create()
    {
        super.create();
        
        FlxG.camera.pixelPerfectRender = true;
        bar = new Bar(0, 100);
        bar.velocity.set(100, 100);
        bar.elasticity = 1;
        add(bar);
        
        walls = FlxCollision.createCameraWall(FlxG.camera, 10);
    }
    
    override function update(elapsed)
    {
        super.update(elapsed);
        
        FlxG.collide(bar, walls);
        
        if (FlxG.keys.justPressed.P)
            openSubState(new PauseSubState());
        
        bar.angularVelocity = 180 * ((FlxG.keys.pressed.RIGHT ? 1 : 0) - (FlxG.keys.pressed.LEFT ? 1 : 0));
    }
}

class PauseSubState extends flixel.FlxSubState
{
    override function update(elapsed:Float)
    {
        if (FlxG.keys.justPressed.Q)
            close();
    }
}

@:forward
abstract Bar(FlxBar) to FlxBar
{
    public function new(min = 0, max = 100):Void
    {
        this = new FlxBar(0, 0, LEFT_TO_RIGHT, 20, 5, null, "", min, max, true);
        this.createFilledBar(0xff510000, 0xfff40000, true);
        
        this.value = (max - min) / 2;
    }
}
```