### PR TITLE
Add FlxContainer - a group that removes members from other containers

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -1,6 +1,7 @@
 package flixel;
 
-import flixel.util.FlxDestroyUtil.IFlxDestroyable;
+import flixel.group.FlxContainer;
+import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxStringUtil;
 
 /**
@@ -69,6 +70,11 @@ class FlxBasic implements IFlxDestroyable
 
 	@:noCompletion
 	var _cameras:Array<FlxCamera>;
+	
+	/**
+	 * The parent containing this basic, typically if you check this recursively you should reach the state
+	 */
+	public var container(default, null):Null<FlxContainer>;
 
 	public function new() {}
 
@@ -84,6 +90,10 @@ class FlxBasic implements IFlxDestroyable
 	 */
 	public function destroy():Void
 	{
+		if (container != null)
+			container.remove(this);
+		
+		container = null;
 		exists = false;
 		_cameras = null;
 	}

--- a/flixel/group/FlxContainer.hx
+++ b/flixel/group/FlxContainer.hx
@@ -1,0 +1,46 @@
+package flixel.group;
+
+import flixel.FlxBasic;
+import flixel.group.FlxGroup;
+
+/**
+ * An alias for `FlxTypedContainer<FlxBasic>`, meaning any flixel object or basic can be added to a
+ * `FlxContainer`, even another `FlxContainer`.
+ */
+typedef FlxContainer = FlxTypedContainer<FlxBasic>;
+
+/**
+ * An exclusive `FlxGroup`, meaning that a `FlxBasic` can only be in ONE container at any given time.
+ * Adding them to a second container will remove them from any previous container they were in.
+ * You can determine which container a basic is in by using the basic's `container` field.
+ * ## When to use FlxGroup or FlxContainer
+ * `FlxGroups` are better for organising arbitrary groups for things like iterating or collision.
+ * `FlxContainers` are recommended when you are adding them to the current `FlxState`, or a
+ * child (or grandchild, and so on) of the state.
+ */
+class FlxTypedContainer<T:FlxBasic> extends FlxTypedGroup<T>
+{
+	/**
+	 * @param   maxSize  Maximum amount of members allowed.
+	 */
+	public function new(maxSize = 0)
+	{
+		super(maxSize);
+	}
+	
+	override function onMemberAdd(member:T)
+	{
+		// remove from previous container
+		if (member.container != null)
+			member.container.remove(member);
+		
+		member.container = (cast this:FlxContainer);
+		super.onMemberAdd(member);
+	}
+	
+	override function onMemberRemove(member:T)
+	{
+		member.container = null;
+		super.onMemberRemove(member);
+	}
+}

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -205,10 +205,9 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			{
 				length = index + 1;
 			}
-
-			if (_memberAdded != null)
-				_memberAdded.dispatch(basic);
-
+			
+			onMemberAdd(basic);
+			
 			return basic;
 		}
 
@@ -219,10 +218,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		// If we made it this far, we need to add the basic to the group.
 		members.push(basic);
 		length++;
-
-		if (_memberAdded != null)
-			_memberAdded.dispatch(basic);
-
+		onMemberAdd(basic);
+		
 		return basic;
 	}
 
@@ -254,10 +251,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		if (position < length && members[position] == null)
 		{
 			members[position] = object;
-
-			if (_memberAdded != null)
-				_memberAdded.dispatch(object);
-
+			onMemberAdd(object);
+			
 			return object;
 		}
 
@@ -268,9 +263,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		// If we made it this far, we need to insert the object into the group at the specified position.
 		members.insert(position, object);
 		length++;
-
-		if (_memberAdded != null)
-			_memberAdded.dispatch(object);
+		onMemberAdd(object);
 
 		return object;
 	}
@@ -369,10 +362,9 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 		else
 			members[index] = null;
-
-		if (_memberRemoved != null)
-			_memberRemoved.dispatch(basic);
-
+		
+		onMemberRemove(basic);
+		
 		return basic;
 	}
 
@@ -393,10 +385,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 
 		members[index] = newObject;
 
-		if (_memberRemoved != null)
-			_memberRemoved.dispatch(oldObject);
-		if (_memberAdded != null)
-			_memberAdded.dispatch(newObject);
+		onMemberRemove(oldObject);
+		onMemberAdd(newObject);
 
 		return newObject;
 	}
@@ -676,10 +666,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		if (_memberRemoved != null)
 		{
 			for (member in members)
-			{
-				if (member != null)
-					_memberRemoved.dispatch(member);
-			}
+				onMemberRemove(member);
 		}
 
 		FlxArrayUtil.clearArray(members);
@@ -888,8 +875,7 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 
 			if (basic != null)
 			{
-				if (_memberRemoved != null)
-					_memberRemoved.dispatch(cast basic);
+				onMemberRemove(basic);
 
 				basic.destroy();
 			}
@@ -897,6 +883,18 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 		}
 
 		return maxSize;
+	}
+	
+	function onMemberAdd(member:T)
+	{
+		if (_memberAdded != null)
+			_memberAdded.dispatch(cast member);
+	}
+	
+	function onMemberRemove(member:T)
+	{
+		if (_memberRemoved != null)
+			_memberRemoved.dispatch(cast member);
 	}
 
 	@:noCompletion


### PR DESCRIPTION
A `FlxContainer` is a `FlxGroup` that removes it's members from their previous container, when added, meaning a `FlxBasic` can only ever be in one container at a time. The main benefits  is that it ensures a `FlxBasic` is only in the draw-tree once, where `FlxGroups` can result in sprites being drawn or updated twice per frame.

The long term goal of this change is to replace `FlxSpriteGroup` and `FlxNestedSprite` with a system closer to Flash's DisplayObjectContainer tree, where object's x and y may refer to it's local position in the parent, but the global position may be calculated at any time by iterating up the "parents" until reaching the state. Many flixel features currently can only truly know where a sprite will *actually* be drawn while in the draw() phase, especially when there are multiple cameras with different zooms.

Related: #2715
By adding a drawContext arg to draw we will be able to pass down vars that dictate how objects are drawn, so in this proposed replacement for `FlxSpriteGroup` and `FlxNestedSprite` a parent collection with (for instance) x, y, angle, scale properties will augment the context's transformation matrix with it's properties before passing it to it's members, that will use it to draw their "global" position