### PR TITLE
Honor scale in FlxBitmapText width and height, add setCharFrame

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -285,7 +285,7 @@ class FlxBitmapText extends FlxSprite
 		super.updateHitbox();
 	}
 
-	inline function checkPendingChanges(useTiles:Bool = false):Void
+	function checkPendingChanges(useTiles:Bool = false):Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -1269,6 +1269,8 @@ class FlxBitmapText extends FlxSprite
 
 	function updatePixels(useTiles:Bool = false):Void
 	{
+		pendingPixelsChange = false;
+
 		var colorForFill:Int = background ? backgroundColor : FlxColor.TRANSPARENT;
 		var bitmap:BitmapData = null;
 
@@ -1306,12 +1308,12 @@ class FlxBitmapText extends FlxSprite
 				textDrawData.splice(0, textDrawData.length);
 				borderDrawData.splice(0, borderDrawData.length);
 			}
-
-			width = frameWidth;
-			height = frameHeight;
-
-			origin.x = frameWidth * 0.5;
-			origin.y = frameHeight * 0.5;
+			
+			// use local var to avoid get_width and recursion
+			final newWidth = width = Math.abs(scale.x) * frameWidth;
+			final newHeight = height = Math.abs(scale.y) * frameHeight;
+			offset.set(-0.5 * (newWidth - frameWidth), -0.5 * (newHeight - frameHeight));
+			centerOrigin();
 		}
 
 		if (!useTiles)
@@ -1410,8 +1412,9 @@ class FlxBitmapText extends FlxSprite
 		{
 			dirty = true;
 		}
-
-		pendingPixelsChange = false;
+		
+		if (pendingPixelsChange)
+			throw "pendingPixelsChange was changed to true while processing changed pixels";
 	}
 
 	function drawText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData, useTiles:Bool = false):Void


### PR DESCRIPTION
1. Adds setCharFrame to allow the adjustment of char frames after it's created, all the methods in FlxBitmapFont are private making it hard to make custom fonts via code, example, currently I have the following code in a project:
```hx
static function createFont()
{
	final font = FlxBitmapFont.fromMonospace(AssetPaths.font__png, "", new FlxPoint(8, 8));
	
	final chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ!";
	final widths = ['I'.code=>3, '!'.code=>3, 'T'.code=>7];
	var x:Int = 0;
	for (i in 0...chars.length)
	{
		final charCode = chars.charCodeAt(i);
		final width = widths.exists(charCode) ? widths[charCode] : 8;
		final frame = FlxRect.get(x, 0, width, 8);
		@:privateAccess
		font.addCharFrame(charCode, frame, FlxPoint.weak(), width);
		x += width;
	}
	return font;
}
```
I shouldn't need to use @:privateAccess to adjust a few chars. We could add a new arg to fromMonospace (or make a new func) that takes a map of widths and a default width, but we should really expose some of these methods, anyway

2. when you scale up a bitmap text and call updateHitbox the width/height is set to the correct value, but anytime you change something it gets set back to the frameWidth/frameHeight. This will honor scale whenever it sets width and height. Ideally it shouldn't set width and height ever, only frameWidth and frameHeight because w/h are used for collision but thats an old ass problem I don't want to fix now