### PR TITLE
allow FlxG.watch.addFunction to overwrite existing

### DIFF
--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -43,7 +43,7 @@ class Watch extends Window
 		{
 			switch (data)
 			{
-				case QUICK(value):
+				case QUICK(_) | FUNCTION(_):
 					existing.data = data;
 				case _:
 			}
@@ -71,7 +71,7 @@ class Watch extends Window
 	{
 		for (entry in entries)
 		{
-			if (data == null || data.match(QUICK(_)))
+			if (data == null || data.match(QUICK(_) | FUNCTION(_)))
 			{
 				if (entry.displayName == displayName)
 					return entry;


### PR DESCRIPTION
prior, the following would add 3 separate watchers, this fix causes the second and third call to replace the prior

```hx
FlxG.watch.addFunction("foo", ()->1);
FlxG.watch.addFunction("foo", ()->2);
FlxG.watch.addFunction("foo", ()->3);
```

