### PR TITLE
Prevent a requirement for `@:privateAccess`-ing the _customSoundTray object.

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -176,7 +176,16 @@ class FlxGame extends Sprite
 	 * Change this after calling `super()` in the `FlxGame` constructor
 	 * to use a customized sound tray based on `FlxSoundTray`.
 	 */
-	var _customSoundTray:Class<FlxSoundTray> = FlxSoundTray;
+	@:isVar var _customSoundTray(default, set):Class<FlxSoundTray>;
+	
+	private inline function set__customSoundTray(newSoundTray:Class<FlxSoundTray>):Class<FlxSoundTray>
+	{
+		if (soundTray != null) // There's null checking *within* the removeChild function, but just to be safe on a call.
+			removeChild(soundTray);
+		this.soundTray = Type.createInstance(newSoundTray, []);
+		addChild(soundTray);
+		return this._customSoundTray = newSoundTray;
+	}
 	#end
 
 	#if FLX_FOCUS_LOST_SCREEN
@@ -344,8 +353,8 @@ class FlxGame extends Sprite
 		#if !mobile
 		// Volume display tab
 		#if FLX_SOUND_TRAY
-		soundTray = Type.createInstance(_customSoundTray, []);
-		addChild(soundTray);
+		// I moved the setter to be a public function, so that any user may update the sound tray with full access.
+		changeSoundTray(FlxSoundTray);
 		#end
 
 		#if FLX_FOCUS_LOST_SCREEN
@@ -682,6 +691,17 @@ class FlxGame extends Sprite
 		#if FLX_DEBUG
 		debugger.stats.activeObjects(FlxBasic.activeCount);
 		#end
+	}
+	// Very basic description, *please* feel free to rewrite the documentation.
+	
+	/** 
+	 * This is how you may apply custom sound trays to your game.
+	 * This can be called anytime to update the soundTray.
+	 * @param newSoundTray The class path to your new sound tray. It must extend `FlxSoundTray` in order to work.
+	 */
+	public function changeSoundTray(newSoundTray:Class<FlxSoundTray>):Void
+	{
+		this._customSoundTray = newSoundTray;
 	}
 
 	function handleReplayRequests():Void

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -177,17 +177,6 @@ class FlxGame extends Sprite
 	 * to use a customized sound tray based on `FlxSoundTray`.
 	 */
 	@:isVar var _customSoundTray(default, set):Class<FlxSoundTray>;
-	
-	private inline function set__customSoundTray(newSoundTray:Class<FlxSoundTray>):Class<FlxSoundTray>
-	{
-		var oldIndex:Int = 0;
-		if (soundTray != null) // There's null checking *within* the removeChild function, but just to be safe on a call.
-			oldIndex = getChildIndex(soundTray);
-		removeChild(soundTray);
-		this.soundTray = Type.createInstance(newSoundTray, []);
-		addChildAt(soundTray, oldIndex);
-		return this._customSoundTray = newSoundTray;
-	}
 	#end
 
 	#if FLX_FOCUS_LOST_SCREEN
@@ -694,17 +683,6 @@ class FlxGame extends Sprite
 		debugger.stats.activeObjects(FlxBasic.activeCount);
 		#end
 	}
-	// Very basic description, *please* feel free to rewrite the documentation.
-	
-	/** 
-	 * This is how you may apply custom sound trays to your game.
-	 * This can be called anytime to update the soundTray.
-	 * @param newSoundTray The class path to your new sound tray. It must extend `FlxSoundTray` in order to work.
-	 */
-	public function changeSoundTray(newSoundTray:Class<FlxSoundTray>):Void
-	{
-		this._customSoundTray = newSoundTray;
-	}
 
 	function handleReplayRequests():Void
 	{
@@ -920,6 +898,10 @@ class FlxGame extends Sprite
 		debugger.stats.flixelDraw(getTicks() - ticks);
 		#end
 	}
+	inline function changeSoundTray(newSoundTray:Class<FlxSoundTray>):Void
+	{
+		this._customSoundTray = newSoundTray;
+	}
 
 	inline function getTicks()
 	{
@@ -930,6 +912,16 @@ class FlxGame extends Sprite
 	{
 		// expensive, only call if necessary
 		return Lib.getTimer();
+	}
+	private function set__customSoundTray(newSoundTray:Class<FlxSoundTray>):Class<FlxSoundTray>
+	{
+		var oldIndex:Int = 0;
+		if (soundTray != null) // There's null checking *within* the removeChild function, but just to be safe on a call.
+			oldIndex = getChildIndex(soundTray);
+		removeChild(soundTray);
+		this.soundTray = Type.createInstance(newSoundTray, []);
+		addChildAt(soundTray, oldIndex);
+		return this._customSoundTray = newSoundTray;
 	}
 }
 

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -180,10 +180,12 @@ class FlxGame extends Sprite
 	
 	private inline function set__customSoundTray(newSoundTray:Class<FlxSoundTray>):Class<FlxSoundTray>
 	{
+		var oldIndex:Int = 0;
 		if (soundTray != null) // There's null checking *within* the removeChild function, but just to be safe on a call.
-			removeChild(soundTray);
+			oldIndex = getChildIndex(soundTray);
+		removeChild(soundTray);
 		this.soundTray = Type.createInstance(newSoundTray, []);
-		addChild(soundTray);
+		addChildAt(soundTray, oldIndex);
 		return this._customSoundTray = newSoundTray;
 	}
 	#end


### PR DESCRIPTION
...And also allowing for it to be changed at runtime.

### Access
Before, to change the sound tray, you would have to access the variable as such:
```haxe
var game:FlxGame;

//...

@:privateAccess(flixel.FlxGame)
game._customSoundTray = CustomSoundTray;
```
And your access would have to be called *before* the game was created.

Now, you can change the sound tray at *any* time, through the method of:
```haxe
FlxG.game.changeSoundTray(CustomSoundTray);
```

Now as long as your `CustomSoundTray` was a child of `flixel.system.ui.soundFlxSoundTray`, it would work.