### PR TITLE
add camera(s) unit tests to sprite groups

### DIFF
--- a/tests/unit/src/flixel/group/FlxContainerTest.hx
+++ b/tests/unit/src/flixel/group/FlxContainerTest.hx
@@ -2,6 +2,7 @@
 package flixel.group;
 
 import flixel.FlxBasic;
+import flixel.group.FlxContainer;
 import massive.munit.Assert;
 
 class FlxContainerTest extends FlxGroupTest
@@ -14,5 +15,28 @@ class FlxContainerTest extends FlxGroupTest
 			group.add(new FlxBasic());
 		}
 		return group;
+	}
+	
+	@Test
+	function testMemberCameras()
+	{
+		final subGroup1 = new FlxContainer();
+		group.add(subGroup1);
+		final subGroup2 = new FlxTypedContainer<FlxSprite>();
+		subGroup1.add(subGroup2);
+		final member1 = new FlxSprite();
+		final member2 = new FlxSprite();
+		subGroup1.add(member1);
+		subGroup2.add(member2);
+		
+		final cam = new FlxCamera();
+		group.camera = cam;
+		Assert.areEqual(cam, member1.getCameras()[0]);
+		Assert.areEqual(cam, member2.getCameras()[0]);
+		
+		final cams = [new FlxCamera()];
+		group.cameras = cams;
+		Assert.areEqual(cams, member1.getCameras());
+		Assert.areEqual(cams, member2.getCameras());
 	}
 }

--- a/tests/unit/src/flixel/group/FlxSpriteContainerTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteContainerTest.hx
@@ -13,4 +13,26 @@ class FlxSpriteContainerTest extends FlxSpriteGroupTest
 			group.add(new FlxSpriteContainer());
 		destroyable = group;
 	}
+	
+	override function testMemberCameras()
+	{
+		final subGroup1 = new FlxSpriteContainer();
+		group.add(subGroup1);
+		final subGroup2 = new FlxSpriteContainer();
+		subGroup1.add(subGroup2);
+		final member1 = new FlxSprite();
+		final member2 = new FlxSprite();
+		subGroup2.add(member1);
+		subGroup2.add(member2);
+		
+		final cam = new FlxCamera();
+		group.camera = cam;
+		Assert.areEqual(cam, member1.getCameras()[0]);
+		Assert.areEqual(cam, member2.getCameras()[0]);
+		
+		final cams = [new FlxCamera()];
+		group.cameras = cams;
+		Assert.areEqual(cams, member1.getCameras());
+		Assert.areEqual(cams, member2.getCameras());
+	}
 }

--- a/tests/unit/src/flixel/group/FlxSpriteContainerTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteContainerTest.hx
@@ -2,6 +2,7 @@ package flixel.group;
 
 import flixel.FlxSprite;
 import flixel.math.FlxRect;
+import flixel.group.FlxSpriteContainer;
 import massive.munit.Assert;
 
 class FlxSpriteContainerTest extends FlxSpriteGroupTest
@@ -18,11 +19,11 @@ class FlxSpriteContainerTest extends FlxSpriteGroupTest
 	{
 		final subGroup1 = new FlxSpriteContainer();
 		group.add(subGroup1);
-		final subGroup2 = new FlxSpriteContainer();
+		final subGroup2 = new FlxTypedSpriteContainer<FlxSprite>();
 		subGroup1.add(subGroup2);
 		final member1 = new FlxSprite();
 		final member2 = new FlxSprite();
-		subGroup2.add(member1);
+		subGroup1.add(member1);
 		subGroup2.add(member2);
 		
 		final cam = new FlxCamera();

--- a/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
@@ -144,11 +144,11 @@ class FlxSpriteGroupTest extends FlxTest
 	{
 		final subGroup1 = new FlxSpriteGroup();
 		group.add(subGroup1);
-		final subGroup2 = new FlxSpriteGroup();
+		final subGroup2 = new FlxTypedSpriteGroup<FlxSprite>();
 		subGroup1.add(subGroup2);
 		final member1 = new FlxSprite();
 		final member2 = new FlxSprite();
-		subGroup2.add(member1);
+		subGroup1.add(member1);
 		subGroup2.add(member2);
 		
 		final cam = new FlxCamera();

--- a/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
+++ b/tests/unit/src/flixel/group/FlxSpriteGroupTest.hx
@@ -1,5 +1,6 @@
 package flixel.group;
 
+import flixel.group.FlxSpriteGroup;
 import flixel.FlxSprite;
 import flixel.math.FlxRect;
 import massive.munit.Assert;
@@ -136,7 +137,33 @@ class FlxSpriteGroupTest extends FlxTest
 		Assert.isTrue(member1.revived);
 		Assert.isFalse(member2.killed);
 		Assert.isFalse(member2.revived);
-		return group;
+	}
+	
+	@Test
+	function testMemberCameras()
+	{
+		final subGroup1 = new FlxSpriteGroup();
+		group.add(subGroup1);
+		final subGroup2 = new FlxSpriteGroup();
+		subGroup1.add(subGroup2);
+		final member1 = new FlxSprite();
+		final member2 = new FlxSprite();
+		subGroup2.add(member1);
+		subGroup2.add(member2);
+		
+		final cam = new FlxCamera();
+		group.camera = cam;
+		Assert.areEqual(cam, member1.getCameras()[0]);
+		Assert.areEqual(cam, member2.getCameras()[0]);
+		Assert.areEqual(cam, member1.camera);
+		Assert.areEqual(cam, member2.camera);
+		
+		final cams = [new FlxCamera()];
+		group.cameras = cams;
+		Assert.areEqual(cams, member1.getCameras());
+		Assert.areEqual(cams, member2.getCameras());
+		Assert.areEqual(cams, member1.cameras);
+		Assert.areEqual(cams, member2.cameras);
 	}
 }
 


### PR DESCRIPTION
adds unit tests to ensure I don't break spritegroups and containers again