### PR TITLE
Deprecation fix when compiling to android

### DIFF
--- a/flixel/input/android/FlxAndroidKey.hx
+++ b/flixel/input/android/FlxAndroidKey.hx
@@ -6,8 +6,7 @@ import flixel.system.macros.FlxMacroUtil;
 /**
  * Maps enum values and strings to integer keycodes.
  */
-@:enum
-abstract FlxAndroidKey(Int) from Int to Int
+enum abstract FlxAndroidKey(Int) from Int to Int
 {
 	public static var fromStringMap(default, null):Map<String, FlxAndroidKey> = FlxMacroUtil.buildMap("flixel.input.android.FlxAndroidKey");
 	public static var toStringMap(default, null):Map<FlxAndroidKey, String> = FlxMacroUtil.buildMap("flixel.input.android.FlxAndroidKey", true);


### PR DESCRIPTION
There was a forgotten `@:enum` in `FlxAndroidKey` class