### PR TITLE
fix camera lerping speeds on lower fps

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1278,8 +1278,8 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			scroll.x += (_scrollTarget.x - scroll.x) * followLerp * FlxG.updateFramerate / 60;
-			scroll.y += (_scrollTarget.y - scroll.y) * followLerp * FlxG.updateFramerate / 60;
+			scroll.x += (_scrollTarget.x - scroll.x) * followLerp * (60 / FlxG.updateFramerate);
+			scroll.y += (_scrollTarget.y - scroll.y) * followLerp * (60 / FlxG.updateFramerate);
 		}
 	}
 


### PR DESCRIPTION
fixes camera lerping being slower than usual on lower framerates

for example if you set the cam lerp speed to like 0.05 it'll be way slower on 15-30 fps than on 60 fps

this makes it consistent between all framerates so it always has the same speed