### PR TITLE
use DynamicAccess instead of Hash<T>

### DIFF
--- a/flixel/graphics/atlas/AtlasBase.hx
+++ b/flixel/graphics/atlas/AtlasBase.hx
@@ -1,5 +1,7 @@
 package flixel.graphics.atlas;
 
+import haxe.DynamicAccess;
+
 typedef AtlasBase<T> =
 {
 	frames:T
@@ -62,23 +64,4 @@ typedef AtlasFrame =
 	var spriteSourceSize:AtlasRect;
 }
 
-/**
- * Internal helper used to enumerate the fields of an atlas that has frame data keyed by frame names.
- */
-abstract Hash<T>(Dynamic)
-{
-	public inline function keyValueIterator():KeyValueIterator<String, T>
-	{
-		var keys = Reflect.fields(this).iterator();
-		return {
-			hasNext: keys.hasNext,
-			next: () ->
-			{
-				final key = keys.next();
-				return {key: key, value: Reflect.field(this, key)};
-			}
-		};
-	}
-}
-
-typedef HashOrArray<T> = flixel.util.typeLimit.OneOfTwo<AtlasBase.Hash<T>, Array<T>>;
+typedef HashOrArray<T> = flixel.util.typeLimit.OneOfTwo<DynamicAccess<T>, Array<T>>;

--- a/flixel/graphics/atlas/AtlasBase.hx
+++ b/flixel/graphics/atlas/AtlasBase.hx
@@ -64,4 +64,35 @@ typedef AtlasFrame =
 	var spriteSourceSize:AtlasRect;
 }
 
-typedef HashOrArray<T> = flixel.util.typeLimit.OneOfTwo<DynamicAccess<T>, Array<T>>;
+abstract HashOrArray<T>(Dynamic) from DynamicAccess<T> from Array<T>
+{
+	public inline function isArray()
+	{
+		return (this is Array);
+	}
+	
+	public inline function isHash()
+	{
+		return !isArray();
+	}
+	
+	@:to
+	public inline function toArray():Array<T>
+	{
+		return this;
+	}
+	
+	@:to
+	public inline function toHash():DynamicAccess<T>
+	{
+		return this;
+	}
+	
+	public inline function iterator():Iterator<T>
+	{
+		if (isArray())
+			return toArray().iterator();
+		else
+			return toHash().iterator();
+	}
+}

--- a/flixel/graphics/atlas/TexturePackerAtlas.hx
+++ b/flixel/graphics/atlas/TexturePackerAtlas.hx
@@ -7,6 +7,6 @@ typedef TexturePackerAtlasFrame = AtlasFrame &
 	?duration:Int
 }
 
-typedef TexturePackerAtlasHash = AtlasBase<AtlasBase.Hash<TexturePackerAtlasFrame>>;
+typedef TexturePackerAtlasHash = AtlasBase<haxe.DynamicAccess<TexturePackerAtlasFrame>>;
 typedef TexturePackerAtlas = AtlasBase<HashOrArray<TexturePackerAtlasFrame>>;
 typedef TexturePackerAtlasArray = AtlasBase<Array<TexturePackerAtlasFrame>>;

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -9,7 +9,6 @@ import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import haxe.xml.Access;
-import haxe.DynamicAccess;
 import openfl.Assets;
 import openfl.geom.Rectangle;
 

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -9,6 +9,7 @@ import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import haxe.xml.Access;
+import haxe.DynamicAccess;
 import openfl.Assets;
 import openfl.geom.Rectangle;
 
@@ -92,7 +93,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		// JSON-Hash
 		else
 		{
-			final frameHash:Hash<TexturePackerAtlasFrame> = data.frames;
+			final frameHash:DynamicAccess<TexturePackerAtlasFrame> = data.frames;
 			for (name=>frame in frameHash)
 				texturePackerHelper(name, frame, frames, useFrameDuration);
 		}

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -82,19 +82,16 @@ class FlxAtlasFrames extends FlxFramesCollection
 		frames = new FlxAtlasFrames(graphic);
 
 		final data:TexturePackerAtlas = description.getData();
-
 		// JSON-Array
-		if (data.frames is Array)
+		if (data.frames.isArray())
 		{
-			final frameArray:Array<TexturePackerAtlasFrame> = data.frames;
-			for (frame in frameArray)
+			for (frame in data.frames.toArray())
 				texturePackerHelper(frame.filename, frame, frames, useFrameDuration);
 		}
 		// JSON-Hash
 		else
 		{
-			final frameHash:DynamicAccess<TexturePackerAtlasFrame> = data.frames;
-			for (name=>frame in frameHash)
+			for (name=>frame in data.frames.toHash())
 				texturePackerHelper(name, frame, frames, useFrameDuration);
 		}
 


### PR DESCRIPTION
The `Hash<T>` type was essentially a bad implementation of haxe's [DynamicAccess<T>](https://api.haxe.org/haxe/DynamicAccess.html), this shouldn't be any faster but it's more typesafe and simpler to read