### PR TITLE
deprecate old plugin functions, add replcements

### DIFF
--- a/flixel/system/frontEnds/PluginFrontEnd.hx
+++ b/flixel/system/frontEnds/PluginFrontEnd.hx
@@ -18,38 +18,65 @@ class PluginFrontEnd
 
 	/**
 	 * Adds a new plugin to the global plugin array.
+	 * **DEPRECATED:** In a later version this will be changed to allow duplicate types.
 	 *
-	 * @param	Plugin	Any object that extends FlxBasic. Useful for managers and other things.
-	 * @return	The same plugin you passed in.
+	 * @param   plugin  Any object that extends FlxBasic. Useful for managers and other things.
+	 * @return  The same plugin you passed in.
 	 */
 	@:generic
-	public function add<T:FlxBasic>(Plugin:T):T
+	@:deprecated("FlxG.plugins.add is deprecated, use `addIfUniqueType` or `addPlugin`, instead")
+	public inline function add<T:FlxBasic>(plugin:T):T
 	{
-		// Don't add repeats
-		for (plugin in list)
+		return addIfUniqueType(plugin);
+	}
+	
+	/**
+	 * Adds a new plugin to the global plugin array, does not check for existing instances of this type.
+	 * **Note:** This is a temporary function. Eventually `add` will allow duplicates
+	 *
+	 * @param   plugin  Any object that extends FlxBasic. Useful for managers and other things.
+	 * @return  The same plugin you passed in.
+	 */
+	public function addPlugin<T:FlxBasic>(plugin:T):T
+	{
+		// No repeats found
+		list.push(plugin);
+		return plugin;
+	}
+	
+	/**
+	 * Adds a new plugin to the global plugin array.
+	 * **Note:** If there is already a plugin of this type, it will not be added
+	 *
+	 * @param   plugin  Any object that extends FlxBasic. Useful for managers and other things.
+	 * @return  The same plugin you passed in.
+	 */
+	public function addIfUniqueType<T:FlxBasic>(plugin:T):T
+	{
+		// Check for repeats
+		for (p in list)
 		{
-			if (FlxStringUtil.sameClassName(Plugin, plugin))
-			{
-				return Plugin;
-			}
+			if (FlxStringUtil.sameClassName(plugin, p))
+				return plugin;
 		}
-
-		// No repeats! safe to add a new instance of this plugin
-		list.push(Plugin);
-		return Plugin;
+		
+		// No repeats found
+		list.push(plugin);
+		return plugin;
 	}
 
 	/**
-	 * Retrieves a plugin based on its class name from the global plugin array.
+	 * Retrieves the first plugin found that matches the specified type.
 	 *
-	 * @param	ClassType	The class name of the plugin you want to retrieve. See the FlxPath or FlxTimer constructors for example usage.
-	 * @return	The plugin object, or null if no matching plugin was found.
+	 * @param   type  The class name of the plugin you want to retrieve.
+	 *                See the `FlxPath` or `FlxTimer` constructors for example usage.
+	 * @return  The plugin object, or null if no matching plugin was found.
 	 */
-	public function get<T:FlxBasic>(ClassType:Class<T>):T
+	public inline function get<T:FlxBasic>(type:Class<T>):T
 	{
 		for (plugin in list)
 		{
-			if (Std.isOfType(plugin, ClassType))
+			if (Std.isOfType(plugin, type))
 			{
 				return cast plugin;
 			}
@@ -61,47 +88,39 @@ class PluginFrontEnd
 	/**
 	 * Removes an instance of a plugin from the global plugin array.
 	 *
-	 * @param	Plugin	The plugin instance you want to remove.
-	 * @return	The same plugin you passed in.
+	 * @param   plugin  The plugin instance you want to remove.
+	 * @return  The same plugin you passed in.
 	 */
-	public function remove<T:FlxBasic>(Plugin:T):T
+	public inline function remove<T:FlxBasic>(plugin:T):T
 	{
-		// Don't add repeats
-		var i:Int = list.length - 1;
-
-		while (i >= 0)
-		{
-			if (list[i] == Plugin)
-			{
-				list.splice(i, 1);
-				return Plugin;
-			}
-			i--;
-		}
-
-		return Plugin;
+		list.remove(plugin);
+		return plugin;
 	}
 
 	/**
 	 * Removes all instances of a plugin from the global plugin array.
 	 *
-	 * @param	ClassType	The class name of the plugin type you want removed from the array.
-	 * @return	Whether or not at least one instance of this plugin type was removed.
+	 * @param   type  The class name of the plugin type you want removed from the array.
+	 * @return  Whether or not at least one instance of this plugin type was removed.
 	 */
-	public function removeType(ClassType:Class<FlxBasic>):Bool
+	@:deprecated("FlxG.plugin.removeType is deprecated, use `removeAllByType` instead")
+	public inline function removeType(type:Class<FlxBasic>):Bool
 	{
-		// Don't add repeats
+		return removeAllByType(type);
+	}
+	
+	public function removeAllByType(type:Class<FlxBasic>):Bool
+	{
 		var results:Bool = false;
-		var i:Int = list.length - 1;
 
-		while (i >= 0)
+		var i = list.length;
+		while (i-- > 0)
 		{
-			if (Std.isOfType(list[i], ClassType))
+			if (Std.isOfType(list[i], type))
 			{
 				list.splice(i, 1);
 				results = true;
 			}
-			i--;
 		}
 
 		return results;
@@ -110,9 +129,9 @@ class PluginFrontEnd
 	@:allow(flixel.FlxG)
 	function new()
 	{
-		add(FlxTimer.globalManager = new FlxTimerManager());
-		add(FlxTween.globalManager = new FlxTweenManager());
-		add(FlxMouseEvent.globalManager = new FlxMouseEventManager());
+		addPlugin(FlxTimer.globalManager = new FlxTimerManager());
+		addPlugin(FlxTween.globalManager = new FlxTweenManager());
+		addPlugin(FlxMouseEvent.globalManager = new FlxMouseEventManager());
 	}
 
 	/**

--- a/flixel/system/frontEnds/PluginFrontEnd.hx
+++ b/flixel/system/frontEnds/PluginFrontEnd.hx
@@ -18,13 +18,13 @@ class PluginFrontEnd
 
 	/**
 	 * Adds a new plugin to the global plugin array.
-	 * **DEPRECATED:** In a later version this will be changed to allow duplicate types.
+	 * **DEPRECATED:** In a later version this will be changed to behave like `addPlugin`.
 	 *
 	 * @param   plugin  Any object that extends FlxBasic. Useful for managers and other things.
 	 * @return  The same plugin you passed in.
 	 */
 	@:generic
-	@:deprecated("FlxG.plugins.add is deprecated, use `addIfUniqueType` or `addPlugin`, instead")
+	@:deprecated("FlxG.plugins.add is deprecated, use `addIfUniqueType` or `addPlugin`, instead.\nNote: In a later version `add` will be changed to behave like `addPlugin`")
 	public inline function add<T:FlxBasic>(plugin:T):T
 	{
 		return addIfUniqueType(plugin);


### PR DESCRIPTION
fixes #2917

There's really no reason to force `FlxG.plugins` to have only one instance of any type, but we can't just change the functionality of this whole system, so for now I'm:
- deprecating `add` and `removeType`
- add `addPlugin`, which doesn't check existing types. `addIfUniqueType` which does. Also `removeAllByType`
- changed some formatting, docs and args