### PR TITLE
fix CI errors from FlxPool changes

### DIFF
--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -12,7 +12,7 @@ class FlxRect implements IFlxPooled
 {
 	public static var pool(get, never):IFlxPool<FlxRect>;
 
-	static var _pool = new FlxPool(FlxRect.new.bind(0, 0, 0, 0));
+	static var _pool:FlxPool<FlxRect> = new FlxPool(FlxRect.new.bind(0, 0, 0, 0));
 	// With the version below, this caused weird CI issues when FLX_NO_POINT_POOL is defined
 	// static var _pool = new FlxPool<FlxRect>(FlxRect);
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -19,7 +19,12 @@ private enum UserDefines
 	FLX_NO_FOCUS_LOST_SCREEN;
 	FLX_NO_DEBUG;
 	FLX_RECORD;
+	/* Defined in HaxeFlixel CI tests, do not use */
 	FLX_UNIT_TEST;
+	/* Defined in HaxeFlixel CI tests, do not use */
+	FLX_COVERAGE_TEST;
+	/* Defined in HaxeFlixel CI tests, do not use */
+	FLX_SWF_VERSION_TEST;
 	/* additional rendering define */
 	FLX_RENDER_TRIANGLE;
 	/* Uses flixel 4.0 legacy collision */
@@ -57,7 +62,16 @@ private enum HelperDefines
 	FLX_DRAW_QUADS;
 	FLX_POINT_POOL;
 	FLX_PITCH;
+	/* Used in HaxeFlixel CI, should have no effect on personal projects */
 	FLX_NO_UNIT_TEST;
+	/* Used in HaxeFlixel CI, should have no effect on personal projects */
+	FLX_NO_COVERAGE_TEST;
+	/* Used in HaxeFlixel CI, should have no effect on personal projects */
+	FLX_NO_SWF_VERSION_TEST;
+	/* Used in HaxeFlixel CI, should have no effect on personal projects */
+	FLX_CI;
+	/* Used in HaxeFlixel CI, should have no effect on personal projects */
+	FLX_NO_CI;
 	FLX_SAVE;
 }
 
@@ -135,10 +149,17 @@ class FlxDefines
 		defineInversion(FLX_NO_DEBUG, FLX_DEBUG);
 		defineInversion(FLX_NO_POINT_POOL, FLX_POINT_POOL);
 		defineInversion(FLX_UNIT_TEST, FLX_NO_UNIT_TEST);
+		defineInversion(FLX_COVERAGE_TEST, FLX_NO_COVERAGE_TEST);
+		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
 	}
 
 	static function defineHelperDefines()
 	{
+		if (defined(FLX_UNIT_TEST) || defined(FLX_COVERAGE_TEST) || defined(FLX_SWF_VERSION_TEST))
+			define(FLX_CI);
+		else
+			define(FLX_NO_CI);
+		
 		if (!defined(FLX_NO_MOUSE) && !defined(FLX_NO_MOUSE_ADVANCED) && (!defined("flash") || defined("flash11_2")))
 			define(FLX_MOUSE_ADVANCED);
 

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -33,6 +33,7 @@
 	
 	<haxeflag name="--macro" value="include('flixel', true, ['flixel.system.macros'])" />
 	
+	<haxedef name="FLX_COVERAGE_TEST" />
 	<section if="coverage1">
 		<haxedef name="FLX_NO_MOUSE_ADVANCED" />
 		<haxedef name="FLX_NO_GAMEPAD" />


### PR DESCRIPTION
Fixes issues on -Dcoverage1:
>   /home/runner/haxe/haxelib/flixel/git/flixel/math/FlxRect.hx:25: characters 20-23 : { putUnsafe : flixel.math.FlxRect -> Void } has no field get
>   /home/runner/haxe/haxelib/flixel/git/flixel/math/FlxRect.hx:27: characters 3-14 : flixel.math.FlxRect should be { _inPool : Bool }
>   /home/runner/haxe/haxelib/flixel/git/flixel/math/FlxRect.hx:27: characters 3-14 : ... The field _inPool is not public
>   /home/runner/haxe/haxelib/flixel/git/flixel/math/FlxRect.hx:518: characters 3-15 : { putUnsafe : flixel.math.FlxRect -> Void } should be flixel.util.IFlxPool<flixel.math.FlxRect>

Note that i haven't been able to reproduce coverage2 issues:
> /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:174: characters 28-32 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field keys
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:174: characters 16-34 : You can't iterate on a Dynamic value, please specify Iterator or Iterable
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:112: characters 16-38 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field iterator
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:230: characters 16-19 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field set (Suggestion: get)
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:249: characters 16-22 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field remove
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:307: characters 17-20 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field set (Suggestion: get)
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:360: characters 17-20 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field set (Suggestion: get)
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:416: characters 17-20 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field set (Suggestion: get)
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:496: characters 17-20 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field set (Suggestion: get)
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:836: characters 17-28 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field iterator
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:853: characters 29-33 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field keys
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:853: characters 17-35 : You can't iterate on a Dynamic value, please specify Iterator or Iterable
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:868: characters 22-28 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field exists
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:885: characters 15-18 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field set (Suggestion: get)
>   /home/runner/haxe/haxelib/flixel/git/flixel/animation/FlxAnimationController.hx:887: characters 15-21 : { get : String -> Null<flixel.animation.FlxAnimation> } has no field remove

gonna mess with those in another PR