### PR TITLE
Additional glyphs

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -570,6 +570,7 @@ class FlxBitmapText extends FlxSprite
 
 	function set_text(value:String):String
 	{
+		value = parseExtraGlyphs(value);
 		if (value != text)
 		{
 			text = value;
@@ -577,6 +578,19 @@ class FlxBitmapText extends FlxSprite
 		}
 
 		return value;
+	}
+
+	function parseExtraGlyphs(?value:String = ""):String
+	{
+		var regex:EReg = new EReg("{{([a-zA-Z0-9 ]+)}}", "g");
+		
+		return regex.map(value, (r) ->
+		{
+			var unicode:String = font.lookupTable.get(r.matched(1));
+			if (unicode == null)
+				unicode = "!";
+			return unicode;
+		});
 	}
 
 	function updateText():Void


### PR DESCRIPTION
Adding `appendGlyphs` function to `FlxBitmapFont`.

See [https://github.com/AxolStudio/HFAdditionalGlyphsDemo](https://github.com/AxolStudio/HFAdditionalGlyphsDemo) for an example and details.