### PR TITLE
Permit centering a sprite at its origin on a flxpath

### DIFF
--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -387,8 +387,6 @@ class FlxPath implements IFlxDestroyable
 		}
 
 		// first check if we need to be pointing at the next node yet
-		_point.x = object.x;
-		_point.y = object.y;
 		_point = computeCenter(_point);
 
 		var node:FlxPoint = _nodes[nodeIndex];
@@ -424,7 +422,7 @@ class FlxPath implements IFlxDestroyable
 		if (object != null && speed != 0)
 		{
 			// set velocity based on path mode
-			computeCenter(_point);
+			_point = computeCenter(_point);
 
 			if (!_point.equals(node))
 			{


### PR DESCRIPTION
Currently when a FlxSprite follows a FlxPath it cannot center itself on the path at its center of rotation. This can lead to some odd visuals in tilemaps or when the path itself is visible. This change attempts to maintain backward compatibility with the existing mechanism for choosing the center point while providing a new way to control the center point. This would support eventual deprecation of the autoCenter property in the future.