### PR TITLE
Add FlxTimer.wait and FlxTimer.loop

### DIFF
--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -24,15 +24,27 @@ class FlxTimer implements IFlxDestroyable
 	/**
 	 * Handy tool to create and start a `FlxTimer`
 	 * @param   time        The duration of the timer, in seconds. If `0` then `onComplete`
+	 *                      fires on the next game update.
+	 * @param   onComplete  Triggered whenever the time runs out
+	 * @return  The `FlxTimer` instance
+	 */
+	public static inline function wait(time:Float, onComplete:()->Void)
+	{
+		return new FlxTimer().start(time, (_)->onComplete());
+	}
+	
+	/**
+	 * Handy tool to create and start a `FlxTimer`
+	 * @param   time        The duration of the timer, in seconds. If `0` then `onComplete`
 	 *                      fires on the next game update, and the `loops` argument is ignored.
-	 * @param   onComplete  Optional, triggered whenever the time runs out, once for each loop.
-	 *                      Callback should be formed `onTimer(Timer:FlxTimer);`
+	 * @param   onComplete  triggered whenever the time runs out, once for each loop.
+	 *                      Should take a single `Int` arg representing the number of completed loops
 	 * @param   loops       How many times the timer should go off. `0` means "looping forever".
 	 * @return  The `FlxTimer` instance
 	 */
-	public static inline function wait(time:Float, onComplete:(FlxTimer)->Void, loops = 1)
+	public static inline function loop(time:Float, onComplete:(loop:Int)->Void, loops:Int)
 	{
-		return new FlxTimer().start(time, onComplete, loops);
+		return new FlxTimer().start(time, (t)->onComplete(loops - t.loopsLeft), loops);
 	}
 	
 	/**

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -30,7 +30,7 @@ class FlxTimer implements IFlxDestroyable
 	 * @param   loops       How many times the timer should go off. `0` means "looping forever".
 	 * @return  The `FlxTimer` instance
 	 */
