### PR TITLE
Regen graphic in `FlxText.getScreenBounds()`

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1,5 +1,6 @@
 package flixel.text;
 
+import flixel.math.FlxRect;
 import openfl.display.BitmapData;
 import openfl.geom.ColorTransform;
 import openfl.text.TextField;
@@ -535,6 +536,12 @@ class FlxText extends FlxSprite
 	{
 		regenGraphic();
 		super.updateHitbox();
+	}
+
+	override public function getScreenBounds(?newRect:FlxRect, ?camera:FlxCamera):FlxRect
+	{
+		regenGraphic();
+		return super.getScreenBounds(newRect, camera);
 	}
 
 	function set_fieldWidth(value:Float):Float

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1,6 +1,6 @@
 package flixel.text;
 
-import flixel.math.FlxRect;
+import openfl.Assets;
 import openfl.display.BitmapData;
 import openfl.geom.ColorTransform;
 import openfl.text.TextField;
@@ -15,11 +15,11 @@ import flixel.graphics.atlas.FlxNode;
 import flixel.graphics.frames.FlxFramesCollection;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
+import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.helpers.FlxRange;
-import openfl.Assets;
 
 using flixel.util.FlxStringUtil;
 using flixel.util.FlxUnicodeUtil;
@@ -538,7 +538,7 @@ class FlxText extends FlxSprite
 		super.updateHitbox();
 	}
 
-	override public function getScreenBounds(?newRect:FlxRect, ?camera:FlxCamera):FlxRect
+	override function getScreenBounds(?newRect:FlxRect, ?camera:FlxCamera):FlxRect
 	{
 		regenGraphic();
 		return super.getScreenBounds(newRect, camera);


### PR DESCRIPTION
It is possible to get wrong screen bounds if the bounds are read just after dimensions were changed

```haxe
var text = new FlxText(10, 10, 0, 'hello', 16);
text.fieldWidth = 100;
text.fieldHeight = 100;
add(text);
trace(text.getScreenBounds());
```

actual
```
(x: 10 | y: 10 | w: 52 | h: 24)
```

expected
```
(x: 10 | y: 10 | w: 100 | h: 100)
```

### Note

This pr changes `FlxText`, but maybe `FlxSprite` should be changed? Other similar methods (`getRotatedBounds`, `inWorldBounds`) use `width`/`height` (getters that trigger actual recalculation of size) while `getScreenBounds` uses `frameWidth`:

https://github.com/HaxeFlixel/flixel/blob/a33b47d51691b972b16b0566c7e0c2c13dd70f92/flixel/FlxSprite.hx#L1302