### PR TITLE
Add a setter to FlxObject's `health`

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -704,7 +704,7 @@ class FlxObject extends FlxBasic
 	 * Handy for storing health percentage or armor points or whatever.
 	 */
 	@:deprecated("object.health is being removed in version 6.0.0")
-	public var health:Float = 1;
+	public var health(default, set):Float = 1;
 	#end
 
 	/**
@@ -1432,6 +1432,12 @@ class FlxObject extends FlxBasic
 	function get_height():Float
 	{
 		return height;
+	}
+
+	@:noCompletion
+	function set_health(value:Float):Float
+	{
+		return health = value;
 	}
 
 	@:noCompletion


### PR DESCRIPTION
# Hello Haxeflixel Github, I'd like to make `health` more useful!
It'z_Miles. Enough about me though, I'm making games with haxeflixel!
I was designing a character controller for a platform fighter when I noticed that the character wasn't dying when its `health` was zero, so I took a look into FlxObject to see what was under the hood.
![image](https://github.com/HaxeFlixel/flixel/assets/95124554/4b05fe06-5017-46bc-8021-8ba510132902)
<sub>Ah, I see. Looks like that code has some legacy under its belt!</sub>

I wanted to override some functionality, but it looks like I had to resort to a custom health implementation or settle with the hurt function. I quickly made my way over here to suggest some changes and write up a pull request. Much to my dismay, however, it was being removed from future flixel versions!

If flixel was to continue holding innovation in one hand and support in the other, a different and much simpler approach could be made. That's when I came up with adding a setter!
![image](https://github.com/HaxeFlixel/flixel/assets/95124554/70ba1745-dd10-4530-b7b8-90270e328deb)
### Implementing this means that `FlxObjects`:
* allow child classes to override `health` behavior
* preserve legacy `health` functionality
* have absolutely _no_ breaking changes for `v6.0.0`
## Miles out. Let me know if you have a verdict, and thanks for keeping flixel alive!