### PR TITLE
Cleaning up `FlxSubState`s

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -904,7 +904,7 @@ class FlxGame extends Sprite
 	function updateState(elapsed:Float):Void
 	{
 		if (_state.persistentUpdate || _state.subState == null)
-			_state.update(FlxG.elapsed);
+			_state.update(elapsed);
 
 		if (_state.subState != null)
 		{

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -908,14 +908,14 @@ class FlxGame extends Sprite
 
 		if (_state.subState != null)
 		{
-			var _subState:FlxSubState = _state.subState;
+			var subState:FlxSubState = _state.subState;
 
-			while (_subState != null)
+			while (subState != null)
 			{
-				if (_subState.persistentUpdate || _subState.subState == null)
-					_subState.update(elapsed);
+				if (subState.persistentUpdate || subState.subState == null)
+					subState.update(elapsed);
 
-				_subState = _subState.subState;
+				subState = subState.subState;
 			}
 		}
 	}
@@ -927,14 +927,14 @@ class FlxGame extends Sprite
 
 		if (_state.subState != null)
 		{
-			var _subState:FlxSubState = _state.subState;
+			var subState:FlxSubState = _state.subState;
 
-			while (_subState != null)
+			while (subState != null)
 			{
-				if (_subState.persistentDraw || _subState.subState == null)
-					_subState.draw();
+				if (subState.persistentDraw || subState.subState == null)
+					subState.draw();
 
-				_subState = _subState.subState;
+				subState = subState.subState;
 			}
 		}
 	}

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -747,7 +747,7 @@ class FlxGame extends Sprite
 		#end
 		FlxG.plugins.update(FlxG.elapsed);
 
-		_state.tryUpdate(FlxG.elapsed);
+		updateState(FlxG.elapsed);
 
 		FlxG.cameras.update(FlxG.elapsed);
 		FlxG.signals.postUpdate.dispatch();
@@ -872,13 +872,15 @@ class FlxGame extends Sprite
 
 		if (FlxG.plugins.drawOnTop)
 		{
-			_state.draw();
+			drawState();
+
 			FlxG.plugins.draw();
 		}
 		else
 		{
 			FlxG.plugins.draw();
-			_state.draw();
+			
+			drawState();
 		}
 
 		if (FlxG.renderTile)
@@ -897,6 +899,44 @@ class FlxGame extends Sprite
 		#if FLX_DEBUG
 		debugger.stats.flixelDraw(getTicks() - ticks);
 		#end
+	}
+
+	function updateState(elapsed:Float):Void
+	{
+		if (_state.persistentUpdate || _state.subState == null)
+			_state.update(FlxG.elapsed);
+
+		if (_state.subState != null)
+		{
+			var _subState:FlxSubState = _state.subState;
+
+			while (_subState != null)
+			{
+				if (_subState.persistentUpdate || _subState.subState == null)
+					_subState.update(elapsed);
+
+				_subState = _subState.subState;
+			}
+		}
+	}
+
+	function drawState():Void
+	{
+		if (_state.persistentDraw || _state.subState == null)
+			_state.draw();
+
+		if (_state.subState != null)
+		{
+			var _subState:FlxSubState = _state.subState;
+
+			while (_subState != null)
+			{
+				if (_subState.persistentDraw || _subState.subState == null)
+					_subState.draw();
+
+				_subState = _subState.subState;
+			}
+		}
 	}
 
 	inline function getTicks()

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -31,18 +31,14 @@ class FlxSubState extends FlxState
 	@:noCompletion
 	var _bgSprite:FlxBGSprite;
 
-	/**
-	 * Helper var for `close()` so `closeSubState()` can be called on the parent.
-	 */
-	@:allow(flixel.FlxState.resetSubState)
-	var _parentState:FlxState;
-
 	@:noCompletion
 	var _bgColor:FlxColor;
 
-	@:noCompletion
-	@:allow(flixel.FlxState.resetSubState)
-	var _created:Bool = false;
+	/**
+	 * Stores a reference to the origin of `this` `FlxSubState`.
+	 */
+	@:allow(flixel.FlxState.openSubState)
+	public var parentState(default, null):FlxState;
 
 	/**
 	 * @param   BGColor   background color for this substate
@@ -55,6 +51,7 @@ class FlxSubState extends FlxState
 
 		if (FlxG.renderTile)
 			_bgSprite = new FlxBGSprite();
+
 		bgColor = BGColor;
 	}
 
@@ -80,19 +77,22 @@ class FlxSubState extends FlxState
 	override public function destroy():Void
 	{
 		super.destroy();
+
 		closeCallback = null;
 		openCallback = null;
-		_parentState = null;
+
+		parentState = null;
+
 		_bgSprite = FlxDestroyUtil.destroy(_bgSprite);
 	}
 
 	/**
-	 * Closes this substate.
+	 * Closes `this` `FlxSubState`.
 	 */
 	public function close():Void
 	{
-		if (_parentState != null && _parentState.subState == this)
-			_parentState.closeSubState();
+		if (parentState != null && parentState.subState == this)
+			parentState.closeSubState();
 	}
 
 	@:noCompletion

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -40,6 +40,9 @@ class FlxSubState extends FlxState
 	@:allow(flixel.FlxState.openSubState)
 	public var parentState(default, null):FlxState;
 
+	@:deprecated("`FlxSubState._parentState` is deprecated, use `FlxSubState.parentState instead.")
+	var _parentState(get, never):FlxState;
+
 	/**
 	 * @param   BGColor   background color for this substate
 	 */
@@ -108,5 +111,11 @@ class FlxSubState extends FlxState
 			_bgSprite.pixels.setPixel32(0, 0, Value);
 
 		return _bgColor = Value;
+	}
+	
+	@:noCompletion
+	function get__parentState():FlxState
+	{
+		return parentState;
 	}
 }

--- a/flixel/system/frontEnds/InputFrontEnd.hx
+++ b/flixel/system/frontEnds/InputFrontEnd.hx
@@ -133,7 +133,7 @@ class InputFrontEnd
 	}
 
 	@:allow(flixel.FlxGame)
-	@:allow(flixel.FlxState.resetSubState)
+	@:allow(flixel.FlxState.openSubState)
 	function onStateSwitch():Void
 	{
 		if (resetOnStateSwitch)


### PR DESCRIPTION
A lot of this code is very old, with some odd workarounds for certain things.

Changes:
`FlxSubState`s are now updated and drawn through `FlxGame`. This removes the need for `FlxState.tryUpdate`.
`_subStateOpened` and `_subStateClosed` have been removed and fully replaced with their public counterparts.
Remove `resetSubState` and related variables.

This is a draft because I want to see how CI reacts and also discuss breaking changes.

**To-Do**
- Update Demos, Snippets, etc to use `FlxSubState.parentState` instead of `FlxSubState._parentState`
- Find a way of effectively deprecating `resetSubState` instead of outright removing it. (Need suggestions)