### PR TITLE
prevent double sound destroy

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -114,9 +114,16 @@ class FlxSound extends FlxBasic
 	public var length(get, never):Float;
 	
 	/**
-	 * The sound group this sound belongs to
+	 * The sound group this sound belongs to, can only be in one group.
+	 * NOTE: This setter is deprecated, use `group.add(sound)` or `group.remove(sound)`.
 	 */
-	public var group(default, set):FlxSoundGroup;
+	public var group(get, set):FlxSoundGroup;
+	
+	/**
+	 * The sound group this sound belongs to. This is a temporary proxy for group, until it is removed
+	 */
+	@:allow(flixel.sound.FlxSoundGroup)
+	var _group:FlxSoundGroup;
 	
 	/**
 	 * Whether or not this sound should loop.
@@ -707,24 +714,31 @@ class FlxSound extends FlxBasic
 	}
 	#end
 	
-	function set_group(group:FlxSoundGroup):FlxSoundGroup
+	// Will be removed in a major version, and become a simple `(default,null)` var
+	inline function get_group():FlxSoundGroup
 	{
-		if (this.group != group)
+		return _group;
+	}
+	
+	@:deprecated("sound.group = myGroup is deprecated, use myGroup.add(sound)") // 5.7.0
+	function set_group(value:FlxSoundGroup):FlxSoundGroup
+	{
+		if (_group != value)
 		{
-			var oldGroup:FlxSoundGroup = this.group;
+			final oldGroup = _group;
 			
 			// New group must be set before removing sound to prevent infinite recursion
-			this.group = group;
+			_group = value;
 			
 			if (oldGroup != null)
 				oldGroup.remove(this);
 				
-			if (group != null)
-				group.add(this);
-				
+			if (value != null)
+				value.add(this);
+			
 			updateTransform();
 		}
-		return group;
+		return value;
 	}
 	
 	inline function get_playing():Bool

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -117,13 +117,7 @@ class FlxSound extends FlxBasic
 	 * The sound group this sound belongs to, can only be in one group.
 	 * NOTE: This setter is deprecated, use `group.add(sound)` or `group.remove(sound)`.
 	 */
