### PR TITLE
Prevent point/rect pool leaks

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -3,6 +3,7 @@ package flixel;
 import flixel.graphics.tile.FlxDrawBaseItem;
 import flixel.system.FlxSplash;
 import flixel.util.FlxArrayUtil;
+import flixel.util.FlxDestroyUtil;
 import flixel.util.typeLimit.NextState;
 import openfl.Assets;
 import openfl.Lib;
@@ -756,7 +757,13 @@ class FlxGame extends Sprite
 		#end
 
 		#if FLX_POINTER_INPUT
-		FlxArrayUtil.clearArray(FlxG.swipes);
+		var len = FlxG.swipes.length;
+		while(len-- > 0)
+		{
+			final swipe = FlxG.swipes.pop();
+			if (swipe != null)
+				swipe.destroy();
+		}
 		#end
 
 		filters = filtersEnabled ? _filters : null;

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -473,7 +473,7 @@ class FlxGraphic implements IFlxDestroyable
 		key = null;
 		assetsKey = null;
 		assetsClass = null;
-		imageFrame = null; // no need to dispose _imageFrame since it exists in imageFrames
+		imageFrame = FlxDestroyUtil.destroy(imageFrame);
 
 		if (frameCollections == null) // no need to destroy frame collections if it's already null
 			return;
@@ -602,7 +602,7 @@ class FlxGraphic implements IFlxDestroyable
 	function get_imageFrame():FlxImageFrame
 	{
 		if (imageFrame == null)
-			imageFrame = FlxImageFrame.fromRectangle(this, FlxRect.get(0, 0, bitmap.width, bitmap.height));
+			imageFrame = FlxImageFrame.fromRectangle(this);
 
 		return imageFrame;
 	}

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -602,7 +602,7 @@ class FlxFrame implements IFlxDestroyable
 			return clippedFrame;
 		}
 
