### PR TITLE
Better description for `persistentUpdate & persistentDraw` in `FlxState`

### DIFF
--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -33,7 +33,7 @@ class FlxState extends FlxContainer
 	 *
 	 * By default, this is set to `true`, so the background states will continue to be "drawn" behind the current state.
 	 *
-	 * If the background states are not supposed to be `visible` when you have a different state on top,
+	 * If you do not want background states to be `visible` when you have a different state on top,
 	 * then you should set this to `false` for improved performance.
 	 */
 	public var persistentDraw:Bool = true;

--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -18,21 +18,23 @@ import flixel.util.typeLimit.NextState;
 class FlxState extends FlxContainer
 {
 	/**
-	 * Determines whether or not this state is updated even when it is not the active state.
-	 * For example, if you have your game state first, and then you push a menu state on top of it,
-	 * if this is set to `true`, the game state would continue to update in the background.
-	 * By default this is `false`, so background states will be "paused" when they are not active.
+	 * Determines whether the current state is updated, even when it is not the active state.
+	 * For example, if you have your game state open first, and then you push a pause state on top of it,
+	 * if this is set to `true`, the game state would still continue to be updated in the background.
+	 *
+	 * By default, this is set to `false`, so the background states will continue to be "paused" when they are not active.
 	 */
 	public var persistentUpdate:Bool = false;
 
 	/**
-	 * Determines whether or not this state is updated even when it is not the active state.
-	 * For example, if you have your game state first, and then you push a menu state on top of it,
-	 * if this is set to `true`, the game state would continue to be drawn behind the pause state.
-	 * By default this is `true`, so background states will continue to be drawn behind the current state.
+	 * Determines whether the current state is drawn, even when it is not the active state.
+	 * For example, if you have your game state open first, and then you push a pause state on top of it,
+	 * if this is set to `true`, the game state would still continue to be drawn behind that pause state.
 	 *
-	 * If background states are not `visible` when you have a different state on top,
-	 * you should set this to `false` for improved performance.
+	 * By default, this is set to `true`, so the background states will continue to be "drawn" behind the current state.
+	 *
+	 * If the background states are not supposed to be `visible` when you have a different state on top,
+	 * then you should set this to `false` for improved performance.
 	 */
 	public var persistentDraw:Bool = true;
 


### PR DESCRIPTION
Tiny updated description documentation for persistentUpdate & persistentDraw in FlxState, so that they try to make more sense, and get to be understandable better.

This also fixes the "update" part(s) in persistentDraw's description, when they instead should be using the word "draw(n)".