-	public var group(get, set):FlxSoundGroup;
-	
-	/**
-	 * The sound group this sound belongs to. This is a temporary proxy for group, until it is removed
-	 */
-	@:allow(flixel.sound.FlxSoundGroup)
-	var _group:FlxSoundGroup;
+	public var group(default, set):FlxSoundGroup;
 	
 	/**
 	 * Whether or not this sound should loop.
@@ -714,29 +708,18 @@ class FlxSound extends FlxBasic
 	}
 	#end
 	
-	// Will be removed in a major version, and become a simple `(default,null)` var
-	inline function get_group():FlxSoundGroup
-	{
-		return _group;
-	}
-	
 	@:deprecated("sound.group = myGroup is deprecated, use myGroup.add(sound)") // 5.7.0
 	function set_group(value:FlxSoundGroup):FlxSoundGroup
 	{
-		if (_group != value)
+		if (value != null)
 		{
-			final oldGroup = _group;
-			
-			// New group must be set before removing sound to prevent infinite recursion
-			_group = value;
-			
-			if (oldGroup != null)
-				oldGroup.remove(this);
-				
-			if (value != null)
-				value.add(this);
-			
-			updateTransform();
+			// add to new group, also removes from prev and calls updateTransform
+			value.add(this);
+		}
+		else
+		{
+			// remove from prev group, also calls updateTransform
+			group.remove(this);
 		}
 		return value;
 	}

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -252,6 +252,10 @@ class FlxSound extends FlxBasic
 	
 	override public function destroy():Void
 	{
+		// Prevents double destroy
+		if (group != null)
+			group.remove(this);
+		
 		_transform = null;
 		exists = false;
 		active = false;

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -25,16 +25,20 @@ class FlxSoundGroup
 	}
 
 	/**
-	 * Add a sound to this group
+	 * Add a sound to this group, will remove the sound from any group it is currently in
 	 * @param	sound The sound to add to this group
 	 * @return True if sound was successfully added, false otherwise
 	 */
 	public function add(sound:FlxSound):Bool
 	{
-		if (sounds.indexOf(sound) < 0)
+		if (!sounds.contains(sound))
 		{
+			if (sound._group != null)
+				sound._group.sounds.remove(sound);
+			
 			sounds.push(sound);
-			sound.group = this;
+			sound._group = this;
+			sound.updateTransform();
 			return true;
 		}
 		return false;
@@ -47,10 +51,12 @@ class FlxSoundGroup
 	 */
 	public function remove(sound:FlxSound):Bool
 	{
-		if (sounds.indexOf(sound) >= 0)
+		if (sounds.contains(sound))
 		{
-			sound.group = null;
-			return sounds.remove(sound);
+			sound._group = null;
+			sounds.remove(sound);
+			sound.updateTransform();
+			return true;
 		}
 		return false;
 	}

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -33,11 +33,13 @@ class FlxSoundGroup
 	{
 		if (!sounds.contains(sound))
 		{
-			if (sound._group != null)
-				sound._group.sounds.remove(sound);
+			// remove from prev group
+			if (sound.group != null)
+				sound.group.sounds.remove(sound);
 			
 			sounds.push(sound);
-			sound._group = this;
+			@:bypassAccessor
+			sound.group = this;
 			sound.updateTransform();
 			return true;
 		}
@@ -53,7 +55,8 @@ class FlxSoundGroup
 	{
 		if (sounds.contains(sound))
 		{
-			sound._group = null;
+			@:bypassAccessor
+			sound.group = null;
 			sounds.remove(sound);
 			sound.updateTransform();
 			return true;

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -106,6 +106,9 @@ class SoundFrontEnd
 	 */
 	public function playMusic(embeddedMusic:FlxSoundAsset, volume = 1.0, looped = true, ?group:FlxSoundGroup):Void
 	{
+		if (group == null)
+			group = defaultMusicGroup;
+		
 		if (music == null)
 		{
 			music = new FlxSound();
@@ -114,11 +117,11 @@ class SoundFrontEnd
 		{
 			music.stop();
 		}
-
+		
 		music.loadEmbedded(embeddedMusic, looped);
 		music.volume = volume;
 		music.persist = true;
-		music.group = (group == null) ? defaultMusicGroup : group;
+		group.add(music);
 		music.play();
 	}
 
@@ -180,14 +183,15 @@ class SoundFrontEnd
 
 	function loadHelper(sound:FlxSound, volume:Float, group:FlxSoundGroup, autoPlay = false):FlxSound
 	{
+		if (group == null)
+			group = defaultSoundGroup;
+		
 		sound.volume = volume;
-
+		group.add(sound);
+		
 		if (autoPlay)
-		{
 			sound.play();
-		}
-
-		sound.group = (group == null) ? defaultSoundGroup : group;
+		
 		return sound;
 	}
 

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -308,7 +308,7 @@ class SoundFrontEnd
 	{
 		if (music != null && (forceDestroy || !music.persist))
 		{
-			destroySound(music);
+			music.destroy();
 			music = null;
 		}
 
@@ -316,16 +316,9 @@ class SoundFrontEnd
 		{
 			if (sound != null && (forceDestroy || !sound.persist))
 			{
-				destroySound(sound);
+				sound.destroy();
 			}
 		}
-	}
-
-	function destroySound(sound:FlxSound):Void
-	{
-		defaultMusicGroup.remove(sound);
-		defaultSoundGroup.remove(sound);
-		sound.destroy();
 	}
 
 	/**

--- a/tests/unit/src/flixel/sound/FlxSoundGroupTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundGroupTest.hx
@@ -1,5 +1,6 @@
 package flixel.sound;
 
+import flixel.FlxG;
 import massive.munit.Assert;
 
 class FlxSoundGroupTest
@@ -8,7 +9,23 @@ class FlxSoundGroupTest
 	function testLengthAfterAdd()
 	{
 		var group = new FlxSoundGroup();
-		group.add(new FlxSound());
+		var sound = new FlxSound();
+		group.add(sound);
 		Assert.areEqual(1, group.sounds.length);
+		FlxG.sound.defaultSoundGroup.add(sound);
+		Assert.areEqual(0, group.sounds.length);
+		Assert.areEqual(1, FlxG.sound.defaultSoundGroup.sounds.length);
+	}
+	
+	@:haxe.warning("-WDeprecated")
+	function testSetter()
+	{
+		var group = new FlxSoundGroup();
+		var sound = new FlxSound();
+		sound.group = group;
+		Assert.areEqual(1, group.sounds.length);
+		sound.group = FlxG.sound.defaultSoundGroup;
+		Assert.areEqual(0, group.sounds.length);
+		Assert.areEqual(1, FlxG.sound.defaultSoundGroup.sounds.length);
 	}
 }


### PR DESCRIPTION
destroying sounds created via FlxG.sound.load in substates get destroyed but not removed from the groups, later when destroying the state they are removed from their groups causing a null ref via updateTransform

I've deprecated the sound.group setter, this is a pretty terrible system and many parts of the code have to walk on egg shells to avoid unintended recursion, and it provides almost no real benefit over simple calls to `group.add(sound)` (which will still remove it from prior groups)