### PR TITLE
Fix FlxSpriteGroup origin

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -1057,7 +1057,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		Sprite.offset.copyFrom(Offset);
 
 	inline function originTransform(Sprite:FlxSprite, Origin:FlxPoint)
-		Sprite.origin.copyFrom(Origin);
+		Sprite.origin.set(x + origin.x - Sprite.x, y + origin.y - Sprite.y);
 
 	inline function scaleTransform(Sprite:FlxSprite, Scale:FlxPoint)
 		Sprite.scale.copyFrom(Scale);

--- a/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
@@ -137,6 +137,33 @@ class FlxSpriteGroupTest extends FlxTest
 		Assert.isFalse(member2.revived);
 		return group;
 	}
+	@Test
+	/**
+	 * Ensure that member origins are correctly set when 
+	 * the group origin is set.
+	 */
+	function testOriginTransform()
+	{
+		var f1 = new FlxSprite(-10, 100);
+		var f2 = new FlxSprite(50, 50);
+		group.add(f1);
+		group.add(f2);
+		
+		group.setPosition(280, 300);
+		group.origin.set(300, 400);
+		
+		// Verify positions are updated - absolute
+		Assert.areEqual(270, f1.x);
+		Assert.areEqual(400, f1.y);
+		Assert.areEqual(330, f2.x);
+		Assert.areEqual(350, f2.y);
+		
+		// Verify origins are correct - relative
+		Assert.areEqual(310, f1.origin.x);
+		Assert.areEqual(300, f1.origin.y);
+		Assert.areEqual(250, f2.origin.x);
+		Assert.areEqual(350, f2.origin.y);
+	}
 }
 
 class Member extends FlxSprite


### PR DESCRIPTION
Currently, rotation and scaling on a FlxSpriteGroup produces strange results. The problem stems from the fact that the originTransform function does not set all the member origin fields to point to the same place - to do this the origin of each member must be set relative to its own position. The current originTransform sets all the origins to the same value. This change fixes this computing the correct relative origin for each child. A unit test is added also. I have also tested this with an application which demonstrates that the rotation and scaling work as expected.