### PR TITLE
Fix for FlxStrip when drawDebug is `true` #2904

### DIFF
--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -93,7 +93,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		{
 			var gfx:Graphics = camera.debugLayer.graphics;
 			gfx.lineStyle(1, FlxColor.BLUE, 0.5);
-			gfx.drawTriangles(vertices, indices);
+			gfx.drawTriangles(vertices, indices, uvtData);
 		}
 		#end
 


### PR DESCRIPTION
Fixes #2904, I tested it on html5 and windows