### PR TITLE
account for scale, origin, offset, angle and pixelPerfectPosition in getGraphicMidpoint

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1223,6 +1223,7 @@ class FlxSprite extends FlxObject
 	 * Retrieves the world bounds of this sprite's graphic
 	 *
 	 * @param   rect  The resulting rect, if `null` a new one is created
+	 * @since 5.9.0
 	 */
 	public function getGraphicBounds(?rect:FlxRect):FlxRect
 	{

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1206,7 +1206,7 @@ class FlxSprite extends FlxObject
 		dirty = false;
 		return framePixels;
 	}
-
+	
 	/**
 	 * Retrieve the midpoint of this sprite's graphic in world coordinates.
 	 *
@@ -1219,6 +1219,7 @@ class FlxSprite extends FlxObject
 		rect.put();
 		return point;
 	}
+	
 	/**
 	 * Retrieves the world bounds of this sprite's graphic
 	 * **Note:** Ignores `scrollFactor`, to get the screen position of the graphic use
@@ -1246,7 +1247,7 @@ class FlxSprite extends FlxObject
 		
 		return rect;
 	}
-
+	
 	/**
 	 * Check and see if this object is currently on screen. Differs from `FlxObject`'s implementation
 	 * in that it takes the actual graphic into account, not just the hitbox or bounding box or whatever.

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1221,6 +1221,8 @@ class FlxSprite extends FlxObject
 	}
 	/**
 	 * Retrieves the world bounds of this sprite's graphic
+	 * **Note:** Ignores `scrollFactor`, to get the screen position of the graphic use
+	 * `getScreenBounds`
 	 *
 	 * @param   rect  The resulting rect, if `null` a new one is created
 	 * @since 5.9.0

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1218,7 +1218,16 @@ class FlxSprite extends FlxObject
 	{
 		if (point == null)
 			point = FlxPoint.get();
-		return point.set(x + frameWidth * 0.5 * scale.x, y + frameHeight * 0.5 * scale.y);
+		
+		point.set(x, y);
+		if (pixelPerfectPosition)
+			point.floor();
+		
+		_scaledOrigin.set(origin.x * scale.x, origin.y * scale.y);
+		point.x += origin.x - offset.x - _scaledOrigin.x + frameWidth * 0.5 * scale.x;
+		point.y += origin.y - offset.y - _scaledOrigin.y + frameHeight * 0.5 * scale.y;
+		
+		return point;
 	}
 
 	/**

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1210,24 +1210,38 @@ class FlxSprite extends FlxObject
 	/**
 	 * Retrieve the midpoint of this sprite's graphic in world coordinates.
 	 *
-	 * @param   point   Allows you to pass in an existing `FlxPoint` if you're so inclined.
-	 *                  Otherwise a new one is created.
-	 * @return  A `FlxPoint` containing the midpoint of this sprite's graphic in world coordinates.
+	 * @param   point  The resulting point, if `null` a new one is created
 	 */
 	public function getGraphicMidpoint(?point:FlxPoint):FlxPoint
 	{
-		if (point == null)
-			point = FlxPoint.get();
+		final rect = getGraphicBounds();
+		point = rect.getMidpoint(point);
+		rect.put();
+		return point;
+	}
+	/**
+	 * Retrieves the world bounds of this sprite's graphic
+	 *
+	 * @param   rect  The resulting rect, if `null` a new one is created
+	 */
+	public function getGraphicBounds(?rect:FlxRect):FlxRect
+	{
+		if (rect == null)
+			rect = FlxRect.get();
 		
-		point.set(x, y);
+		rect.set(x, y);
 		if (pixelPerfectPosition)
-			point.floor();
+			rect.floor();
 		
 		_scaledOrigin.set(origin.x * scale.x, origin.y * scale.y);
-		point.x += origin.x - offset.x - _scaledOrigin.x + frameWidth * 0.5 * scale.x;
-		point.y += origin.y - offset.y - _scaledOrigin.y + frameHeight * 0.5 * scale.y;
+		rect.x += origin.x - offset.x - _scaledOrigin.x;
+		rect.y += origin.y - offset.y - _scaledOrigin.y;
+		rect.setSize(frameWidth * scale.x, frameHeight * scale.y);
 		
-		return point;
+		if (angle % 360 != 0)
+			rect.getRotatedBounds(angle, _scaledOrigin, rect);
+		
+		return rect;
 	}
 
 	/**

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -462,7 +462,19 @@ class FlxRect implements IFlxPooled
 		rect.putWeak();
 		return result.set(x0, y0, x1 - x0, y1 - y0);
 	}
-
+	
+	/**
+	 * The middle point of this rect
+	 * @param   point  The point to hold the result, if `null` a new one is created
+	 */
+	public function getMidpoint(?point:FlxPoint)
+	{
+		if (point == null)
+			point = FlxPoint.get();
+		
+		return point.set(x + 0.5 * width, y + 0.5 * height);
+	}
+	
 	/**
 	 * Convert object to readable string name. Useful for debugging, save games, etc.
 	 */

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -465,7 +465,9 @@ class FlxRect implements IFlxPooled
 	
 	/**
 	 * The middle point of this rect
+	 * 
 	 * @param   point  The point to hold the result, if `null` a new one is created
+	 * @since 5.9.0
 	 */
 	public function getMidpoint(?point:FlxPoint)
 	{

--- a/tests/unit/src/flixel/FlxSpriteTest.hx
+++ b/tests/unit/src/flixel/FlxSpriteTest.hx
@@ -4,6 +4,7 @@ import openfl.display.BitmapData;
 import flixel.animation.FlxAnimation;
 import flixel.graphics.atlas.FlxAtlas;
 import flixel.math.FlxRect;
+import flixel.math.FlxPoint;
 import flixel.text.FlxText;
 import flixel.util.FlxColor;
 import massive.munit.Assert;
@@ -328,4 +329,44 @@ class FlxSpriteTest extends FlxTest
 		
 		expected.put();
 	}
