### PR TITLE
Fix one-time listener is not removed from FlxSignal on HashLink

### DIFF
--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -133,14 +133,19 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 			var handler = getHandler(listener);
 			if (handler != null)
 			{
-				if (processingListeners)
-					pendingRemove.push(handler);
-				else
-				{
-					handlers.remove(handler);
-					handler.destroy();
-				}
+				removeHandler(handler);
 			}
+		}
+	}
+	
+	inline function removeHandler(handler:FlxSignalHandler<T>):Void
+	{
+		if (processingListeners)
+			pendingRemove.push(handler)
+		else
+		{
+			handlers.remove(handler);
+			handler.destroy();
 		}
 	}
 
@@ -292,14 +297,14 @@ private class Macro
 				handler.listener($a{exprs});
 
 				if (handler.dispatchOnce)
-					remove(handler.listener);
+					removeHandler(handler);
 			}
 
 			processingListeners = false;
 
 			for (handler in pendingRemove)
 			{
-				remove(handler.listener);
+				removeHandler(handler);
 			}
 			if (pendingRemove.length > 0)
 				pendingRemove = [];

--- a/tests/unit/src/flixel/util/FlxSignalTest.hx
+++ b/tests/unit/src/flixel/util/FlxSignalTest.hx
@@ -29,6 +29,9 @@ class FlxSignalTest extends FlxTest
 	function callbackIncrementCounter()
 		counter++;
 
+	function callbackIncrementCounter_Int(v:Int):Void
+		counter++;
+
 	function addAllEmptyCallbacks():Void
 	{
 		signal0.add(callbackEmpty1);
@@ -156,6 +159,20 @@ class FlxSignalTest extends FlxTest
 		signal0.dispatch();
 
 		Assert.areEqual(3, counter);
+	}
+
+	@Test
+	function testDispatchOnce_signal1():Void
+	{
+		// see https://github.com/HaxeFoundation/hashlink/issues/578
+		
+		signal1.addOnce(callbackIncrementCounter_Int);
+		
+		signal1.dispatch(42);
+		signal1.dispatch(42);
+		signal1.dispatch(42);
+		
+		Assert.areEqual(1, counter);
 	}
 
 	@Test


### PR DESCRIPTION
One-time listeners other than `Void->Void` is not removed from signals on HashLink (see https://github.com/HaxeFoundation/hashlink/issues/578 ).

Use updated tests but old FlxSignal to see `addOnce()` does not work as expected on HashLink

```
haxelib run munit gen -filter flixel.util.FlxSignalTest
haxelib run lime test hl

#---
Class: flixel.util.FlxSignalTest .....!..........
    FAIL: massive.munit.AssertionException: Value [3] was not equal to expected value [1] at flixel.util.FlxSignalTest#testDispatchOnce_signal1 (175)
==============================
FAILED
Tests: 16  Passed: 15  Failed: 1 Errors: 0 Ignored: 0 Time: 0.005
```