### PR TITLE
FlxCamera: make the filters array public

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -493,7 +493,7 @@ class FlxCamera extends FlxBasic
 	var _point:FlxPoint = FlxPoint.get();
 
 	/**
-	 * The filters array to be applied to the camera. Default value to null for performance reasons.
+	 * The filters array to be applied to the camera.
 	 */
 	public var filters:Null<Array<BitmapFilter>> = null;
 
@@ -1601,16 +1601,6 @@ class FlxCamera extends FlxBasic
 	public function setFilters(filters:Array<BitmapFilter>):Void
 	{
 		this.filters = filters;
-	}
-
-	/**
-	 * Gets the filter array applied to the camera.
-     * WARNING: can return `null`.
-	 */
-	@:deprecated("getFilters() is deprecated, use the filters array instead")
-	public function getFilters():Array<BitmapFilter>
-	{
-		return filters;
 	}
 
 	/**

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -495,20 +495,10 @@ class FlxCamera extends FlxBasic
 	/**
 	 * The filters array to be applied to the camera. Default value to null for performance reasons.
 	 */
-	public var filters:Null<Array<BitmapFilter>>;
+	public var filters:Null<Array<BitmapFilter>> = null;
 
 	@:deprecated("_filters is deprecated, use filters instead")
-	var _filters(get, set):Null<Array<BitmapFilter>>;
-
-	private function get__filters():Array<BitmapFilter>
-	{
-		return filters;
-	}
-
-	private function set__filters(Value:Array<BitmapFilter>):Array<BitmapFilter>
-	{
-		return filters = Value;
-	}
+	var _filters(get, set):Null<Array<BitmapFilter>> = null;
 
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.
@@ -2200,6 +2190,16 @@ class FlxCamera extends FlxBasic
 	inline function get_viewOffsetHeight():Float
 	{
 		return viewMarginBottom;
+	}
+
+	inline function get__filters():Array<BitmapFilter>
+	{
+		return filters;
+	}
+
+	inline function set__filters(Value:Array<BitmapFilter>):Array<BitmapFilter>
+	{
+		return filters = Value;
 	}
 	
 	/**

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -493,9 +493,9 @@ class FlxCamera extends FlxBasic
 	var _point:FlxPoint = FlxPoint.get();
 
 	/**
-	 * Internal, the filters array to be applied to the camera.
+	 * The filters array to be applied to the camera. Default value to null for performance reasons.
 	 */
-	var _filters:Array<BitmapFilter>;
+	public var filters:Array<BitmapFilter>;
 
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.
@@ -1150,7 +1150,7 @@ class FlxCamera extends FlxBasic
 		updateFlash(elapsed);
 		updateFade(elapsed);
 
-		flashSprite.filters = filtersEnabled ? _filters : null;
+		flashSprite.filters = filtersEnabled ? filters : null;
 
 		updateFlashSpritePosition();
 		updateShake(elapsed);
@@ -1594,9 +1594,10 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Sets the filter array to be applied to the camera.
 	 */
+	@:deprecated("setFilters() is deprecated, use the filters array instead")
 	public function setFilters(filters:Array<BitmapFilter>):Void
 	{
-		_filters = filters;
+		this.filters = filters;
 	}
 
     /**
@@ -1611,12 +1612,12 @@ class FlxCamera extends FlxBasic
             return;
         }
 
-        // The _filters array is null by default
-        if (_filters == null)
+        // The filters array is null by default
+        if (filters == null)
         {
-            _filters = [];
+            filters = [];
         }
-        _filters.push(filter);
+        filters.push(filter);
     }
 
     /**
@@ -1625,21 +1626,22 @@ class FlxCamera extends FlxBasic
      */
     public function removeFilter(filter:BitmapFilter):Void
     {
-        if (filter == null || _filters == null || _filters.length < 1 || !_filters.contains(filter))
+        if (filter == null || filters == null || filters.length < 1 || !filters.contains(filter))
         {
             return;
         }
 
-        _filters.remove(filter);
+        filters.remove(filter);
     }
 
 	/**
 	 * Gets the filter array applied to the camera.
      * WARNING: can return `null`.
 	 */
