### PR TITLE
Eric changes

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -634,6 +634,10 @@ class FlxCamera extends FlxBasic
 		{
 			itemToReturn = new FlxDrawItem();
 		}
+		
+		// TODO: catch this error when the dev actually messes up, not in the draw phase
+		if (graphic.isDestroyed)
+			throw 'Attempted to queue an invalid FlxDrawItem, did you destroy a cached sprite?';
 
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smooth;

--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -166,23 +166,21 @@ class FlxFlicker implements IFlxDestroyable
 	/**
 	 * Just a helper function for flicker() to update object's visibility.
 	 */
-	function flickerProgress(Timer:FlxTimer):Void
+	function flickerProgress(timer:FlxTimer):Void
 	{
 		object.visible = !object.visible;
-
+		
 		if (progressCallback != null)
-		{
 			progressCallback(this);
-		}
-
-		if (Timer.loops > 0 && Timer.loopsLeft == 0)
+		
+		if (timer.loops > 0 && timer.loopsLeft == 0)
 		{
 			object.visible = endVisibility;
 			if (completionCallback != null)
-			{
 				completionCallback(this);
-			}
-			release();
+			
+			if (this.timer == timer)
+				release();
 		}
 	}
 

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -498,8 +498,11 @@ class FlxGraphic implements IFlxDestroyable
 	{
 		if (collection.type != null)
 		{
-			var collections:Array<Dynamic> = getFramesCollections(collection.type);
-			collections.push(collection);
+			final collections = getFramesCollections(collection.type);
+			if (collections.contains(collection))
+				FlxG.log.warn('Attempting to add already added collection');
+			else
+				collections.push(collection);
 		}
 	}
 

--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -114,8 +114,12 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 	{
 		if (rects.length == 0)
 			return;
-
-		var shader = shader != null ? shader : graphics.shader;
+		
+		// TODO: catch this error when the dev actually messes up, not in the draw phase
+		if (shader == null && graphics.isDestroyed)
+			throw 'Attempted to render an invalid FlxDrawItem, did you destroy a cached sprite?';
+		
+		final shader = shader != null ? shader : graphics.shader;
 		shader.bitmap.input = graphics.bitmap;
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
 		shader.alpha.value = alphas;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -287,14 +287,16 @@ class BitmapFrontEnd
 
 	/**
 	 * Totally removes specified FlxGraphic object.
-	 * @param	FlxGraphic object you want to remove and destroy.
+	 * @param   graphic  object you want to remove and destroy.
 	 */
 	public function remove(graphic:FlxGraphic):Void
 	{
 		if (graphic != null)
 		{
 			removeKey(graphic.key);
-			graphic.destroy();
+			// TODO: find causes of this, and prevent crashes from double graphic destroys
+			if (!graphic.isDestroyed)
+				graphic.destroy();
 		}
 	}
 


### PR DESCRIPTION
Some issues and fixes discovered by @EliteMasterEric 

- check graphic.isDestroyed for better error messages when using destroyed graphics
- prevent double graphic destroys
- Prevent double adding of frame collections to a graphic
- prevent double release() call in  FlxFlicker
