### PR TITLE
Fix getGraphicMidpoint() in FlxSprite

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1218,7 +1218,7 @@ class FlxSprite extends FlxObject
 	{
 		if (point == null)
 			point = FlxPoint.get();
-		return point.set(x + frameWidth * 0.5, y + frameHeight * 0.5);
+		return point.set(x + frameWidth * 0.5 * scale.x, y + frameHeight * 0.5 * scale.y);
 	}
 
 	/**


### PR DESCRIPTION
Currently, if you use `getGraphicMidpoint()` on an FlxSprite that has been scaled it will return the midpoint of the sprite as if it was not scaled. This pull request fixes this by multiplying the midpoint by the sprite's scale.

This image shows the current behavior of getGraphicMidpoint (red) vs the changed behavior (cyan) on various scaled boxes. 
![image](https://github.com/HaxeFlixel/flixel/assets/35246975/26fbe3e6-a561-4a04-941c-64af633fad7e)
The first box has a scale of 1 so both points are the same. If you measure the distance between the top left corner and the red square, the distance is the same for each box.