### PR TITLE
Add graphic.isDestroyed, prevent render crashes

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -774,6 +774,16 @@ class FlxSprite extends FlxObject
 	{
 		if (_frame == null)
 			loadGraphic("flixel/images/logo/default.png");
+		else if (graphic != null && graphic.isDestroyed)
+		{
+			// switch graphic but log and preserve size
+			final width = this.width;
+			final height = this.height;
+			FlxG.log.warn('Cannot render a destroyed graphic, the placeholder image will be used instead');
+			loadGraphic("flixel/images/logo/default.png");
+			this.width = width;
+			this.height = height;
+		}
 	}
 
 	/**

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -779,7 +779,7 @@ class FlxSprite extends FlxObject
 			// switch graphic but log and preserve size
 			final width = this.width;
 			final height = this.height;
-			FlxG.log.warn('Cannot render a destroyed graphic, the placeholder image will be used instead');
+			FlxG.log.error('Cannot render a destroyed graphic, the placeholder image will be used instead');
 			loadGraphic("flixel/images/logo/default.png");
 			this.width = width;
 			this.height = height;

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -314,6 +314,12 @@ class FlxGraphic implements IFlxDestroyable
 	public var isLoaded(get, never):Bool;
 
 	/**
+	 * Whether `destroy` was called on this graphic
+	 * @since 5.6.0
+	 */
+	public var isDestroyed(get, never):Bool;
+
+	/**
 	 * Whether the `BitmapData` of this graphic object can be dumped for decreased memory usage,
 	 * but may cause some issues (when you need direct access to pixels of this graphic.
 	 * If the graphic is dumped then you should call `undump()` and have total access to pixels.
@@ -388,14 +394,14 @@ class FlxGraphic implements IFlxDestroyable
 	 * @param   Persist   Whether or not this graphic stay in the cache after resetting it.
 	 *                    Default value is `false`, which means that this graphic will be destroyed at the cache reset.
 	 */
-	function new(Key:String, Bitmap:BitmapData, ?Persist:Bool)
+	function new(key:String, bitmap:BitmapData, ?persist:Bool)
 	{
-		key = Key;
-		persist = (Persist != null) ? Persist : defaultPersist;
+		this.key = key;
+		this.persist = (persist != null) ? persist : defaultPersist;
 
 		frameCollections = new Map<FlxFrameCollectionType, Array<Dynamic>>();
 		frameCollectionTypes = new Array<FlxFrameCollectionType>();
-		bitmap = Bitmap;
+		this.bitmap = bitmap;
 
 		shader = new FlxShader();
 	}
@@ -551,6 +557,11 @@ class FlxGraphic implements IFlxDestroyable
 	inline function get_isLoaded()
 	{
 		return bitmap != null && !bitmap.rect.isEmpty();
+	}
+	
+	inline function get_isDestroyed()
+	{
+		return shader == null;
 	}
 
 	inline function get_canBeDumped():Bool


### PR DESCRIPTION
Closes #2968

adds graphic.isDestroyed, detects when a destroyed graphic is being drawn, logs an error and displays the flixel logo, instead.

Note to @EliteMasterEric:
- I went with `isDestroyed` to match `isLoaded` and `isDumped`.
- I also use `FlxG.log.error` instead of throwing an error. I try to throw when I want the game to pause right when they did something wrong, not later, when I discover that something previously went wrong