-	public static inline function wait(time:Float, callback:(FlxTimer)->Void, loops = 1)
+	public static inline function wait(time:Float, onComplete:(FlxTimer)->Void, loops = 1)
 	{
 		return new FlxTimer().start(time, onComplete, loops);
 	}

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -22,6 +22,20 @@ import flixel.util.FlxDestroyUtil.IFlxDestroyable;
 class FlxTimer implements IFlxDestroyable
 {
 	/**
+	 * Handy tool to create and start a `FlxTimer`
+	 * @param   time        The duration of the timer, in seconds. If `0` then `onComplete`
+	 *                      fires on the next game update, and the `loops` argument is ignored.
+	 * @param   onComplete  Optional, triggered whenever the time runs out, once for each loop.
+	 *                      Callback should be formed `onTimer(Timer:FlxTimer);`
+	 * @param   loops       How many times the timer should go off. `0` means "looping forever".
+	 * @return  The `FlxTimer` instance
+	 */
+	public static inline function wait(time:Float, callback:(FlxTimer)->Void, loops = 1)
+	{
+		return new FlxTimer().start(time, onComplete, loops);
+	}
+	
+	/**
 	 * The global timer manager that handles global timers
 	 * @since 4.2.0
 	 */
@@ -115,14 +129,14 @@ class FlxTimer implements IFlxDestroyable
 	/**
 	 * Starts the timer and adds the timer to the timer manager.
 	 *
-	 * @param   time        How many seconds it takes for the timer to go off.
-	 *                      If 0 then timer will fire OnComplete callback only once at the first call of update method (which means that Loops argument will be ignored).
+	 * @param   time        The duration of the timer, in seconds. If `0` then `onComplete`
+	 *                      fires on the next game update, and the `loops` argument is ignored.
 	 * @param   onComplete  Optional, triggered whenever the time runs out, once for each loop.
-	 *                      Callback should be formed "onTimer(Timer:FlxTimer);"
+	 *                      Callback should be formed `onTimer(Timer:FlxTimer);`
 	 * @param   loops       How many times the timer should go off. 0 means "looping forever".
 	 * @return  A reference to itself (handy for chaining or whatever).
 	 */
-	public function start(time:Float = 1, ?onComplete:FlxTimer->Void, loops:Int = 1):FlxTimer
+	public function start(time:Float = 1, ?onComplete:(FlxTimer)->Void, loops:Int = 1):FlxTimer
 	{
 		if (manager != null && !_inManager)
 		{

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -80,10 +80,9 @@ class FlxTimer implements IFlxDestroyable
 	public var finished:Bool = false;
 
 	/**
-	 * Function that gets called when timer completes.
-	 * Callback should be formed "onTimer(Timer:FlxTimer);"
+	 * Called when timer completes. The function header should be `(timer:FlxTimer)`
 	 */
-	public var onComplete:FlxTimer->Void;
+	public var onComplete:(FlxTimer)->Void;
 
 	/**
 	 * Read-only: check how much time is left on the timer.
@@ -144,7 +143,7 @@ class FlxTimer implements IFlxDestroyable
 	 * @param   time        The duration of the timer, in seconds. If `0` then `onComplete`
 	 *                      fires on the next game update, and the `loops` argument is ignored.
 	 * @param   onComplete  Optional, triggered whenever the time runs out, once for each loop.
-	 *                      Callback should be formed `onTimer(Timer:FlxTimer);`
+	 *                      The function header should be `(timer:FlxTimer)`
 	 * @param   loops       How many times the timer should go off. 0 means "looping forever".
 	 * @return  A reference to itself (handy for chaining or whatever).
 	 */

--- a/flixel/util/FlxTimer.hx
+++ b/flixel/util/FlxTimer.hx
@@ -44,7 +44,7 @@ class FlxTimer implements IFlxDestroyable
 	 */
 	public static inline function loop(time:Float, onComplete:(loop:Int)->Void, loops:Int)
 	{
-		return new FlxTimer().start(time, (t)->onComplete(loops - t.loopsLeft), loops);
+		return new FlxTimer().start(time, (t)->onComplete(t.elapsedLoops), loops);
 	}
 	
 	/**

--- a/tests/unit/src/flixel/util/FlxTimerTest.hx
+++ b/tests/unit/src/flixel/util/FlxTimerTest.hx
@@ -18,8 +18,9 @@ class FlxTimerTest extends FlxTest
 	{
 		var calledBack:Bool = false;
 		timer.start(0, function(_) calledBack = true);
+		
+		Assert.isFalse(calledBack);
 		step();
-
 		Assert.isTrue(calledBack);
 	}
 
@@ -66,5 +67,29 @@ class FlxTimerTest extends FlxTest
 		// make sure these timers were updated
 		Assert.isTrue(timer2.progress > 0);
 		Assert.isTrue(timer3.progress > 0);
+	}
+	
+	@Test
+	function testWait()
+	{
+		var calledBack = false;
+		function onComplete() { calledBack = true; }
+		final timer1 = FlxTimer.wait(2/60, onComplete);
+		final timer2 = FlxTimer.wait(0.0001, timer1.cancel);
+		
+		step(3);
+		Assert.isTrue(timer1.finished && calledBack);
+	}
+	
+	@Test
+	function testLoop()
+	{
+		var calledBack = false;
+		function onComplete(n) { calledBack = true; }
+		final timer1 = FlxTimer.loop(2/60, onComplete, 0);
+		final timer2 = FlxTimer.loop(0.0001, (loop)->{ if (loop == 3) timer1.cancel(); }, 3);
+		
+		step(3);
+		Assert.isTrue(timer1.finished && calledBack);
 	}
 }


### PR DESCRIPTION
Rather than doing 
```hx
var timer = new FlxTimer().start(duration, (timer:FlxTimer)->onTimerComplete());
```
can do
```hx
var timer = FlxTimer.wait(duration, onTimerComplete);
```
similarly instead of 
```hx
var timer = new FlxTimer().start(duration, (timer:FlxTimer)->trace('${timer.elapsedLoops} loops'), 10);
```
can do
```hx
FlxTimer.loop(duration, (loops:Int)->trace('$loops loops'), 10);
```