### PR TITLE
Allow flxspritegroup to follow a path

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -208,6 +208,9 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		group.update(elapsed);
 
+		if (path != null && path.active)
+			path.update(elapsed);
+
 		if (moves)
 			updateMotion(elapsed);
 	}


### PR DESCRIPTION
Currently, if you set the path property on a FlxSpriteGroup and then call path.start() it will not follow the path.
The desired behaviour is that it follow the path as a regular FlxSprite does.

It turns out that this is due to the fact that the FlxSpriteGroup update() method does not call super.update() and also does not call path.update(). The fix is to add :

```
		if (path != null && path.active)
			path.update(elapsed);
```
to the update() method. This is what this PR does. I don't have a test right now, but I'm happy to try to add one if this change is in principle ok.