### PR TITLE
Updated the URL to HAxeFlixel site in the debugger

### DIFF
--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -509,7 +509,7 @@ class FlxDebugger extends openfl.display.Sprite
 
 	inline function openHomepage():Void
 	{
-		FlxG.openURL("http://www.haxeflixel.com");
+		FlxG.openURL("http://haxeflixel.com");
 	}
 
 	inline function openGitHub():Void


### PR DESCRIPTION
the link was pointing to www.haxeflixel.com which now seems to not work.