### PR TITLE
Small improvement to FlxPointer.overlaps

### DIFF
--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -114,7 +114,7 @@ class FlxPointer
 	public function overlaps(ObjectOrGroup:FlxBasic, ?Camera:FlxCamera):Bool
 	{
 		if (Camera == null)
-			Camera = ObjectOrGroup.cameras[0];
+			Camera = ObjectOrGroup.camera;
 		
 		var result:Bool = false;
 

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -113,6 +113,9 @@ class FlxPointer
 	@:access(flixel.group.FlxTypedGroup.resolveGroup)
 	public function overlaps(ObjectOrGroup:FlxBasic, ?Camera:FlxCamera):Bool
 	{
+		if (Camera == null)
+			Camera = ObjectOrGroup.cameras[0];
+		
 		var result:Bool = false;
 
 		var group = FlxTypedGroup.resolveGroup(ObjectOrGroup);


### PR DESCRIPTION
If the `Camera` argument is null when calling, it simply refers to `ObjectOrGroup`'s first camera.