### PR TITLE
Destroy `_bgSprite` in `FlxSubState`

### DIFF
--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -2,6 +2,7 @@ package flixel;
 
 import flixel.system.FlxBGSprite;
 import flixel.util.FlxColor;
+import flixel.util.FlxDestroyUtil;
 
 /**
  * A `FlxSubState` can be opened inside of a `FlxState`.
@@ -82,7 +83,7 @@ class FlxSubState extends FlxState
 		closeCallback = null;
 		openCallback = null;
 		_parentState = null;
-		_bgSprite = null;
+		_bgSprite = FlxDestroyUtil.destroy(_bgSprite);
 	}
 
 	/**


### PR DESCRIPTION
This fixes `_bgSprite` not being destroyed when the substate is, which causes its graphic to keep being marked as used and thus not being cleared automatically.