### PR TITLE
FlxBitmapText, textColor not applied correctly

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -337,7 +337,7 @@ class FlxBitmapText extends FlxSprite
 				textRed *= textColor.redFloat;
 				textGreen *= textColor.greenFloat;
 				textBlue *= textColor.blueFloat;
-				tAlpha *= textColor.alpha;
+				tAlpha *= textColor.alphaFloat;
 			}
 
 			var bgRed:Float = cr;


### PR DESCRIPTION
Fixes #2916
Alpha value isn't applied correctly, textColor.alphaFloat required instead of alpha. Otherwise the text color is full white.