-		var clippedRect:FlxRect = FlxRect.get(0, 0).setSize(frame.width, frame.height);
+		final clippedRect:FlxRect = FlxRect.get(0, 0).setSize(frame.width, frame.height);
 		if (angle != FlxFrameAngle.ANGLE_0)
 		{
 			clippedRect.width = frame.height;
@@ -611,7 +611,7 @@ class FlxFrame implements IFlxDestroyable
 
 		clip.offset(-offset.x, -offset.y);
 		var frameRect:FlxRect = clippedRect.intersection(clip);
-		clippedRect = FlxDestroyUtil.put(clippedRect);
+		clippedRect.put();
 
 		if (frameRect.isEmpty)
 		{

--- a/flixel/graphics/frames/FlxFramesCollection.hx
+++ b/flixel/graphics/frames/FlxFramesCollection.hx
@@ -163,7 +163,9 @@ class FlxFramesCollection implements IFlxDestroyable
 	 */
 	public function addSpriteSheetFrame(region:FlxRect):FlxFrame
 	{
-		var frame = new FlxFrame(parent);
+		// Ensure region not a weak rect
+		region = FlxRect.get().copyFrom(region);
+		final frame = new FlxFrame(parent);
 		frame.frame = checkFrame(region);
 		frame.sourceSize.set(region.width, region.height);
 		frame.offset.set(0, 0);

--- a/flixel/graphics/frames/FlxImageFrame.hx
+++ b/flixel/graphics/frames/FlxImageFrame.hx
@@ -95,21 +95,26 @@ class FlxImageFrame extends FlxFramesCollection
 			return null;
 
 		// find ImageFrame, if there is one already
-		var checkRegion:FlxRect = region;
-
-		if (checkRegion == null)
-			checkRegion = FlxRect.weak(0, 0, graphic.width, graphic.height);
-
-		var imageFrame:FlxImageFrame = FlxImageFrame.findFrame(graphic, checkRegion);
+		final checkRegion = FlxRect.get(0, 0, graphic.width, graphic.height);
+		if (region != null)
+			region.copyTo(checkRegion);
+		
+		final imageFrame:FlxImageFrame = FlxImageFrame.findFrame(graphic, checkRegion);
+		checkRegion.put();
 		if (imageFrame != null)
+		{
+			if (region != null)
+				region.putWeak();
+			
 			return imageFrame;
+		}
 
 		// or create it, if there is no such object
-		imageFrame = new FlxImageFrame(graphic);
+		final imageFrame = new FlxImageFrame(graphic);
 
 		if (region == null)
 		{
-			region = FlxRect.get(0, 0, graphic.width, graphic.height);
+			region = FlxRect.weak(0, 0, graphic.width, graphic.height);
 		}
 		else
 		{
@@ -192,14 +197,16 @@ class FlxImageFrame extends FlxFramesCollection
 	{
 		if (frameBorder == null)
 			frameBorder = FlxPoint.weak();
-
+		
 		var imageFrames:Array<FlxImageFrame> = cast graphic.getFramesCollections(FlxFrameCollectionType.IMAGE);
 		for (imageFrame in imageFrames)
 		{
 			if (imageFrame.equals(frameRect, frameBorder) && imageFrame.frame.type != FlxFrameType.EMPTY)
 				return imageFrame;
 		}
-
+		
+		frameBorder.putWeak();
+		frameRect.putWeak();
 		return null;
 	}
 
@@ -243,12 +250,6 @@ class FlxImageFrame extends FlxFramesCollection
 		imageFrame = new FlxImageFrame(parent, resultBorder);
 		imageFrame.pushFrame(frame.setBorderTo(border));
 		return imageFrame;
-	}
-
-	override public function destroy():Void
-	{
-		super.destroy();
-		FlxDestroyUtil.destroy(frame);
 	}
 
 	function get_frame():FlxFrame

--- a/flixel/input/FlxSwipe.hx
+++ b/flixel/input/FlxSwipe.hx
@@ -3,11 +3,12 @@ package flixel.input;
 import flixel.FlxG;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
+import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxStringUtil;
 
 @:allow(flixel.input.mouse.FlxMouseButton)
 @:allow(flixel.input.touch.FlxTouch)
-class FlxSwipe
+class FlxSwipe implements IFlxDestroyable
 {
 	/**
 	 * Either LEFT_MOUSE, MIDDLE_MOUSE or RIGHT_MOUSE,
@@ -35,6 +36,12 @@ class FlxSwipe
 		endPosition = EndPosition;
 		_startTimeInTicks = StartTimeInTicks;
 		_endTimeInTicks = FlxG.game.ticks;
+	}
+	
+	public function destroy()
+	{
+		startPosition = FlxDestroyUtil.put(startPosition);
+		endPosition = FlxDestroyUtil.put(endPosition);
 	}
 
 	inline function toString():String

--- a/flixel/input/mouse/FlxMouseButton.hx
+++ b/flixel/input/mouse/FlxMouseButton.hx
@@ -40,7 +40,7 @@ class FlxMouseButton extends FlxInput<Int> implements IFlxDestroyable
 		#if FLX_POINTER_INPUT
 		else if (justReleased)
 		{
-			FlxG.swipes.push(new FlxSwipe(ID, justPressedPosition, FlxG.mouse.getScreenPosition(), justPressedTimeInTicks));
+			FlxG.swipes.push(new FlxSwipe(ID, justPressedPosition.copyTo(), FlxG.mouse.getScreenPosition(), justPressedTimeInTicks));
 		}
 		#end
 	}

--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -87,7 +87,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		#if FLX_POINTER_INPUT
 		else if (justReleased)
 		{
-			FlxG.swipes.push(new FlxSwipe(touchPointID, justPressedPosition, getScreenPosition(), justPressedTimeInTicks));
+			FlxG.swipes.push(new FlxSwipe(touchPointID, justPressedPosition.copyTo(), getScreenPosition(), justPressedTimeInTicks));
 		}
 		#end
 	}

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -299,7 +299,7 @@ import openfl.geom.Point;
 
 	public inline function new(x:Float = 0, y:Float = 0)
 	{
-		this = new FlxBasePoint(x, y);
+		this = FlxPoint.get(x, y);
 	}
 
 	/**

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -39,6 +39,8 @@ private enum UserDefines
 	FLX_NO_POINT_POOL;
 	FLX_NO_PITCH;
 	FLX_NO_SAVE;
+	/** Adds trackers to FlxPool instances, only available on debug*/
+	FLX_TRACK_POOLS;
 }
 
 /**
@@ -80,6 +82,7 @@ private enum HelperDefines
 	FLX_NO_CI;
 	FLX_SAVE;
 	FLX_HEALTH;
+	FLX_NO_TRACK_POOLS;
 }
 
 class FlxDefines
@@ -179,6 +182,7 @@ class FlxDefines
 		defineInversion(FLX_COVERAGE_TEST, FLX_NO_COVERAGE_TEST);
 		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
 		defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
+		defineInversion(FLX_TRACK_POOLS, FLX_NO_TRACK_POOLS);
 	}
 
 	static function defineHelperDefines()
@@ -237,6 +241,9 @@ class FlxDefines
 		// should always be defined as of 5.5.1 and, therefore, deprecated
 		define(FLX_DRAW_QUADS);
 		// #end
+		
+		if (defined(FLX_TRACK_POOLS) && !defined("debug"))
+			abort("Can only define FLX_TRACK_POOLS on debug mode", (macro null).pos);
 	}
 
 	static function defineInversion(userDefine:UserDefines, invertedDefine:HelperDefines)

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -202,7 +202,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 */
 	public function calcRayEntry(start, end, ?result)
 	{
-		var bounds = getBounds();
+		var bounds = getBounds(FlxRect.weak());
 		// subtract 1 from size otherwise `getTileIndexByCoords` will have weird edge cases (literally)
 		bounds.width--;
 		bounds.height--;

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -147,11 +147,10 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 			if (_pool.length == 0)
 				preAllocate(1);
 			
-			id = Type.getClassName(Type.getClass(_pool[0])).split(".").pop().split("Flx").pop();
+			id = Type.getClassName(Type.getClass(_pool[0])).split(".").pop().split("FlxBase").pop().split("Flx").pop();
 		}
 		
-		FlxG.watch.addFunction(id + "-pool", () -> '$length/$_totalCreated');
-		FlxG.watch.addFunction(id + "-top-leak", function()
+		FlxG.watch.addFunction(id + "-pool", function()
 		{
 			var most = 0;
 			var topStack:String = null;
@@ -165,10 +164,10 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 				}
 			}
 			
-			return if (topStack == null)
-				null;
-			else
-				'${prettyStack(topStack)}: $most';
+			var msg = '$length/$_totalCreated';
+			if (topStack != null)
+				msg += ' | $most from ${prettyStack(topStack)}';
+			return msg;
 		});
 	}
 	
@@ -212,7 +211,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	
 	inline function prettyStack(pos:String)
 	{
-		return pos.split("/").pop().split(".hx").shift();
+		return pos.split("/").pop().split(".hx").join("");
 	}
 	#end
 }

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -212,7 +212,7 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	
 	inline function prettyStack(pos:String)
 	{
-		return topStack.split("/").pop().split(".hx").shift()
+		return pos.split("/").pop().split(".hx").shift();
 	}
 	#end
 }

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -1,6 +1,7 @@
 package flixel.util;
 
