### PR TITLE
Add `drawOnTop` to PluginFrontEnd

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -863,9 +863,16 @@ class FlxGame extends Sprite
 
 		FlxG.cameras.lock();
 
-		FlxG.plugins.draw();
-
-		_state.draw();
+		if (FlxG.plugins.drawOnTop)
+		{
+			_state.draw();
+			FlxG.plugins.draw();
+		}
+		else
+		{
+			FlxG.plugins.draw();
+			_state.draw();
+		}
 
 		if (FlxG.renderTile)
 		{

--- a/flixel/system/frontEnds/PluginFrontEnd.hx
+++ b/flixel/system/frontEnds/PluginFrontEnd.hx
@@ -17,6 +17,12 @@ class PluginFrontEnd
 	public var list(default, null):Array<FlxBasic> = [];
 
 	/**
+	 * If `true`, then plugins will be drawn over the current state instead of under it.
+	 * @since 5.7.0
+	 */
+	public var drawOnTop:Bool = false;
+
+	/**
 	 * Adds a new plugin to the global plugin array.
 	 * **DEPRECATED:** In a later version this will be changed to behave like `addPlugin`.
 	 *


### PR DESCRIPTION
This PR adds a variable that allows plugins to be drawn on top of everything else, instead of under.

Closes #3054 