### PR TITLE
Allow linear drag and max speed, drag on skid

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -847,8 +847,8 @@ class FlxObject extends FlxBasic
 	{
 		velocity = FlxPoint.get();
 		acceleration = FlxPoint.get();
-		function setDrag(p:FlxPoint) dragMode = BILINEAR(p.x, p.y);
-		function setMaxSpeed(p:FlxPoint) maxSpeedMode = BILINEAR(p.x, p.y);
+		function setDrag(p:FlxPoint) dragMode = XY(p.x, p.y);
+		function setMaxSpeed(p:FlxPoint) maxSpeedMode = XY(p.x, p.y);
 		drag = new FlxCallbackPoint(setDrag, setDrag, setDrag);
 		maxVelocity = new FlxCallbackPoint(setMaxSpeed, setMaxSpeed, setMaxSpeed);
 	}
@@ -1564,7 +1564,7 @@ enum FlxMovementType
 	LINEAR(value:Float);
 	
 	/** Along two independant axes */
-	BILINEAR(x:Float, y:Float);
+	XY(x:Float, y:Float);
 	
 	NONE;
 }

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -794,7 +794,17 @@ import openfl.geom.Point;
 		p.putWeak();
 		return dotProductWeak(normalized);
 	}
-
+	
+	/**
+	 * Check if the angle between 2 vectors are less than 90 degrees
+	 *
+	 * @param   p  point to check
+	 */
+	public inline function areSameFacing(p:FlxPoint):Bool
+	{
+		return dotProduct(p) > 0;
+	}
+	
 	/**
 	 * Check the perpendicularity of two points.
 	 *

--- a/flixel/math/FlxVelocity.hx
+++ b/flixel/math/FlxVelocity.hx
@@ -329,7 +329,7 @@ class FlxVelocity
 				velocity.x += elapsed * acceleration.x;
 				velocity.y += elapsed * acceleration.y;
 				
-			case BILINEAR(dragX, dragY):
+			case XY(dragX, dragY):
 				
 				velocity.x = computeSpeed1D(elapsed, velocity.x, acceleration.x, dragX, dragApply);
 				velocity.y = computeSpeed1D(elapsed, velocity.y, acceleration.y, dragY, dragApply);
@@ -371,7 +371,7 @@ class FlxVelocity
 		switch(max)
 		{
 			case NONE:
-			case BILINEAR(maxX, maxY):
+			case XY(maxX, maxY):
 				
 				velocity.x = capSpeed1D(velocity.x, maxX);
 				velocity.y = capSpeed1D(velocity.y, maxY);
@@ -408,6 +408,6 @@ class FlxVelocity
 			source.velocity.set(0, 0);
 
 		source.acceleration.set(cosA * acceleration, sinA * acceleration);
-		source.maxSpeedMode = BILINEAR(Math.abs(cosA * maxSpeed), Math.abs(sinA * maxSpeed));
+		source.maxSpeedMode = XY(Math.abs(cosA * maxSpeed), Math.abs(sinA * maxSpeed));
 	}
 }


### PR DESCRIPTION
Attempt number 2 at #2704:

## Allow linear drag and max speed
Meaning it's calculated based on velocity's magnitude rather than the individual x/y speed. New fields: `dragMode` and `maxSpeedMode`

### Examples
```hx
// old code
// drag.x = drag.y = 800;
// maxVelocity.x = maxVelocity.y = SPEED; // possible to go SPEED * sqrt(2)

// new code
dragMode = XY(800, 800); // behaves identical to old code
maxSpeedMode = LINEAR(SPEED); // impossible to go faster than SPEED
```

## Drag on skid
New field `dragApplyMode`:
INERTIAL  - old behavior where drag is applied when acceleration is 0
ALWAYS - drag is always applied
SKID - drag is applied when inertial  or decelerating 

## TO DO
- [ ] Docs
- [ ] Allow different drag modes for X/Y (important for platformers) **this might kill this feature if I don't do this right**
- [ ] Remove deprecation warnings (only added them to remove refs in other flixel tools)