### PR TITLE
Use unicode string instead of FlxUnicodeUtil

### DIFF
--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -14,8 +14,6 @@ import openfl.display.BitmapData;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
 
-using flixel.util.FlxUnicodeUtil;
-
 /**
  * Holds information and bitmap characters for a bitmap font.
  */
@@ -232,7 +230,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	 * @param   charBGColor   An additional background color to remove. Defaults to `FlxColor.TRANSPARENT`.
 	 * @return  Generated bitmap font object.
 	 */
-	public static function fromXNA(source:FlxBitmapFontGraphicAsset, ?letters:String, charBGColor:Int = FlxColor.TRANSPARENT):FlxBitmapFont
+	public static function fromXNA(source:FlxBitmapFontGraphicAsset, ?letters:UnicodeString, charBGColor:Int = FlxColor.TRANSPARENT):FlxBitmapFont
 	{
 		var graphic:FlxGraphic = null;
 		var frame:FlxFrame = null;
@@ -266,7 +264,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		var frameWidth:Int = Std.int(frame.frame.width);
 		var frameHeight:Int = Std.int(frame.frame.height);
 		var letterIdx:Int = 0;
-		var numLetters:Int = letters.uLength();
+		var numLetters:Int = letters.length;
 
 		var cy:Int = 0;
 		while (cy < frameHeight && letterIdx < numLetters)
@@ -309,7 +307,7 @@ class FlxBitmapFont extends FlxFramesCollection
 					final gw = gx - cx;
 					final gh = gy - cy;
 
-					final charCode = letters.uCharCodeAt(letterIdx);
+					final charCode = letters.charCodeAt(letterIdx);
 					final rect = FlxRect.get(cx, cy, gw, gh);
 					final xAdvance = gw;
 
@@ -451,7 +449,7 @@ class FlxBitmapFont extends FlxFramesCollection
 			for (i in 0...numCols)
 			{
 				final charRect = FlxRect.get(startX + i * spacedWidth, startY + j * spacedHeight, charWidth, charHeight);
-				font.addCharFrame(letters.uCharCodeAt(letterIndex), charRect, xAdvance);
+				font.addCharFrame(letters.charCodeAt(letterIndex), charRect, xAdvance);
 				letterIndex++;
 
 				if (letterIndex >= numLetters)
@@ -475,7 +473,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	 */
 	function addCharFrame(charCode:Int, frame:FlxRect, ?offset:FlxPoint, xAdvance:Int):Void
 	{
-		final charName:String = new UnicodeBuffer().addChar(charCode).toString();
+		var charName:String = String.fromCharCode(charCode);
 		if (frame.width == 0 || frame.height == 0 || getByName(charName) != null)
 			return;
 		
@@ -492,7 +490,7 @@ class FlxBitmapFont extends FlxFramesCollection
 	 */
 	public function setCharFrame(charCode:Int, frame:FlxRect, xAdvance:Int, ?offset:FlxPoint):Void
 	{
-		final charName:String = new UnicodeBuffer().addChar(charCode).toString();
+		final charName:UnicodeString = String.fromCharCode(charCode);
 		if (frame.width == 0 || frame.height == 0)
 			FlxG.log.error('Invalid frame size: $frame for char "$charName" in font "$fontName"');
 		
@@ -580,7 +578,7 @@ class FlxBitmapFont extends FlxFramesCollection
 		{
 			charWithBorder = char.setBorderTo(border);
 			font.pushFrame(charWithBorder);
-			code = char.name.uCharCodeAt(0);
+			code = (char.name:UnicodeString).charCodeAt(0);
 			font.charMap.set(code, charWithBorder);
 			font.charAdvance.set(code, charAdvance.get(code));
 		}

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -15,7 +15,6 @@ import flixel.util.FlxDestroyUtil;
 import openfl.geom.ColorTransform;
 
 using flixel.util.FlxColorTransformUtil;
-using flixel.util.FlxUnicodeUtil;
 
 /**
  * Extends FlxSprite to support rendering text.
@@ -43,7 +42,7 @@ class FlxBitmapText extends FlxSprite
 	 * Helper array which contains actual strings for rendering.
 	 */
 	// TODO: switch it to Array<Array<Int>> (for optimizations - i.e. less Utf8 usage)
-	var _lines:Array<String> = [];
+	var _lines:Array<UnicodeString> = [];
 
 	/**
 	 * Helper array which contains width of each displayed lines.
@@ -589,7 +588,7 @@ class FlxBitmapText extends FlxSprite
 
 	function updateText():Void
 	{
-		var tmp:String = (autoUpperCase) ? text.toUpperCase() : text;
+		var tmp:UnicodeString = (autoUpperCase) ? (text:UnicodeString).toUpperCase() : text;
 
 		_lines = tmp.split("\n");
 
@@ -663,12 +662,12 @@ class FlxBitmapText extends FlxSprite
 	 * @param	str	String to calculate width for
 	 * @return	The width of result bitmap text.
 	 */
-	public function getStringWidth(str:String):Int
+	public function getStringWidth(str:UnicodeString):Int
 	{
 		var spaceWidth:Int = font.spaceWidth;
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
 
-		var lineLength:Int = str.uLength();
+		var lineLength:Int = str.length;
 		var lineWidth:Float = font.minOffsetX;
 
 		var charCode:Int; // current character in word
@@ -677,7 +676,7 @@ class FlxBitmapText extends FlxSprite
 
 		for (c in 0...lineLength)
 		{
-			charCode = str.uCharCodeAt(c);
+			charCode = str.charCodeAt(c);
 			charWidth = 0;
 
 			if (charCode == FlxBitmapFont.SPACE_CODE)
@@ -719,9 +718,9 @@ class FlxBitmapText extends FlxSprite
 		{
 			var lineWidth = font.minOffsetX;
 
-			for (c in 0..._lines[i].uLength())
+			for (c in 0..._lines[i].length)
 			{
-				switch (_lines[i].uCharCodeAt(c))
+				switch (_lines[i].charCodeAt(c))
 				{
 					case FlxBitmapFont.SPACE_CODE:
 						lineWidth += font.spaceWidth;
@@ -735,7 +734,7 @@ class FlxBitmapText extends FlxSprite
 				if (lineWidth > _fieldWidth - 2 * padding)
 				{
 					// cut every character after this
-					_lines[i] = _lines[i].uSub(0, c);
+					_lines[i] = _lines[i].substr(0, c);
 					break;
 				}
 			}
@@ -778,35 +777,30 @@ class FlxBitmapText extends FlxSprite
 	 * @param	line	line to split.
 	 * @param	words	result array to fill with words.
 	 */
-	function splitLineIntoWords(line:String, words:Array<String>):Void
+	function splitLineIntoWords(line:UnicodeString, words:Array<UnicodeString>):Void
 	{
-		var word:String = ""; // current word to process
-		var wordUtf8 = new UnicodeBuffer();
+		var word:UnicodeString = ""; // current word to process
 		var isSpaceWord:Bool = false; // whether current word consists of spaces or not
-		var lineLength:Int = line.uLength(); // lenght of the current line
-
+		var lineLength:Int = line.length; // lenght of the current line
+		
 		var c:Int = 0; // char index on the line
-		var charCode:Int; // code for the current character in word
-
 		while (c < lineLength)
 		{
-			charCode = line.uCharCodeAt(c);
-			word = wordUtf8.toString();
-
+			final charCode = line.charCodeAt(c);
 			if (charCode == FlxBitmapFont.SPACE_CODE || charCode == FlxBitmapFont.TAB_CODE)
 			{
 				if (!isSpaceWord)
 				{
 					isSpaceWord = true;
-
+					
 					if (word != "")
 					{
 						words.push(word);
-						wordUtf8 = new UnicodeBuffer();
+						word = "";
 					}
 				}
-
-				wordUtf8 = wordUtf8.addChar(charCode);
+				
+				word = word + String.fromCharCode(charCode);
 			}
 			else if (charCode == '-'.code)
 			{
@@ -818,12 +812,10 @@ class FlxBitmapText extends FlxSprite
 				}
 				else if (!isSpaceWord)
 				{
-					var charUtf8 = new UnicodeBuffer();
-					charUtf8 = charUtf8.addChar(charCode);
-					words.push(word + charUtf8.toString());
+					words.push(word + String.fromCharCode(charCode));
 				}
-
-				wordUtf8 = new UnicodeBuffer();
+				
+				word = "";
 			}
 			else
 			{
@@ -831,16 +823,15 @@ class FlxBitmapText extends FlxSprite
 				{
 					isSpaceWord = false;
 					words.push(word);
-					wordUtf8 = new UnicodeBuffer();
+					word = "";
 				}
-
-				wordUtf8 = wordUtf8.addChar(charCode);
+				
+				word = word + String.fromCharCode(charCode);
 			}
-
+			
 			c++;
 		}
-
-		word = wordUtf8.toString();
+		
 		if (word != "")
 			words.push(word);
 	}
@@ -1025,7 +1016,7 @@ class FlxBitmapText extends FlxSprite
 	
 	inline function isSpaceWord(word:UnicodeString)
 	{
-		final firstCode = word.uCharCodeAt(0);
+		final firstCode = word.charCodeAt(0);
 		return firstCode == FlxBitmapFont.SPACE_CODE || firstCode == FlxBitmapFont.TAB_CODE;
 	}
 
@@ -1126,9 +1117,9 @@ class FlxBitmapText extends FlxSprite
 		var curX:Float = startX;
 		var curY:Int = startY;
 
-		var line:String = _lines[lineIndex];
+		var line:UnicodeString = _lines[lineIndex];
 		var spaceWidth:Int = font.spaceWidth;
-		var lineLength:Int = line.uLength();
+		var lineLength:Int = line.length;
 		var textWidth:Int = this.textWidth;
 
 		if (alignment == FlxTextAlign.JUSTIFY)
@@ -1137,7 +1128,7 @@ class FlxBitmapText extends FlxSprite
 
 			for (i in 0...lineLength)
 			{
-				charCode = line.uCharCodeAt(i);
+				charCode = line.charCodeAt(i);
 
 				if (charCode == FlxBitmapFont.SPACE_CODE)
 				{
@@ -1156,11 +1147,9 @@ class FlxBitmapText extends FlxSprite
 
 		var tabWidth:Int = spaceWidth * numSpacesInTab;
 
-		var charUt8:UnicodeBuffer;
-
 		for (i in 0...lineLength)
 		{
-			charCode = line.uCharCodeAt(i);
+			charCode = line.charCodeAt(i);
 
 			if (charCode == FlxBitmapFont.SPACE_CODE)
 			{
@@ -1185,8 +1174,6 @@ class FlxBitmapText extends FlxSprite
 						curX += font.getCharAdvance(charCode) + letterSpacing;
 					}
 					charFrame.paint(textBitmap, _flashPoint, true);
-					charUt8 = new UnicodeBuffer();
-					charUt8 = charUt8.addChar(charCode);
 				}
 			}
 		}
@@ -1206,7 +1193,7 @@ class FlxBitmapText extends FlxSprite
 
 		var line:String = _lines[lineIndex];
 		var spaceWidth:Int = font.spaceWidth;
-		var lineLength:Int = line.uLength();
+		var lineLength:Int = line.length;
 		var textWidth:Int = this.textWidth;
 
 		if (alignment == FlxTextAlign.JUSTIFY)
@@ -1215,7 +1202,7 @@ class FlxBitmapText extends FlxSprite
 
 			for (i in 0...lineLength)
 			{
-				charCode = line.uCharCodeAt(i);
+				charCode = line.charCodeAt(i);
 
 				if (charCode == FlxBitmapFont.SPACE_CODE)
 				{
@@ -1236,7 +1223,7 @@ class FlxBitmapText extends FlxSprite
 
 		for (i in 0...lineLength)
 		{
-			charCode = line.uCharCodeAt(i);
+			charCode = line.charCodeAt(i);
 
 			if (charCode == FlxBitmapFont.SPACE_CODE)
 			{

--- a/flixel/util/FlxUnicodeUtil.hx
+++ b/flixel/util/FlxUnicodeUtil.hx
@@ -41,7 +41,7 @@ abstract UnicodeBuffer(UnicodeString) from UnicodeString
 
 	public inline function addChar(c:Int):UnicodeBuffer
 	{
-		return new UnicodeString(this + String.fromCharCode(c));
+		return String.fromCharCode(c);
 	}
 
 	public inline function toString():String

--- a/flixel/util/FlxUnicodeUtil.hx
+++ b/flixel/util/FlxUnicodeUtil.hx
@@ -5,7 +5,7 @@ package flixel.util;
  */
 @:dox(hide)
 @:noCompletion
-@:deprecated("Use unicodeString")
+@:deprecated("Use UnicodeString")
 class FlxUnicodeUtil
 {
 	public static inline function uLength(s:String):Int
@@ -31,8 +31,8 @@ class FlxUnicodeUtil
 
 @:dox(hide)
 @:noCompletion
-@:deprecated("Use unicodeString")
-abstract UnicodeBuffer(UnicodeString)
+@:deprecated("Use UnicodeString")
+abstract UnicodeBuffer(UnicodeString) from UnicodeString
 {
 	public inline function new(s:String = "")
 	{
@@ -41,7 +41,7 @@ abstract UnicodeBuffer(UnicodeString)
 
 	public inline function addChar(c:Int):UnicodeBuffer
 	{
-		return new UnicodeBuffer(this + String.fromCharCode(c));
+		return new UnicodeString(this + String.fromCharCode(c));
 	}
 
 	public inline function toString():String

--- a/flixel/util/FlxUnicodeUtil.hx
+++ b/flixel/util/FlxUnicodeUtil.hx
@@ -32,7 +32,7 @@ class FlxUnicodeUtil
 @:dox(hide)
 @:noCompletion
 @:deprecated("Use UnicodeString")
-abstract UnicodeBuffer(UnicodeString) from UnicodeString
+abstract UnicodeBuffer(UnicodeString) from UnicodeString from String
 {
 	public inline function new(s:String = "")
 	{

--- a/flixel/util/FlxUnicodeUtil.hx
+++ b/flixel/util/FlxUnicodeUtil.hx
@@ -32,7 +32,7 @@ class FlxUnicodeUtil
 @:dox(hide)
 @:noCompletion
 @:deprecated("Use UnicodeString")
-abstract UnicodeBuffer(UnicodeString) from UnicodeString from String
+abstract UnicodeBuffer(UnicodeString)
 {
 	public inline function new(s:String = "")
 	{
@@ -41,7 +41,7 @@ abstract UnicodeBuffer(UnicodeString) from UnicodeString from String
 
 	public inline function addChar(c:Int):UnicodeBuffer
 	{
-		return String.fromCharCode(c);
+		return new UnicodeBuffer(this + String.fromCharCode(c));
 	}
 
 	public inline function toString():String


### PR DESCRIPTION
FlxUnicodeUtil is a leftover from before UnicodeString was added to Haxe, it was migrated from using openfl's Utf8String tools and none of this is no longer neccessary 