### PR TITLE
Various FlxBar fixes

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -128,7 +128,7 @@ class FlxBar extends FlxSprite
 	var _fillHorizontal:Bool;
 
 	/**
-	 * FlxSprite which is used for rendering front graphics of bar (showing value) in tile render mode.
+	 * FlxFrame which is used for rendering front graphics of bar (showing value) in tile render mode.
 	 */
 	var _frontFrame:FlxFrame;
 
@@ -198,9 +198,9 @@ class FlxBar extends FlxSprite
 	{
 		positionOffset = FlxDestroyUtil.put(positionOffset);
 
-		if (FlxG.renderBlit)
+		if (FlxG.renderTile)
 		{
-			_frontFrame = null;
+			frontFrames = null;
 			_filledFlxRect = FlxDestroyUtil.put(_filledFlxRect);
 		}
 		else
@@ -214,7 +214,6 @@ class FlxBar extends FlxSprite
 		_filledBarPoint = null;
 
 		parent = null;
-		positionOffset = null;
 		emptyCallback = null;
 		filledCallback = null;
 
@@ -984,8 +983,14 @@ class FlxBar extends FlxSprite
 	{
 		if (FlxG.renderTile)
 		{
+			if (value != null)
+				value.parent.incrementUseCount();
+				
+			if (frontFrames != null)
+				frontFrames.parent.decrementUseCount();
+
 			frontFrames = value;
-			_frontFrame = (value != null) ? value.frame.copyTo(_frontFrame) : null;
+			_frontFrame = (value != null) ? value.frame.copyTo(_frontFrame) : FlxDestroyUtil.destroy(_frontFrame);
 		}
 		else
 		{


### PR DESCRIPTION
- Fixed `frontFrames` graphic not changing its `useCount` (for example, if you added an FlxBar and then called `FlxG.bitmap.clearUnused()`, the front graphic would be destroyed and the game would crash when trying to draw it)
- Render-method-specific variables are now destroyed correctly. It used to try to destroy variables that are only used in the opposite render method
- `_frontFrame` is now destroyed when being set to `null`
- Fixed `_frontFrame` documentation referring to it as an FlxSprite
- Removed redundant `positionOffset = null` code (the variable is already set to `null` earlier in the function)