### PR TITLE
use factory functions in flxpool

### DIFF
--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -12,7 +12,7 @@ import flixel.util.FlxTimer;
  */
 class FlxFlicker implements IFlxDestroyable
 {
-	static var _pool:FlxPool<FlxFlicker> = new FlxPool<FlxFlicker>(FlxFlicker, FlxFlicker.new);
+	static var _pool:FlxPool<FlxFlicker> = new FlxPool<FlxFlicker>(FlxFlicker.new);
 
 	/**
 	 * Internal map for looking up which objects are currently flickering and getting their flicker data.

--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -12,7 +12,7 @@ import flixel.util.FlxTimer;
  */
 class FlxFlicker implements IFlxDestroyable
 {
-	static var _pool:FlxPool<FlxFlicker> = new FlxPool<FlxFlicker>(FlxFlicker);
+	static var _pool:FlxPool<FlxFlicker> = new FlxPool<FlxFlicker>(FlxFlicker, FlxFlicker.new);
 
 	/**
 	 * Internal map for looking up which objects are currently flickering and getting their flicker data.

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -1436,7 +1436,7 @@ import openfl.geom.Point;
 class FlxBasePoint implements IFlxPooled
 {
 	#if FLX_POINT_POOL
-	static var pool:FlxPool<FlxBasePoint> = new FlxPool(FlxBasePoint, FlxBasePoint.new.bind(0, 0));
+	static var pool:FlxPool<FlxBasePoint> = new FlxPool(FlxBasePoint.new.bind(0, 0));
 	#end
 
 	/**

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -1436,7 +1436,7 @@ import openfl.geom.Point;
 class FlxBasePoint implements IFlxPooled
 {
 	#if FLX_POINT_POOL
-	static var pool:FlxPool<FlxBasePoint> = new FlxPool(FlxBasePoint);
+	static var pool:FlxPool<FlxBasePoint> = new FlxPool(FlxBasePoint, FlxBasePoint.new.bind(0, 0));
 	#end
 
 	/**

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -12,7 +12,7 @@ class FlxRect implements IFlxPooled
 {
 	public static var pool(get, never):IFlxPool<FlxRect>;
 
-	static var _pool:FlxPool<FlxRect> = new FlxPool(FlxRect, FlxRect.new.bind(0, 0, 0, 0));
+	static var _pool = new FlxPool(FlxRect.new.bind(0, 0, 0, 0));
 	// With the version below, this caused weird CI issues when FLX_NO_POINT_POOL is defined
 	// static var _pool = new FlxPool<FlxRect>(FlxRect);
 

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -12,7 +12,7 @@ class FlxRect implements IFlxPooled
 {
 	public static var pool(get, never):IFlxPool<FlxRect>;
 
-	static var _pool:FlxPool<FlxRect> = new FlxPool(FlxRect);
+	static var _pool:FlxPool<FlxRect> = new FlxPool(FlxRect, FlxRect.new.bind(0, 0, 0, 0));
 	// With the version below, this caused weird CI issues when FLX_NO_POINT_POOL is defined
 	// static var _pool = new FlxPool<FlxRect>(FlxRect);
 

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -14,7 +14,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	public var length(get, never):Int;
 
 	var _pool:Array<T> = [];
-	var _class:Class<T>;
+	var _constructor:()->T;
 
 	/**
 	 * Objects aren't actually removed from the array in order to improve performance.
@@ -22,16 +22,27 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	 */
 	var _count:Int = 0;
 
-	public function new(classObj:Class<T>)
+	/**
+	 * Creates a pool of the specified type
+	 * @param   classRef     The type the pool will hold, used to create new instances, if no
+	 *                       constructor was given
+	 * @param   constructor  Used to create new instances, example: `FlxPoint.new.bind(0, 0)`
+	 */
+	public function new(?classRef:Class<T>, ?constructor:()->T)
 	{
-		_class = classObj;
+		if (constructor != null)
+			_constructor = constructor;
+		else if (classRef != null)
+			_constructor = ()->Type.createInstance(classRef, []);
+		else
+			throw 'FlxPool constructor must contain either a class or a factory function';
 	}
 
 	public function get():T
 	{
 		if (_count == 0)
 		{
-			return Type.createInstance(_class, []);
+			return _constructor();
 		}
 		return _pool[--_count];
 	}
@@ -64,7 +75,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	{
 		while (numObjects-- > 0)
 		{
-			_pool[_count++] = Type.createInstance(_class, []);
+			_pool[_count++] = _constructor();
 		}
 	}
 

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -6,9 +6,6 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
  * A generic container that facilitates pooling and recycling of objects.
  * WARNING: Pooled objects must have parameter-less constructors: function new()
  */
-#if !display
-@:generic
-#end
 class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 {
 	public var length(get, never):Int;

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -683,8 +683,8 @@ class FlxStringUtil
 
 class LabelValuePair implements IFlxDestroyable
 {
-	static var _pool = new FlxPool<LabelValuePair>(LabelValuePair, LabelValuePair.new);
-
+	static var _pool = new FlxPool(LabelValuePair.new);
+	
 	public static inline function weak(label:String, value:Dynamic):LabelValuePair
 	{
 		return _pool.get().create(label, value);

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -683,7 +683,7 @@ class FlxStringUtil
 
 class LabelValuePair implements IFlxDestroyable
 {
-	static var _pool = new FlxPool<LabelValuePair>(LabelValuePair);
+	static var _pool = new FlxPool<LabelValuePair>(LabelValuePair, LabelValuePair.new);
 
 	public static inline function weak(label:String, value:Dynamic):LabelValuePair
 	{

--- a/tests/unit/src/flixel/util/FlxPoolTest.hx
+++ b/tests/unit/src/flixel/util/FlxPoolTest.hx
@@ -10,7 +10,7 @@ class FlxPoolTest extends FlxTest
 	@Before
 	function before():Void
 	{
-		ppool = new FlxPool(FlxBasePoint.new.bind());
+		ppool = new FlxPool(FlxBasePoint.new.bind(0, 0));
 	}
 
 	@Test

--- a/tests/unit/src/flixel/util/FlxPoolTest.hx
+++ b/tests/unit/src/flixel/util/FlxPoolTest.hx
@@ -10,7 +10,13 @@ class FlxPoolTest extends FlxTest
 	@Before
 	function before():Void
 	{
-		ppool = new FlxPool(FlxBasePoint);
+		ppool = new FlxPool(FlxBasePoint.new.bind());
+	}
+
+	@Test
+	function testLegacy():Void
+	{
+		final pool = new FlxPool(FlxBasePoint);
 	}
 
 	@Test


### PR DESCRIPTION
`Type.createInstance` is far slower and should be avoided, which is easy to do in this case

TODO: i should look into a single arg that accepts a class ref or a function and shows a deprecation warning on a class ref