### PR TITLE
Add interface IFlxObject to FlxObject

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1538,7 +1538,8 @@ enum abstract CollisionDragType(Int)
 	var HEAVIER = 3;
 }
 
-interface IFlxObject extends IFlxBasic {
+interface IFlxObject extends IFlxBasic
+{
 	var x(default, set):Float;
 	var y(default, set):Float;
 

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1,5 +1,6 @@
 package flixel;
 
+import flixel.FlxBasic.IFlxBasic;
 import openfl.display.Graphics;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.math.FlxPoint;
@@ -1535,4 +1536,22 @@ enum abstract CollisionDragType(Int)
 
 	/** Drags when colliding with heavier objects. Immovable objects have infinite mass. */
 	var HEAVIER = 3;
+}
+
+interface IFlxObject extends IFlxBasic {
+	var x(default, set):Float;
+	var y(default, set):Float;
+
+	var angle(default, set):Float;
+	var moves(default, set):Bool;
+	var immovable(default, set):Bool;
+
+	var velocity(default, null):FlxPoint;
+	var maxVelocity(default, null):FlxPoint;
+	var acceleration(default, null):FlxPoint;
+	var drag(default, null):FlxPoint;
+	var scrollFactor(default, null):FlxPoint;
+
+	function reset(X:Float, Y:Float):Void;
+	function setPosition(X:Float = 0, Y:Float = 0):Void;
 }

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1,6 +1,6 @@
 package flixel;
 
-import flixel.FlxBasic.IFlxBasic;
+import flixel.FlxObject.IFlxObject;
 import flixel.animation.FlxAnimationController;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.frames.FlxFrame;
@@ -1651,25 +1651,12 @@ class FlxSprite extends FlxObject
 	}
 }
 
-interface IFlxSprite extends IFlxBasic
+interface IFlxSprite extends IFlxObject
 {
-	var x(default, set):Float;
-	var y(default, set):Float;
 	var alpha(default, set):Float;
-	var angle(default, set):Float;
 	var facing(default, set):FlxDirectionFlags;
-	var moves(default, set):Bool;
-	var immovable(default, set):Bool;
 
 	var offset(default, null):FlxPoint;
 	var origin(default, null):FlxPoint;
 	var scale(default, null):FlxPoint;
-	var velocity(default, null):FlxPoint;
-	var maxVelocity(default, null):FlxPoint;
-	var acceleration(default, null):FlxPoint;
-	var drag(default, null):FlxPoint;
-	var scrollFactor(default, null):FlxPoint;
-
-	function reset(X:Float, Y:Float):Void;
-	function setPosition(X:Float = 0, Y:Float = 0):Void;
 }


### PR DESCRIPTION
Only creates a interface for FlxObjects called ``IFlxObject`` as a middle ground between ``IFlxBasic`` and ``IFlxSprite``