### PR TITLE
add FlxBasePath, extends base in FlxPath

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1266,12 +1266,16 @@ class FlxObject extends FlxBasic
 		if (ignoreDrawDebug)
 			return;
 		
+		final drawPath = path != null && !path.ignoreDrawDebug;
+		
 		for (camera in getCamerasLegacy())
 		{
 			drawDebugOnCamera(camera);
-
-			if (path != null && !path.ignoreDrawDebug)
-				path.drawDebug();
+			
+			if (drawPath)
+			{
+				path.drawDebugOnCamera(camera);
+			}
 		}
 	}
 

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -19,7 +19,7 @@ import openfl.display.Graphics;
  * The following is an example of a class that moves the target to the next node and
  * and advances the iterator when it is near.
 ```haxe
-class FlxSimplePath extends flixel.path.FlxBasePath
+class SimplePath extends flixel.path.FlxBasePath
 {
 	public var speed:Float;
 	
@@ -34,7 +34,7 @@ class FlxSimplePath extends flixel.path.FlxBasePath
 		final frameSpeed = elapsed * speed;
 		final deltaX = next.x - target.x;
 		final deltaY = next.y - target.y;
-		// whether we will reach the next node this frame
+		// Whether the distance remaining is less than the distance we will travel this frame
 		return Math.sqrt(deltaX * deltaX + deltaY * deltaY) <= frameSpeed;
 	}
 	

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -80,10 +80,10 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	/** Called when the end is reached and `loopType1 is `ONCE` */
 	public var onFinish(default, null) = new FlxTypedSignal<(FlxTypedBasePath<TTarget>)->Void>();
 	
-	/** The index of the last node the target has reached */
-	public var currentIndex(default, null):Int = 0;
-	/** The index of the node the target is currently moving toward */
-	public var nextIndex(default, null):Null<Int> = null;
+	/** The index of the last node the target has reached, `-1` means "no current node" */
+	public var currentIndex(default, null):Int = -1;
+	/** The index of the node the target is currently moving toward, `-1` means the path is finished */
+	public var nextIndex(default, null):Int = -1;
 	
 	/** The last node the target has reached */
 	public var current(get, never):Null<FlxPoint>;
