### PR TITLE
Added `letterSpacing` variable to `FlxText`.

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -66,7 +66,7 @@ class FlxText extends FlxSprite
 	 *
 	 * The default value is `null`, which means that 0 pixels of letter spacing is used.
 	 */
-	public var spacing(default, set):Null<Float> = null;
+	public var letterSpacing(default, set):Null<Float> = null;
 
 	/**
 	 * The font used for this text (assuming that it's using embedded font).
@@ -649,9 +649,9 @@ class FlxText extends FlxSprite
 		return Size;
 	}
 
-	function set_spacing(Spacing:Null<Float>):Null<Float>
+	function set_letterSpacing(LetterSpacing:Null<Float>):Null<Float>
 	{
-		_defaultFormat.letterSpacing = Spacing;
+		_defaultFormat.letterSpacing = LetterSpacing;
 		updateDefaultFormat();
 		return Spacing;
 	}

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -63,10 +63,8 @@ class FlxText extends FlxSprite
 	 * A number representing the amount of space that is uniformly distributed
 	 * between all characters. The value specifies the number of pixels that are
 	 * added to the advance after each character.
-	 *
-	 * The default value is `null`, which means that 0 pixels of letter spacing is used.
 	 */
-	public var letterSpacing(default, set):Null<Float> = null;
+	public var letterSpacing(get, set):Float;
 
 	/**
 	 * The font used for this text (assuming that it's using embedded font).
@@ -649,7 +647,12 @@ class FlxText extends FlxSprite
 		return Size;
 	}
 
-	function set_letterSpacing(LetterSpacing:Null<Float>):Null<Float>
+	inline function get_letterSpacing():Float
+	{
+		return _defaultFormat.letterSpacing;
+	}
+
+	function set_letterSpacing(LetterSpacing:Float):Float
 	{
 		_defaultFormat.letterSpacing = LetterSpacing;
 		updateDefaultFormat();

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -60,6 +60,15 @@ class FlxText extends FlxSprite
 	public var size(get, set):Int;
 
 	/**
+	 * A number representing the amount of space that is uniformly distributed
+	 * between all characters. The value specifies the number of pixels that are
+	 * added to the advance after each character.
+	 *
+	 * The default value is `null`, which means that 0 pixels of letter spacing is used.
+	 */
+	public var spacing(default, set):Null<Float> = null;
+
+	/**
 	 * The font used for this text (assuming that it's using embedded font).
 	 */
 	public var font(get, set):String;
@@ -638,6 +647,13 @@ class FlxText extends FlxSprite
 		_defaultFormat.size = Size;
 		updateDefaultFormat();
 		return Size;
+	}
+
+	function set_spacing(Spacing:Null<Float>):Null<Float>
+	{
+		_defaultFormat.letterSpacing = Spacing;
+		updateDefaultFormat();
+		return Spacing;
 	}
 
 	override function set_color(Color:FlxColor):Int

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -226,6 +226,7 @@ class FlxText extends FlxSprite
 		textField.multiline = true;
 		textField.wordWrap = true;
 		_defaultFormat = new TextFormat(null, Size, 0xffffff);
+		letterSpacing = 0;
 		font = FlxAssets.FONT_DEFAULT;
 		_formatAdjusted = new TextFormat();
 		textField.defaultTextFormat = _defaultFormat;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -653,7 +653,7 @@ class FlxText extends FlxSprite
 	{
 		_defaultFormat.letterSpacing = LetterSpacing;
 		updateDefaultFormat();
-		return Spacing;
+		return LetterSpacing;
 	}
 
 	override function set_color(Color:FlxColor):Int


### PR DESCRIPTION
Adds access to openfl's letterSpacing in FlxText instances.

related issue, letterSpacing doesn't work on html5 - https://github.com/openfl/openfl/issues/1700