### PR TITLE
Implement `wasDestroyed` check on FlxGraphic

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -635,6 +635,11 @@ class FlxCamera extends FlxBasic
 			itemToReturn = new FlxDrawItem();
 		}
 
+		if (graphic.wasDestroyed) {
+			// Throw an exception here, because throwing in `FlxDrawQuadsItem.render()` is not helpful.
+			throw 'Attempted to queue invalid FlxDrawItem, did you dispose of a cached sprite?';
+		}
+
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smooth;
 		itemToReturn.colored = colored;

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -344,6 +344,16 @@ class FlxGraphic implements IFlxDestroyable
 	public var atlasFrames(get, never):FlxAtlasFrames;
 
 	/**
+	 * This value is `true` if this graphic has been disposed.
+	 * Attempting to render a disposed graphic will cause an error.
+	 */
+	public var wasDestroyed(get, never):Bool;
+
+	function get_wasDestroyed():Bool {
+		return shader == null;
+	}
+
+	/**
 	 * Storage for all available frame collection of all types for this graphic object.
 	 */
 	var frameCollections:Map<FlxFrameCollectionType, Array<Dynamic>>;

--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -115,6 +115,12 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 			return;
 
 		var shader = shader != null ? shader : graphics.shader;
+
+		if (shader == null) {
+			// If this gets called, the check for `graphic.wasDestroyed` in FlxCamera failed.
+			throw 'Attempted to render invalid FlxDrawItem, did you dispose of a cached sprite?';
+		}
+
 		shader.bitmap.input = graphics.bitmap;
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
 		shader.alpha.value = alphas;


### PR DESCRIPTION
When attempting to render a destroyed graphic (which is wrong and the library user needs to diagnose the issue), determining which sprite was the cause of the issue is difficult, due to the error taking place long after the draw is queued. This change ensures that the error is thrown WHEN the sprite's `draw()` call is performed rather than after; this allows developers to step up to `FlxSprite.draw()` when debugging and view the affected sprite in the local variable scope.