### PR TITLE
Update FlxG.collide() and FlxG.overlap() to take callbacks with FlxObject parameters

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -417,8 +417,8 @@ class FlxG
 	 *                            will only be called if `ProcessCallback` returns true for those objects!
 	 * @return  Whether any overlaps were detected.
 	 */
-	public static function overlap(?ObjectOrGroup1:FlxBasic, ?ObjectOrGroup2:FlxBasic, ?NotifyCallback:Dynamic->Dynamic->Void,
-			?ProcessCallback:Dynamic->Dynamic->Bool):Bool
+	public static function overlap(?ObjectOrGroup1:FlxBasic, ?ObjectOrGroup2:FlxBasic, ?NotifyCallback:FlxObject->FlxObject->Void,
+			?ProcessCallback:FlxObject->FlxObject->Bool):Bool
 	{
 		if (ObjectOrGroup1 == null)
 			ObjectOrGroup1 = state;
@@ -470,7 +470,7 @@ class FlxG
 	 *                           that is called if those two objects overlap.
 	 * @return  Whether any objects were successfully collided/separated.
 	 */
-	public static inline function collide(?ObjectOrGroup1:FlxBasic, ?ObjectOrGroup2:FlxBasic, ?NotifyCallback:Dynamic->Dynamic->Void):Bool
+	public static inline function collide(?ObjectOrGroup1:FlxBasic, ?ObjectOrGroup2:FlxBasic, ?NotifyCallback:FlxObject->FlxObject->Void):Bool
 	{
 		return overlap(ObjectOrGroup1, ObjectOrGroup2, NotifyCallback, FlxObject.separate);
 	}


### PR DESCRIPTION
At the moment, `FlxG.collide` and `FlxG.overlap`'s callbacks (`NotifyCallback` & `ProcessCallback`) accept `Dynamic` arguments, rather than `FlxObject`s and anything that extends it, making the function prone to errors if a user inputs an object that isn't a `FlxObject` or derives from it due to `FlxQuadTree.load` taking in callbacks that have `FlxObject` parameters

This commit fixes that issue by changing the callbacks' parameters to accept `FlxObject`s instead of `Dynamic` objects.

I also assume that this will very slightly optimize things.