### PR TITLE
Fix crash on gamepad disconnection

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -327,6 +327,8 @@ class FlxGamepad implements IFlxDestroyable
 	 */
 	public inline function checkStatusRaw(RawID:Int, Status:FlxInputState):Bool
 	{
+		if(buttons == null)
+			return false;
 		var button = buttons[RawID];
 		return button != null && button.hasState(Status);
 	}


### PR DESCRIPTION
When unplugging a controller (specifically a Switch Pro controller), this calls a `destroy()` on the gamepad and sets `buttons = null;`. This causes an application crash if another function calls `FlxGamepad.checkStatusRaw()` since it tries to reference an element in a null array.

In this example, it happens when a `FlxUICursor` is polling a controller:
```
Uncaught exception: Null access .length
Called from flixel.addons.ui.FlxMultiGamepad.checkJustPressed(flixel/addons/ui/FlxMultiGamepad.hx:33)
Called from flixel.addons.ui.FlxBaseMultiInput.justPressed(flixel/addons/ui/FlxBaseMultiInput.hx:65)
Called from flixel.addons.ui.FlxUICursor._checkKeys(flixel/addons/ui/FlxUICursor.hx:807)
Called from flixel.addons.ui.FlxUICursor.update(flixel/addons/ui/FlxUICursor.hx:340)
Called from flixel.group.FlxTypedGroup.update(flixel/group/FlxGroup.hx:170)
Called from flixel.addons.ui.FlxUISubState.update(flixel/addons/ui/FlxUISubState.hx:182)
```

A working fix is to check if the array is valid before attempting to access it.