### PR TITLE
Changes to Flixel's Debug Pointer and Mover tools

### DIFF
--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -37,7 +37,14 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 		return null;
 	}
-
+	
+	@:noCompletion
+	@:allow(flixel.system.debug.interaction.Interaction)
+	static inline function resolveSelectionGroup(basic:FlxBasic)
+	{
+		return resolveGroup(basic);
+	}
+	
 	/**
 	 * `Array` of all the members in this group.
 	 */

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -609,9 +609,9 @@ class Interaction extends Window
 	 * @param   area   The rectangular area to search
 	 * @since 5.6.0
 	 */
-	public function getItemsWithinState(state:FlxState, area:FlxRect):Array<FlxBasic>
+	public function getItemsWithinState(state:FlxState, area:FlxRect):Array<FlxObject>
 	{
-		final items = new Array<FlxBasic>();
+		final items = new Array<FlxObject>();
 		
 		addItemsWithinArea(items, state.members, area);
 		if (state.subState != null)
@@ -623,7 +623,7 @@ class Interaction extends Window
 	@:deprecated("findItemsWithinState is deprecated, use getItemsWithinState or addItemsWithinState")
 	public inline function findItemsWithinState(items:Array<FlxBasic>, state:FlxState, area:FlxRect):Void
 	{
-		addItemsWithinState(items, state, area);
+		addItemsWithinState(cast items, state, area);
 	}
 	
 	/**
@@ -635,7 +635,7 @@ class Interaction extends Window
 	 * @param   area   The rectangular area to search
 	 * @since 5.6.0
 	 */
-	public function addItemsWithinState(items:Array<FlxBasic>, state:FlxState, area:FlxRect):Void
+	public function addItemsWithinState(items:Array<FlxObject>, state:FlxState, area:FlxRect):Void
 	{
 		addItemsWithinArea(items, state.members, area);
 		if (state.subState != null)
@@ -649,7 +649,7 @@ class Interaction extends Window
 	 * @param   area   The rectangular area to search
 	 * @since 5.6.0
 	 */
-	public function getTopItemWithinState(state:FlxState, area:FlxRect):FlxBasic
+	public function getTopItemWithinState(state:FlxState, area:FlxRect):FlxObject
 	{
 		if (state.subState != null)
 			return getTopItemWithinState(state.subState, area);
@@ -670,7 +670,7 @@ class Interaction extends Window
 	@:deprecated("findItemsWithinArea is deprecated, use addItemsWithinArea")// since 5.6.0
 	public inline function findItemsWithinArea(items:Array<FlxBasic>, members:Array<FlxBasic>, area:FlxRect):Void
 	{
-		addItemsWithinArea(items, members, area);
+		addItemsWithinArea(cast items, members, area);
 	}
 	
 	/**
@@ -684,7 +684,7 @@ class Interaction extends Window
 	 * @param   area     A rectangle that describes the area where the method should search within.
 	 * @since 5.6.0
 	 */
-	public function addItemsWithinArea(items:Array<FlxBasic>, members:Array<FlxBasic>, area:FlxRect):Void
+	public function addItemsWithinArea(items:Array<FlxObject>, members:Array<FlxBasic>, area:FlxRect):Void
 	{
 		// we iterate backwards to get the sprites on top first
 		var i = members.length;
@@ -698,8 +698,12 @@ class Interaction extends Window
 			final group = FlxTypedGroup.resolveSelectionGroup(member);
 			if (group != null)
 				addItemsWithinArea(items, group.members, area);
-			else if ((member is FlxObject) && area.overlaps(cast(member, FlxObject).getHitbox()))
-				items.push(cast member);
+			else if (member is FlxObject)
+			{
+				final object:FlxObject = cast member;
+				if (area.overlaps(object.getHitbox()))
+					items.push(object);
+			}
 		}
 	}
 	
@@ -712,7 +716,7 @@ class Interaction extends Window
 	 * @since 5.6.0
 	 */
 	@:access(flixel.group.FlxTypedGroup)
-	public function getTopItemWithinArea(members:Array<FlxBasic>, area:FlxRect):FlxBasic
+	public function getTopItemWithinArea(members:Array<FlxBasic>, area:FlxRect):FlxObject
 	{
 		// we iterate backwards to get the sprites on top first
 		var i = members.length;
@@ -726,8 +730,13 @@ class Interaction extends Window
 			final group = FlxTypedGroup.resolveGroup(member);
 			if (group != null)
 				return getTopItemWithinArea(group.members, area);
-			else if ((member is FlxObject) && area.overlaps(cast(member, FlxObject).getHitbox()))
-				return member;
+			
+			if (member is FlxObject)
+			{
+				final object:FlxObject = cast member;
+				if (area.overlaps(object.getHitbox()))
+					return object;
+			}
 		}
 		return null;
 	}

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -60,6 +60,8 @@ class Interaction extends Window
 		true;
 		#elseif (js && html5)
 		untyped js.Syntax.code("/AppleWebKit/.test (navigator.userAgent) && /Mobile\\/\\w+/.test (navigator.userAgent) || /Mac/.test (navigator.platform)");
+		#else
+		false;
 		#end
 	
 	var _container:Sprite;

--- a/flixel/system/debug/interaction/tools/Mover.hx
+++ b/flixel/system/debug/interaction/tools/Mover.hx
@@ -36,7 +36,7 @@ class Mover extends Tool
 	{
 		final key = _brain.macKeyboard ? Keyboard.COMMAND : Keyboard.CONTROL;
 		// Is the tool active or its hotkey pressed?
-		if (!isActive() && !_brain.keyPressed(key))
+		if (!isActive() && !_brain.keyPressed(key) && !_dragging)
 			return;
 
 		if (_brain.pointerPressed && !_dragging)

--- a/flixel/system/debug/interaction/tools/Mover.hx
+++ b/flixel/system/debug/interaction/tools/Mover.hx
@@ -25,7 +25,7 @@ class Mover extends Tool
 		_lastCursorPosition = new FlxPoint(brain.flixelPointer.x, brain.flixelPointer.x);
 
 		_name = "Mover";
-		_shortcut = "Shift";
+		_shortcut = brain.macKeyboard ? "⌘" : "Ctrl";
 		setButton(GraphicMoverTool);
 		setCursor(new GraphicMoverTool(0, 0));
 
@@ -34,8 +34,9 @@ class Mover extends Tool
 
 	override public function update():Void
 	{
+		final key = _brain.macKeyboard ? Keyboard.COMMAND : Keyboard.CONTROL;
 		// Is the tool active or its hotkey pressed?
-		if (!isActive() && !_brain.keyPressed(Keyboard.SHIFT))
+		if (!isActive() && !_brain.keyPressed(key))
 			return;
 
 		if (_brain.pointerPressed && !_dragging)

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -62,16 +62,9 @@ class Pointer extends Tool
 			return;
 		
 		final selectedItems = stopSelectionAndFindItems();
-
+		final drewRect = _selectionArea.width != 0 || _selectionArea.height != 0;
 		// If we have items in the selection area, handle them
-		if (selectedItems != null && selectedItems.length > 0)
-		{
-			handleItemAddition(selectedItems);
-		}
-		else if (!_brain.keyPressed(Keyboard.SHIFT))
-			// User clicked an empty space without holding the "add more items" key,
-			// so it's time to unselect everything.
-			_brain.clearSelection();
+		updateSelectedItems(selectedItems, drewRect);
 	}
 
 	function calculateSelectionArea():Void
@@ -162,25 +155,39 @@ class Pointer extends Tool
 		});
 	}
 
