### PR TITLE
Add `useGlobalTimeScale` to `FlxAnimationController`

### DIFF
--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -71,6 +71,11 @@ class FlxAnimationController implements IFlxDestroyable
 	public var timeScale:Float = 1.0;
 
 	/**
+	 * Whether the animation is affected by `FlxG.animationTimeScale` or not.
+	**/
+	public var useGlobalTimeScale:Bool = true;
+
+	/**
 	 * Internal, reference to owner sprite.
 	 */
 	var _sprite:FlxSprite;
@@ -97,7 +102,10 @@ class FlxAnimationController implements IFlxDestroyable
 	{
 		if (_curAnim != null)
 		{
-			_curAnim.update(elapsed * (timeScale * FlxG.animationTimeScale));
+			var _timeScale:Float = timeScale;
+			if (useGlobalTimeScale)
+				_timeScale *= FlxG.animationTimEcale;
+			_curAnim.update(elapsed * timeScale);
 		}
 		else if (_prerotated != null)
 		{

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -104,7 +104,7 @@ class FlxAnimationController implements IFlxDestroyable
 		{
 			var _timeScale:Float = timeScale;
 			if (useGlobalTimeScale)
-				_timeScale *= FlxG.animationTimEcale;
+				_timeScale *= FlxG.animationTimeScale;
 			_curAnim.update(elapsed * timeScale);
 		}
 		else if (_prerotated != null)

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -102,10 +102,10 @@ class FlxAnimationController implements IFlxDestroyable
 	{
 		if (_curAnim != null)
 		{
-			var _timeScale:Float = timeScale;
+			var speed:Float = timeScale;
 			if (useGlobalTimeScale)
-				_timeScale *= FlxG.animationTimeScale;
-			_curAnim.update(elapsed * timeScale);
+				speed *= FlxG.animationTimeScale;
+			_curAnim.update(elapsed * speed);
 		}
 		else if (_prerotated != null)
 		{

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -71,7 +71,7 @@ class FlxAnimationController implements IFlxDestroyable
 	public var timeScale:Float = 1.0;
 
 	/**
-	 * Whether the animation is affected by `FlxG.animationTimeScale` or not.
+	 * Whether the animation's `timeScale` is affected by `FlxG.animationTimeScale` or not.
 	**/
 	public var useGlobalTimeScale:Bool = true;
 


### PR DESCRIPTION
this is to allow users to ignore the global time scale in `FlxG` if needed