### PR TITLE
Add `@:from` metadata to `FlxColor#fromString`

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -88,7 +88,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param	Value And Int with bytes in the format 0xAARRGGBB
 	 * @return	The color as a FlxColor
 	 */
-	public static inline function fromInt(Value:Int):FlxColor
+	@:from public static inline function fromInt(Value:Int):FlxColor
 	{
 		return new FlxColor(Value);
 	}

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -184,7 +184,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param	str 	The string to be parsed
 	 * @return	A `FlxColor` or `null` if the `String` couldn't be parsed
 	 */
-	public static function fromString(str:String):Null<FlxColor>
+	@:from public static function fromString(str:String):Null<FlxColor>
 	{
 		var result:Null<FlxColor> = null;
 		str = StringTools.trim(str);


### PR DESCRIPTION
With that addition it's gonna be possible to manipulate `FlxColor`s with strings.

```haxe
// create an FlxColor from a string
var col:FlxColor = "white";
col = "black";

// changing `FlxColor` fields with strings
mySprite.color = "red";
mySubState.bgColor = "green";
```