### PR TITLE
Remove functions that should be unavailable to macros

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -1,10 +1,14 @@
 package flixel.math;
 
 import openfl.geom.Rectangle;
+#if !macro
+#if FLX_MOUSE
 import flixel.FlxG;
+#end
 import flixel.FlxSprite;
 #if FLX_TOUCH
 import flixel.input.touch.FlxTouch;
+#end
 #end
 
 /**
@@ -187,7 +191,7 @@ class FlxMath
 		return pointX >= rect.x && pointX <= rect.right && pointY >= rect.y && pointY <= rect.bottom;
 	}
 
-	#if FLX_MOUSE
+	#if (FLX_MOUSE && !macro)
 	/**
 	 * Returns true if the mouse world x/y coordinate are within the given rectangular block
 	 *
@@ -309,7 +313,7 @@ class FlxMath
 	{
 		return Math.sqrt(dx * dx + dy * dy);
 	}
-
+	#if !macro
 	/**
 	 * Find the distance (in pixels, rounded) between two FlxSprites, taking their origin into account
 	 *
@@ -454,6 +458,7 @@ class FlxMath
 		else
 			return dx * dx + dy * dy < Distance * Distance;
 	}
+	#end
 	#end
 
 	/**


### PR DESCRIPTION
when using `FlxMath` in macros, as specified by #2893, they might not work due to functions that are involved with `FlxG`, in other terms, functions that should be used in a non macro way but as helpers to the day to day coding basis.
This fixes it + adds a compiler conditional around `FlxG` due to it being used only for `FLX_MOUSE`.

Fixes #2893  