### PR TITLE
Replace references to FlxG.camera with this.getDefaultCamera

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -194,13 +194,27 @@ class FlxBasic implements IFlxDestroyable
 	}
 	
 	/**
+	 * The main camera that will draw this. Use `this.cameras` to set specific cameras for this
+	 * object, otherwise the container's camera is used, or the container's container and so on.
+	 * If there is no container, say, if this is inside `FlxGroups` rather than a `FlxContainer`
+	 * then `FlxG.camera` is returned.
+	 * @since 5.7.0
+	 */
+	public function getDefaultCamera():FlxCamera
+	{
+		final cameras = getCameras();
+		// should never be null, unless people do something stupid, but just in case
+		return cameras == null || cameras.length == 0 ? FlxG.camera : cameras[0];
+	}
+	
+	/**
 	 * The cameras that will draw this. Use `this.cameras` to set specific cameras for this object,
 	 * otherwise the container's cameras are used, or the container's container and so on. If there
 	 * is no container, say, if this is inside `FlxGroups` rather than a `FlxContainer` then the
 	 * default draw cameras are returned.
 	 * @since 5.7.0
 	 */
-	public function getCameras()
+	public function getCameras():Array<FlxCamera>
 	{
 		return if (_cameras != null)
 				_cameras;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -850,11 +850,10 @@ class FlxObject extends FlxBasic
 	 * If the group has a LOT of things in it, it might be faster to use `FlxG.overlap()`.
 	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
 	 *
-	 * @param   objectOrGroup   The object or group being tested.
-	 * @param   inScreenSpace   Whether to take scroll factors into account when checking for overlap.
-	 *                          Default is `false`, or "only compare in world space."
-	 * @param   camera          Specify which game camera you want.
-	 *                          If `null`, it will just grab the first global camera.
+	 * @param   objectOrGroup  The object or group being tested.
+	 * @param   inScreenSpace  Whether to take scroll factors into account when checking for overlap.
+	 *                         Default is `false`, or "only compare in world space."
+	 * @param   camera         The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether or not the two objects overlap.
 	 */
 	@:access(flixel.group.FlxTypedGroup)
@@ -881,9 +880,8 @@ class FlxObject extends FlxBasic
 		}
 
 		if (camera == null)
-		{
-			camera = FlxG.camera;
-		}
+			camera = getDefaultCamera();
+		
 		var objectScreenPos:FlxPoint = object.getScreenPosition(null, camera);
 		getScreenPosition(_point, camera);
 		return (objectScreenPos.x + object.width > _point.x)
@@ -905,15 +903,14 @@ class FlxObject extends FlxBasic
 	 * rather than taking the object's size into account.
 	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
 	 *
-	 * @param   x               The X position you want to check.
-	 *                          Pretends this object (the caller, not the parameter) is located here.
-	 * @param   y               The Y position you want to check.
-	 *                          Pretends this object (the caller, not the parameter) is located here.
-	 * @param   objectOrGroup   The object or group being tested.
-	 * @param   inScreenSpace   Whether to take scroll factors into account when checking for overlap.
-	 *                          Default is `false`, or "only compare in world space."
-	 * @param   camera          Specify which game camera you want.
-	 *                          If `null`, it will just grab the first global camera.
+	 * @param   x              The X position you want to check.
+	 *                         Pretends this object (the caller, not the parameter) is located here.
+	 * @param   y              The Y position you want to check.
+	 *                         Pretends this object (the caller, not the parameter) is located here.
+	 * @param   objectOrGroup  The object or group being tested.
+	 * @param   inScreenSpace  Whether to take scroll factors into account when checking for overlap.
+	 *                         Default is `false`, or "only compare in world space."
+	 * @param   camera         The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether or not the two objects overlap.
 	 */
 	@:access(flixel.group.FlxTypedGroup)
@@ -942,9 +939,8 @@ class FlxObject extends FlxBasic
 		}
 
 		if (camera == null)