+	
+	@Test
+	function testGetGraphicMidpoint()
+	{
+		final full:SimplePoint = [sprite1.frameWidth, sprite1.frameHeight];
+		final mid:SimplePoint = [full.x / 2, full.y / 2];
+		final zero:SimplePoint = [0, 0];
+		assertGraphicMidpoint({ pos:[0, 5], size:full, origin:mid, offset:zero});
+		assertGraphicMidpoint({ pos:[0, 5], size:full, origin:full, offset:zero});
+		assertGraphicMidpoint({ pos:[0, 5], size:[10, 10], origin:mid, offset:zero});
+		assertGraphicMidpoint({ pos:[0, 5], size:[50, 50], origin:mid, offset:[1, 3]});
+		assertGraphicMidpoint({ pos:[0, 5], size:[50, 50], origin:zero, offset:zero});
+		assertGraphicMidpoint({ pos:[0, 5], size:[50, 50], origin:full, offset:[50, 60]});
+		assertGraphicMidpoint({ pos:[0, 5], size:[50, 100], origin:[10, 20], offset:[-50, 60]});
+	}
+	
+	function assertGraphicMidpoint(orientation:Orientation, ?pos:PosInfos)
+	{
+		sprite1.x = orientation.pos.x;
+		sprite1.y = orientation.pos.y;
+		sprite1.setGraphicSize(orientation.size.x, orientation.size.y);
+		sprite1.offset.set(orientation.offset.x, orientation.offset.y);
+		sprite1.origin.set(orientation.origin.x, orientation.origin.y);
+		final actual = sprite1.getGraphicMidpoint(FlxPoint.weak());
+		
+		// check against getScreenBounds
+		final rect = sprite1.getScreenBounds(FlxRect.weak());
+		FlxAssert.areNear(rect.x + 0.5 * rect.width, actual.x, 0.001, pos);
+		FlxAssert.areNear(rect.y + 0.5 * rect.height, actual.y, 0.001, pos);
+	}
 }
+
+abstract SimplePoint(Array<Float>) from Array<Float>
+{
+	public var x(get, never):Float;
+	inline function get_x() return this[0];
+	
+	public var y(get, never):Float;
+	inline function get_y() return this[1];
+} 
+typedef Orientation = { pos:SimplePoint, size:SimplePoint, offset:SimplePoint, origin:SimplePoint }


### PR DESCRIPTION
Adds `getGraphicBounds` as well, which `getGraphicMidpoint` uses. Accounts everything except scrollFactor

Note: I've ignored `scrollFactor` because we are getting the graphic's position in world space, not screen space, the "idea" is that the object *physically* exists in the world at its x and y regardless of `scrollFactor`, which only changes where we "perceive" it to be