### PR TITLE
Allow ()->FlxState args in FlxG.switchState

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -378,14 +378,7 @@ class FlxG
 	{
 		final stateOnCall = FlxG.state;
 		
-		var canSwitch = true;
-		if (nextState.isInstance())
-		{
-			// Use reflection to avoid deprecation warning on switchTo
-			canSwitch = Reflect.callMethod(state, Reflect.field(state, 'switchTo'), [nextState]);
-		}
-		
-		if (canSwitch)
+		if (!nextState.isInstance() || canSwitchTo(cast nextState))
 		{
 			state.startOutro(function()
 			{
@@ -396,6 +389,12 @@ class FlxG
 			});
 		}
 	}
+	
+	static function canSwitchTo(nextState:FlxState)
+	{
+		// Use reflection to avoid deprecation warning on switchTo
+		return Reflect.callMethod(state, Reflect.field(state, 'switchTo'), [nextState]);
+	}
 
 	/**
 	 * Request a reset of the current game state.
@@ -405,8 +404,11 @@ class FlxG
 	{
 		if (state == null || state._constructor == null)
 			FlxG.log.error("FlxG.resetState was called while switching states");
-		else
+		else if(!state._constructor.isInstance())
 			switchState(state._constructor);
+		else
+			// create new instance here so that state.switchTo is called (for backwards compatibility)
+			switchState(Type.createInstance(Type.getClass(state), []));
 	}
 
 	/**

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -395,11 +395,16 @@ class FlxG
 	 * This will be removed in Flixel 6.0.0
 	 * @since 5.6.0
 	 */
-	@:haxe.warning("-WDeprecated")
 	@:noCompletion
-	static inline function canSwitchTo(nextState:FlxState)
+	@:haxe.warning("-WDeprecated")
+	static function canSwitchTo(nextState:FlxState)
 	{
+		#if (haxe < version("4.3.0"))
+		// Use reflection because @:haxe.warning("-WDeprecated") doesn't work until haxe 4.3
+		return Reflect.callMethod(state, Reflect.field(state, 'switchTo'), [nextState]);
+		#else
 		return state.switchTo(nextState);
+		#end
 	}
 
 	/**

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -390,10 +390,16 @@ class FlxG
 		}
 	}
 	
-	static function canSwitchTo(nextState:FlxState)
+	/**
+	 * Calls state.switchTo(nextState) without a deprecation warning.
+	 * This will be removed in Flixel 6.0.0
+	 * @since 5.6.0
+	 */
+	@:haxe.warning("-WDeprecated")
+	@:noCompletion
+	static inline function canSwitchTo(nextState:FlxState)
 	{
-		// Use reflection to avoid deprecation warning on switchTo
-		return Reflect.callMethod(state, Reflect.field(state, 'switchTo'), [nextState]);
+		return state.switchTo(nextState);
 	}
 
 	/**

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -1,14 +1,15 @@
 package flixel;
 
+import flixel.graphics.tile.FlxDrawBaseItem;
+import flixel.system.FlxSplash;
+import flixel.util.FlxArrayUtil;
+import flixel.util.typeLimit.NextState;
+import openfl.Assets;
 import openfl.Lib;
 import openfl.display.Sprite;
 import openfl.display.StageAlign;
 import openfl.display.StageScaleMode;
 import openfl.events.Event;
-import flixel.graphics.tile.FlxDrawBaseItem;
-import flixel.system.FlxSplash;
-import flixel.util.FlxArrayUtil;
-import openfl.Assets;
 import openfl.filters.BitmapFilter;
 #if desktop
 import openfl.events.FocusEvent;
@@ -92,7 +93,7 @@ class FlxGame extends Sprite
 	/**
 	 * Class type of the initial/first game state for the game, usually `MenuState` or something like that.
 	 */
-	var _initialState:Class<FlxState>;
+	var _initialState:NextState;
 
 	/**
 	 * Current game state.
@@ -201,7 +202,7 @@ class FlxGame extends Sprite
 	/**
 	 * If a state change was requested, the new state object is stored here until we switch to it.
 	 */