-		{
-			camera = FlxG.camera;
-		}
+			camera = getDefaultCamera();
+		
 		var objectScreenPos:FlxPoint = object.getScreenPosition(null, camera);
 		getScreenPosition(_point, camera);
 		return (objectScreenPos.x + object.width > _point.x)
@@ -962,10 +958,9 @@ class FlxObject extends FlxBasic
 	/**
 	 * Checks to see if a point in 2D world space overlaps this `FlxObject`.
 	 *
-	 * @param   point           The point in world space you want to check.
-	 * @param   inScreenSpace   Whether to take scroll factors into account when checking for overlap.
-	 * @param   camera          Specify which game camera you want.
-	 *                          If `null`, it will just grab the first global camera.
+	 * @param   point          The point in world space you want to check.
+	 * @param   inScreenSpace  Whether to take scroll factors into account when checking for overlap.
+	 * @param   camera         The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether or not the point overlaps this object.
 	 */
 	public function overlapsPoint(point:FlxPoint, inScreenSpace = false, ?camera:FlxCamera):Bool
@@ -976,11 +971,10 @@ class FlxObject extends FlxBasic
 		}
 
 		if (camera == null)
-		{
-			camera = FlxG.camera;
-		}
-		var xPos:Float = point.x - camera.scroll.x;
-		var yPos:Float = point.y - camera.scroll.y;
+			camera = getDefaultCamera();
+		
+		final xPos:Float = point.x - camera.scroll.x;
+		final yPos:Float = point.y - camera.scroll.y;
 		getScreenPosition(_point, camera);
 		point.putWeak();
 		return (xPos >= _point.x) && (xPos < _point.x + width) && (yPos >= _point.y) && (yPos < _point.y + height);
@@ -1001,7 +995,7 @@ class FlxObject extends FlxBasic
 	 * Returns the screen position of this object.
 	 *
 	 * @param   result  Optional arg for the returning point
-	 * @param   camera  The desired "screen" coordinate space. If `null`, `FlxG.camera` is used.
+	 * @param   camera  The desired "screen" coordinate space. If `null`, `getDefaultCamera()` is used.
 	 * @return  The screen position of this object.
 	 */
 	public function getScreenPosition(?result:FlxPoint, ?camera:FlxCamera):FlxPoint
@@ -1010,7 +1004,7 @@ class FlxObject extends FlxBasic
 			result = FlxPoint.get();
 
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 
 		result.set(x, y);
 		if (pixelPerfectPosition)
@@ -1058,8 +1052,8 @@ class FlxObject extends FlxBasic
 	 * Handy function for reviving game objects.
 	 * Resets their existence flags and position.
 	 *
-	 * @param   x   The new X position of this object.
-	 * @param   y   The new Y position of this object.
+	 * @param   x  The new X position of this object.
+	 * @param   y  The new Y position of this object.
 	 */
 	public function reset(x:Float, y:Float):Void
 	{
@@ -1074,14 +1068,13 @@ class FlxObject extends FlxBasic
 	/**
 	 * Check and see if this object is currently on screen.
 	 *
-	 * @param   camera   Specify which game camera you want.
-	 *                   If `null`, it will just grab the first global camera.
+	 * @param   camera  Specify which game camera you want. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether the object is on screen or not.
 	 */
 	public function isOnScreen(?camera:FlxCamera):Bool
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 
 		getScreenPosition(_point, camera);
 		return camera.containsPoint(_point, width, height);
@@ -1093,7 +1086,7 @@ class FlxObject extends FlxBasic
 	public function isPixelPerfectRender(?camera:FlxCamera):Bool
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 		return pixelPerfectRender == null ? camera.pixelPerfectRender : pixelPerfectRender;
 	}
 

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1016,7 +1016,7 @@ class FlxSprite extends FlxObject
 	 *
 	 * @param   worldPoint      point in world space you want to check.
 	 * @param   alphaTolerance  Used to determine what counts as solid.
-	 * @param   camera          The desired "screen" coordinate space. If `null`, `FlxG.camera` is used.
+	 * @param   camera          The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether or not the point overlaps this object.
 	 */
 	public function pixelsOverlapPoint(worldPoint:FlxPoint, alphaTolerance = 0xFF, ?camera:FlxCamera):Bool
