### PR TITLE
avoid division by zero in QuadPath (issue #2958)

### DIFF
--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -212,8 +212,8 @@ class QuadPath extends Motion
 			
 		p1.x = start.x - 2 * safeControl.x + finish.x;
 		p1.y = start.y - 2 * safeControl.y + finish.y;
-		p2.x = 2 * control.x - 2 * start.x;
-		p2.y = 2 * control.y - 2 * start.y;
+		p2.x = 2 * safeControl.x - 2 * start.x;
+		p2.y = 2 * safeControl.y - 2 * start.y;
 		var a:Float = 4 * (p1.x * p1.x + p1.y * p1.y),
 			b:Float = 4 * (p1.x * p2.x + p1.y * p2.y),
 			c:Float = p2.x * p2.x + p2.y * p2.y,

--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -1,5 +1,6 @@
 package flixel.tweens.motion;
 
+import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.tweens.FlxTween.FlxTweenManager;
 import flixel.tweens.FlxTween.TweenOptions;
@@ -199,11 +200,18 @@ class QuadPath extends Motion
 
 	function getCurveLength(start:FlxPoint, control:FlxPoint, finish:FlxPoint):Float
 	{
+		var safeControl = control.clone();
 		var p1 = FlxPoint.get();
 		var p2 = FlxPoint.get();
 
-		p1.x = start.x - 2 * control.x + finish.x;
-		p1.y = start.y - 2 * control.y + finish.y;
+		if (safeControl.equals(start))
+			safeControl.add(FlxMath.EPSILON, FlxMath.EPSILON);
+			
+		if (safeControl.equals(finish))
+			safeControl.add(FlxMath.EPSILON, FlxMath.EPSILON);
+			
+		p1.x = start.x - 2 * safeControl.x + finish.x;
+		p1.y = start.y - 2 * safeControl.y + finish.y;
 		p2.x = 2 * control.x - 2 * start.x;
 		p2.y = 2 * control.y - 2 * start.y;
 		var a:Float = 4 * (p1.x * p1.x + p1.y * p1.y),
@@ -213,14 +221,12 @@ class QuadPath extends Motion
 			a2:Float = Math.sqrt(a),
 			a32:Float = 2 * a * a2,
 			c2:Float = 2 * Math.sqrt(c),
-			ba:Float = (a2 == 0) ? b / 0.00001 : b / a2,
-			bac2:Float = ((ba + c2) == 0) ? 0.00001 : ba + c2,
-			a32denom:Float = (a32 == 0) ? 0.00001 : a32;
-
+			ba:Float = b / a2;
 
 		p1.put();
 		p2.put();
+		safeControl.put();
 
-		return (a32 * abc + a2 * b * (abc - c2) + (4 * c * a - b * b) * Math.log((2 * a2 + ba + abc) / (bac2))) / (4 * a32denom);
+		return (a32 * abc + a2 * b * (abc - c2) + (4 * c * a - b * b) * Math.log((2 * a2 + ba + abc) / (ba + c2))) / (4 * a32);
 	}
 }

--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -213,11 +213,14 @@ class QuadPath extends Motion
 			a2:Float = Math.sqrt(a),
 			a32:Float = 2 * a * a2,
 			c2:Float = 2 * Math.sqrt(c),
-			ba:Float = b / a2;
+			ba:Float = (a2 == 0) ? 0.00001 : b / a2,
+			bac2:Float = (ba == c2) ? 0.00001 : ba + c2,
+			a32denom:Float = (a32 == 0) ? 0.0001 : a32;
+
 
 		p1.put();
 		p2.put();
 
-		return (a32 * abc + a2 * b * (abc - c2) + (4 * c * a - b * b) * Math.log((2 * a2 + ba + abc) / (ba + c2))) / (4 * a32);
+		return (a32 * abc + a2 * b * (abc - c2) + (4 * c * a - b * b) * Math.log((2 * a2 + ba + abc) / (bac2))) / (4 * a32denom);
 	}
 }

--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -204,6 +204,8 @@ class QuadPath extends Motion
 		var p1 = FlxPoint.get();
 		var p2 = FlxPoint.get();
 
+		// we add a small quantity if two consecutive points are equal
+		// otherwise the final equation will have a division by zero
 		if (safeControl.equals(start))
 			safeControl.add(FlxMath.EPSILON, FlxMath.EPSILON);
 			

--- a/flixel/tweens/motion/QuadPath.hx
+++ b/flixel/tweens/motion/QuadPath.hx
@@ -213,9 +213,9 @@ class QuadPath extends Motion
 			a2:Float = Math.sqrt(a),
 			a32:Float = 2 * a * a2,
 			c2:Float = 2 * Math.sqrt(c),
-			ba:Float = (a2 == 0) ? 0.00001 : b / a2,
-			bac2:Float = (ba == c2) ? 0.00001 : ba + c2,
-			a32denom:Float = (a32 == 0) ? 0.0001 : a32;
+			ba:Float = (a2 == 0) ? b / 0.00001 : b / a2,
+			bac2:Float = ((ba + c2) == 0) ? 0.00001 : ba + c2,
+			a32denom:Float = (a32 == 0) ? 0.00001 : a32;
 
 
 		p1.put();


### PR DESCRIPTION
Changes some variables value from zero to a really small value when used as denominator.