-	function handleItemAddition(itemsInSelectionArea:Array<FlxBasic>):Void
+	function updateSelectedItems(items:Array<FlxBasic>, drewRect:Bool):Void
 	{
 		// We add things to the selection list if the user is pressing the "add-new-item" key
 		final adding = _brain.keyPressed(Keyboard.SHIFT);
-		final prevSelectedItems = _brain.selectedItems;
-
-		if (itemsInSelectionArea.length == 0)
-			return;
-
+		final removing = _brain.keyPressed(Keyboard.ALTERNATE) && !adding;
+		
 		// If we are not selectively adding items, just clear
 		// the brain's list of selected items.
-		if (!adding)
+		if (!adding && !removing)
 			_brain.clearSelection();
-
-		for (item in itemsInSelectionArea)
+		
+		if (items == null || items.length == 0)
+			return;
+		
+		final prevSelectedItems = _brain.selectedItems;
+		if (adding && !drewRect && items.length == 1)
 		{
-			if (prevSelectedItems.members.contains(cast item) && adding)
-				prevSelectedItems.remove(cast item);
+			final item:FlxObject = cast items[0];
+			// if they click a single item, toggle it from the selection
+			if (prevSelectedItems.members.contains(item))
+				prevSelectedItems.remove(item);
 			else
+				prevSelectedItems.add(item);
+		}
+		else if (removing)
+		{
+			for (item in items)
+				prevSelectedItems.remove(cast item);
+		}
+		else
+		{
+			// add them all
+			for (item in items)
 				prevSelectedItems.add(cast item);
 		}
 	}

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -24,7 +24,6 @@ class Pointer extends Tool
 	var _selectionStartPoint:FlxPoint = new FlxPoint();
 	var _selectionEndPoint:FlxPoint = new FlxPoint();
 	var _selectionHappening:Bool = false;
