### PR TITLE
Change FlxG.openURL regex to allow any protocol

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -571,7 +571,7 @@ class FlxG
 	{
 		var prefix:String = "";
 		// if the URL does not already start with a protocol, add it.
-		if (!~/^.*?:\/\//.match(URL))
+		if (!~/^.\w+?:\/*/.match(URL))
 			prefix = "https://";
 		Lib.getURL(new URLRequest(prefix + URL), Target);
 	}

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -570,9 +570,9 @@ class FlxG
 	public static inline function openURL(URL:String, Target:String = "_blank"):Void
 	{
 		var prefix:String = "";
-		// if the URL does not already start with "http://" or "https://", add it.
-		if (!~/^https?:\/\//.match(URL))
-			prefix = "http://";
+		// if the URL does not already start with a protocol, add it.
+		if (!~/^.*?:\/\//.match(URL))
+			prefix = "https://";
 		Lib.getURL(new URLRequest(prefix + URL), Target);
 	}
 


### PR DESCRIPTION
for example, links like `discord://-/users/1078633864014078034` whould have http:// prefixed at the start (sorry if i made a bad regex this is literally the only regex i have made ever)

also come on, HTTP in 2023?