### PR TITLE
Remove warnings about potential typos from `flixel.text.FlxText.hx` in Haxe 4.3.2

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1232,10 +1232,10 @@ enum abstract FlxTextAlign(String) from String
 	{
 		return switch (align)
 		{
-			case LEFT: TextFormatAlign.LEFT;
-			case CENTER: TextFormatAlign.CENTER;
-			case RIGHT: TextFormatAlign.RIGHT;
-			case JUSTIFY: TextFormatAlign.JUSTIFY;
+			case FlxTextAlign.LEFT: TextFormatAlign.LEFT;
+			case FlxTextAlign.CENTER: TextFormatAlign.CENTER;
+			case FlxTextAlign.RIGHT: TextFormatAlign.RIGHT;
+			case FlxTextAlign.JUSTIFY: TextFormatAlign.JUSTIFY;
 			default: TextFormatAlign.LEFT;
 		}
 	}


### PR DESCRIPTION
When I downloaded Haxe 4.3.2 and compiled the game I got warnings like ``Warning: Potential typo detected (expected similar values are flixel.text.FlxTextAlign.LEFT)``.

That's why I made this pull request.