-	var _selectionCancelled:Bool = false;
 	var _selectionArea:FlxRect = new FlxRect();
 
 	override public function init(brain:Interaction):Tool
@@ -69,7 +68,7 @@ class Pointer extends Tool
 		{
 			handleItemAddition(selectedItems);
 		}
-		else if (!_brain.keyPressed(Keyboard.SHIFT) && !_selectionCancelled)
+		else if (!_brain.keyPressed(Keyboard.SHIFT))
 			// User clicked an empty space without holding the "add more items" key,
 			// so it's time to unselect everything.
 			_brain.clearSelection();
@@ -77,22 +76,12 @@ class Pointer extends Tool
 
 	function calculateSelectionArea():Void
 	{
-		_selectionArea.x = _selectionStartPoint.x;
-		_selectionArea.y = _selectionStartPoint.y;
-		_selectionArea.width = _selectionEndPoint.x - _selectionArea.x;
-		_selectionArea.height = _selectionEndPoint.y - _selectionArea.y;
-
-		if (_selectionArea.width < 0)
-		{
-			_selectionArea.width *= -1;
-			_selectionArea.x = _selectionArea.x - _selectionArea.width;
-		}
-
-		if (_selectionArea.height < 0)
-		{
-			_selectionArea.height *= -1;
-			_selectionArea.y = _selectionArea.y - _selectionArea.height;
-		}
+		final start = _selectionStartPoint;
+		final end = _selectionEndPoint;
+		_selectionArea.x = start.x < end.x ? start.x : end.x;
+		_selectionArea.y = start.y < end.y ? start.y : end.y;
+		_selectionArea.right = start.x > end.x ? start.x : end.x;
+		_selectionArea.bottom = start.y > end.y ? start.y : end.y;
 	}
 
 	/**
@@ -102,7 +91,6 @@ class Pointer extends Tool
 	public function startSelection():Void
 	{
 		_selectionHappening = true;
-		_selectionCancelled = false;
 		_selectionStartPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);
 	}
 
@@ -116,7 +104,6 @@ class Pointer extends Tool
 		if (!_selectionHappening)
 			return;
 
-		_selectionCancelled = true;
 		stopSelection();
 	}
 

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -113,7 +113,7 @@ class Pointer extends Tool
 	/**
 	 * Stop any selection activity that is happening.
 	 */
