### PR TITLE
Add support for V1 Sparrow atlases + fix intentional blank instances

### DIFF
--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -254,15 +254,16 @@ class FlxAtlasFrames extends FlxFramesCollection
 
 		for (texture in data.nodes.SubTexture)
 		{
+			var version2 = texture.has.width; 
 			var name = texture.att.name;
 			var trimmed = texture.has.frameX;
-			var rotated = (texture.has.rotated && texture.att.rotated == "true");
+			var rotated = (texture.has.rotated && texture.att.rotated == "true");-
 			var flipX = (texture.has.flipX && texture.att.flipX == "true");
 			var flipY = (texture.has.flipY && texture.att.flipY == "true");
 
-			var rect = FlxRect.get(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat(texture.att.width),
-				Std.parseFloat(texture.att.height));
-
+			var rect = FlxRect.get(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat((version2) ? texture.att.width : texture.att.w),
+				Std.parseFloat((version2) ? texture.att.height : texture.att.h));
+			
 			var size = if (trimmed)
 			{
 				new Rectangle(Std.parseInt(texture.att.frameX), Std.parseInt(texture.att.frameY), Std.parseInt(texture.att.frameWidth),
@@ -272,6 +273,14 @@ class FlxAtlasFrames extends FlxFramesCollection
 			{
 				new Rectangle(0, 0, rect.width, rect.height);
 			}
+
+			if (size.width == 0 && size.height == 0)
+            {
+				size.setSize(1, 1);
+                frames.addEmptyFrame(size);
+                continue;
+            }
+			
 
 			var angle = rotated ? FlxFrameAngle.ANGLE_NEG_90 : FlxFrameAngle.ANGLE_0;
 


### PR DESCRIPTION
In Adobe Animate, there's two versions of Sparrow, that basically work out as the same thing, but the only difference is that the width and height attributes are shortened by their initials, As can be shown here:

| Spritesheet exported with Sparrow V1: | Spritesheet exported with Sparrow V2:
| --- | ---
| <img src="https://github.com/HaxeFlixel/flixel/assets/84867412/0dec7149-9049-4878-91ab-176f175236be" width="350"> | <img src="https://github.com/HaxeFlixel/flixel/assets/84867412/b00093c5-6210-485d-987a-7980afa5be99" width="400">

(Also something to mention, Sparrow V1 doesn't seem to support a trimmed version, aka "frameX" and "frameY")

Plus it fixes a common issue that occurs with debugging, And that is when a spritesheet presents a 0x0 instance frame. This is due to a way to simbolise that the frame its using, its an empty one, but flixel doesn't seem to push those frames, causing sometimes massive errors all over the screen. This also fixes it.

