### PR TITLE
Untie FlxSoundTray animation speed from framerate, and make it much smoother

### DIFF
--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -110,16 +110,16 @@ class FlxSoundTray extends Sprite
 	/**
 	 * This function just updates the soundtray object.
 	 */
-	public function update(MS:Float):Void
+	public function update(elapsed:Float, MS:Float):Void
 	{
 		// Animate stupid sound tray thing
 		if (_timer > 0)
 		{
-			_timer -= MS / 1000;
+			_timer -= (MS / 1000) * elapsed;
 		}
 		else if (y > -height)
 		{
-			y -= (MS / 1000) * FlxG.height * 2;
+			y -= ((MS / 1000) * FlxG.height * 2) * elapsed;
 
 			if (y <= -height)
 			{

--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -119,7 +119,7 @@ class FlxSoundTray extends Sprite
 		}
 		else if (y > -height)
 		{
-			y -= FlxG.height * FlxG.elapsed;
+			y -= (MS / 1000) * height * 0.5;
 
 			if (y <= -height)
 			{

--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -108,18 +108,18 @@ class FlxSoundTray extends Sprite
 	}
 
 	/**
-	 * This function just updates the soundtray object.
+	 * This function updates the soundtray object.
 	 */
-	public function update(elapsed:Float, MS:Float):Void
+	public function update(MS:Float):Void
 	{
-		// Animate stupid sound tray thing
+		// Animate sound tray thing
 		if (_timer > 0)
 		{
-			_timer -= (MS / 1000) * elapsed;
+			_timer -= (MS / 1000);
 		}
 		else if (y > -height)
 		{
-			y -= ((MS / 1000) * FlxG.height * 2) * elapsed;
+			y -= FlxG.height * FlxG.elapsed;
 
 			if (y <= -height)
 			{


### PR DESCRIPTION
I noticed that higher framerates make the FlxSoundTray go-away animation go way too fast, and that it's very janky in general. This really bothered me, so I decided to make a quick fix. This also updates some very old comments to fit the standard more.