-	var _requestedState:FlxState;
+	var _nextState:NextState;
 
 	/**
 	 * A flag for keeping track of whether a game reset was requested or not.
@@ -251,7 +252,8 @@ class FlxGame extends Sprite
 	 *                         If the demensions don't match the `Project.xml`, 
 	 *                         [`scaleMode`](https://api.haxeflixel.com/flixel/system/scaleModes/index.html)
 	 *                         will determine the actual display size of the game.
-	 * @param initialState     The class name of the state you want to create and switch to first (e.g. `MenuState`).
+	 * @param initialState     A constructor for the initial state, ex: `PlayState.new` or `()->new PlayState()`.
+	 *                         Note: Also allows `Class<FlxState>` for backwards compatibility.
 	 * @param updateFramerate  How frequently the game should update. Default is 60 fps.
 	 * @param drawFramerate    Sets the actual display / draw framerate for the game. Default is 60 fps.
 	 * @param skipSplash       Whether you want to skip the flixel splash screen with `FLX_NO_DEBUG`.
@@ -259,7 +261,7 @@ class FlxGame extends Sprite
 	 *
 	 * @see [scale modes](https://api.haxeflixel.com/flixel/system/scaleModes/index.html)
 	 */
-	public function new(gameWidth = 0, gameHeight = 0, ?initialState:Class<FlxState>, updateFramerate = 60, drawFramerate = 60, skipSplash = false,
+	public function new(gameWidth = 0, gameHeight = 0, ?initialState:InitialState, updateFramerate = 60, drawFramerate = 60, skipSplash = false,
 			startFullscreen = false)
 	{
 		super();
@@ -289,7 +291,7 @@ class FlxGame extends Sprite
 		#end
 
 		// Then get ready to create the game object for real
-		_initialState = (initialState == null) ? FlxState : initialState;
+		_initialState = (initialState == null) ? FlxState.new : initialState.toNextState();
 
 		addEventListener(Event.ADDED_TO_STAGE, create);
 	}
@@ -524,7 +526,7 @@ class FlxGame extends Sprite
 				{
 					FlxG.vcr.stepRequested = false;
 				}
-				else if (_state == _requestedState) // don't pause a state switch request
+				else if (_nextState == null) // don't pause a state switch request
 				{
 					#if FLX_DEBUG
 					debugger.update();
@@ -580,24 +582,18 @@ class FlxGame extends Sprite
 		#if FLX_DEBUG
 		_skipSplash = true;
 		#end
-
-		if (_skipSplash || FlxSplash.nextState != null) // already played
+		
+		if (_skipSplash)
 		{
-			_requestedState = cast Type.createInstance(_initialState, []);
-			if (FlxSplash.nextState == null)
-				_gameJustStarted = true;
+			_nextState = _initialState;
+			_gameJustStarted = true;
 		}
 		else
 		{
 			FlxSplash.nextState = _initialState;
-			_requestedState = new FlxSplash();
+			_nextState = new FlxSplash();
 			_skipSplash = true; // only play it once
 		}
-
-		#if FLX_DEBUG
-		if ((_requestedState is FlxSubState))
-			throw "You can't set FlxSubState class instance as the state for you game";
-		#end
 
 		FlxG.reset();
 
@@ -632,7 +628,9 @@ class FlxGame extends Sprite
 		FlxG.bitmap.clearCache();
 
 		// Finally assign and create the new state
-		_state = _requestedState;
+		_state = _nextState.createInstance();
+		_state._constructor = _nextState.getConstructor();
+		_nextState = null;
 
 		if (_gameJustStarted)
 			FlxG.signals.preGameStart.dispatch();
@@ -725,7 +723,7 @@ class FlxGame extends Sprite
 		if (!_state.active || !_state.exists)
 			return;
 
-		if (_state != _requestedState)
+		if (_nextState != null)
 			switchState();
 
 		#if FLX_DEBUG

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -87,7 +87,7 @@ class FlxGame extends Sprite
 	/**
 	 * A flag for triggering the `preGameStart` and `postGameStart` "events".
 	 */
-	@:allow(flixel.system.FlxSplash)
+	@:allow(flixel.FlxIntroSplash)
 	var _gameJustStarted:Bool = false;
 
 	/**
@@ -590,8 +590,7 @@ class FlxGame extends Sprite
 		}
 		else
 		{
-			FlxSplash.nextState = _initialState;
-			_nextState = new FlxSplash();
+			_nextState = ()->new FlxIntroSplash(_initialState);
 			_skipSplash = true; // only play it once
 		}
 
@@ -895,5 +894,14 @@ class FlxGame extends Sprite
 	{
 		// expensive, only call if necessary
 		return Lib.getTimer();
+	}
+}
+
+private class FlxIntroSplash extends FlxSplash
+{
+	override function startOutro(onOutroComplete:() -> Void)
+	{
+		FlxG.game._gameJustStarted = true;
+		super.startOutro(onOutroComplete);
 	}
 }

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -629,7 +629,7 @@ class FlxGame extends Sprite
 
 		// Finally assign and create the new state
 		_state = _nextState.createInstance();
-		_state._constructor = _nextState.getConstructor();
+		_state._constructor = _nextState;
 		_nextState = null;
 
 		if (_gameJustStarted)

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -3,7 +3,8 @@ package flixel;
 import flixel.group.FlxGroup;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
-import flixel.util.FlxSignal.FlxTypedSignal;
+import flixel.util.FlxSignal;
+import flixel.util.typeLimit.NextState;
 
 /**
  * This is the basic game "state" object - e.g. in a simple game you might have a menu state and a play state.
@@ -46,9 +47,12 @@ class FlxState extends FlxGroup
 	 */
 	public var bgColor(get, set):FlxColor;
 	
+	/**
+	 * The specific argument that was passed into `switchState` or `FlxGame.new`
+	 */
 	@:allow(flixel.FlxGame)
 	@:allow(flixel.FlxG)
-	var _constructor:()->FlxState;
+	var _constructor:NextState;
 	
 	/**
 	 * Current substate. Substates also can be nested.

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -45,7 +45,11 @@ class FlxState extends FlxGroup
 	 * The natural background color the cameras default to. In `AARRGGBB` format.
 	 */
 	public var bgColor(get, set):FlxColor;
-
+	
+	@:allow(flixel.FlxGame)
+	@:allow(flixel.FlxG)
+	var _constructor:()->FlxState;
+	
 	/**
 	 * Current substate. Substates also can be nested.
 	 */
@@ -83,7 +87,12 @@ class FlxState extends FlxGroup
 
 	@:noCompletion
 	var _subStateClosed:FlxTypedSignal<FlxSubState->Void>;
-    
+	
+	public function new ()
+	{
+		super(0);
+	}
+	
 	/**
 	 * This function is called after the game engine successfully switches states.
 	 * Override this function, NOT the constructor, to initialize or set up your game state.
@@ -156,11 +165,15 @@ class FlxState extends FlxGroup
 		}
 	}
 
-	override public function destroy():Void
+	override function destroy():Void
 	{
+		_constructor = function():FlxState
+		{
+			throw "Attempting to resetState while the current state is destroyed";
+		};
 		FlxDestroyUtil.destroy(_subStateOpened);
 		FlxDestroyUtil.destroy(_subStateClosed);
-        
+		
 		if (subState != null)
 		{
 			subState.destroy();

--- a/flixel/system/FlxSplash.hx
+++ b/flixel/system/FlxSplash.hx
@@ -16,17 +16,15 @@ import flixel.util.typeLimit.NextState;
 
 class FlxSplash extends FlxState
 {
-	public static var nextState:NextState;
-
 	/**
 	 * @since 4.8.0
 	 */
 	public static var muted:Bool = #if html5 true #else false #end;
-
+	
 	var _sprite:Sprite;
 	var _gfx:Graphics;
 	var _text:TextField;
-
+	
 	var _times:Array<Float>;
 	var _colors:Array<Int>;
 	var _functions:Array<Void->Void>;
@@ -34,7 +32,15 @@ class FlxSplash extends FlxState
 	var _cachedBgColor:FlxColor;
 	var _cachedTimestep:Bool;
 	var _cachedAutoPause:Bool;
-
+	
+	var nextState:NextState;
+	
+	public function new(nextState:NextState)
+	{
+		super();
+		this.nextState = nextState;
+	}
+	
 	override public function create():Void
 	{
 		_cachedBgColor = FlxG.cameras.bgColor;
@@ -96,7 +102,12 @@ class FlxSplash extends FlxState
 		_functions = null;
 		super.destroy();
 	}
-
+	
+	function complete()
+	{
+		FlxG.switchState(nextState);
+	}
+	
 	override public function onResize(Width:Int, Height:Int):Void
 	{
 		super.onResize(Width, Height);
@@ -122,7 +133,7 @@ class FlxSplash extends FlxState
 		if (_curPart == 5)
 		{
 			// Make the logo a tad bit longer, so our users fully appreciate our hard work :D
-			FlxTween.tween(_sprite, {alpha: 0}, 3.0, {ease: FlxEase.quadOut, onComplete: onComplete});
+			FlxTween.tween(_sprite, {alpha: 0}, 3.0, {ease: FlxEase.quadOut, onComplete: (_)->complete()});
 			FlxTween.tween(_text, {alpha: 0}, 3.0, {ease: FlxEase.quadOut});
 		}
 	}
@@ -190,7 +201,7 @@ class FlxSplash extends FlxState
 		_gfx.endFill();
 	}
 
-	function onComplete(Tween:FlxTween):Void
+	override function startOutro(onOutroComplete:() -> Void)
 	{
 		FlxG.cameras.bgColor = _cachedBgColor;
 		FlxG.fixedTimestep = _cachedTimestep;
@@ -200,7 +211,7 @@ class FlxSplash extends FlxState
 		#end
 		FlxG.stage.removeChild(_sprite);
 		FlxG.stage.removeChild(_text);
-		FlxG.switchState(nextState);
-		FlxG.game._gameJustStarted = true;
+		
+		super.startOutro(onOutroComplete);
 	}
 }

