### PR TITLE
Toggle debug boxes

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1303,8 +1303,8 @@ class FlxObject extends FlxBasic
 		}
 
 		// fill static graphics object with square shape
-		gfx.lineStyle(1, color, 0.5);
-		gfx.drawRect(rect.x, rect.y, rect.width, rect.height);
+		gfx.lineStyle(1, color, 0.75);
+		gfx.drawRect(rect.x + 0.5, rect.y + 0.5, rect.width - 1.0, rect.height - 1.0);
 	}
 
 	inline function beginDrawDebug(camera:FlxCamera):Graphics

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -2,6 +2,7 @@ package flixel.system.debug;
 
 import openfl.display.BitmapData;
 import openfl.display.Sprite;
+#if FLX_DEBUG
 import openfl.events.MouseEvent;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
@@ -23,45 +24,45 @@ import flixel.system.ui.FlxSystemButton;
 import flixel.util.FlxHorizontalAlign;
 
 using flixel.util.FlxArrayUtil;
+#end
 
-@:bitmap("assets/images/debugger/flixel.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/flixel.png") #end
 private class GraphicFlixel extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/drawDebug.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/drawDebug.png") #end
 private class GraphicDrawDebug extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/log.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/log.png") #end
 @:noCompletion class GraphicLog extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/stats.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/stats.png") #end
 @:noCompletion class GraphicStats extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/watch.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/watch.png") #end
 @:noCompletion class GraphicWatch extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/bitmapLog.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/bitmapLog.png") #end
 @:noCompletion class GraphicBitmapLog extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/console.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/console.png") #end
 @:noCompletion class GraphicConsole extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/arrowLeft.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/arrowLeft.png") #end
 @:noCompletion class GraphicArrowLeft extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/arrowRight.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/arrowRight.png") #end
 @:noCompletion class GraphicArrowRight extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/close.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/close.png") #end
 @:noCompletion class GraphicCloseButton extends BitmapData {}
 
-@:bitmap("assets/images/debugger/buttons/interactive.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/buttons/interactive.png") #end
 @:noCompletion class GraphicInteractive extends BitmapData {}
-
 /**
  * Container for the new debugger overlay. Most of the functionality is in the debug folder widgets,
  * but this class instantiates the widgets and handles their basic formatting and arrangement.
  */