@@ -1035,7 +1035,7 @@ class FlxSprite extends FlxObject
 	 * Factors in `scale`, `angle`, `offset`, `origin`, and `scrollFactor`.
 	 * 
 	 * @param  worldPoint  The point in world space
-	 * @param  camera      The camera, used for `scrollFactor`. If `null`, `FlxG.camera` is used.
+	 * @param  camera      The camera, used for `scrollFactor`. If `null`, `getDefaultCamera()` is used.
 	 * @return a `FlxColor`, if the point is in the sprite's graphic, otherwise `null` is returned.
 	 * @since 5.0.0
 	 */
@@ -1058,7 +1058,7 @@ class FlxSprite extends FlxObject
 	 * Factors in `scale`, `angle`, `offset`, `origin`, and `scrollFactor`.
 	 * 
 	 * @param  screenPoint  The point in screen space
-	 * @param  camera       The desired "screen" coordinate space. If `null`, `FlxG.camera` is used.
+	 * @param  camera       The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @return a `FlxColor`, if the point is in the sprite's graphic, otherwise `null` is returned.
 	 * @since 5.0.0
 	 */
@@ -1081,14 +1081,14 @@ class FlxSprite extends FlxObject
 	 * is the top left of the graphic.
 	 * Factors in `scale`, `angle`, `offset`, `origin`, and `scrollFactor`.
 	 * 
-	 * @param   worldPoint  The world coordinates.
-	 * @param   camera      The camera, used for `scrollFactor`. If `null`, `FlxG.camera` is used.
+	 * @param   worldPoint  The world coordinates
+	 * @param   camera      The camera, used for `scrollFactor`. If `null`, `getDefaultCamera()` is used
 	 * @param   result      Optional arg for the returning point
 	 */
 	public function transformWorldToPixels(worldPoint:FlxPoint, ?camera:FlxCamera, ?result:FlxPoint):FlxPoint
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 		
 		var screenPoint = FlxPoint.weak(worldPoint.x - camera.scroll.x, worldPoint.y - camera.scroll.y);
 		worldPoint.putWeak();
@@ -1126,7 +1126,7 @@ class FlxSprite extends FlxObject
 	 * Factors in `scale`, `angle`, `offset`, `origin`, and `scrollFactor`.
 	 * 
 	 * @param   screenPoint  The screen coordinates
-	 * @param   camera       The desired "screen" coordinate space. If `null`, `FlxG.camera` is used.
+	 * @param   camera       The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @param   result       Optional arg for the returning point
 	 */
 	public function transformScreenToPixels(screenPoint:FlxPoint, ?camera:FlxCamera, ?result:FlxPoint):FlxPoint
@@ -1225,13 +1225,13 @@ class FlxSprite extends FlxObject
 	 * Check and see if this object is currently on screen. Differs from `FlxObject`'s implementation
 	 * in that it takes the actual graphic into account, not just the hitbox or bounding box or whatever.
 	 *
-	 * @param   Camera  Specify which game camera you want. If `null`, `FlxG.camera` is used.
+	 * @param   camera  Specify which game camera you want. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether the object is on screen or not.
 	 */
 	override public function isOnScreen(?camera:FlxCamera):Bool
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 		
 		return camera.containsRect(getScreenBounds(_rect, camera));
 	}
@@ -1284,8 +1284,8 @@ class FlxSprite extends FlxObject
 	/**
 	 * Calculates the smallest globally aligned bounding box that encompasses this sprite's graphic as it
 	 * would be displayed. Honors scrollFactor, rotation, scale, offset and origin.
-	 * @param newRect Optional output `FlxRect`, if `null`, a new one is created.
-	 * @param camera  Optional camera used for scrollFactor, if null `FlxG.camera` is used.
+	 * @param newRect  Optional output `FlxRect`, if `null`, a new one is created
+	 * @param camera   Optional camera used for scrollFactor, if null `getDefaultCamera()` is used
 	 * @return A globally aligned `FlxRect` that fully contains the input sprite.
 	 * @since 4.11.0
 	 */
