### PR TITLE
add instance framePadding and re-add FlxTilemap.defaultFramePadding

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -114,12 +114,12 @@ class FlxTilemap extends FlxTypedTilemap<FlxTile>
 	 */
 	public static var defaultFramePadding(get, set):Int;
 	
-	public static inline function get_defaultFramePadding()
+	static inline function get_defaultFramePadding()
 	{
 		return FlxTypedTilemap.defaultFramePadding;
 	}
 	
-	public static inline function set_defaultFramePadding(value:Int)
+	static inline function set_defaultFramePadding(value:Int)
 	{
 		return FlxTypedTilemap.defaultFramePadding = value;
 	}


### PR DESCRIPTION
FlxTilemap.defaultFramePadding was moved to FlxTypedTilemap in #2734, this is an accidental breaking change, so we're adding it back as  setter/getter for the new location.

Also adds tilemap.framePadding which defaults to null, meaning "use the default". I fear this may be confusing though as it doesn't change the current framePadding if a map was already loaded