### PR TITLE
Support for loading `FlxGraphic`'s through `FlxMouse.load`

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -10,6 +10,7 @@ import openfl.events.MouseEvent;
 import openfl.Lib;
 import openfl.ui.Mouse;
 import flixel.FlxG;
+import flixel.graphics.FlxGraphic;
 import flixel.input.IFlxInputManager;
 import flixel.input.FlxInput.FlxInputState;
 import flixel.input.mouse.FlxMouseButton.FlxMouseButtonID;
@@ -261,9 +262,13 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		{
 			cursor = Type.createInstance(Graphic, []);
 		}
+		else if ((Graphic is FlxGraphic))
+		{
+			cursor = new Bitmap(cast (Graphic, FlxGraphic).bitmap);
+		}
 		else if ((Graphic is BitmapData))
 		{
-			cursor = new Bitmap(cast Graphic);
+			cursor = new Bitmap(cast (Graphic, BitmapData));
 		}
 		else if ((Graphic is String))
 		{


### PR DESCRIPTION
I was working on a project and I noticed that `FlxMouse` doesn't natively support loading `FlxGraphic`s, I found this odd, it supports `BitmapData` and even custom classes, why not the main one for Flixel graphics?