### PR TITLE
Fix negative animation frame number

### DIFF
--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -4,6 +4,7 @@ import openfl.display.BitmapData;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
 import flixel.graphics.FlxGraphic;
+import flixel.math.FlxMath;
 import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
@@ -54,7 +55,7 @@ class FlxFrame implements IFlxDestroyable
 		if (num2 == null)
 			num2 = 0;
 
-		return Math.abs(num1) - Math.abs(num2);
+		return FlxMath.absInt(num1) - FlxMath.absInt(num2);
 	}
 
 	public var name:String;

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -54,7 +54,7 @@ class FlxFrame implements IFlxDestroyable
 		if (num2 == null)
 			num2 = 0;
 
-		return num1 - num2;
+		return Math.abs(num1) - Math.abs(num2);
 	}
 
 	public var name:String;


### PR DESCRIPTION
I got in the situation when animations play backwards despite in aseprite editor they are clearly normal. The reason was that I used format for exported frames like this `bla-bla-{frame}` and prefix to add the anim like `bla-bla`. With this combination the frames are treated as negative integers, which results with reversed frame order. 

I think there is no such thing as "negative frame numbers" in spritesheet animations, so here is the fix.