### PR TITLE
Add version compatibility checks to Flixel-Addons and Flixel-UI, bump minimum OpenFL/Lime versions

### DIFF
--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -3,6 +3,10 @@ package flixel.system.macros;
 import haxe.macro.Compiler;
 import haxe.macro.Context;
 import haxe.macro.Expr.Position;
+#if (flixel_addons >= "3.2.2")
+import flixel.addons.system.macros.FlxAddonDefines;
+#end
+
 
 using StringTools;
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -80,17 +80,21 @@ class FlxDefines
 	public static function run()
 	{
 		#if !display
-		checkDependencyCompatibility();
+		checkCompatibility();
 		checkDefines();
 		if (defined("flash"))
 			checkSwfVersion();
 		#end
-
+		
 		defineInversions();
 		defineHelperDefines();
+		
+		#if (flixel_addons >= "3.2.2")
+		flixel.addons.system.macros.FlxAddonDefines.run();
+		#end
 	}
 
-	static function checkDependencyCompatibility()
+	static function checkCompatibility()
 	{
 		#if (haxe < version("4.2.5"))
 		abortVersion("Haxe", "4.2.5 or newer", "haxe_ver", (macro null).pos);
@@ -99,16 +103,20 @@ class FlxDefines
 		#if !nme
 		checkOpenFLVersions();
 		#end
+		
+		#if (flixel_addons < "3.0.2")
+		abortVersion("Flixel Addons", "3.0.2 or newer", "flixel-addons", (macro null).pos);
+		#end
 	}
 
 	static function checkOpenFLVersions()
 	{
-		#if ((lime < "6.3.0") && ((lime < "2.8.1") || (lime >= "3.0.0")))
-		abortVersion("Lime", "6.3.0 or newer and 2.8.1-2.9.1", "lime", (macro null).pos);
+		#if (lime < "8.0.2")
+		abortVersion("Lime", "8.0.2 or newer", "lime", (macro null).pos);
 		#end
 
-		#if ((openfl < "8.0.0") && ((openfl < "3.5.0") || (openfl >= "4.0.0")))
-		abortVersion("OpenFL", "8.0.0 or newer and 3.5.0-3.6.1", "openfl", (macro null).pos);
+		#if (openfl < "9.2.2")
+		abortVersion("OpenFL", "9.2.2 or newer", "openfl", (macro null).pos);
 		#end
 	}
 
@@ -122,14 +130,20 @@ class FlxDefines
 		for (define in HelperDefines.getConstructors())
 			abortIfDefined(define);
 
-		var userDefinable = UserDefines.getConstructors();
 		for (define in Context.getDefines().keys())
 		{
-			if (define.startsWith("FLX_") && userDefinable.indexOf(define) == -1)
+			if (isValidUserDefine(define))
 			{
 				Context.warning('"$define" is not a valid flixel define.', (macro null).pos);
 			}
 		}
+	}
+	
+	static var userDefinable = UserDefines.getConstructors();
+	static function isValidUserDefine(define:String)
+	{
+		return (define.startsWith("FLX_") && userDefinable.indexOf(define) == -1)
+			#if (flixel_addons >= version("3.2.2")) || FlxAddonDefines.isValidUserDefine(define) #end;
 	}
 
 	static function abortIfDefined(define:String)


### PR DESCRIPTION
In order to better communicate and keep track of compatible versions of flixel haxelibs, we need to check versions of flixel-addons and flixel-ui and vice versa. This will run macro functions on flixel-addons and flixel-ui that throw errors when versions are incompatible.

It also raises the minimum version of OpenFL to 9.2.2 and Lime to 8.0.2