+	@:deprecated("getFilters() is deprecated, use the filters array instead")
 	public function getFilters():Array<BitmapFilter>
 	{
-		return _filters;
+		return filters;
 	}
 
 	/**

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1603,33 +1603,6 @@ class FlxCamera extends FlxBasic
 		this.filters = filters;
 	}
 
-	/*
-    public function addFilter(filter:BitmapFilter):Void
-    {
-        if (filter == null)
-        {
-            FlxG.log.warn("Cannot add a null filter to the camera.");
-            return;
-        }
-
-        // The filters array is null by default
-        if (filters == null)
-        {
-            filters = [];
-        }
-        filters.push(filter);
-    }
-
-    public function removeFilter(filter:BitmapFilter):Void
-    {
-        if (filter == null || filters == null || filters.length < 1 || !filters.contains(filter))
-        {
-            return;
-        }
-
-        filters.remove(filter);
-    } */
-
 	/**
 	 * Gets the filter array applied to the camera.
      * WARNING: can return `null`.

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -495,10 +495,20 @@ class FlxCamera extends FlxBasic
 	/**
 	 * The filters array to be applied to the camera. Default value to null for performance reasons.
 	 */
-	public var filters:Array<BitmapFilter>;
+	public var filters:Null<Array<BitmapFilter>>;
 
 	@:deprecated("_filters is deprecated, use filters instead")
-	var _filters:Array<BitmapFilter>;
+	var _filters(get, set):Null<Array<BitmapFilter>>;
+
+	private function get__filters():Array<BitmapFilter>
+	{
+		return filters;
+	}
+
+	private function set__filters(Value:Array<BitmapFilter>):Array<BitmapFilter>
+	{
+		return filters = Value;
+	}
 
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.
@@ -1603,10 +1613,7 @@ class FlxCamera extends FlxBasic
 		this.filters = filters;
 	}
 
-    /**
-     * Adds a new filter to be applied to the camera.
-     * @param filter The filter to add
-     */
+	/*
     public function addFilter(filter:BitmapFilter):Void
     {
         if (filter == null)
@@ -1623,10 +1630,6 @@ class FlxCamera extends FlxBasic
         filters.push(filter);
     }
 
-    /**
-     * Removes a filter from the camera.
-     * @param filter The filter to remove
-     */
     public function removeFilter(filter:BitmapFilter):Void
     {
         if (filter == null || filters == null || filters.length < 1 || !filters.contains(filter))
@@ -1635,7 +1638,7 @@ class FlxCamera extends FlxBasic
         }
 
         filters.remove(filter);
-    }
+    } */
 
 	/**
 	 * Gets the filter array applied to the camera.

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1599,10 +1599,45 @@ class FlxCamera extends FlxBasic
 		_filters = filters;
 	}
 
+    /**
+     * Adds a new filter to be applied to the camera.
+     * @param filter The filter to add
+     */
+    public function addFilter(filter:BitmapFilter):Void
+    {
+        if (filter == null)
+        {
+            FlxG.log.warn("Cannot add a null filter to the camera.");
+            return;
+        }
+
+        // The _filters array is null by default
+        if (_filters == null)
+        {
+            _filters = [];
+        }
+        _filters.push(filter);
+    }
+
+    /**
+     * Removes a filter from the camera.
+     * @param filter The filter to remove
+     */
+    public function removeFilter(filter:BitmapFilter):Void
+    {
+        if (filter == null || _filters == null || _filters.length < 1 || !_filters.contains(filter))
+        {
+            return;
+        }
+
+        _filters.remove(filter);
+    }
+
 	/**
 	 * Gets the filter array applied to the camera.
+     * WARNING: can return `null`.
 	 */
-	public function getFilters()
+	public function getFilters():Array<BitmapFilter>
 	{
 		return _filters;
 	}

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -498,7 +498,7 @@ class FlxCamera extends FlxBasic
 	public var filters:Null<Array<BitmapFilter>> = null;
 
 	@:deprecated("_filters is deprecated, use filters instead")
-	var _filters(get, set):Null<Array<BitmapFilter>> = null;
+	var _filters(get, set):Null<Array<BitmapFilter>>;
 
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -497,6 +497,9 @@ class FlxCamera extends FlxBasic
 	 */
 	public var filters:Array<BitmapFilter>;
 
+	@:deprecated("_filters is deprecated, use filters instead")
+	var _filters:Array<BitmapFilter>;
+
 	/**
 	 * Camera's initial zoom value. Used for camera's scale handling.
 	 */


### PR DESCRIPTION
This pull request add the `addFilter` and `removeFilter` functions to `FlxCamera`.
Should be useful for many situations