@@ -1295,7 +1295,7 @@ class FlxSprite extends FlxObject
 			newRect = FlxRect.get();
 		
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 		
 		newRect.setPosition(x, y);
 		if (pixelPerfectPosition)

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -770,7 +770,7 @@ class FlxPath implements IFlxDestroyable
 
 		if (camera == null)
 		{
-			camera = getDefaultCamera();
+			camera = object != null ? object.getDefaultCamera() : FlxG.camera;
 		}
 
 		var gfx:Graphics = null;

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -770,7 +770,7 @@ class FlxPath implements IFlxDestroyable
 
 		if (camera == null)
 		{
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 		}
 
 		var gfx:Graphics = null;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -1029,7 +1029,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 *
 	 * @param   worldPoint     The point in world space you want to check.
 	 * @param   inScreenSpace  Whether to take scroll factors into account when checking for overlap.
-	 * @param   camera         Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
+	 * @param   camera         The desired "screen" space. If `null`, `getDefaultCamera()` is used
 	 * @return  Whether or not the point overlaps this object.
 	 */
 	override public function overlapsPoint(worldPoint:FlxPoint, inScreenSpace = false, ?camera:FlxCamera):Bool
@@ -1037,7 +1037,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		if (inScreenSpace)
 		{
 			if (camera == null)
-				camera = FlxG.camera;
+				camera = getDefaultCamera();
 
 			worldPoint.subtractPoint(camera.scroll);
 			worldPoint.putWeak();

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -329,7 +329,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	/**
 	 * Clean up memory.
 	 */
-	override public function destroy():Void
+	override function destroy():Void
 	{
 		_flashPoint = null;
 		_flashRect = null;
@@ -531,7 +531,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	}
 
 	#if FLX_DEBUG
-	override public function drawDebugOnCamera(camera:FlxCamera):Void
+	override function drawDebugOnCamera(camera:FlxCamera):Void
 	{
 		if (!FlxG.renderTile)
 			return;
@@ -606,10 +606,10 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 * @param   camera  Specify which game camera you want. If `null`, it will just grab the first global camera.
 	 * @return  Whether the object is on screen or not.
 	 */
-	override public function isOnScreen(?camera:FlxCamera):Bool
+	override function isOnScreen(?camera:FlxCamera):Bool
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 
 		var minX:Float = x - offset.x - camera.scroll.x * scrollFactor.x;
 		var minY:Float = y - offset.y - camera.scroll.y * scrollFactor.y;
@@ -621,7 +621,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	/**
 	 * Draws the tilemap buffers to the cameras.
 	 */
-	override public function draw():Void
+	override function draw():Void
 	{
 		// don't try to render a tilemap that isn't loaded yet
 		if (graphic == null)
@@ -695,7 +695,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 *
 	 * @param   dirty  Whether to flag the tilemap buffers as dirty or not.
 	 */
-	override public function setDirty(dirty:Bool = true):Void
+	override function setDirty(dirty:Bool = true):Void
 	{
 		if (FlxG.renderTile)
 			return;
@@ -718,7 +718,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 * @param   position            Optional, specify a custom position for the tilemap (used for `overlapsAt`).
 	 * @return  Whether there were overlaps, and the result of the callback, if one was specified.
 	 */
-	override public function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false,
+	override function overlapsWithCallback(object:FlxObject, ?callback:FlxObject->FlxObject->Bool, flipCallbackParams:Bool = false,
 			?position:FlxPoint):Bool
 	{
 		var results = false;
@@ -802,7 +802,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		return results;
 	}
 
-	override public function getTileIndexByCoords(coord:FlxPoint):Int
+	override function getTileIndexByCoords(coord:FlxPoint):Int
 	{
 		var localX = coord.x - x;
 		var localY = coord.y - y;
@@ -814,7 +814,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		return Std.int(localY / scaledTileHeight) * widthInTiles + Std.int(localX / scaledTileWidth);
 	}
 
-	override public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
+	override function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
 	{
 		var point = FlxPoint.get(x + (index % widthInTiles) * scaledTileWidth, y + Std.int(index / widthInTiles) * scaledTileHeight);
 		if (midpoint)
@@ -865,14 +865,16 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	/**
 	 * Call this function to lock the automatic camera to the map's edges.
 	 *
-	 * @param   camera       Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
-	 * @param   border       Adjusts the camera follow boundary by whatever number of tiles you specify here.  Handy for blocking off deadends that are offscreen, etc.  Use a negative number to add padding instead of hiding the edges.
+	 * @param   camera       The desired camera.  If `null`, `getDefaultCamera()` is used.
+	 * @param   border       Adjusts the camera follow boundary by whatever number of tiles you
+	 *                       specify here. Handy for blocking off deadends that are offscreen, etc.
+	 *                       Use a negative number to add padding instead of hiding the edges.
 	 * @param   updateWorld  Whether to update the collision system's world size, default value is true.
 	 */
 	public function follow(?camera:FlxCamera, border = 0, updateWorld = true):Void
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = getDefaultCamera();
 
 		camera.setScrollBoundsRect(
 			x + border * scaledTileWidth,

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -159,16 +159,16 @@ class FlxSpriteUtil
 	/**
 	 * Checks the sprite's screen bounds of the FlxSprite and keeps them within the camera by wrapping it around.
 	 *
-	 * @param	sprite	The FlxSprite to wrap.
-	 * @param	camera	The camera to wrap around. If left null, `FlxG.camera` is used.
-	 * @param	edges	The edges FROM which to wrap. Use constants like `LEFT`, `RIGHT`, `UP|DOWN` or `ANY`.
-	 * @return	The FlxSprite for chaining
+	 * @param   sprite  The FlxSprite to wrap.
+	 * @param   camera  The camera to wrap around. If `null`, `sprite.getDefaultCamera()` is used.
+	 * @param   edges   The edges FROM which to wrap. Use constants like `LEFT`, `RIGHT`, `UP|DOWN` or `ANY`.
+	 * @return  The FlxSprite for chaining
 	 * @since 4.11.0
 	 */
 	public static function cameraWrap(sprite:FlxSprite, ?camera:FlxCamera, edges:FlxDirectionFlags = ANY):FlxSprite
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = sprite.getDefaultCamera();
 		
 		var spriteBounds = sprite.getScreenBounds(camera);
 		var offset = FlxPoint.get(
@@ -195,16 +195,16 @@ class FlxSpriteUtil
 	/**
 	 * Checks the sprite's screen bounds and keeps it entirely within the camera.
 	 *
-	 * @param	sprite	The FlxSprite to restrict.
-	 * @param	camera	The camera resitricting the sprite. If left null, `FlxG.camera` is used.
-	 * @param	edges	The edges to restrict. Use constants like `LEFT`, `RIGHT`, `UP|DOWN` or `ANY`.
-	 * @return	The FlxSprite for chaining
+	 * @param   sprite  The FlxSprite to restrict.
+	 * @param   camera  The camera resitricting the sprite. If left null, `sprite.getDefaultCamera()` is used.
+	 * @param   edges   The edges to restrict. Use constants like `LEFT`, `RIGHT`, `UP|DOWN` or `ANY`.
+	 * @return  The FlxSprite for chaining
 	 * @since 4.11.0
 	 */
 	public static function cameraBound(sprite:FlxSprite, ?camera:FlxCamera, edges:FlxDirectionFlags = ANY):FlxSprite
 	{
 		if (camera == null)
-			camera = FlxG.camera;
+			camera = sprite.getDefaultCamera();
 		
 		var spriteBounds = sprite.getScreenBounds(camera);
 		var offset = FlxPoint.get(


### PR DESCRIPTION
`FlxG.camera` was used because we had no idea what camera things were actually using, now we do, so let's use that by default. this is kind of a breaking change and needs to be thoroughly explained in the migration doc