### PR TITLE
Correct FlxFlicker.flicker() doc

### DIFF
--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -20,7 +20,7 @@ class FlxFlicker implements IFlxDestroyable
 	static var _boundObjects:Map<FlxObject, FlxFlicker> = new Map<FlxObject, FlxFlicker>();
 
 	/**
-	 * A simple flicker effect for sprites using a ping-pong tween by toggling visibility.
+	 * A simple flicker effect for sprites using a `FlxTimer` to toggle visibility.
 	 *
 	 * @param   Object               The object.
 	 * @param   Duration             How long to flicker for (in seconds). `0` means "forever".


### PR DESCRIPTION
It is said it uses ping-pong tween but actually it uses FlxTimer.