### PR TITLE
Replay duration

### DIFF
--- a/flixel/input/keyboard/FlxKeyboard.hx
+++ b/flixel/input/keyboard/FlxKeyboard.hx
@@ -168,16 +168,16 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 	 * @param	Record	Array of data about key states.
 	 */
 	@:allow(flixel.system.replay.FlxReplay)
-	function playback(Record:Array<CodeValuePair>):Void
+	function playback(record:Array<CodeValuePair>):Void
 	{
-		var i:Int = 0;
-		var l:Int = Record.length;
+		var i = 0;
+		final len = record.length;
 
-		while (i < l)
+		while (i < len)
 		{
-			var o = Record[i++];
-			var o2 = getKey(o.code);
-			o2.current = o.value;
+			final keyRecord = record[i++];
+			final key = getKey(keyRecord.code);
+			key.current = keyRecord.value;
 		}
 	}
 }

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -24,6 +24,7 @@ class FlxReplay
 
 	/**
 	 * The number of frames in this recording.
+	 * **Note:** This doesn't include empty records, unlike `getDuration()`
 	 */
 	public var frameCount:Int;
 
@@ -243,13 +244,18 @@ class FlxReplay
 	}
 	
 	/**
-	 * Returns the last recorded frame index. **Note:** this is different from `frameCount`, which
+	 * The duration of this replay, in frames. **Note:** this is different from `frameCount`, which
 	 * is the number of unique records, which doesn't count frames with no input
+	 * 
+	 * @since 5.9.0
 	 */
 	public function getDuration()
 	{
 		if (_frames != null)
+		{
+			// Add 1 to the last frame index, because they are zero-based
 			return _frames[_frames.length - 1].frame + 1;
+		}
 		
 		return 0;
 	}

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -241,4 +241,16 @@ class FlxReplay
 		FlxArrayUtil.setLength(_frames, _capacity);
 		frameCount = 0;
 	}
+	
+	/**
+	 * Returns the last recorded frame index. **Note:** this is different from `frameCount`, which
+	 * is the number of unique records, which doesn't count frames with no input
+	 */
+	public function getDuration()
+	{
+		if (_frames != null)
+			return _frames[_frames.length - 1].frame;
+		
+		return 0;
+	}
 }

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -249,7 +249,7 @@ class FlxReplay
 	public function getDuration()
 	{
 		if (_frames != null)
-			return _frames[_frames.length - 1].frame;
+			return _frames[_frames.length - 1].frame + 1;
 		
 		return 0;
 	}

--- a/tests/unit/src/flixel/system/replay/FlxReplayTest.hx
+++ b/tests/unit/src/flixel/system/replay/FlxReplayTest.hx
@@ -102,6 +102,15 @@ class FlxReplayTest extends FlxTest
 	{
 		return new FrameRecord().create(i, null, new MouseRecord(0, 0, mouseState, 0));
 	}
+	
+	@Test // #3135
+	function testGetDuration()
+	{
+		var replay = new FlxReplay();
+		replay.load("987654321\n299km0,0,2,0\n");
+		// add 1 because frame indices are zero-based
+		Assert.areEqual(300, replay.getDuration());
+	}
 }
 
 class ReplayState extends FlxState


### PR DESCRIPTION
Adds replay.duration, which is distinctly different from the number of frames in a replay, because `duration` counts empty frames