### PR TITLE
FlxContainer fixes and features

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -196,7 +196,8 @@ class FlxBasic implements IFlxDestroyable
 	/**
 	 * The cameras that will draw this. Use `this.cameras` to set specific cameras for this object,
 	 * otherwise the container's cameras are used, or the container's container and so on. If there
-	 * is no container, like if this is only inside a `FlxGroup` rather than a `FlxContainer`.
+	 * is no container, say, if this is inside `FlxGroups` rather than a `FlxContainer` then the
+	 * default draw cameras are returned.
 	 * @since 5.7.0
 	 */
 	public function getCameras()

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -197,6 +197,7 @@ class FlxBasic implements IFlxDestroyable
 	 * The cameras that will draw this. Use `this.cameras` to set specific cameras for this object,
 	 * otherwise the container's cameras are used, or the container's container and so on. If there
 	 * is no container, like if this is only inside a `FlxGroup` rather than a `FlxContainer`.
+	 * @since 5.7.0
 	 */
 	public function getCameras()
 	{
@@ -230,9 +231,9 @@ class FlxBasic implements IFlxDestroyable
 		return _cameras = Value;
 	}
 	
-	@:noCompletion
 	// Only needed for FlxSpriteContainer.SpriteContainer
 	// TODO: remove this when FlxSpriteContainer is removed
+	@:noCompletion
 	function get_container()
 	{
 		return this.container;

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -74,7 +74,7 @@ class FlxBasic implements IFlxDestroyable
 	/**
 	 * The parent containing this basic, typically if you check this recursively you should reach the state
 	 */
-	public var container(default, null):Null<FlxContainer>;
+	public var container(get, null):Null<FlxContainer>;
 
 	public function new() {}
 
@@ -211,7 +211,7 @@ class FlxBasic implements IFlxDestroyable
 	 * Helper while moving away from `get_cameras`. Should only be used in the draw phase
 	 */
 	@:noCompletion
-	inline function getCamerasLegacy()
+	function getCamerasLegacy()
 	{
 		@:privateAccess
 		return (_cameras == null) ? FlxCamera._defaultCameras : _cameras;
@@ -227,6 +227,12 @@ class FlxBasic implements IFlxDestroyable
 	function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
 	{
 		return _cameras = Value;
+	}
+	
+	@:noCompletion
+	function get_container()
+	{
+		return this.container;
 	}
 }
 

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -191,7 +191,22 @@ class FlxBasic implements IFlxDestroyable
 			_cameras[0] = Value;
 		return Value;
 	}
-
+	
+	/**
+	 * The cameras that will draw this. Use `this.cameras` to set specific cameras for this object,
+	 * otherwise the container's cameras are used, or the container's container and so on. If there
+	 * is no container, like if this is only inside a `FlxGroup` rather than a `FlxContainer`.
+	 */
+	public function getCameras()
+	{
+		return if (_cameras != null)
+				_cameras;
+			else if (_cameras == null && container != null)
+				container.getCameras();
+			else
+				@:privateAccess FlxCamera._defaultCameras;
+	}
+	
 	@:noCompletion
 	function get_cameras():Array<FlxCamera>
 	{

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -207,10 +207,20 @@ class FlxBasic implements IFlxDestroyable
 				@:privateAccess FlxCamera._defaultCameras;
 	}
 	
+	/**
+	 * Helper while moving away from `get_cameras`. Should only be used in the draw phase
+	 */
+	@:noCompletion
+	inline function getCamerasLegacy()
+	{
+		@:privateAccess
+		return (_cameras == null) ? FlxCamera._defaultCameras : _cameras;
+	}
+	
 	@:noCompletion
 	function get_cameras():Array<FlxCamera>
 	{
-		return (_cameras == null) ? FlxCamera._defaultCameras : _cameras;
+		return getCamerasLegacy();
 	}
 
 	@:noCompletion

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -73,6 +73,7 @@ class FlxBasic implements IFlxDestroyable
 	
 	/**
 	 * The parent containing this basic, typically if you check this recursively you should reach the state
+	 * @since 5.7.0
 	 */
 	public var container(get, null):Null<FlxContainer>;
 
