### PR TITLE
Fix Frame Collections not being destroyed

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -516,6 +516,8 @@ class FlxGraphic implements IFlxDestroyable
 		{
 			var collections:Array<Dynamic> = getFramesCollections(collection.type);
 			collections.push(collection);
+			if (!frameCollectionTypes.contains(collection.type))
+				frameCollectionTypes.push(collection.type);
 		}
 	}
 

--- a/flixel/graphics/frames/FlxImageFrame.hx
+++ b/flixel/graphics/frames/FlxImageFrame.hx
@@ -245,12 +245,6 @@ class FlxImageFrame extends FlxFramesCollection
 		return imageFrame;
 	}
 
-	override public function destroy():Void
-	{
-		super.destroy();
-		FlxDestroyUtil.destroy(frame);
-	}
-
 	function get_frame():FlxFrame
 	{
 		return frames[0];


### PR DESCRIPTION
Unsure if this causes any crashes elsewhere so thats why this is a draft

Btw FlxImageFrame got edited because frames gets destroyed in super.destroy()