-	public function stopSelectionAndFindItems():Array<FlxBasic>
+	public function stopSelectionAndFindItems():Array<FlxObject>
 	{
 		if (!_selectionHappening)
 			throw "stopSelectionAndFindItems called when not selecting";
@@ -121,7 +121,7 @@ class Pointer extends Tool
 		_selectionEndPoint.set(_brain.flixelPointer.x, _brain.flixelPointer.y);
 		calculateSelectionArea();
 
-		var items:Array<FlxBasic> = null;
+		var items:Array<FlxObject> = null;
 		if (_selectionArea.width != 0 || _selectionArea.height != 0)
 		{
 			items = _brain.getItemsWithinState(FlxG.state, _selectionArea);
@@ -145,7 +145,7 @@ class Pointer extends Tool
 	/**
 	 * We register the current selection to the console for easy interaction.
 	 */
-	function updateConsoleSelection(items:Array<FlxBasic>)
+	function updateConsoleSelection(items:Array<FlxObject>)
 	{
 		FlxG.console.registerObject("selection", switch (items)
 		{
@@ -155,7 +155,7 @@ class Pointer extends Tool
 		});
 	}
 
-	function updateSelectedItems(items:Array<FlxBasic>, drewRect:Bool):Void
+	function updateSelectedItems(items:Array<FlxObject>, drewRect:Bool):Void
 	{
 		// We add things to the selection list if the user is pressing the "add-new-item" key
 		final adding = _brain.keyPressed(Keyboard.SHIFT);
@@ -172,7 +172,7 @@ class Pointer extends Tool
 		final prevSelectedItems = _brain.selectedItems;
 		if (adding && !drewRect && items.length == 1)
 		{
-			final item:FlxObject = cast items[0];
+			final item = items[0];
 			// if they click a single item, toggle it from the selection
 			if (prevSelectedItems.members.contains(item))
 				prevSelectedItems.remove(item);
@@ -182,13 +182,13 @@ class Pointer extends Tool
 		else if (removing)
 		{
 			for (item in items)
-				prevSelectedItems.remove(cast item);
+				prevSelectedItems.remove(item);
 		}
 		else
 		{
 			// add them all
 			for (item in items)
-				prevSelectedItems.add(cast item);
+				prevSelectedItems.add(item);
 		}
 	}
 


### PR DESCRIPTION
## How the Debug Pointer Tool worked before this change:
- Click to select all `FlxSprites` under mouse
- Click, drag and release to select all `FlxSprites` touching the rect
- Hold SHIFT to select MOVER tool, SHIFT+drag to move selected `FlxSprites`
- CTRL/CONTROL(on Mac) + click to toggle selection of all `FlxSprites` under mouse. That is all objects previously selected will be deselected, and vice versa
- CTRL/CONTROL(on Mac) + drag rect to toggle selection of all `FlxSprites` inside rect
- Note that the tooltip for the Mover tool shows "Mover(Shift)" when hovered

## How it works after this change
- Note: The previous version only checked for `FlxSprites`, and can now select `FlxObjects`
- Click to select top-most\* `FlxObject` touching the mouse
- Click, drag and release to select all `FlxObject` touching the rect
- Hold CTRL/CMD to select MOVER tool, CTRL/CMD+drag to move selected `FlxSprites`
- SHIFT + click to toggle the top-most\* `FlxObject` from the current selection
- SHIFT + click, drag and release to ADD all `FlxObjects` in the rect to the current selection
- ALT/OPTION + click to toggle the top-most\* `FlxObject` from the current selection (same  as SHIFT + Click)
- ALT/OPTION + click, drag and release to REMOVE all `FlxObjects` in the rect from the current selection
- Note that the tooltip for the Mover tool shows "Mover(Ctrl)" when hovered when using a windows keyboard and "Mover(⌘)" when using a Mac keyboard

\* The "top-most" object is the one who's draw function would be called last when the `FlxState` is drawn. this may not be the object rendered on top of all others, if sprites are drawn to different cameras. this may be fixed in the future but it's not a huge deal right now.

Notes: "Option" or "⌥" is the Mac keyboard equivalent to "Alt" and "Command", "Cmd" or "⌘" is the Mac keyboard equivalent to "Ctrl", not to be confused with Mac's "Control" or "⌃" key