### PR TITLE
Add COMMAND (MacOS) to FlxKey

### DIFF
--- a/flixel/input/keyboard/FlxKey.hx
+++ b/flixel/input/keyboard/FlxKey.hx
@@ -74,6 +74,7 @@ enum abstract FlxKey(Int) from Int to Int
 	var GRAVEACCENT = 192;
 	var CONTROL = 17;
 	var ALT = 18;
+	var COMMAND = 224;
 	var SPACE = 32;
 	var UP = 38;
 	var DOWN = 40;


### PR DESCRIPTION
The Command key (typically represented by the `⌘` symbol) currently has no value in the FlxKey enumeration. This PR adds it.