### PR TITLE
redraw buffers when loading maps

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -382,7 +382,15 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	{
 		_checkBufferChanges = true;
 	}
-
+	
+	override function loadMapHelper(tileGraphic, tileWidth = 0, tileHeight = 0, ?autoTile, startingIndex = 0, drawIndex = 1, collideIndex = 1)
+	{
+		// redraw buffers, fixes https://github.com/HaxeFlixel/flixel/issues/2882
+		_checkBufferChanges = true;
+		
+		super.loadMapHelper(tileGraphic, tileWidth, tileHeight, autoTile, startingIndex, drawIndex, collideIndex);
+	}
+	
 	override function cacheGraphics(tileWidth:Int, tileHeight:Int, tileGraphic:FlxTilemapGraphicAsset):Void
 	{
 		if ((tileGraphic is FlxFramesCollection))


### PR DESCRIPTION
fixes #2882

Test file:
```hx
import flixel.math.FlxPoint;
import lime.math.Rectangle;
import flixel.FlxCamera;
import flixel.FlxG;
import flixel.FlxState;
import flixel.tile.FlxTilemap;
import flixel.util.FlxColor;

class TilemapSizeTestState2882 extends FlxState
{
	var tiles = new openfl.display.BitmapData(64, 32, true, 0x0);

	var mapCam:FlxCamera;
	var map:FlxTilemap;

	override public function create()
	{
		mapCam = new FlxCamera(0, 0, 1280, 720);
		mapCam.bgColor = FlxColor.TRANSPARENT;
		FlxG.cameras.add(mapCam, false);
		
		tiles.fillRect(new openfl.geom.Rectangle(32, 0, 32, 32), FlxColor.WHITE);
		
		map = new FlxTilemap();
		final mapData = [for (y in 0...3)[for (x in 0...10) (x+y) % 2 ]];
		map.loadMapFrom2DArray(mapData, tiles, 32, 32, OFF, -1, 0);
		add(map);
		map.cameras = [mapCam];
		super.create();
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);
		
		if (FlxG.keys.justPressed.L)
		{
			// without fix, the 11 row does not show up until the game is resized
			final mapData = [for (y in 0...3)[for (x in 0...11) 1 - ((x+y) % 2) ]];
			map.loadMapFrom2DArray(mapData, tiles, 32, 32, OFF, -1, 0);
		}
		
		if (FlxG.mouse.justPressed)
		{
			var index = map.getTileIndexByCoords(FlxG.mouse.getWorldPosition(FlxPoint.weak()));
			map.setTileByIndex(index, 1 - map.getTileByIndex(index));
		}
	}
}
```