### PR TITLE
Remove (now redundant) health variable and function in FlxObject

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -700,11 +700,6 @@ class FlxObject extends FlxBasic
 	public var maxAngular:Float = 10000;
 
 	/**
-	 * Handy for storing health percentage or armor points or whatever.
-	 */
-	public var health:Float = 1;
-
-	/**
 	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts. Use bitwise operators to check the values
 	 * stored here, or use isTouching(), justTouched(), etc. You can even use them broadly as boolean values if you're feeling saucy!
 	 */
@@ -1197,19 +1192,6 @@ class FlxObject extends FlxBasic
 	public inline function justTouched(direction:FlxDirectionFlags):Bool
 	{
 		return touching.hasAny(direction) && !wasTouching.hasAny(direction);
-	}
-
-	/**
-	 * Reduces the `health` variable of this object by the amount specified in `Damage`.
-	 * Calls `kill()` if health drops to or below zero.
-	 *
-	 * @param   Damage   How much health to take away (use a negative number to give a health bonus).
-	 */
-	public function hurt(damage:Float):Void
-	{
-		health = health - damage;
-		if (health <= 0)
-			kill();
 	}
 
 	/**

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -702,6 +702,7 @@ class FlxObject extends FlxBasic
 	/**
 	 * Handy for storing health percentage or armor points or whatever.
 	 */
+	@:deprecated("This is no longer needed, as you can extend FlxObject")
 	public var health:Float = 1;
 
 	/**
@@ -1205,6 +1206,7 @@ class FlxObject extends FlxBasic
 	 *
 	 * @param   Damage   How much health to take away (use a negative number to give a health bonus).
 	 */
+	@:deprecated("This is no longer needed, as you can extend FlxObject")
 	public function hurt(damage:Float):Void
 	{
 		health = health - damage;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -700,6 +700,11 @@ class FlxObject extends FlxBasic
 	public var maxAngular:Float = 10000;
 
 	/**
+	 * Handy for storing health percentage or armor points or whatever.
+	 */
+	public var health:Float = 1;
+
+	/**
 	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts. Use bitwise operators to check the values
 	 * stored here, or use isTouching(), justTouched(), etc. You can even use them broadly as boolean values if you're feeling saucy!
 	 */
@@ -1192,6 +1197,19 @@ class FlxObject extends FlxBasic
 	public inline function justTouched(direction:FlxDirectionFlags):Bool
 	{
 		return touching.hasAny(direction) && !wasTouching.hasAny(direction);
+	}
+
+	/**
+	 * Reduces the `health` variable of this object by the amount specified in `Damage`.
+	 * Calls `kill()` if health drops to or below zero.
+	 *
+	 * @param   Damage   How much health to take away (use a negative number to give a health bonus).
+	 */
+	public function hurt(damage:Float):Void
+	{
+		health = health - damage;
+		if (health <= 0)
+			kill();
 	}
 
 	/**


### PR DESCRIPTION
I couldn't find any duplicates to this, but if you wanna correct me on this Geokureli, you can, but this just seems pretty redundant now, this was probably kept for backwards compatibility or legacy reasons, but it seems pretty useless now since you could just extend FlxObject to readd it or something similar like that.

There are many other ways of doing it though, so I feel like this really isn't needed now, especially since it was last updated around **11 years ago** and I don't think this is really used a lot, or just not at all in contrast to now