-class FlxDebugger extends Sprite
+class FlxDebugger extends openfl.display.Sprite
 {
 	#if FLX_DEBUG
 	/**

--- a/flixel/system/debug/Window.hx
+++ b/flixel/system/debug/Window.hx
@@ -15,7 +15,7 @@ import flixel.system.ui.FlxSystemButton;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 
-@:bitmap("assets/images/debugger/windowHandle.png")
+#if FLX_DEBUG @:bitmap("assets/images/debugger/windowHandle.png") #end
 private class GraphicWindowHandle extends BitmapData {}
 
 /**

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -397,9 +397,11 @@ class Interaction extends Window
 		{
 			if (member != null && member.scrollFactor != null && member.isOnScreen())
 			{
-				// Render a red rectangle centered at the selected item
-				gfx.lineStyle(0.9, 0xff0000);
-				gfx.drawRect(member.x - FlxG.camera.scroll.x, member.y - FlxG.camera.scroll.y, member.width * 1.0, member.height * 1.0);
+				final margin = 0.5;
+				final scroll = FlxG.camera.scroll;
+				// Render a white rectangle centered at the selected item
+				gfx.lineStyle(1.0, 0xFFFFFF, 0.75);
+				gfx.drawRect(member.x - scroll.x - margin, member.y - scroll.y - margin, member.width + margin*2, member.height + margin*2);
 			}
 		}
 

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -18,6 +18,7 @@ import flixel.system.debug.interaction.tools.Eraser;
 import flixel.system.debug.interaction.tools.Mover;
 import flixel.system.debug.interaction.tools.Pointer;
 import flixel.system.debug.interaction.tools.Tool;
+import flixel.system.debug.interaction.tools.ToggleBounds;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
 #if !(FLX_NATIVE_CURSOR && FLX_MOUSE)
@@ -90,6 +91,7 @@ class Interaction extends Window
 		addTool(new Mover());
 		addTool(new Eraser());
 		addTool(new Transform());
+		addTool(new ToggleBounds());
 
 		FlxG.signals.postDraw.add(postDraw);
 		FlxG.debugger.visibilityChanged.add(handleDebuggerVisibilityChanged);

--- a/flixel/system/debug/interaction/tools/ToggleBounds.hx
+++ b/flixel/system/debug/interaction/tools/ToggleBounds.hx
@@ -1,0 +1,76 @@
+package flixel.system.debug.interaction.tools;
+
+import openfl.display.BitmapData;
+import openfl.display.Graphics;
+import openfl.display.LineScaleMode;
+import openfl.display.CapsStyle;
+import flixel.math.FlxPoint;
+import flixel.math.FlxRect;
+import flixel.math.FlxAngle;
+import flixel.math.FlxMath;
+import flixel.system.debug.interaction.Interaction;
+import flixel.system.debug.Tooltip;
+import flixel.util.FlxSpriteUtil;
+import flixel.util.FlxColor;
+
+using flixel.util.FlxArrayUtil;
+
+@:bitmap("assets/images/debugger/buttons/drawDebug.png")
+private class GraphicToggleBoundsTool extends BitmapData {}
+
+/**
+ * A tool to scale and rotate selected game elements.
+ *
+ * @author Fernando Bevilacqua (dovyski@gmail.com)
+ */
+class ToggleBounds extends Tool
+{
+	override function init(brain:Interaction):Tool
+	{
+		super.init(brain);
+		
+		_name = "Toggle Debug Draw";
+		setButton(GraphicToggleBoundsTool);
+		button.toggleMode = false;
+		
+		// _tooltip = Tooltip.add(null, "");
+		// _tooltip.textField.wordWrap = false;
+		
+		return this;
+	}
+	
+	override function update():Void
+	{
+		button.enabled = FlxG.debugger.drawDebug && _brain.selectedItems.countLiving() > 0;
+		button.mouseEnabled = button.enabled; 
+		button.alpha = button.enabled ? 0.3 : 0.1;
+	}
+	
+	override function onButtonClicked()
+	{
+		// super.onButtonClicked();
+		if (_brain.selectedItems.length == 0)
+			return;
+		
+		// get whether any selected object is being debug drawn
+		var anyEnabled = false;
+		for (member in _brain.selectedItems)
+		{
+			if (member != null && !member.ignoreDrawDebug)
+			{
+				anyEnabled = true;
+				break;
+			}
+		}
+		
+		for (member in _brain.selectedItems)
+		{
+			if (member != null)
+			{
+				// If any were debug drawn, set all to not draw, otherwise set all to draw
+				member.ignoreDrawDebug = anyEnabled;
+			}
+		}
+		// _brain.selectedItems.clear();
+	}
+}

--- a/flixel/system/debug/interaction/tools/ToggleBounds.hx
+++ b/flixel/system/debug/interaction/tools/ToggleBounds.hx
@@ -15,7 +15,9 @@ import flixel.util.FlxColor;
 
 using flixel.util.FlxArrayUtil;
 
+#if debug
 @:bitmap("assets/images/debugger/buttons/drawDebug.png")
+#end
 private class GraphicToggleBoundsTool extends BitmapData {}
 
 /**

--- a/flixel/system/debug/interaction/tools/ToggleBounds.hx
+++ b/flixel/system/debug/interaction/tools/ToggleBounds.hx
@@ -21,9 +21,9 @@ using flixel.util.FlxArrayUtil;
 private class GraphicToggleBoundsTool extends BitmapData {}
 
 /**
- * A tool to scale and rotate selected game elements.
+ * A tool to toggle `ignoreDrawDebug` on objects
  *
- * @author Fernando Bevilacqua (dovyski@gmail.com)
+ * @author George
  */
 class ToggleBounds extends Tool
 {

--- a/flixel/system/debug/interaction/tools/ToggleBounds.hx
+++ b/flixel/system/debug/interaction/tools/ToggleBounds.hx
@@ -50,6 +50,7 @@ class ToggleBounds extends Tool
 	
 	override function onButtonClicked()
 	{
+		#if FLX_DEBUG // needed for coverage tests
 		// super.onButtonClicked();
 		if (_brain.selectedItems.length == 0)
 			return;
@@ -74,5 +75,6 @@ class ToggleBounds extends Tool
 			}
 		}
 		// _brain.selectedItems.clear();
+		#end
 	}
 }

--- a/flixel/system/debug/interaction/tools/Tool.hx
+++ b/flixel/system/debug/interaction/tools/Tool.hx
@@ -4,7 +4,7 @@ import openfl.display.BitmapData;
 import openfl.display.Sprite;
 import flixel.system.debug.interaction.Interaction;
 import flixel.system.ui.FlxSystemButton;
-import flixel.util.FlxDestroyUtil.IFlxDestroyable;
+import flixel.util.FlxDestroyUtil;
 
 /**
  * The base class of all tools in the interactive debug.
@@ -42,15 +42,15 @@ class Tool extends Sprite implements IFlxDestroyable
 		return _brain.activeTool == this && _brain.visible;
 	}
 
-	function setButton(Icon:Class<BitmapData>):Void
+	function setButton(icon:Class<BitmapData>):Void
 	{
-		button = new FlxSystemButton(Type.createInstance(Icon, [0, 0]), onButtonClicked, true);
+		button = new FlxSystemButton(Type.createInstance(icon, [0, 0]), onButtonClicked, true);
 		button.toggled = true;
 
-		var tooltip = _name;
+		var tooltipName = _name;
 		if (_shortcut != null)
-			tooltip += ' ($_shortcut)';
-		Tooltip.add(button, tooltip);
+			tooltipName += ' ($_shortcut)';
+		Tooltip.add(button, tooltipName);
 	}
 
 	/**


### PR DESCRIPTION
A button that toggles `ignoreDrawDebug` on selected objects