-import flixel.util.FlxDestroyUtil.IFlxDestroyable;
+import flixel.FlxG;
+import flixel.util.FlxDestroyUtil;
 import flixel.util.typeLimit.OneOfTwo;
 
 /**
@@ -47,6 +48,16 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	 * _count keeps track of the valid, accessible pool objects.
 	 */
 	var _count:Int = 0;
+	
+	#if FLX_TRACK_POOLS
+	/** Set to false before creating FlxGame to prevent logs */
+	public var autoLog = true;
+	
+	final _tracked = new Map<T, String>();
+	final _leakCount = new Map<String, Int>();
+	var _totalCreated = 0;
+	var _autoLogInitted = false;
+	#end
 
 	/**
 	 * Creates a pool of the specified type
@@ -61,11 +72,21 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 
 	public function get():T
 	{
-		if (_count == 0)
+		final obj:T = if (_count == 0)
 		{
-			return _constructor();
+			#if FLX_TRACK_POOLS
+			_totalCreated++;
+			#end
+			_constructor();
 		}
-		return _pool[--_count];
+		else
+			_pool[--_count];
+		
+		#if FLX_TRACK_POOLS
+		trackGet(obj);
+		#end
+		
+		return obj;
 	}
 
 	public function put(obj:T):Void
@@ -91,6 +112,10 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	{
 		obj.destroy();
 		_pool[_count++] = obj;
+		
+		#if FLX_TRACK_POOLS
+		trackPut(obj);
+		#end
 	}
 
 	public function preAllocate(numObjects:Int):Void
@@ -113,6 +138,83 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 	{
 		return _count;
 	}
+	
+	#if FLX_TRACK_POOLS
+	public function addLogs(?id:String)
+	{
+		if (id == null)
+		{
+			if (_pool.length == 0)
+				preAllocate(1);
+			
+			id = Type.getClassName(Type.getClass(_pool[0])).split(".").pop().split("Flx").pop();
+		}
+		
+		FlxG.watch.addFunction(id + "-pool", () -> '$length/$_totalCreated');
+		FlxG.watch.addFunction(id + "-top-leak", function()
+		{
+			var most = 0;
+			var topStack:String = null;
+			for (stack in _leakCount.keys())
+			{
+				final count = _leakCount[stack];
+				if (most < count)
+				{
+					most = count;
+					topStack = stack;
+				}
+			}
+			
+			return if (topStack == null)
+				null;
+			else
+				'${prettyStack(topStack)}: $most';
+		});
+	}
+	
+	function trackGet(obj:T)
+	{
+		final callStack = haxe.CallStack.callStack();
+		final stack = stackToString(callStack[3]);
+		if (stack == null)
+			return;
+		
+		if (autoLog && !_autoLogInitted && FlxG.signals != null)
+		{
+			_autoLogInitted = true;
+			FlxG.signals.postStateSwitch.add(()->addLogs());
+			if (FlxG.game != null && FlxG.state != null)
+				addLogs();
+		}
+		
+		_tracked[obj] = stack;
+		if (_leakCount.exists(stack) == false)
+			_leakCount[stack] = 0;
+		
+		_leakCount[stack]++;
+	}
+	
+	inline function trackPut(obj:T)
+	{
+		final stack = _tracked[obj];
+		_tracked.remove(obj);
+		_leakCount[stack]--;
+	}
+	
+	function stackToString(stack:haxe.CallStack.StackItem)
+	{
+		return switch (stack)
+		{
+			case FilePos(_, file, line, _): '$file[$line]';
+			default: null;
+		}
+	}
+	
+	inline function prettyStack(pos:String)
+	{
+		return topStack.split("/").pop().split(".hx").shift()
+	}
+	#end
 }
 
 interface IFlxPooled extends IFlxDestroyable

--- a/flixel/util/FlxPool.hx
+++ b/flixel/util/FlxPool.hx
@@ -76,20 +76,21 @@ class FlxPool<T:IFlxDestroyable> implements IFlxPool<T>
 			var i:Int = _pool.indexOf(obj);
 			// if the object's spot in the pool was overwritten, or if it's at or past _count (in the inaccessible zone)
 			if (i == -1 || i >= _count)
-			{
-				obj.destroy();
-				_pool[_count++] = obj;
-			}
+				putHelper(obj);
 		}
 	}
 
 	public function putUnsafe(obj:T):Void
 	{
+		// TODO: remove null check and make private?
 		if (obj != null)
-		{
-			obj.destroy();
-			_pool[_count++] = obj;
-		}
+			putHelper(obj);
+	}
+	
+	function putHelper(obj:T)
+	{
+		obj.destroy();
+		_pool[_count++] = obj;
 	}
 
 	public function preAllocate(numObjects:Int):Void

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -56,5 +56,6 @@
 	</section>
 	<section if="coverage2">
 		<haxedef name="debug" />
+		<haxedef name="FLX_TRACK_POOLS" />
 	</section>
 </project>


### PR DESCRIPTION
Found that certain flixel features were not correctly putting points and rects back into the pool and FlxImageFrames were never destroyed

Added FLX_TRACK_POOLS which adds watch values for each pool and tracks where all the unpooled objects are going and never returning