### PR TITLE
Minor FlxDrawTrianglesItem optimization

### DIFF
--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -101,10 +101,17 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	override public function reset():Void
 	{
 		super.reset();
+		#if (flash || openfl >= "4.0.0")
+		vertices.length = 0;
+		indices.length = 0;
+		uvtData.length = 0;
+		colors.length = 0;
+		#else
 		vertices.splice(0, vertices.length);
 		indices.splice(0, indices.length);
 		uvtData.splice(0, uvtData.length);
 		colors.splice(0, colors.length);
+		#end
 
 		verticesPosition = 0;
 		indicesPosition = 0;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -13,7 +13,7 @@ import openfl.display.ShaderParameter;
 import openfl.display.TriangleCulling;
 import openfl.geom.ColorTransform;
 
-typedef DrawData<T> = #if (flash || openfl >= "4.0.0") openfl.Vector<T> #else Array<T> #end;
+typedef DrawData<T> = openfl.Vector<T>;
 
 /**
  * @author Zaphod
@@ -101,17 +101,10 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	override public function reset():Void
 	{
 		super.reset();
-		#if (flash || openfl >= "4.0.0")
 		vertices.length = 0;
 		indices.length = 0;
 		uvtData.length = 0;
 		colors.length = 0;
-		#else
-		vertices.splice(0, vertices.length);
-		indices.splice(0, indices.length);
-		uvtData.splice(0, uvtData.length);
-		colors.splice(0, colors.length);
-		#end
 
 		verticesPosition = 0;
 		indicesPosition = 0;


### PR DESCRIPTION
Uses openfl's vector length function instead of splice for a minor performance boost clearing the vectors.