@@ -174,7 +174,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 		{
 			nextIndex = switch (loopType)
 			{
-				case ONCE: null;
+				case ONCE: -1;
 				case LOOP: 0;
 				case YOYO:
 					direction = BACKWARD;
@@ -189,7 +189,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 		{
 			nextIndex = switch (loopType)
 			{
-				case ONCE: null;
+				case ONCE: -1;
 				case LOOP: nodes.length - 1;
 				case YOYO:
 					direction = FORWARD;
@@ -206,7 +206,8 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	 * Change the path node this object is currently at.
 	 *
 	 * @param  index      The index of the new node out of path.nodes.
-	 * @param  direction  Whether to head towards the head or the tail
+	 * @param  direction  Whether to head towards the head or the tail, if `null` the previous
+	 *                    value is maintained
 	 */
 	public function startAt(index:Int, ?direction:FlxPathDirection):FlxTypedBasePath<TTarget>
 	{
@@ -254,17 +255,17 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	
 	inline function get_finished()
 	{
-		return nextIndex == null;
+		return nextIndex < 0;
 	}
 	
 	inline function get_current()
 	{
-		return nodes != null ? nodes[currentIndex] : null;
+		return nodes != null && currentIndex >= 0 ? nodes[currentIndex] : null;
 	}
 	
 	inline function get_next()
 	{
-		return nodes != null ? nodes[nextIndex] : null;
+		return nodes != null && nextIndex >= 0? nodes[nextIndex] : null;
 	}
 	
 	/**

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -335,7 +335,7 @@ enum abstract FlxPathDirection(Bool)
 	var FORWARD = true;
 	var BACKWARD = false;
 	
-	inline public function toInt()
+	public inline function toInt()
 	{
 		return this ? 1 : -1;
 	}

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -102,7 +102,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	 * @param   nodes   An Optional array of nodes. Unlike `FlxPath`, no copy is made
 	 * @param   target  The target traversing our path
 	 */
-	public function new (?nodes:Array<FlxPoint>, ?target:TTarget)
+	public function new (?nodes:Array<FlxPoint>, ?target:TTarget, direction = FORWARD)
 	{
 		this.nodes = nodes;
 		this.target = target;

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -109,7 +109,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 		super();
 		
 		if (nodes != null && nodes.length > 0 && target != null)
-			restartPath();
+			restart();
 	}
 	
 	override function destroy():Void
@@ -120,13 +120,10 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	}
 	
 	/**
-	 * Sets the current node to the desired end node
-	 * 
-	 * @param   direction  If `FORWARD`, it starts at the beginning
+	 * Sets the current node to the beginning, or the end if `direction` is `BACKWARD`
 	 */
-	public function restartPath(direction = FlxPathDirection.FORWARD):FlxTypedBasePath<TTarget>
+	public function restart():FlxTypedBasePath<TTarget>
 	{
-		this.direction = direction;
 		currentIndex = getStartingNode();
 		setNextIndex();
 		

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -65,6 +65,12 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	/** The target traversing our path */
 	public var target:TTarget;
 	
+	/** Behavior when the end(s) are reached */
+	public var loopType:FlxPathLoopType = LOOP;
+	
+	/** The direction the list of nodes is being traversed. `FORWARD` leads to the last node */
+	public var direction(default, null) = FlxPathDirection.FORWARD;
+	
 	/** The length of the `nodes` array */
 	public var totalNodes(get, never):Int;
 	
@@ -89,12 +95,6 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	public var current(get, never):Null<FlxPoint>;
 	/** The node the target is currently moving toward */
 	public var next(get, never):Null<FlxPoint>;
-	
-	/** Behavior when the end(s) are reached */
-	public var loopType:FlxPathLoopType = LOOP;
-	
-	/** The direction the list of nodes is being traversed. `FORWARD` leads to the last node */
-	public var direction(default, null) = FlxPathDirection.FORWARD;
 	
 	/**
 	 * Creates a new path. If valid nodes and a target are given it will start immediately.

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -30,7 +30,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	/** Called whenenever any node reached */
 	public var onNodeReached(default, null) = new FlxTypedSignal<(FlxTypedBasePath<TTarget>)->Void>();
 	
-	/** Called when the end is reached and loop is ONCE */
+	/** Called when the end is reached and loopType is ONCE */
 	public var onFinish(default, null) = new FlxTypedSignal<(FlxTypedBasePath<TTarget>)->Void>();
 	
 	/** The index of the last node the target has reached */
@@ -44,7 +44,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	public var next(get, never):Null<FlxPoint>;
 	
 	/** Behavior when the end(s) are reached */
-	public var loop:FlxPathLoop = LOOP;
+	public var loopType:FlxPathLoopType = LOOP;
 	
 	/** The direction the list of nodes is being traversed. `FORWARD` leads to the last node */
 	public var direction(default, null) = FlxPathDirection.FORWARD;
@@ -119,7 +119,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 		// reached last
 		if (currentIndex == nodes.length - 1 && direction == FORWARD)
 		{
-			nextIndex = switch (loop)
+			nextIndex = switch (loopType)
 			{
 				case ONCE: null;
 				case LOOP: 0;
@@ -134,7 +134,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 		// reached first
 		if (currentIndex == 0 && direction == BACKWARD)
 		{
-			nextIndex = switch (loop)
+			nextIndex = switch (loopType)
 			{
 				case ONCE: null;
 				case LOOP: nodes.length - 1;
@@ -301,7 +301,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 			// draw a box for the node
 			drawNode(gfx, prevNodeScreen, nodeSize, nodeColor);
 			
-			if (i + 1 < length || loop == LOOP)
+			if (i + 1 < length || loopType == LOOP)
 			{
 				// draw a line to the next node, if LOOP, get connect the tail and head
 				final nextNode = nodes[(i + 1) % length];
@@ -366,7 +366,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 /**
  * Path behavior controls
  */
-enum abstract FlxPathLoop(Int) from Int to Int
+enum abstract FlxPathLoopType(Int) from Int to Int
 {
 	/** Stops when reaching the end */
 	var ONCE = 0x000000;

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -67,6 +67,8 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	
 	/** The length of the `nodes` array */
 	public var totalNodes(get, never):Int;
+	
+	/** Whether this path is done, only `true` when `loopType` is `ONCE` */
 	public var finished(get, never):Bool;
 	
 	/** Called whenenever the end is reached, for `YOYO` this means both ends */

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -206,11 +206,8 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	 * @param  direction  Whether to head towards the head or the tail, if `null` the previous
 	 *                    value is maintained
 	 */
-	public function startAt(index:Int, ?direction:FlxPathDirection):FlxTypedBasePath<TTarget>
+	public function startAt(index:Int):FlxTypedBasePath<TTarget>
 	{
-		if (direction != null)
-			this.direction = direction;
-		
 		currentIndex = index;
 		setNextIndex();
 		

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -22,7 +22,7 @@ class FlxBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroyable
 	public var length(get, never):Int;
 	public var finished(get, never):Bool;
 	
-	public final onComplete = new FlxTypedSignal<(FlxBasePath<TTarget>)->Void>();
+	public var onComplete(default, null) = new FlxTypedSignal<(FlxBasePath<TTarget>)->Void>();
 	
 	/**
 	 * Tracks which node of the path this object is currently moving toward.

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -1,0 +1,351 @@
+package flixel.path;
+
+import flixel.FlxG;
+import flixel.FlxObject;
+import flixel.math.FlxPoint;
+import flixel.util.FlxAxes;
+import flixel.util.FlxColor;
+import flixel.util.FlxDestroyUtil;
+import flixel.util.FlxSignal;
+import flixel.util.FlxSpriteUtil;
+import openfl.display.Graphics;
+
+class FlxBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroyable
+{
+	/**
+	 * The list of FlxPoints that make up the path data.
+	 */
+	public var nodes:Array<FlxPoint>;
+	
+	public var target:TTarget;
+	
+	public var length(get, never):Int;
+	public var finished(get, never):Bool;
+	
+	public final onComplete = new FlxTypedSignal<(FlxBasePath<TTarget>)->Void>();
+	
+	/**
+	 * Tracks which node of the path this object is currently moving toward.
+	 */
+	public var currentIndex(default, null):Int = 0;
+	public var nextIndex(default, null):Null<Int> = null;
+	
+	public var current(get, never):Null<FlxPoint>;
+	public var next(get, never):Null<FlxPoint>;
+	
+	/**
+	 * Path behavior flag (like looping, yoyo, etc)
+	 */
+	public var loop:FlxPathLoop = LOOP;
+	
+	public var direction = FlxPathDirection.FORWARD;
+	
+	public function new (?nodes:Array<FlxPoint>, ?target:TTarget)
+	{
+		this.nodes = nodes;
+		this.target = target;
+		super();
+		
+		if (nodes != null && nodes.length > 0)
+			restartPath();
+	}
+	
+	/**
+	 * Clean up memory.
+	 */
+	override function destroy():Void
+	{
+		FlxDestroyUtil.putArray(nodes);
+		nodes = null;
+		onComplete.removeAll();
+	}
+	
+	public function restartPath(direction = FlxPathDirection.FORWARD):FlxBasePath<TTarget>
+	{
+		this.direction = direction;
+		currentIndex = getStartingNode();
+		setNextIndex();
+		
+		return this;
+	}
+	
+	public function getStartingNode()
+	{
+		return direction == BACKWARD ? nodes.length - 1 : 0;
+	}
+	
+	public function advance()
+	{
+		if (finished)
+		{
+			FlxG.log.warn('Cannot advance after path is finished');
+			return;
+		}
+		
+		currentIndex = nextIndex;
+		setNextIndex();
+	}
+	
+	function setNextIndex()
+	{
+		// reached last
+		if (currentIndex == nodes.length - 1 && direction == FORWARD)
+		{
+			nextIndex = switch (loop)
+			{
+				case ONCE: null;
+				case LOOP: 0;
+				case YOYO:
+					direction = BACKWARD;
+					currentIndex - 1;
+			}
+			onComplete.dispatch(this);
+			return;
+		}
+		
+		// reached first
+		if (currentIndex == 0 && direction == BACKWARD)
+		{
+			nextIndex = switch (loop)
+			{
+				case ONCE: null;
+				case LOOP: nodes.length - 1;
+				case YOYO:
+					direction = FORWARD;
+					currentIndex + 1;
+			}
+			onComplete.dispatch(this);
+			return;
+		}
+		
+		nextIndex = currentIndex + direction.toInt();
+	}
+	
+	/**
+	 * Change the path node this object is currently at.
+	 *
+	 * @param  index    The index of the new node out of path.nodes.
+	 */
+	public function startAt(index:Int, ?direction:FlxPathDirection):FlxBasePath<TTarget>
+	{
+		if (direction != null)
+			this.direction = direction;
+		
+		currentIndex = index;
+		setNextIndex();
+		
+		return this;
+	}
+	
+	// Following logic
+	
+	override function update(elapsed:Float)
+	{
+		super.update(elapsed);
+		
+		if (finished || target == null)
+			return;
+		
+		if (isTargetAtNext(elapsed))
+		{
+			advance();
+		}
+		
+		updateTarget(elapsed);
+	}
+	
+	/** Override this with your logic that whether the target has reached the next node */
+	function isTargetAtNext(elapsed:Float)
+	{
+		return false;
+	}
+	
+	/** Override this with your logic that brings the target towards the next node */
+	function updateTarget(elapsed:Float) {}
+	
+	inline function get_length()
+	{
+		return nodes != null ? nodes.length : 0;
+	}
+	
+	inline function get_finished()
+	{
+		return nextIndex == null;
+	}
+	
+	inline function get_current()
+	{
+		return nodes != null ? nodes[currentIndex] : null;
+	}
+	
+	inline function get_next()
+	{
+		return nodes != null ? nodes[nextIndex] : null;
+	}
+	
+	
+
+	#if FLX_DEBUG
+	/**
+	 * Specify a debug display color for the path. Default is WHITE.
+	 */
+	public var debugDrawData:FlxPathDrawData = {};
+	
+	/**
+	 * Setting this to true will prevent the object from appearing
+	 * when FlxG.debugger.drawDebug is true.
+	 */
+	public var ignoreDrawDebug:Bool = false;
+	
+	/**
+	 * While this doesn't override `FlxBasic.drawDebug()`, the behavior is very similar.
+	 * Based on this path data, it draws a simple lines-and-boxes representation of the path
+	 * if the `drawDebug` mode was toggled in the debugger overlay.
+	 * You can use `debugColor` to control the path's appearance.
+	 *
+	 * @param camera   The camera object the path will draw to.
+	 */
+	@:access(flixel.FlxCamera)
+	public function drawDebug(?camera:FlxCamera):Void
+	{
+		if (nodes == null || nodes.length <= 0)
+		{
+			return;
+		}
+
+		if (camera == null)
+		{
+			camera = FlxG.camera;
+		}
+
+		var gfx:Graphics = null;
+
+		// Set up our global flash graphics object to draw out the path
+		if (FlxG.renderBlit)
+		{
+			gfx = FlxSpriteUtil.flashGfx;
+			gfx.clear();
+		}
+		else
+		{
+			gfx = camera.debugLayer.graphics;
+		}
+		
+		final _point = FlxPoint.get();
+
+		// Then fill up the object with node and path graphics
+		var length = nodes.length;
+		for (i in 0...length)
+		{
+			// get a reference to the current node
+			var node = nodes[i];
+
+			// find the screen position of the node on this camera
+			_point.x = node.x;// - (camera.scroll.x * target.scrollFactor.x); // copied from getScreenPosition()
+			_point.y = node.y;// - (camera.scroll.y * target.scrollFactor.y);
+
+			camera.transformPoint(_point);
+
+			// decide what color this node should be
+			var nodeSize:Int = debugDrawData.nodeSize;
+			var nodeColor:FlxColor = debugDrawData.nodeColor;
+			if (length > 1)
+			{
+				if (i == 0)
+				{
+					nodeColor = debugDrawData.startColor;
+					nodeSize = debugDrawData.startSize;
+				}
+				else if (i == length - 1)
+				{
+					nodeColor = debugDrawData.endColor;
+					nodeSize = debugDrawData.endSize;
+				}
+			}
+
+			// draw a box for the node
+			gfx.beginFill(nodeColor.rgb, nodeColor.alphaFloat);
+			gfx.lineStyle();
+			var nodeOffset = Math.floor(nodeSize * 0.5);
+			gfx.drawRect(_point.x - nodeOffset, _point.y - nodeOffset, nodeSize, nodeSize);
+			gfx.endFill();
+
+			// then find the next node in the path
+			var nextNode:FlxPoint;
+			if (i < length - 1)
+			{
+				nextNode = nodes[i + 1];
+			}
+			else
+			{
+				nextNode = nodes[i];
+			}
+
+			// then draw a line to the next node
+			var lineOffset = debugDrawData.lineSize / 2;
+			gfx.moveTo(_point.x + lineOffset, _point.y + lineOffset);
+			gfx.lineStyle(debugDrawData.lineSize, debugDrawData.lineColor & 0xFFFFFF, debugDrawData.lineColor.alphaFloat);
+			_point.x = nextNode.x;// - (camera.scroll.x * target.scrollFactor.x); // copied from getScreenPosition()
+			_point.y = nextNode.y;// - (camera.scroll.y * target.scrollFactor.y);
+
+			if (FlxG.renderBlit)
+				_point.subtract(camera.viewMarginX, camera.viewMarginY);
+
+			gfx.lineTo(_point.x + lineOffset, _point.y + lineOffset);
+		}
+
+		if (FlxG.renderBlit)
+		{
+			// then stamp the path down onto the game buffer
+			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
+		}
+		
+		_point.put();
+	}
+	#end
+}
+
+/**
+ * Path behavior controls
+ */
+enum abstract FlxPathLoop(Int) from Int to Int
+{
+	/**
+	 * Move from the start of the path to the end then stop.
+	 */
+	var ONCE = 0x000000;
+	
+	/**
+	 * Move from the start of the path to the end then directly back to the start, and start over.
+	 */
+	var LOOP = 0x000010;
+	
+	/**
+	 * Move from the start of the path to the end then turn around and go back to the start, over and over.
+	 */
+	var YOYO = 0x001000;
+}
+
+enum abstract FlxPathDirection(Bool)
+{
+	var FORWARD = true;
+	var BACKWARD = false;
+	
+	public function toInt()
+	{
+		return this ? 1 : -1;
+	}
+}
+
+@:structInit
+class FlxPathDrawData
+{
+	public var lineColor  = FlxColor.WHITE;
+	public var nodeColor  = FlxColor.WHITE;
+	public var startColor = FlxColor.GREEN;
+	public var endColor   = FlxColor.RED;
+	public var lineSize   = 1;
+	public var nodeSize   = 3;
+	public var startSize  = 5;
+	public var endSize    = 5;
+}

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -713,27 +713,27 @@ class FlxPath extends FlxBasePath
 	function get__mode()
 	{
 		final isForward = direction == FlxPathDirection.FORWARD;
-		return switch(loop)
+		return switch(loopType)
 		{
-			case FlxPathLoop.ONCE:
+			case FlxPathLoopType.ONCE:
 				isForward ? FlxPathType.FORWARD : FlxPathType.BACKWARD;
-			case FlxPathLoop.LOOP:
+			case FlxPathLoopType.LOOP:
 				isForward ? FlxPathType.LOOP_FORWARD : FlxPathType.LOOP_BACKWARD;
-			case FlxPathLoop.YOYO:
+			case FlxPathLoopType.YOYO:
 				FlxPathType.YOYO;
 		}
 	}
 	
 	function set__mode(value:FlxPathType):FlxPathType
 	{
-		loop = switch (value)
+		loopType = switch (value)
 		{
 			case FlxPathType.YOYO:
-				FlxPathLoop.YOYO;
+				FlxPathLoopType.YOYO;
 			case FlxPathType.FORWARD | FlxPathType.BACKWARD:
-				FlxPathLoop.ONCE;
+				FlxPathLoopType.ONCE;
 			case FlxPathType.LOOP_FORWARD | FlxPathType.LOOP_BACKWARD:
-				FlxPathLoop.LOOP;
+				FlxPathLoopType.LOOP;
 		}
 		
 		direction = switch (value)

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -1,9 +1,9 @@
 package flixel.path;
 
-import flixel.path.FlxBasePath;
 import flixel.FlxG;
 import flixel.FlxObject;
 import flixel.math.FlxPoint;
+import flixel.path.FlxBasePath;
 import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
@@ -73,7 +73,7 @@ enum CenterMode
  * object.path = new FlxPath([new FlxPoint(0, 0), new FlxPoint(100, 0)]).start();
  * ```
  */
-class FlxPath extends FlxBasePath<FlxObject>
+class FlxPath extends FlxBasePath
 {
 	/**
 	 * Move from the start of the path to the end then stop.
@@ -159,6 +159,7 @@ class FlxPath extends FlxBasePath<FlxObject>
 	 */
 	public var angleOffset:Float = 0;
 	
+	public var onComplete:FlxPath->Void;
 	/**
 	 * Tracks which node of the path this object is currently moving toward.
 	 */
@@ -196,6 +197,11 @@ class FlxPath extends FlxBasePath<FlxObject>
 		super(nodes != null ? nodes.copy() : []);
 		
 		active = false;
+		onPathComplete.add(function (_)
+		{
+			if (onComplete != null)
+				onComplete(this);
+		});
 	}
 
 	/**
@@ -417,47 +423,46 @@ class FlxPath extends FlxBasePath<FlxObject>
 	 */
 	function advancePath(snap:Bool = true):FlxPoint
 	{
-		if (snap)
+		advance();
+		
+		return current;
+	}
+	
+	override function advance()
+	{
+		if (axes.x)
 		{
-			var oldNode:FlxPoint = nodes[nodeIndex];
-			if (oldNode != null)
+			object.x = next.x;
+			switch (centerMode)
 			{
-				if (axes.x)
-				{
-					object.x = oldNode.x;
-					switch (centerMode)
-					{
-						case ORIGIN:
-							if (object is FlxSprite)
-								object.x -= (cast object:FlxSprite).origin.x;
-						case CUSTOM(offset):
-							object.x -= offset.x;
-						case CENTER:
-							object.x -= object.width * 0.5;
-						case TOP_LEFT:
-					}
-				}
-				if (axes.y)
-				{
-					object.y = oldNode.y;
-					switch (centerMode)
-					{
-						case ORIGIN:
-							if (object is FlxSprite)
-								object.y -= (cast object:FlxSprite).origin.y;
-						case CUSTOM(offset):
-							object.y -= offset.y;
-						case CENTER:
-							object.y -= object.height * 0.5;
-						case TOP_LEFT:
-					}
-				}
+				case ORIGIN:
+					if (object is FlxSprite)
+						object.x -= (cast object:FlxSprite).origin.x;
+				case CUSTOM(offset):
+					object.x -= offset.x;
+				case CENTER:
+					object.x -= object.width * 0.5;
+				case TOP_LEFT:
 			}
 		}
-
-		advance();
-
-		return nodes[nodeIndex];
+		
+		if (axes.y)
+		{
+			object.y = next.y;
+			switch (centerMode)
+			{
+				case ORIGIN:
+					if (object is FlxSprite)
+						object.y -= (cast object:FlxSprite).origin.y;
+				case CUSTOM(offset):
+					object.y -= offset.y;
+				case CENTER:
+					object.y -= object.height * 0.5;
+				case TOP_LEFT:
+			}
+		}
+		
+		super.advance();
 	}
 
 	/**

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -233,7 +233,8 @@ class FlxPath extends FlxBasePath
 	 */
 	@:allow(flixel.FlxObject)
 	var object(get, set):FlxObject;
-
+	
+	@:haxe.warning("-WDeprecated")
 	public function new(?nodes:Array<FlxPoint>)
 	{
 		super(nodes != null ? nodes.copy() : []);
@@ -320,9 +321,9 @@ class FlxPath extends FlxBasePath
 	 *
 	 * @return This path object.
 	 */
-	public function restart():FlxPath
+	override function restart():FlxPath
 	{
-		restartPath();
+		super.restart();
 		active = nodes.length > 0;
 		return this;
 	}

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -197,7 +197,7 @@ class FlxPath extends FlxBasePath
 		super(nodes != null ? nodes.copy() : []);
 		
 		active = false;
-		onPathComplete.add(function (_)
+		onEndReached.add(function (_)
 		{
 			if (onComplete != null)
 				onComplete(this);
@@ -464,6 +464,29 @@ class FlxPath extends FlxBasePath
 		
 		super.advance();
 	}
+	
+	#if FLX_DEBUG
+	
+	/**
+	 * While this doesn't override `FlxBasic.drawDebug()`, the behavior is very similar.
+	 * Based on this path data, it draws a simple lines-and-boxes representation of the path
+	 * if the `drawDebug` mode was toggled in the debugger overlay.
+	 * You can use `debugColor` to control the path's appearance.
+	 *
+	 * @param camera   The camera object the path will draw to.
+	 */
+	@:deprecated("FlxPath.debugDraw() is deprecated, use draw() OR drawDebugOnCamera(camera), instead")
+	public function drawDebug(?camera:FlxCamera):Void
+	{
+		if (nodes == null || nodes.length <= 0 || ignoreDrawDebug)
+			return;
+		
+		if (camera == null)
+			camera = FlxG.camera;
+		
+		drawDebugOnCamera(camera);
+	}
+	#end
 
 	/**
 	 * Stops the path's movement.

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -198,10 +198,13 @@ class FlxPath extends FlxBasePath
 	 */
 	public var angleOffset:Float = 0;
 	
+	@:deprecated("onComplete is deprecated, use the onEndReached signal, instead")
 	public var onComplete:FlxPath->Void;
+	
 	/**
 	 * Tracks which node of the path this object is currently moving toward.
 	 */
+	@:deprecated("nodeIndex is deprecated, use nextIndex, instead")
 	public var nodeIndex(get, never):Int;
 	
 	/**


### PR DESCRIPTION
FlxPath does too much, in a way that makes it hard to do anything else. FlxBasePath allows to you create your own follow logic. This is mainly because `FlxPath` has a lot of features that I feel I need to work around, and other features that, frankly, don't make any sense to me, like `axes`.

`FlxBasePath` is also a complete overhaul of `FlxPath` and will eventually fecilitate it's replacement in a (much) later version. Here's is a list of those changes:
- Paths extend `FlxBasic` and behave in line with most other flixel objects. This means you can add a path to a group to control an object, too.
- `onComplete = func;` is deprecated for `onEndReached.add(func);`, also added `onFinished` and `onNodeReached`
- Base paths do not make a copy of `nodes` passed into the constructor, if you want a copy, make a copy
- Base Paths do not have FlxPath's `start` function or `setProperties` function. To stop or disable a path set it's `active` to `false`. If a `nodes` and `target` is supplied in the constructor, it will begin, if not it is considered `finished` and you'll need to supply nodes, a target and call `restart()` or `startAt(i)`
- You should see NO DIFFERENCE in the behavior of FlxPaths, if you do, let me know

Note: FlxObject.path is still a FlxPath, if you want to use custom path logic you'll need to manage it yourself 

## Long Term
I'd like to deprecate `FlxPath` or rename it to `FlxPathLegacy` and then make a new simplified version that doesn't have: `axes`, `immovable` and all the specific functions currently replaced by new FlxBasePath ones

## To Do
Thoroughly check that FlxPath still works, lol
- ~~Check Pathfinding demo~~
- ~~Check debug draw~~