### PR TITLE
Fix `FlxPointer.overlaps` with different cameras

### DIFF
--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -129,7 +129,7 @@ class FlxPointer
 		}
 		else
 		{
-			getPosition(_cachedPoint);
+			getWorldPosition(Camera, _cachedPoint);
 			var object:FlxObject = cast ObjectOrGroup;
 			result = object.overlapsPoint(_cachedPoint, true, Camera);
 		}


### PR DESCRIPTION
This fixes pointer overlaps when using a camera that isn't the global one.
Currently, it uses the pointer's position in the global camera (`getPosition`), which won't work properly when using another one unless its properties are the exact same.

Code to reproduce this issue:
```haxe
import flixel.FlxCamera;
import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;
import flixel.text.FlxText;

class PlayState extends FlxState
{
	var hudCamera:FlxCamera;
	var spr:FlxSprite;
	var text:FlxText;

	override public function create()
	{
		hudCamera = new FlxCamera(0, 0, Std.int(FlxG.width * 0.25), Std.int(FlxG.height * 0.25));
		hudCamera.setPosition(FlxG.width - hudCamera.width, FlxG.height - hudCamera.height);
		hudCamera.bgColor = flixel.util.FlxColor.GRAY;
		FlxG.cameras.add(hudCamera, false);

		add(spr = new FlxSprite());
		spr.cameras = [hudCamera];

		add(text = new FlxText(5, 5, FlxG.width - 10, '', 16));

		super.create();
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);

		text.text = FlxG.mouse.overlaps(spr, hudCamera) ? "Overlapping" : "Not overlapping";
	}
}
```