### PR TITLE
better long term solution for sprite group cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+5.7.2 (April 17, 2024)
+#### Bugfixes:
+- `FlxSpriteGroup`: Better long term fix for members cameras ([#3116](https://github.com/HaxeFlixel/flixel/pull/3116))
+
 5.7.1 (April 16, 2024)
 #### Bugfixes:
 - `FlxImageFrame`: Prevent null ref from destroyed graphics ([#3113](https://github.com/HaxeFlixel/flixel/pull/3113))

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -310,7 +310,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		sprite.y += y;
 		sprite.alpha *= alpha;
 		sprite.scrollFactor.copyFrom(scrollFactor);
-		sprite._cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
+		sprite.cameras = _cameras; // _cameras instead of cameras because get_cameras() will not return null
 
 		if (clipRect != null)
 			clipRectTransform(sprite, clipRect);
@@ -679,7 +679,6 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		if (camera != Value)
 			transformChildren(cameraTransform, Value);
-		group.camera = Value;
 		return super.set_camera(Value);
 	}
 
@@ -687,7 +686,6 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	{
 		if (_cameras != Value)
 			transformChildren(camerasTransform, Value);
-		group.cameras = Value;
 		return super.set_cameras(Value);
 	}
 

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
 	"license": "MIT",
 	"tags": ["game", "openfl", "flash", "html5", "neko", "cpp", "android", "ios", "cross"],
 	"description": "HaxeFlixel is a 2D game engine based on OpenFL that delivers cross-platform games.",
-	"version": "5.7.1",
-	"releasenote": "Fix sprite group cameras",
+	"version": "5.7.2",
+	"releasenote": "Better long term fix for spritegroup cameras",
 	"contributors": ["haxeflixel", "Gama11", "GeoKureli"],
 	"dependencies": {}
 }


### PR DESCRIPTION
this reverts spritegroups back to their previous behavior where they set all members cameras. the issue was from setting _cameras which didn't propegate it down to nested spritegroups' members