### PR TITLE
Easier extension of FlxTypedTilemap and FlxTile

### DIFF
--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -2,6 +2,7 @@ package flixel.tile;
 
 import flixel.FlxObject;
 import flixel.graphics.frames.FlxFrame;
+import flixel.tile.FlxTilemap;
 import flixel.util.FlxDirectionFlags;
 
 /**
@@ -29,7 +30,7 @@ class FlxTile extends FlxObject
 	/**
 	 * A reference to the tilemap this tile object belongs to.
 	 */
-	public var tilemap:FlxTilemap;
+	public var tilemap:FlxTypedTilemap<FlxTile>;
 
 	/**
 	 * The index of this tile type in the core map data.
@@ -60,7 +61,7 @@ class FlxTile extends FlxObject
 	 * @param   visible          Whether the tile is visible or not.
 	 * @param   allowCollisions  The collision flags for the object.  By default this value is ANY or NONE depending on the parameters sent to loadMap().
 	 */
-	public function new(tilemap:FlxTilemap, index:Int, width:Float, height:Float, visible:Bool, allowCollisions:FlxDirectionFlags)
+	public function new(tilemap:FlxTypedTilemap<FlxTile>, index:Int, width:Float, height:Float, visible:Bool, allowCollisions:FlxDirectionFlags)
 	{
 		super(0, 0, width, height);
 

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -129,28 +129,10 @@ class FlxTilemap extends FlxTypedTilemap<FlxTile>
 	{
 		super();
 	}
-
-	override function initTileObjects():Void
+	
+	override function createTile(index, width, height, visible, allowCollisions):FlxTile
 	{
-		if (frames == null)
-			return;
-
-		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
-		// Create some tile objects that we'll use for overlap checks (one for each tile)
-		_tileObjects = new Array<FlxTile>();
-
-		var length:Int = frames.numFrames;
-		length += _startingIndex;
-
-		for (i in 0...length)
-			_tileObjects[i] = new FlxTile(this, i, tileWidth, tileHeight, (i >= _drawIndex), (i >= _collideIndex) ? allowCollisions : NONE);
-
-		// Create debug tiles for rendering bounding boxes on demand
-		#if FLX_DEBUG
-		updateDebugTileBoundingBoxSolid();
-		updateDebugTileBoundingBoxNotSolid();
-		updateDebugTileBoundingBoxPartial();
-		#end
+		return new FlxTile(this, index, width, height, visible, allowCollisions);
 	}
 }
 
@@ -384,7 +366,35 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 		super.destroy();
 	}
+	
+	override function initTileObjects():Void
+	{
+		if (frames == null)
+			return;
 
+		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
+		// Create some tile objects that we'll use for overlap checks (one for each tile)
+		_tileObjects = [];
+
+		var length:Int = frames.numFrames;
+		length += _startingIndex;
+
+		for (i in 0...length)
+			_tileObjects[i] = createTile(i, tileWidth, tileHeight, (i >= _drawIndex), (i >= _collideIndex) ? allowCollisions : NONE);
+
+		// Create debug tiles for rendering bounding boxes on demand
+		#if FLX_DEBUG
+		updateDebugTileBoundingBoxSolid();
+		updateDebugTileBoundingBoxNotSolid();
+		updateDebugTileBoundingBoxPartial();
+		#end
+	}
+	
+	function createTile(index, width, height, visible, allowCollisions):Tile
+	{
+		throw "createTile not implemented";
+	}
+	
 	function set_frames(value:FlxFramesCollection):FlxFramesCollection
 	{
 		frames = value;


### PR DESCRIPTION
It's now easier to extend `FlxTypedTilemap`, all you need now is to override `createTile`, like so:

```hx
class SpecialTile extends FlxTile
{
    public var specialField:SpecialType;
    
    public function new (tilemap:SpecialTilemap, index, width, height, visible, allowCollisions)
    {
        this.specialField = Global.getSpecialValue(index);
        
        super(cast tilemap, index, width, height, visible, allowCollisions);
    }
}

class SpecialTilemap extends FlxTypedTilemap<SpecialTile>
{
    override function createTile(index, width, height, visible, allowCollisions)
    {
        return new SpecialTile(this, index, width, height, visible, allowCollisions);
    }
}
```

you can also use the existing method, which is to override `initTileObjects` and create all the tiles, there