### PR TITLE
FlxCamera updateFollow() framerate consistent lerp fixins

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1278,9 +1278,14 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			scroll.x += (_scrollTarget.x - scroll.x) * followLerp * (60 / FlxG.updateFramerate);
-			scroll.y += (_scrollTarget.y - scroll.y) * followLerp * (60 / FlxG.updateFramerate);
+			scroll.x = cameraLerp(scroll.x, _scrollTarget.x, followLerp);
+			scroll.y = cameraLerp(scroll.y, _scrollTarget.y, followLerp);
 		}
+	}
+
+	function cameraLerp(base:Float, target:Float, ratio:Float):Float
+	{
+		return base + (ratio * (FlxG.elapsed / (1 / 60))) * (target - base);
 	}
 
 	function updateFlash(elapsed:Float):Void


### PR DESCRIPTION
Makes the camera LERP account for the framerate, usually helpful when the game isn't on a fixedTimestep!

This is used in our lil internal FNF FlxCamera stuff.... where really.. the only dedicated part is this!

I made the code use less functions than our internal FNF one does, but it should act the same. 

The following is from FNF code to hopefully explain the math a bit more!
```hx
class MathUtil
{
  /**
   * Perform linear interpolation between the base and the target, based on the current framerate.
   */
  public static function coolLerp(base:Float, target:Float, ratio:Float):Float
  {
    return base + cameraLerp(ratio) * (target - base);
  }

  public static function cameraLerp(lerp:Float):Float
  {
    return lerp * (FlxG.elapsed / (1 / 60)); // Multiply the lerp by the potential framerate.
    
   // At 60fps, FlxG.elapsed should == (1 / 60), so it would be lerp * 1
   //
   // At 30fps FlxG.elapsed should be DOUBLE of 1 / 60 (since each frame takes LONGER), 
   // so it would be lerp * 2. Which is what we want since the camera should move FASTER to catch up from the lag
   // 
   // At something like 120fps FlxG.elapsed should be HALF of 1 / 60 (since each frame is SHORTER)
   // so it would be lerp * 0.5. Which is what we want since at higher framerate would mean the lerp goes faster than intended!
    
  }
}
```

`SwagCamera.hx` from FNF source code (just extends FlxCamera and changes `updateFollow()` in a similar way as this PR!
```hx
scroll.x = MathUtil.coolLerp(scroll.x, _scrollTarget.x, followLerp);
scroll.y = MathUtil.coolLerp(scroll.y, _scrollTarget.y, followLerp);
```

All of this shouldn't affect existing FlxCamera related lerp code (HF runs at fixedTimestep at 60fps by default), UNLESS someone specifically found their own high/low fps work around to camera lerping 