### PR TITLE
Fix plus keybind on Mac

### DIFF
--- a/flixel/input/keyboard/FlxKeyboard.hx
+++ b/flixel/input/keyboard/FlxKeyboard.hx
@@ -51,6 +51,7 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 		_nativeCorrection.set("123_222", FlxKey.LBRACKET);
 		_nativeCorrection.set("125_187", FlxKey.RBRACKET);
 		_nativeCorrection.set("126_233", FlxKey.GRAVEACCENT);
+		#if mac _nativeCorrection.set("0_43", FlxKey.PLUS); #end
 
 		_nativeCorrection.set("0_80", FlxKey.F1);
 		_nativeCorrection.set("0_81", FlxKey.F2);


### PR DESCRIPTION
This allows pressing + on Mac. Might only work for Swedish Mac keyboards since i don't have a english keyboard