### PR TITLE
Implement `FlxG.animationTimeScale`

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -80,7 +80,12 @@ class FlxG
 	/**
 	 * How fast or slow time should pass in the game; default is `1.0`.
 	 */
-	public static var timeScale:Float = 1;
+	public static var timeScale:Float = 1.0;
+	
+	/**
+	 * How fast or slow animations should pass in the game; default is `1.0`.
+	 */
+	public static var animationTimeScale:Float = 1.0;
 
 	/**
 	 * How many times the quad tree should divide the world on each axis.
@@ -712,6 +717,7 @@ class FlxG
 		autoPause = true;
 		fixedTimestep = true;
 		timeScale = 1.0;
+		animationTimeScale = 1.0;
 		elapsed = 0;
 		maxElapsed = 0.1;
 		worldBounds.set(-10, -10, width + 20, height + 20);

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -97,7 +97,7 @@ class FlxAnimationController implements IFlxDestroyable
 	{
 		if (_curAnim != null)
 		{
-			_curAnim.update(elapsed * timeScale);
+			_curAnim.update(elapsed * (timeScale * FlxG.animationTimeScale));
 		}
 		else if (_prerotated != null)
 		{


### PR DESCRIPTION
A more convenient way of setting global animation speeds.

Also adjusted `FlxG.timeScale`'s initialization value to match the comment.

Fixes #2936