### PR TITLE
Various improvements and new features for animations 

### DIFF
--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -29,7 +29,7 @@ class FlxAnimation extends FlxBaseAnimation
 	 * Note: `FlxFrameCollections` and `FlxAtlasFrames` may have their own duration set per-frame,
 	 * those values will override this value.
 	 */
-	public var frameDuration(default, null):Float = 0;
+	public var frameDuration:Float = 0;
 
 	/**
 	 * Seconds between frames (inverse of the framerate)
@@ -50,7 +50,7 @@ class FlxAnimation extends FlxBaseAnimation
 	/**
 	 * Whether or not the animation is looped.
 	 */
-	public var looped(default, null):Bool = true;
+	public var looped:Bool = true;
 
 	/**
 	 * The custom loop point for this animation.

--- a/flixel/animation/FlxAnimation.hx
+++ b/flixel/animation/FlxAnimation.hx
@@ -78,6 +78,13 @@ class FlxAnimation extends FlxBaseAnimation
 	 * @since 4.2.0
 	 */
 	public var frames:Array<Int>;
+	
+	/**
+	 * How fast or slow time should pass for this animation.
+	 * 
+	 * Similar to `FlxAnimationController`'s `timeScale`, but won't effect other animations.
+	 */
+	public var timeScale:Float = 1.0;
 
 	/**
 	 * Internal, used to time each frame of animation.
@@ -199,7 +206,7 @@ class FlxAnimation extends FlxBaseAnimation
 		if (curFrameDuration == 0 || finished || paused)
 			return;
 
-		_frameTimer += elapsed;
+		_frameTimer += elapsed * timeScale;
 		while (_frameTimer > curFrameDuration && !finished)
 		{
 			_frameTimer -= curFrameDuration;

--- a/flixel/graphics/FlxAsepriteUtil.hx
+++ b/flixel/graphics/FlxAsepriteUtil.hx
@@ -1,5 +1,6 @@
 package flixel.graphics;
 
+import flixel.graphics.atlas.AseAtlas;
 import flixel.animation.FlxAnimationController;
 import flixel.math.FlxMath;
 import flixel.graphics.frames.FlxAtlasFrames;
@@ -100,9 +101,10 @@ class FlxAsepriteUtil
 			if (excludeTags == null || !excludeTags.contains(name))
 			{
 				final expectedFrames = tag.to - tag.from + 1;
-				animations.addByPrefix(name, name + tagSuffix);
+				animations.addByPrefix(name, name + tagSuffix, 30, tag.repeat.loops);
 				// Animations aren't added if no frames are found
 				final anim = animations.getByName(name);
+				setFramesDirection(anim.frames, tag.direction);
 				final actualFrames = anim == null ? 0 : anim.numFrames;
 				if (actualFrames != expectedFrames)
 				{
@@ -179,7 +181,30 @@ class FlxAsepriteUtil
 			}
 			
 			final toFrame = FlxMath.minInt(frameTag.to, maxFrameNumber);
-			animations.add(frameTag.name, [for (i in frameTag.from...toFrame + 1) i]);
+			final frames = [for (i in frameTag.from...toFrame + 1) i];
+			setFramesDirection(frames, frameTag.direction);
+			// In Aseprite 0 or lower isn't a possible value, and toggling the "repeat" checkbox
+			// toggles between "1" and infinity, which omits the field from json
+			animations.add(frameTag.name, frames, 30, frameTag.repeat.loops);
+		}
+	}
+	
+	static function setFramesDirection(frames:Array<Int>, direction:AseAtlasTagDirection)
+	{
+		switch(direction)
+		{
+			case FORWARD:// do nothing
+			case REVERSE:
+				
+				frames.reverse();
+			case PINGPONG | PINGPONG_REVERSE:
+				
+				if (direction == PINGPONG_REVERSE)
+					frames.reverse();
+				
+				var i = frames.length - 1;// skip last frame
+				while (i-- > 1) // skip first frame too
+					frames.push(frames[i]);
 		}
 	}
 }

--- a/flixel/graphics/atlas/AseAtlas.hx
+++ b/flixel/graphics/atlas/AseAtlas.hx
@@ -101,9 +101,32 @@ typedef AseAtlasTag = AseObject &
 	/**
 	 * The number of times to repeat this animation before aseprite's timeline switched to the next one.
 	 * 
-	 * Note: not currently used by flixel
+	 * Note: Used by `FlxAseAtlasUtils` to determine whether an animation loops. Loops if `> 0`.
 	 */
-	@:optional var repeat:Int;
+	@:optional var repeat:AseAtlasTagRepeat;
+}
+
+/**
+ * A string expected to always be a string with a valid int value (or null)
+ */
+abstract AseAtlasTagRepeat(Null<String>) from Null<String> to Null<String>
+{
+	/**
+	 * Whether the underlying value indicates whether to loop this animation
+	 */
+	public var loops(get, never):Bool;
+	
+	inline function get_loops()
+	{
+		return this != null && toInt() > 0;
+	}
+	
+	@:to
+	inline public function toInt()
+	{
+		return Std.parseInt(this);
+	}
+	
 }
 
 enum abstract AseAtlasTagDirection(String) to String


### PR DESCRIPTION
Fixes #2927 
- `FlxAnimation`: Make `frameDuration` and `looped` public
- `FlxAnimation`: Add timeScale
- `FlxAseAtlasUtils`: Use fields `repeat` and `direction` when creating animations from Aseprite tag data