--- a/flixel/system/FlxSplash.hx
+++ b/flixel/system/FlxSplash.hx
@@ -12,10 +12,11 @@ import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
 import flixel.util.FlxTimer;
+import flixel.util.typeLimit.NextState;
 
 class FlxSplash extends FlxState
 {
-	public static var nextState:Class<FlxState>;
+	public static var nextState:NextState;
 
 	/**
 	 * @since 4.8.0
@@ -199,7 +200,7 @@ class FlxSplash extends FlxState
 		#end
 		FlxG.stage.removeChild(_sprite);
 		FlxG.stage.removeChild(_text);
-		FlxG.switchState(Type.createInstance(nextState, []));
+		FlxG.switchState(nextState);
 		FlxG.game._gameJustStarted = true;
 	}
 }

--- a/flixel/system/frontEnds/VCRFrontEnd.hx
+++ b/flixel/system/frontEnds/VCRFrontEnd.hx
@@ -1,14 +1,15 @@
 package flixel.system.frontEnds;
 
-import openfl.ui.Mouse;
 import flixel.FlxG;
+import openfl.ui.Mouse;
 #if FLX_RECORD
-import openfl.events.Event;
-import openfl.events.IOErrorEvent;
-import openfl.utils.ByteArray;
+import flixel.util.typeLimit.NextState;
 import flixel.FlxState;
 import flixel.input.keyboard.FlxKey;
 import flixel.math.FlxRandom;
+import openfl.events.Event;
+import openfl.events.IOErrorEvent;
+import openfl.utils.ByteArray;
 #if flash
 import openfl.net.FileReference;
 import openfl.net.FileFilter;
@@ -114,28 +115,33 @@ class VCRFrontEnd
 	/**
 	 * Load replay data from a string and play it back.
 	 *
-	 * @param	Data		The replay that you want to load.
-	 * @param	State		Optional parameter: if you recorded a state-specific demo or cutscene, pass a new instance of that state here.
-	 * @param	CancelKeys	Optional parameter: an array of string names of keys (see FlxKeyboard) that can be pressed to cancel the playback, e.g. ["ESCAPE","ENTER"].  Also accepts 2 custom key names: "ANY" and "MOUSE" (fairly self-explanatory I hope!).
-	 * @param	Timeout		Optional parameter: set a time limit for the replay. CancelKeys will override this if pressed.
-	 * @param	Callback	Optional parameter: if set, called when the replay finishes. Running to the end, CancelKeys, and Timeout will all trigger Callback(), but only once, and CancelKeys and Timeout will NOT call FlxG.stopReplay() if Callback is set!
+	 * @param   data        The replay that you want to load.
+	 * @param   state       If you recorded a state-specific demo or cutscene, pass a state
+	 *                      constructor here, just as you would to to `FlxG.switchState`.
+	 * @param   cancelKeys  An array of string names of keys (see `FlxKeyboard`) that can be pressed
+	 *                      to cancel the playback, e.g. `[ESCAPE,ENTER]`.  Also accepts 2 custom
+	 *                      key names: `ANY` and `MOUSE`.
+	 * @param   timeout     Set a time limit for the replay. `cancelKeys` will override this, if pressed.
+	 * @param   callback    If set, called when the replay finishes, any cancel key is pressed, or
+	 *                      if a timeout is triggered. Note: `cancelKeys` and `timeout` will NOT
+	 *                      call `FlxG.stopReplay()` if `callback` is set!
 	 */
-	public function loadReplay(Data:String, ?State:FlxState, ?CancelKeys:Array<FlxKey>, ?Timeout:Float = 0, ?Callback:Void->Void):Void
+	public function loadReplay(data:String, ?state:NextState, ?cancelKeys:Array<FlxKey>, ?timeout:Float = 0, ?callback:Void->Void):Void
 	{
-		FlxG.game._replay.load(Data);
+		FlxG.game._replay.load(data);
 
-		if (State == null)
+		if (state == null)
 		{
 			FlxG.resetGame();
 		}
 		else
 		{
-			FlxG.switchState(State);
+			FlxG.switchState(state);
 		}
 
-		cancelKeys = CancelKeys;
-		timeout = Std.int(Timeout * 1000);
-		replayCallback = Callback;
+		this.cancelKeys = cancelKeys;
+		this.timeout = Std.int(timeout * 1000);
+		replayCallback = callback;
 		FlxG.game._replayRequested = true;
 
 		#if FLX_KEYBOARD

--- a/flixel/util/typeLimit/NextState.hx
+++ b/flixel/util/typeLimit/NextState.hx
@@ -1,0 +1,146 @@
+package flixel.util.typeLimit;
+
+import flixel.FlxState;
+
+/**
+ * A utility type that allows methods to accept multiple types, when dealing with "future" F`lxStates`.
+ * Prior to haxeFlixel 6, `FlxG.switchState` and other similar methods took a `FlxState` instance
+ * which meant FlxStates were instantiated before the previous state was destroyed, potentially
+ * causing errors. It also meant states with args couldn't be reset via FlxG.resetState. In version
+ * 6.0.0 and higher, these methods now take a function that returns a newly created instance. This
+ * allows the state's instantiation to happen after the previous state is destroyed.
+ * 
+ * ## examples:
+ * You can pass the state's contructor in directly:
+ * ```haxe
+ * FlxG.switchState(PlayState.new);
+ * ```
+ * You can use short lambas (arrow functions) that return a newly created instance:
+ * ```haxe
+ * var levelID = 1;
+ * FlxG.switchState(()->new PlayState(levelID));
+ * ```
+ * You can do things the long way, and use an anonymous function:
+ * ```haxe
+ * FlxG.switchState(function () { return new PlayState(); });
+ * ```
+ * [Deprecated] Lastly, you can use the old way and pass in an instance (until it's removed):
+ * ```haxe
+ * FlxG.switchState(new PlayState());
+ * ```
+ * 
+ * @since 6.0.0
+ * @see [HaxeFlixel issue #2541](https://github.com/HaxeFlixel/flixel/issues/2541)
+ */
+abstract NextState(Dynamic)
+{
+	@:from
+	// @:deprecated("use `MyState.new` or `()->new MyState()` instead of `new MyState()`)") // wait until 6.0.0
+	public static function fromState(state:FlxState):NextState
+	{
+		return cast state;
+	}
+	
+	@:from
+	public static function fromMaker(func:()->FlxState):NextState
+	{
+		return cast func;
+	}
+	
+	@:allow(flixel.FlxG.switchState)
+	inline function isInstance():Bool
+	{
+		return this is FlxState;
+	}
+	
+	@:allow(flixel.FlxG.switchState)
+	inline function isClass():Bool
+	{
+		return this is Class;
+	}
+	
+	public function createInstance():FlxState
+	{
+		if (isInstance())
+			return cast this;
+		else if (isClass())
+			return Type.createInstance(this, []);
+		else
+			return cast this();
+	}
+	
+	public function getConstructor():()->FlxState
+	{
+		if (isInstance())
+		{
+			return function ():FlxState
+			{
+				return cast Type.createInstance(Type.getClass(this), []);
+			}
+		}
+		else if (isClass())
+			return function ():FlxState
+			{
+				return cast Type.createInstance(this, []);
+			}
+		else
+			return cast this;
+	}
+}
+
+/**
+ * A utility type that allows methods to accept multiple types, when dealing with "future" `FlxStates`.
+ * Prior to haxeFlixel 6, the `FlxGame` constructor took a `FlxState` class which meant initial
+ `FlxStates`could not have constructor args. In version 6.0.0 and higher, it now takes a function
+ * that returns a newly created instance.
+ * 
+ * ## examples:
+ * You can pass the state's contructor in directly:
+ * ```haxe
+ * FlxG.switchState(PlayState.new);
+ * ```
+ * You can use short lambas (arrow functions) that return a newly created instance:
+ * ```haxe
+ * var levelID = 1;
+ * FlxG.switchState(()->new PlayState(levelID));
+ * ```
+ * You can do things the long way, and use an anonymous function:
+ * ```haxe
+ * FlxG.switchState(function () { return new PlayState(); });
+ * ```
+ * [Deprecated] Lastly, you can use the old way and pass in a type (until it's removed):
+ * ```haxe
+ * FlxG.switchState(PlayState);
+ * ```
+ * 
+ * @since 6.0.0
+ * @see [HaxeFlixel issue #2541](https://github.com/HaxeFlixel/flixel/issues/2541)
+ */
+abstract InitialState(Dynamic) to NextState
+{
+	@:from
+	public static function fromType(state:Class<FlxState>):InitialState
+	{
+		return cast state;
+	}
+	
+	@:from
+	public static function fromMaker(func:()->FlxState):InitialState
+	{
+		return cast func;
+	}
+	
+	@:to
+	public function toNextState():NextState
+	{
+		if (this is Class)
+		{
+			return function ():FlxState
+			{
+				return cast Type.createInstance(this, []);
+			}
+		}
+		else
+			return cast this;
+	}
+}

--- a/flixel/util/typeLimit/NextState.hx
+++ b/flixel/util/typeLimit/NextState.hx
@@ -47,13 +47,13 @@ abstract NextState(Dynamic)
 		return cast func;
 	}
 	
-	@:allow(flixel.FlxG.switchState)
+	@:allow(flixel.FlxG)
 	inline function isInstance():Bool
 	{
 		return this is FlxState;
 	}
 	
-	@:allow(flixel.FlxG.switchState)
+	@:allow(flixel.FlxG)
 	inline function isClass():Bool
 	{
 		return this is Class;

--- a/tests/unit/src/FlxTest.hx
+++ b/tests/unit/src/FlxTest.hx
@@ -1,11 +1,12 @@
 package;
 
-import openfl.errors.Error;
 import flixel.FlxG;
 import flixel.FlxState;
 import flixel.tweens.FlxTween;
-import flixel.util.FlxDestroyUtil.IFlxDestroyable;
+import flixel.util.FlxDestroyUtil;
+import flixel.util.typeLimit.NextState;
 import massive.munit.Assert;
+import openfl.errors.Error;
 
 class FlxTest
 {
@@ -48,7 +49,7 @@ class FlxTest
 		step();
 	}
 
-	function switchState(nextState:FlxState)
+	function switchState(nextState:NextState)
 	{
 		FlxG.switchState(nextState);
 		step();

--- a/tests/unit/src/flixel/FlxStateTest.hx
+++ b/tests/unit/src/flixel/FlxStateTest.hx
@@ -42,7 +42,7 @@ class FlxStateTest extends FlxTest
 		switchState(finalState);
 		Assert.areEqual(finalState, FlxG.state);
 
-		switchState(new FlxState());
+		switchState(FlxState.new);
 		Assert.areEqual(finalState, FlxG.state);
 
 		resetState();
@@ -69,9 +69,10 @@ class FlxStateTest extends FlxTest
 
 class FinalState extends FlxState
 {
-	override function switchTo(nextState:FlxState):Bool
+	/* prevents state switches */
+	override function startOutro(onOutroComplete:()->Void)
 	{
-		return false;
+		// startOutro(onOutroComplete); 
 	}
 }
 

--- a/tests/unit/src/flixel/FlxStateTest.hx
+++ b/tests/unit/src/flixel/FlxStateTest.hx
@@ -16,15 +16,28 @@ class FlxStateTest extends FlxTest
 	@Ignore // TODO: investigate
 	function testSwitchState()
 	{
-		var state = new FlxState();
-
+		final state = new FlxState();
+		
 		Assert.areNotEqual(state, FlxG.state);
 		switchState(state);
 		Assert.areEqual(state, FlxG.state);
+		
+		// Make sure this compiles
+		switchState(FlxState.new);
+		
+		var nextState:FlxState = null;
+		function createState()
+		{
+			return nextState = new FlxState();
+		}
+		
+		Assert.areNotEqual(nextState, FlxG.state);
+		switchState(createState);
+		Assert.areEqual(nextState, FlxG.state);
 	}
 
 	@Test
-	function testResetState()
+	function testResetStateInstance()
 	{
 		var state = new TestState();
 		switchState(state);
@@ -35,11 +48,46 @@ class FlxStateTest extends FlxTest
 		Assert.isTrue((FlxG.state is TestState));
 	}
 
-	@Test // #1676
-	function testCancelStateSwitch()
+	@Test
+	function testResetStateFunction()
 	{
-		var finalState = new FinalState();
+		var nextState:TestState = null;
+		function createState()
+		{
+			return nextState = new TestState();
+		}
+		
+		switchState(createState);
+		Assert.areEqual(nextState, FlxG.state);
+		
+		final oldState = nextState;
+		resetState();
+		Assert.areNotEqual(oldState, FlxG.state);
+		Assert.areEqual(nextState, FlxG.state);
+		Assert.isTrue((FlxG.state is TestState));
+	}
+	
+	@Test // #1676
+	function testCancelStateSwitchInstance()
+	{
+		var finalState = new FinalStateLegacy();
 		switchState(finalState);
+		Assert.areEqual(finalState, FlxG.state);
+
+		switchState(new FlxState());
+		Assert.areEqual(finalState, FlxG.state);
+
+		resetState();
+		Assert.areEqual(finalState, FlxG.state);
+	}
+	
+	@Test // #1676
+	function testCancelStateSwitchFunction()
+	{
+		switchState(FinalState.new);
+		final finalState = FlxG.state;
+
+		switchState(new FlxState());
 		Assert.areEqual(finalState, FlxG.state);
 
 		switchState(FlxState.new);
@@ -64,6 +112,15 @@ class FlxStateTest extends FlxTest
 		step();
 		Assert.areNotEqual(outroState, FlxG.state);
 		
+	}
+}
+
+class FinalStateLegacy extends FlxState
+{
+	/* prevents state switches */
+	override function switchTo(state)
+	{
+		return false;
 	}
 }
 


### PR DESCRIPTION
Softer version of #2733
Allows `()->FlxState` functions to be used in `FlxG.switchState` as well as FlxGame's constructor

When passing function into switchState, the state won't be created the old state is destroyed, meaning there are no longer caveats to creating flixel objects or referencing global tools inside the state's constructor

we still plan to remove `FlxState:switchTo()` in 6.0.0 and deprecate `FlxState` instances in `switchState`, but this will allow us to transition more smoothly