### PR TITLE
add 'getFilters()' function

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1600,6 +1600,14 @@ class FlxCamera extends FlxBasic
 	}
 
 	/**
+	 * Gets the filter array applied to the camera.
+	 */
+	public function getFilters():Void
+	{
+		return _filters;
+	}
+
+	/**
 	 * Copy the bounds, focus object, and `deadzone` info from an existing camera.
 	 *
 	 * @param   Camera  The camera you want to copy from.

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1602,7 +1602,7 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Gets the filter array applied to the camera.
 	 */
-	public function getFilters():Void
+	public function getFilters()
 	{
 		return _filters;
 	}


### PR DESCRIPTION
add a function to return the camera's shaders by doing
```haxe
FlxG.camera.getFilters();
```
instead of
```haxe
@:privateAccess
FlxG.camera._filters
```
could be useful for applying the filters of one camera to another