### PR TITLE
Allow to use async images that was already loaded

### DIFF
--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -276,7 +276,7 @@ class FlxAssets
 	public static inline function getBitmapData(id:String):BitmapData
 	{
 		if (Assets.exists(id))
-			return Assets.getBitmapData(id, false);
+			return Assets.getBitmapData(id, true);
 		FlxG.log.error('Could not find a BitmapData asset with ID \'$id\'.');
 		return null;
 	}


### PR DESCRIPTION
When I want to use async assets
```xml
<assets path="assets" embed="false" preload="false"/>
```
```haxe
openfl.Assets.loadBitmapData(asset_id, true).onComplete(bd ->
{
	trace('image is loaded');
	FlxAssets.getBitmapData(asset_id);
});
```
I get this 
```
image is loaded
ERROR: IMAGE asset "asset.png" exists, but only asynchronously'
```
because Flixel doesn't use cache when it gets bmd from openfl assets for some reason, I believe it is a bug.

--- update

example is valid for html5