### PR TITLE
FlxSound: updateTransform crash fix

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -588,6 +588,9 @@ class FlxSound extends FlxBasic
 	@:allow(flixel.sound.FlxSoundGroup)
 	function updateTransform():Void
 	{
+		if (_transform == null)
+			return;
+		
 		_transform.volume = #if FLX_SOUND_SYSTEM (FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume * #end
 			(group != null ? group.volume : 1) * _volume * _volumeAdjust;
 


### PR DESCRIPTION
I've got many crashes because of `_transform` being null, then realized that destroyed `FlxSound`s does an `updateTransform` call. This pull request just make the function return nothing if `_transform` is null.