@@ -230,6 +231,8 @@ class FlxBasic implements IFlxDestroyable
 	}
 	
 	@:noCompletion
+	// Only needed for FlxSpriteContainer.SpriteContainer
+	// TODO: remove this when FlxSpriteContainer is removed
 	function get_container()
 	{
 		return this.container;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1259,8 +1259,8 @@ class FlxObject extends FlxBasic
 	{
 		if (ignoreDrawDebug)
 			return;
-
-		for (camera in cameras)
+		
+		for (camera in getCamerasLegacy())
 		{
 			drawDebugOnCamera(camera);
 

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -796,7 +796,7 @@ class FlxSprite extends FlxObject
 		if (dirty) // rarely
 			calcFrame(useFramePixels);
 
-		for (camera in cameras)
+		for (camera in getCamerasLegacy())
 		{
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -1,6 +1,6 @@
 package flixel;
 
-import flixel.group.FlxGroup;
+import flixel.group.FlxContainer;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSignal;
@@ -8,14 +8,14 @@ import flixel.util.typeLimit.NextState;
 
 /**
  * This is the basic game "state" object - e.g. in a simple game you might have a menu state and a play state.
- * It is for all intents and purpose a fancy `FlxGroup`. And really, it's not even that fancy.
+ * It is for all intents and purpose a fancy `FlxContainer`. And really, it's not even that fancy.
  */
 @:keepSub // workaround for HaxeFoundation/haxe#3749
 #if FLX_NO_UNIT_TEST
 @:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("switchTo", "switchTo is deprecated, use startOutro"))
 #end
 // show deprecation warning when `switchTo` is overriden in dereived classes
-class FlxState extends FlxGroup
+class FlxState extends FlxContainer
 {
 	/**
 	 * Determines whether or not this state is updated even when it is not the active state.

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -63,7 +63,7 @@ class FlxSubState extends FlxState
 		// Draw background
 		if (FlxG.renderBlit)
 		{
-			for (camera in cameras)
+			for (camera in getCamerasLegacy())
 			{
 				camera.fill(bgColor);
 			}

--- a/flixel/group/FlxContainer.hx
+++ b/flixel/group/FlxContainer.hx
@@ -13,7 +13,8 @@ typedef FlxContainer = FlxTypedContainer<FlxBasic>;
  * An exclusive `FlxGroup`, meaning that a `FlxBasic` can only be in ONE container at any given time.
  * Adding them to a second container will remove them from any previous container they were in.
  * You can determine which container a basic is in by using the basic's `container` field.
- * ## When to use FlxGroup or FlxContainer
+ *
+ * ## When to use a group or container
  * `FlxGroups` are better for organising arbitrary groups for things like iterating or collision.
  * `FlxContainers` are recommended when you are adding them to the current `FlxState`, or a
  * child (or grandchild, and so on) of the state.

--- a/flixel/group/FlxContainer.hx
+++ b/flixel/group/FlxContainer.hx
@@ -6,6 +6,7 @@ import flixel.group.FlxGroup;
 /**
  * An alias for `FlxTypedContainer<FlxBasic>`, meaning any flixel object or basic can be added to a
  * `FlxContainer`, even another `FlxContainer`.
+ * @since 5.7.0
  */
 typedef FlxContainer = FlxTypedContainer<FlxBasic>;
 

--- a/flixel/group/FlxContainer.hx
+++ b/flixel/group/FlxContainer.hx
@@ -18,6 +18,7 @@ typedef FlxContainer = FlxTypedContainer<FlxBasic>;
  * `FlxGroups` are better for organising arbitrary groups for things like iterating or collision.
  * `FlxContainers` are recommended when you are adding them to the current `FlxState`, or a
  * child (or grandchild, and so on) of the state.
+ * @since 5.7.0
  */
 class FlxTypedContainer<T:FlxBasic> extends FlxTypedGroup<T>
 {

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -9,15 +9,30 @@ import flixel.util.FlxSignal.FlxTypedSignal;
 import flixel.util.FlxSort;
 
 /**
- * An alias for `FlxTypedGroup<FlxBasic>`, meaning any flixel object or basic can be added to a
- * `FlxGroup`, even another `FlxGroup`.
+ * Contains a bunch of `FlxBasic`s for vaious organizational purposes, namely
+ * collision, updating and drawing.
+ * 
+ * ## Collision
+ * When used as an arg in `FlxG.collide` or `FlxG.overlap`, groups will use quadtrees to
+ * greatly reduce the number of overlap checks, resulting in much better peformance compared
+ * to having individual overlap checks on each pair of objects.
+ * 
+ * ## Drawing and Updating
+ * Calling `update` or `draw` on a group will call `update` or `draw` on each member. Typically,
+ * to update or draw a group you add it to the state, or to a group that was added to the state,
+ * this way, the state will update and draw it's members based on the desired framerates.
+ * 
+ * ## FlxContainers
+ * Though objects can be in various organizational groups, it's highly recommended that they only
+ * get drawn or updated by one containing group. For this reason `FlxContainer` was made, objects
+ * can only be in one `FlxContainer` at a time, adding them to a second will remove them from
+ * their previous container, but not from any group.
  */
 typedef FlxGroup = FlxTypedGroup<FlxBasic>;
 
 /**
- * This is an organizational class that can update and render a bunch of `FlxBasic`s.
- * NOTE: Although `FlxGroup` extends `FlxBasic`, it will not automatically
- * add itself to the global collisions quad tree, it will only add its members.
+ * A `FlxGroup` that only allows specific members to be a specific type of `FlxBasic`.
+ * To use any kind of `FlxBasic` use `FlxGroup`, which is an alias for `FlxTypedGroup<FlxBasic>`.
  */
 class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 {

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -113,23 +113,23 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	override public function destroy():Void
 	{
 		super.destroy();
-
+		
 		FlxDestroyUtil.destroy(_memberAdded);
 		FlxDestroyUtil.destroy(_memberRemoved);
-
+		
 		if (members != null)
 		{
-			var i:Int = 0;
-			var basic:FlxBasic = null;
-
-			while (i < length)
+			/* Note: basic.destroy() will remove it from it's container, which may be this group.
+			 * So we need to make sure this loop can handle deletions
+			 */
+			var count = length;
+			while (count-- > 0)
 			{
-				basic = members[i++];
-
+				final basic = members.shift();
 				if (basic != null)
 					basic.destroy();
 			}
-
+			
 			members = null;
 		}
 	}
@@ -139,13 +139,8 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	 */
 	override public function update(elapsed:Float):Void
 	{
-		var i:Int = 0;
-		var basic:FlxBasic = null;
-
-		while (i < length)
+		for (basic in members)
 		{
-			basic = members[i++];
-
 			if (basic != null && basic.exists && basic.active)
 			{
 				basic.update(elapsed);

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -154,9 +154,9 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 	override public function draw():Void
 	{
 		final oldDefaultCameras = FlxCamera._defaultCameras;
-		if (cameras != null)
+		if (_cameras != null)
 		{
-			FlxCamera._defaultCameras = cameras;
+			FlxCamera._defaultCameras = _cameras;
 		}
 
 		for (basic in members)

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -34,7 +34,7 @@ class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
 	override function initGroup(maxSize):Void
 	{
 		@:bypassAccessor
-		group = new FlxTypedContainer<T>(maxSize);
+		group = new SpriteContainer<T>(this, maxSize);
 	}
 	
 	@:deprecated("FlxSpriteContainer.group can not be set")
@@ -66,11 +66,11 @@ private class SpriteContainer<T:FlxSprite> extends FlxTypedContainer<T>
 	
 	override function getCamerasLegacy()
 	{
-		return parentSprite.getCamerasLegacy();
+		return (_cameras != null ? _cameras : parentSprite.getCamerasLegacy());
 	}
 	
 	override function getCameras()
 	{
-		return parentSprite.getCameras();
+		return (_cameras != null ? _cameras : parentSprite.getCameras());
 	}
 }

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -37,6 +37,7 @@ class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
 		group = new FlxTypedContainer<T>(maxSize);
 	}
 	
+	@:deprecated("FlxSpriteContainer.group can not be set")
 	override function set_group(value:FlxTypedGroup<T>):FlxTypedGroup<T>
 	{
 		throw "FlxSpriteContainer.group cannot be set in FlxSpriteContainers";

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -17,6 +17,7 @@ import flixel.util.FlxDestroyUtil;
  * Since `FlxSpriteGroups` and `FlxSpriteContainers` are usually meant to draw groups of sprites
  * rather than organizing them for collision or iterating, it's recommended to always use
  * `FlxSpriteContainer` instead of `FlxSpriteGroup`.
+ * @since 5.7.0
  */
 typedef FlxSpriteContainer = FlxTypedSpriteContainer<FlxSprite>;
 

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -27,6 +27,7 @@ typedef FlxSpriteContainer = FlxTypedSpriteContainer<FlxSprite>;
  * A `FlxSpriteContainer` that only allows specific members to be a specific type of `FlxSprite`.
  * To use any kind of `FlxSprite` use `FlxSpriteContainer`, which is an alias for
  * `FlxTypedSpriteContainer<FlxSprite>`.
+ * @since 5.7.0
  */
 class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
 {
@@ -46,6 +47,7 @@ class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
  * A special `FlxContainer` that shares mirrors the container information of it's
  * containing sprite.
  */
+@:dox(hide)
 private class SpriteContainer<T:FlxSprite> extends FlxTypedContainer<T>
 {
 	var parentSprite:FlxTypedSpriteContainer<T>;

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -42,7 +42,7 @@ class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
  * A special `FlxContainer` that shares mirrors the container information of it's
  * containing sprite.
  */
-private class SpriteContainer<T:FlxSprite> extends FlxContainer<T>
+private class SpriteContainer<T:FlxSprite> extends FlxTypedContainer<T>
 {
 	var parentSprite:FlxTypedSpriteContainer<T>;
 	

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -3,6 +3,8 @@ package flixel.group;
 import flixel.FlxCamera;
 import flixel.FlxSprite;
 import flixel.group.FlxContainer;
+import flixel.group.FlxGroup;
+import flixel.group.FlxSpriteGroup;
 import flixel.util.FlxDestroyUtil;
 
 /**
@@ -30,6 +32,7 @@ class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
 {
 	override function initGroup(maxSize):Void
 	{
+		@:bypassAccessor
 		group = new FlxTypedContainer<T>(maxSize);
 	}
 	

--- a/flixel/group/FlxSpriteContainer.hx
+++ b/flixel/group/FlxSpriteContainer.hx
@@ -1,0 +1,69 @@
+package flixel.group;
+
+import flixel.FlxCamera;
+import flixel.FlxSprite;
+import flixel.group.FlxContainer;
+import flixel.util.FlxDestroyUtil;
+
+/**
+ * `FlxSpriteContainer` is a special `FlxSprite` that can be treated like a single sprite even
+ * if it's made up of several member sprites. It shares the `FlxGroup` API, but it doesn't inherit
+ * from it. Note that `FlxSpriteContainer` is a `FlxSpriteGroup` but the group is a `FlxContainer`.
+ * 
+ * ## When to use a group or container
+ * `FlxGroups` are better for organising arbitrary groups for things like iterating or collision.
+ * `FlxContainers` are recommended when you are adding them to the current `FlxState`, or a
+ * child (or grandchild, and so on) of the state.
+ * Since `FlxSpriteGroups` and `FlxSpriteContainers` are usually meant to draw groups of sprites
+ * rather than organizing them for collision or iterating, it's recommended to always use
+ * `FlxSpriteContainer` instead of `FlxSpriteGroup`.
+ */
+typedef FlxSpriteContainer = FlxTypedSpriteContainer<FlxSprite>;
+
+/**
+ * A `FlxSpriteContainer` that only allows specific members to be a specific type of `FlxSprite`.
+ * To use any kind of `FlxSprite` use `FlxSpriteContainer`, which is an alias for
+ * `FlxTypedSpriteContainer<FlxSprite>`.
+ */
+class FlxTypedSpriteContainer<T:FlxSprite> extends FlxTypedSpriteGroup<T>
+{
+	override function initGroup(maxSize):Void
+	{
+		group = new FlxTypedContainer<T>(maxSize);
+	}
+	
+	override function set_group(value:FlxTypedGroup<T>):FlxTypedGroup<T>
+	{
+		throw "FlxSpriteContainer.group cannot be set in FlxSpriteContainers";
+	}
+}
+
+/**
+ * A special `FlxContainer` that shares mirrors the container information of it's
+ * containing sprite.
+ */
+private class SpriteContainer<T:FlxSprite> extends FlxContainer<T>
+{
+	var parentSprite:FlxTypedSpriteContainer<T>;
+	
+	public function new (parent:FlxTypedSpriteContainer<T>, maxSize:Int)
+	{
+		parentSprite = parent;
+		super(maxSize);
+	}
+	
+	override function get_container()
+	{
+		return parentSprite.container;
+	}
+	
+	override function getCamerasLegacy()
+	{
+		return parentSprite.getCamerasLegacy();
+	}
+	
+	override function getCameras()
+	{
+		return parentSprite.getCameras();
+	}
+}

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -298,7 +298,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		sprite.y += y;
 		sprite.alpha *= alpha;
 		sprite.scrollFactor.copyFrom(scrollFactor);
-		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
+		sprite._cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
 
 		if (clipRect != null)
 			clipRectTransform(sprite, clipRect);
@@ -347,7 +347,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		sprite.x -= x;
 		sprite.y -= y;
 		// alpha
-		sprite.cameras = null;
+		sprite._cameras = null;
 		return group.remove(Sprite, Splice);
 	}
 
@@ -672,7 +672,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	override function set_cameras(Value:Array<FlxCamera>):Array<FlxCamera>
 	{
-		if (cameras != Value)
+		if (_cameras != Value)
 			transformChildren(camerasTransform, Value);
 		return super.set_cameras(Value);
 	}
@@ -1054,7 +1054,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		Sprite.camera = Camera;
 
 	inline function camerasTransform(Sprite:FlxSprite, Cameras:Array<FlxCamera>)
-		Sprite.cameras = Cameras;
+		Sprite._cameras = Cameras;
 
 	inline function offsetTransform(Sprite:FlxSprite, Offset:FlxPoint)
 		Sprite.offset.copyFrom(Offset);

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -16,22 +16,31 @@ import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSort;
 
 /**
- * An alias for `FlxTypedSpriteGroup<FlxSprite>`, meaning any sprite can be added to a
- * `FlxSpriteGroup`, even another `FlxSpriteGroup`.
+ * `FlxSpriteGroup` is a special `FlxSprite` that can be treated like a single sprite even if it's
+ * made up of several member sprites. It shares the `FlxGroup` API, but it doesn't inherit from it.
+ * Note that `FlxSpriteContainer` also exists.
+ * 
+ * ## When to use a group or container
+ * `FlxGroups` are better for organising arbitrary groups for things like iterating or collision.
+ * `FlxContainers` are recommended when you are adding them to the current `FlxState`, or a
+ * child (or grandchild, and so on) of the state.
+ * Since `FlxSpriteGroups` and `FlxSpriteContainers` are usually meant to draw groups of sprites
+ * rather than organizing them for collision or iterating, it's recommended to always use
+ * `FlxSpriteContainer` instead of `FlxSpriteGroup`.
  */
 typedef FlxSpriteGroup = FlxTypedSpriteGroup<FlxSprite>;
 
 /**
- * `FlxSpriteGroup` is a special `FlxSprite` that can be treated like
- * a single sprite even if it's made up of several member sprites.
- * It shares the `FlxTypedGroup` API, but it doesn't inherit from it.
+ * A `FlxSpriteGroup` that only allows specific members to be a specific type of `FlxSprite`.
+ * To use any kind of `FlxSprite` use `FlxSpriteGroup`, which is an alias for
+ * `FlxTypedSpriteGroup<FlxSprite>`.
  */
 class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 {
 	/**
 	 * The actual group which holds all sprites.
 	 */
-	public var group:FlxTypedGroup<T>;
+	public var group(default, set):FlxTypedGroup<T>;
 
 	/**
 	 * The link to a group's `members` array.
@@ -75,10 +84,15 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 */
 	public function new(x = 0.0, y = 0.0, maxSize = 0)
 	{
+		initGroup(maxSize);
 		super(x, y);
+	}
+	
+	function initGroup(maxSize:Int):Void
+	{
 		group = new FlxTypedGroup<T>(maxSize);
 	}
-
+	
 	/**
 	 * This method is used for initialization of variables of complex types.
 	 * Don't forget to call `super.initVars()` if you'll override this method,
@@ -289,9 +303,8 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	 *
 	 * @param	Sprite	The sprite or sprite group that is about to be added or inserted into the group.
 	 */
-	function preAdd(Sprite:T):Void
+	function preAdd(sprite:T):Void
 	{
-		var sprite:FlxSprite = cast Sprite;
 		sprite.x += x;
 		sprite.y += y;
 		sprite.alpha *= alpha;
@@ -1156,7 +1169,12 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		return cast group.members;
 	}
-
+	
+	function set_group(value:FlxTypedGroup<T>):FlxTypedGroup<T>
+	{
+		return this.group = value;
+	}
+	
 	/**
 	 * Internal function to update the current animation frame.
 	 *

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -632,7 +632,7 @@ class FlxMouseEventManager extends FlxBasic
 
 	function checkOverlap<T:FlxObject>(event:FlxMouseEvent<T>):Bool
 	{
-		for (camera in event.object.cameras)
+		for (camera in event.object.getCameras())
 		{
 			#if FLX_MOUSE
 			_point = FlxG.mouse.getPositionInCameraView(camera, _point);

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -20,7 +20,7 @@ class FlxBGSprite extends FlxSprite
 	@:access(flixel.FlxCamera)
 	override public function draw():Void
 	{
-		for (camera in cameras)
+		for (camera in getCamerasLegacy())
 		{
 			if (!camera.visible || !camera.exists)
 			{

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -642,13 +642,12 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			_checkBufferChanges = false;
 		}
 
-		var camera:FlxCamera;
 		var buffer:FlxTilemapBuffer;
 		var l:Int = cameras.length;
 
 		for (i in 0...l)
 		{
-			camera = cameras[i];
+			final camera = cameras[i];
 
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;
@@ -1504,10 +1503,11 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	{
 		scaledTileWidth = tileWidth * scale.x;
 		width = scaledWidth;
-
+		
+		final cameras = getCameras();
 		if (cameras == null)
 			return;
-
+		
 		for (i in 0...cameras.length)
 			if (_buffers[i] != null)
 				_buffers[i].updateColumns(tileWidth, widthInTiles, scale.x, cameras[i]);
@@ -1517,10 +1517,11 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	{
 		scaledTileHeight = tileHeight * scale.y;
 		height = scaledHeight;
-
+		
+		final cameras = getCameras();
 		if (cameras == null)
 			return;
-
+		
 		for (i in 0...cameras.length)
 			if (_buffers[i] != null)
 				_buffers[i].updateRows(tileHeight, heightInTiles, scale.y, cameras[i]);

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -641,7 +641,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			refreshBuffers();
 			_checkBufferChanges = false;
 		}
-
+		
+		final cameras = getCamerasLegacy();
 		var buffer:FlxTilemapBuffer;
 		var l:Int = cameras.length;
 
@@ -683,6 +684,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 	function refreshBuffers():Void
 	{
+		final cameras = getCamerasLegacy();
 		for (i in 0...cameras.length)
 		{
 			var camera = cameras[i];

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -850,7 +850,7 @@ class FlxBar extends FlxSprite
 		
 		if (percent > 0 && _frontFrame.type != FlxFrameType.EMPTY)
 		{
-			for (camera in cameras)
+			for (camera in getCamerasLegacy())
 			{
 				if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				{

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -404,7 +404,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		var overlap = false;
 		#if FLX_MOUSE
-		for (camera in cameras)
+		for (camera in getCameras())
 		{
 			for (buttonID in mouseButtons)
 			{
@@ -423,7 +423,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		var overlap = false;
 		#if FLX_TOUCH
-		for (camera in cameras)
+		for (camera in getCameras())
 		{
 			for (touch in FlxG.touches.list)
 			{

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -325,7 +325,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 
 		if (_spriteLabel != null && _spriteLabel.visible)
 		{
-			_spriteLabel.cameras = cameras;
+			_spriteLabel._cameras = _cameras;
 			_spriteLabel.draw();
 		}
 	}

--- a/tests/unit/src/flixel/group/FlxContainerTest.hx
+++ b/tests/unit/src/flixel/group/FlxContainerTest.hx
@@ -1,0 +1,18 @@
+
+package flixel.group;
+
+import flixel.FlxBasic;
+import massive.munit.Assert;
+
+class FlxContainerTest extends FlxGroupTest
+{
+	override function makeGroup():FlxGroup
+	{
+		var group = new FlxContainer();
+		for (i in 0...10)
+		{
+			group.add(new FlxBasic());
+		}
+		return group;
+	}
+}

--- a/tests/unit/src/flixel/group/FlxGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxGroupTest.hx
@@ -561,4 +561,12 @@ class FlxGroupTest extends FlxTest
 		
 		Assert.areEqual(group.length, count);
 	}
+	
+	@Test
+	function testDestroyRemoveAll()
+	{
+		var members = group.members;
+		group.destroy();
+		Assert.areEqual(0, members.length);
+	}
 }

--- a/tests/unit/src/flixel/group/FlxSpriteContainerTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteContainerTest.hx
@@ -1,0 +1,15 @@
+package flixel.group;
+
+import flixel.FlxSprite;
+import flixel.math.FlxRect;
+import massive.munit.Assert;
+
+class FlxSpriteContainerTest extends FlxSpriteGroupTest
+{
+	override function before()
+	{
+		group = new FlxSpriteContainer();
+		for (i in 0...10)
+			group.add(new FlxSpriteContainer());
+	}
+}


### PR DESCRIPTION
- FlxState extends FlxContainer, which was supposed to happen in #3050 
- Fixes issue where group.destroy removes members during destroy, causing it to skip members while iterating
- Adds getCamera() which looks up the container stack to find which cameras will draw the obj, even outside of the draw() phase
- adds `FlxSpriteContainer`, a spritegroup that removes new members from previous containers (Note: the container of the members is the container, not the spritegroup, and the container's container is the spritegroup's container)
- improves docs