### PR TITLE
add define to remove health fields

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -699,11 +699,13 @@ class FlxObject extends FlxBasic
 	 */
 	public var maxAngular:Float = 10000;
 
+	#if FLX_HEALTH
 	/**
 	 * Handy for storing health percentage or armor points or whatever.
 	 */
-	@:deprecated("This is no longer needed, as you can extend FlxObject")
+	@:deprecated("object.health is being removed in version 6.0.0")
 	public var health:Float = 1;
+	#end
 
 	/**
 	 * Bit field of flags (use with UP, DOWN, LEFT, RIGHT, etc) indicating surface contacts. Use bitwise operators to check the values
@@ -1200,19 +1202,21 @@ class FlxObject extends FlxBasic
 		return touching.hasAny(direction) && !wasTouching.hasAny(direction);
 	}
 
+	#if FLX_HEALTH
 	/**
 	 * Reduces the `health` variable of this object by the amount specified in `Damage`.
 	 * Calls `kill()` if health drops to or below zero.
 	 *
 	 * @param   Damage   How much health to take away (use a negative number to give a health bonus).
 	 */
-	@:deprecated("This is no longer needed, as you can extend FlxObject")
+	@:deprecated("object.health is being removed in version 6.0.0")
 	public function hurt(damage:Float):Void
 	{
 		health = health - damage;
 		if (health <= 0)
 			kill();
 	}
+	#end
 
 	/**
 	 * Centers this `FlxObject` on the screen, either by the x axis, y axis, or both.

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -22,6 +22,8 @@ private enum UserDefines
 	FLX_NO_SOUND_TRAY;
 	FLX_NO_FOCUS_LOST_SCREEN;
 	FLX_NO_DEBUG;
+	/* Removes FlxObject.health */
+	FLX_NO_HEALTH;
 	FLX_RECORD;
 	/* Defined in HaxeFlixel CI tests, do not use */
 	FLX_UNIT_TEST;
@@ -77,6 +79,7 @@ private enum HelperDefines
 	/* Used in HaxeFlixel CI, should have no effect on personal projects */
 	FLX_NO_CI;
 	FLX_SAVE;
+	FLX_HEALTH;
 }
 
 class FlxDefines
@@ -169,6 +172,7 @@ class FlxDefines
 		defineInversion(FLX_UNIT_TEST, FLX_NO_UNIT_TEST);
 		defineInversion(FLX_COVERAGE_TEST, FLX_NO_COVERAGE_TEST);
 		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
+		defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
 	}
 
 	static function defineHelperDefines()

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -49,6 +49,7 @@
 		<haxedef name="FLX_RECORD" />
 		<haxedef name="FLX_RENDER_TRIANGLE" />
 		<haxedef name="FLX_NO_SAVE" />
+		<haxedef name="FLX_NO_HEALTH" />
 	</section>
 	<section if="coverage2">
 		<haxedef name="debug" />


### PR DESCRIPTION
Continuation of #3065

I wasn't happy with the deprecation message of "you don't need it anymore, because you can extend", that's not what redundant means, the field should have never been added, to begin with.

I've added the defines: FLX_NO_HEALTH to remove it, and it's inversion: FLX_HEALTH. this way people can remove it in their projects now and add their own health system. when flixel 6.0.0 is released FLX_NO_HEALTH will be true by default, and FLX_HEALTH will be it's inversion so people can easily fix old projects