### PR TITLE
Major change to FlxTilemap/FlxTiles Improve collision, debug drawing, add various features

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -191,6 +191,10 @@ class FlxObject extends FlxBasic
 	static function processCheckTilemap<T1:FlxObject, T2:FlxObject>
 		(object1:T1, object2:T2, func:(T1, T2)->Bool, isCollision = true):Bool
 	{
+		// two immovable objects cannot collide
+		if (isCollision && object1.immovable && object2.immovable)
+			return false;
+		
 		// If one of the objects is a tilemap, just pass it off.
 		if (object1.flixelType == TILEMAP)
 		{
@@ -226,17 +230,13 @@ class FlxObject extends FlxBasic
 	 */
 	public static function separate(object1:FlxObject, object2:FlxObject):Bool
 	{
-		// can't separate two immovable objects
-		if (object1.immovable && object2.immovable)
-			return false;
-		
-		/*
-		 * Note: We must resolve all X overlaps before Y, otherwise, platformers may collide
-		 * with the bottoms of tiles when jumping along the edge of a column of tiles
-		 */
-		final separatedX = processCheckTilemap(object1, object2, separateXHelper);
-		final separatedY = processCheckTilemap(object1, object2, separateYHelper);
-		return separatedX || separatedY;
+		function helper(object1, object2)
+		{
+			final separatedX = separateXHelper(object1, object2);
+			final separatedY = separateYHelper(object1, object2);
+			return separatedX || separatedY;
+		}
+		return processCheckTilemap(object1, object2, helper);
 	}
 	
 	/**
@@ -247,10 +247,6 @@ class FlxObject extends FlxBasic
 	 */
 	public static function separateX(object1:FlxObject, object2:FlxObject):Bool
 	{
-		// can't separate two immovable objects
-		if (object1.immovable && object2.immovable)
-			return false;
-		
 		return processCheckTilemap(object1, object2, separateXHelper);
 	}
 	
@@ -262,10 +258,6 @@ class FlxObject extends FlxBasic
 	 */
 	public static function separateY(object1:FlxObject, object2:FlxObject):Bool
 	{
-		// can't separate two immovable objects
-		if (object1.immovable && object2.immovable)
-			return false;
-		
 		return processCheckTilemap(object1, object2, separateYHelper);
 	}
 	

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -384,7 +384,7 @@ class FlxObject extends FlxBasic
 	 * The separateX that existed before HaxeFlixel 5.0, preserved for anyone who
 	 * needs to use it in an old project. Does not preserve momentum, avoid if possible
 	 */
-	inline static function legacySeparateX(object1:FlxObject, object2:FlxObject, overlap:Float)
+	static inline function legacySeparateX(object1:FlxObject, object2:FlxObject, overlap:Float)
 	{
 		final vel1 = object1.velocity.x;
 		final vel2 = object2.velocity.x;
@@ -406,7 +406,7 @@ class FlxObject extends FlxBasic
 	 * The separateY that existed before HaxeFlixel 5.0, preserved for anyone who
 	 * needs to use it in an old project. Does not preserve momentum, avoid if possible
 	 */
-	inline static function legacySeparateY(object1:FlxObject, object2:FlxObject, overlap:Float)
+	static inline function legacySeparateY(object1:FlxObject, object2:FlxObject, overlap:Float)
 	{
 		final vel1 = object1.velocity.y;
 		final vel2 = object2.velocity.y;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -290,23 +290,14 @@ class FlxObject extends FlxBasic
 			
 			if (!object1.immovable && !object2.immovable)
 			{
-				final mass1 = object1.mass;
-				final mass2 = object2.mass;
 				#if FLX_4_LEGACY_COLLISION
-				object1.x = object1.x - (overlap * 0.5);
-				object2.x += overlap * 0.5;
-				
-				var newVel1 = Math.sqrt((vel2 * vel2 * mass2) / mass1) * ((vel2 > 0) ? 1 : -1);
-				var newVel2 = Math.sqrt((vel1 * vel1 * mass1) / mass2) * ((vel1 > 0) ? 1 : -1);
-				final average = (newVel1 + newVel2) * 0.5;
-				newVel1 -= average;
-				newVel2 -= average;
-				object1.velocity.x = average + (newVel1 * object1.elasticity);
-				object2.velocity.x = average + (newVel2 * object2.elasticity);
+				legacySeparateX(object1, object2, overlap);
 				#else
 				object1.x -= overlap * 0.5;
 				object2.x += overlap * 0.5;
 				
+				final mass1 = object1.mass;
+				final mass2 = object2.mass;
 				final momentum = mass1 * vel1 + mass2 * vel2;
 				object1.velocity.x = (momentum + object1.elasticity * mass2 * (vel2 - vel1)) / (mass1 + mass2);
 				object2.velocity.x = (momentum + object2.elasticity * mass1 * (vel1 - vel2)) / (mass1 + mass2);
@@ -351,23 +342,14 @@ class FlxObject extends FlxBasic
 			
 			if (!object1.immovable && !object2.immovable)
 			{
-				final mass1 = object1.mass;
-				final mass2 = object2.mass;
 				#if FLX_4_LEGACY_COLLISION
-				object1.y = object1.y - (overlap * 0.5);
-				object2.y += overlap * 0.5;
-				
-				var newVel1 = Math.sqrt((vel2 * vel2 * mass2) / mass1) * ((vel2 > 0) ? 1 : -1);
-				var newVel2 = Math.sqrt((vel1 * vel1 * mass1) / mass2) * ((vel1 > 0) ? 1 : -1);
-				final average = (newVel1 + newVel2) * 0.5;
-				newVel1 -= average;
-				newVel2 -= average;
-				object1.velocity.y = average + newVel1 * object1.elasticity;
-				object2.velocity.y = average + newVel2 * object2.elasticity;
+				legacySeparateY(object1, object2, overlap);
 				#else
 				object1.y -= overlap / 2;
 				object2.y += overlap / 2;
 				
+				final mass1 = object1.mass;
+				final mass2 = object2.mass;
 				final momentum = mass1 * vel1 + mass2 * vel2;
 				final newVel1 = (momentum + object1.elasticity * mass2 * (vel2 - vel1)) / (mass1 + mass2);
 				final newVel2 = (momentum + object2.elasticity * mass1 * (vel1 - vel2)) / (mass1 + mass2);
@@ -396,6 +378,50 @@ class FlxObject extends FlxBasic
 		}
 		
 		return false;
+	}
+	
+	/**
+	 * The separateX that existed before HaxeFlixel 5.0, preserved for anyone who
+	 * needs to use it in an old project. Does not preserve momentum, avoid if possible
+	 */
+	inline static function legacySeparateX(object1:FlxObject, object2:FlxObject, overlap:Float)
+	{
+		final vel1 = object1.velocity.x;
+		final vel2 = object2.velocity.x;
+		final mass1 = object1.mass;
+		final mass2 = object2.mass;
+		object1.x = object1.x - (overlap * 0.5);
+		object2.x += overlap * 0.5;
+		
+		var newVel1 = Math.sqrt((vel2 * vel2 * mass2) / mass1) * ((vel2 > 0) ? 1 : -1);
+		var newVel2 = Math.sqrt((vel1 * vel1 * mass1) / mass2) * ((vel1 > 0) ? 1 : -1);
+		final average = (newVel1 + newVel2) * 0.5;
+		newVel1 -= average;
+		newVel2 -= average;
+		object1.velocity.x = average + (newVel1 * object1.elasticity);
+		object2.velocity.x = average + (newVel2 * object2.elasticity);
+	}
+	
+	/**
+	 * The separateY that existed before HaxeFlixel 5.0, preserved for anyone who
+	 * needs to use it in an old project. Does not preserve momentum, avoid if possible
+	 */
+	inline static function legacySeparateY(object1:FlxObject, object2:FlxObject, overlap:Float)
+	{
+		final vel1 = object1.velocity.y;
+		final vel2 = object2.velocity.y;
+		final mass1 = object1.mass;
+		final mass2 = object2.mass;
+		object1.y = object1.y - (overlap * 0.5);
+		object2.y += overlap * 0.5;
+		
+		var newVel1 = Math.sqrt((vel2 * vel2 * mass2) / mass1) * ((vel2 > 0) ? 1 : -1);
+		var newVel2 = Math.sqrt((vel1 * vel1 * mass1) / mass2) * ((vel1 > 0) ? 1 : -1);
+		final average = (newVel1 + newVel2) * 0.5;
+		newVel1 -= average;
+		newVel2 -= average;
+		object1.velocity.y = average + (newVel1 * object1.elasticity);
+		object2.velocity.y = average + (newVel2 * object2.elasticity);
 	}
 	
 	/**

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -245,32 +245,6 @@ class FlxObject extends FlxBasic
 	}
 	
 	/**
-	 * Separates 2 overlapping objects. If either object may be a tilemap, and you want
-	 * to separate the object from the individual tiles, you should use `separate` instead
-	 * 
-	 * @return  Whether the objects were overlapping and were separated
-	 * @since 5.9.0
-	 */
-	public static inline function separateObjects(object1:FlxObject, object2:FlxObject):Bool
-	{
-		// can't separate two immovable objects
-		if (object1.immovable && object2.immovable)
-			return false;
-		
-		return separateHelper(object1, object2);
-	}
-	
-	/**
-	 * Same as `separate` but assumes both are not immovable and not tilemaps
-	 */
-	static function separateHelper(object1:FlxObject, object2:FlxObject):Bool
-	{
-		final separatedX:Bool = separateXHelper(object1, object2);
-		final separatedY:Bool = separateYHelper(object1, object2);
-		return separatedX || separatedY;
-	}
-	
-	/**
 	 * Separates 2 overlapping objects along the X-axis. if an object is a tilemap,
 	 * it will separate it from any tiles that overlap it.
 	 * 
@@ -298,22 +272,6 @@ class FlxObject extends FlxBasic
 			return false;
 		
 		return processCheckTilemap(object1, object2, separateYHelper);
-	}
-	
-	/**
-	 * Separates 2 overlapping objects in the X-axis. If either object may be a tilemap, and you want
-	 * to separate the object from the individual tiles, you should use `separateX` instead
-	 * 
-	 * @return  Whether the objects were overlapping and were separated along the X-axis.
-	 * @since 5.9.0
-	 */
-	public static inline function separateObjectsX(object1:FlxObject, object2:FlxObject):Bool
-	{
-		// can't separate two immovable objects
-		if (object1.immovable && object2.immovable)
-			return false;
-		
-		return separateXHelper(object1, object2);
 	}
 	
 	/**
@@ -441,22 +399,6 @@ class FlxObject extends FlxBasic
 	}
 	
 	/**
-	 * Separates 2 overlapping objects in the Y-axis. If either object may be a tilemap, and you want
-	 * to separate the object from the individual tiles, you should use `separateY` instead
-	 * 
-	 * @return  Whether the objects were overlapping and were separated along the Y-axis.
-	 * @since 5.9.0
-	 */
-	public static inline function separateObjectsY(object1:FlxObject, object2:FlxObject):Bool
-	{
-		// can't separate two immovable objects
-		if (object1.immovable && object2.immovable)
-			return false;
-		
-		return separateYHelper(object1, object2);
-	}
-	
-	/**
 	 * Checks two objects for overlaps and sets their touching flags, accordingly.
 	 * If either object may be a tilemap, this will check the object against individual tiles
 	 * 
@@ -464,22 +406,13 @@ class FlxObject extends FlxBasic
 	 */
 	public static function updateTouchingFlags(object1:FlxObject, object2:FlxObject):Bool
 	{
-		return processCheckTilemap(object1, object2, updateObjectTouchingFlags, false);
-	}
-	
-	/**
-	 * Checks two objects for overlaps and sets their touching flags, accordingly.
-	 * If either object may be a tilemap, and you want to check individual tiles,
-	 * you should use `updateTouchingFlags` instead
-	 *
-	 * @return  Whether the objects are overlapping
-	 * @since 5.9.0
-	 */
-	public static function updateObjectTouchingFlags(object1:FlxObject, object2:FlxObject):Bool
-	{
-		final touchingX:Bool = updateObjectTouchingFlagsX(object1, object2);
-		final touchingY:Bool = updateObjectTouchingFlagsY(object1, object2);
-		return touchingX || touchingY;
+		function helper(object1:FlxObject, object2:FlxObject):Bool
+		{
+			final touchingX:Bool = updateTouchingFlagsXHelper(object1, object2);
+			final touchingY:Bool = updateTouchingFlagsYHelper(object1, object2);
+			return touchingX || touchingY;
+		}
+		return processCheckTilemap(object1, object2, helper, false);
 	}
 	
 	/**
@@ -490,18 +423,10 @@ class FlxObject extends FlxBasic
 	 */
 	public static function updateTouchingFlagsX(object1:FlxObject, object2:FlxObject):Bool
 	{
-		return processCheckTilemap(object1, object2, updateObjectTouchingFlagsX, false);
+		return processCheckTilemap(object1, object2, updateTouchingFlagsXHelper, false);
 	}
 	
-	/**
-	 * Checks two objects for overlaps along the X-axis and sets their touching flags, accordingly.
-	 * If either object may be a tilemap, and you want to check individual tiles,
-	 * you should use `updateTouchingFlags` instead
-	 *
-	 * @return  Whether the objects are overlapping in the X-axis
-	 * @since 5.9.0
-	 */
-	public static function updateObjectTouchingFlagsX(object1:FlxObject, object2:FlxObject):Bool
+	static function updateTouchingFlagsXHelper(object1:FlxObject, object2:FlxObject):Bool
 	{
 		// Since we are not separating, always return any amount of overlap => false as last parameter
 		return computeOverlapX(object1, object2, false) != 0;
@@ -515,18 +440,10 @@ class FlxObject extends FlxBasic
 	 */
 	public static function updateTouchingFlagsY(object1:FlxObject, object2:FlxObject):Bool
 	{
-		return processCheckTilemap(object1, object2, updateObjectTouchingFlagsY, false);
+		return processCheckTilemap(object1, object2, updateTouchingFlagsYHelper, false);
 	}
 	
-	/**
-	 * Checks two objects for overlaps along the Y-axis and sets their touching flags, accordingly.
-	 * If either object may be a tilemap, and you want to check individual tiles,
-	 * you should use `updateTouchingFlags` instead
-	 *
-	 * @return  Whether the objects are overlapping in the Y-axis
-	 * @since 5.9.0
-	 */
-	public static function updateObjectTouchingFlagsY(object1:FlxObject, object2:FlxObject):Bool
+	static function updateTouchingFlagsYHelper(object1:FlxObject, object2:FlxObject):Bool
 	{
 		// Since we are not separating, always return any amount of overlap => false as last parameter
 		return computeOverlapY(object1, object2, false) != 0;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -188,8 +188,9 @@ class FlxObject extends FlxBasic
 	 * @return  The result of whichever separator was used
 	 * @since 5.9.0
 	 */
-	static function processCheckTilemap<T1:FlxObject, T2:FlxObject>
-		(object1:T1, object2:T2, func:(T1, T2)->Bool, isCollision = true):Bool
+	@:haxe.warning("-WDeprecated")
+	static function processCheckTilemap(object1:FlxObject, object2:FlxObject, func:(FlxObject, FlxObject)->Bool,
+		?position:FlxPoint, isCollision = true):Bool
 	{
 		// two immovable objects cannot collide
 		if (isCollision && object1.immovable && object2.immovable)
@@ -203,9 +204,9 @@ class FlxObject extends FlxBasic
 			function recurseProcess(tile, _)
 			{
 				// Keep tile as first arg
-				return processCheckTilemap(tile, object2, func, isCollision);
+				return processCheckTilemap(tile, object2, func, position, isCollision);
 			}
-			return tilemap.processOverlaps(object2, recurseProcess, null, isCollision);
+			return tilemap.overlapsWithCallback(object2, recurseProcess, false, position);
 		}
 		else if (object2.flixelType == TILEMAP)
 		{
@@ -214,9 +215,9 @@ class FlxObject extends FlxBasic
 			function recurseProcess(tile, _)
 			{
 				// Keep tile as second arg
-				return processCheckTilemap(object1, tile, func, isCollision);
+				return processCheckTilemap(object1, tile, func, position, isCollision);
 			}
-			return tilemap.processOverlaps(object1, recurseProcess, null, isCollision);
+			return tilemap.overlapsWithCallback(object1, recurseProcess, false, position);
 		}
 		
 		return func(object1, object2);
@@ -230,13 +231,23 @@ class FlxObject extends FlxBasic
 	 */
 	public static function separate(object1:FlxObject, object2:FlxObject):Bool
 	{
-		function helper(object1, object2)
-		{
-			final separatedX = separateXHelper(object1, object2);
-			final separatedY = separateYHelper(object1, object2);
-			return separatedX || separatedY;
-		}
-		return processCheckTilemap(object1, object2, helper);
+		final separatedX = separateX(object1, object2);
+		final separatedY = separateY(object1, object2);
+		return separatedX || separatedY;
+		
+		/*
+		 * Note: can't do the following, FlxTilemapExt works better when you separate all
+		 * tiles in the x and then all tiles the y, rather than iterating all overlapping
+		 * tiles and separating the x and y on each of them. If we find a way around this
+		 * if would be more efficient to do the following
+		 */
+		// function helper(object1, object2)
+		// {
+		// 	final separatedX = separateXHelper(object1, object2);
+		// 	final separatedY = separateYHelper(object1, object2);
+		// 	return separatedX || separatedY;
+		// }
+		// return processCheckTilemap(object1, object2, helper);
 	}
 	
 	/**

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -558,9 +558,8 @@ class FlxObject extends FlxBasic
 			final delta1Abs:Float = (delta1 > 0) ? delta1 : -delta1;
 			final delta2Abs:Float = (delta2 > 0) ? delta2 : -delta2;
 			
-			// TODO: why is this object1.x, but computeOverlapY is object1.last.y ?
-			final rect1 = FlxRect.get(object1.x, object1.y - (delta1 > 0 ? delta1 : 0), object1.width, object1.height + delta1Abs);
-			final rect2 = FlxRect.get(object2.x, object2.y - (delta2 > 0 ? delta2 : 0), object2.width, object2.height + delta2Abs);
+			final rect1 = FlxRect.get(object1.last.x, object1.y - (delta1 > 0 ? delta1 : 0), object1.width, object1.height + delta1Abs);
+			final rect2 = FlxRect.get(object2.last.x, object2.y - (delta2 > 0 ? delta2 : 0), object2.width, object2.height + delta2Abs);
 
 			if (rect1.overlaps(rect2))
 			{

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1299,19 +1299,27 @@ class FlxObject extends FlxBasic
 	function drawDebugBoundingBox(gfx:Graphics, rect:FlxRect, allowCollisions:Int, partial:Bool)
 	{
 		// Find the color to use
-		var color:Null<Int> = debugBoundingBoxColor;
-		if (color == null)
-		{
-			if (allowCollisions != FlxDirectionFlags.NONE)
-			{
-				color = partial ? debugBoundingBoxColorPartial : debugBoundingBoxColorSolid;
-			}
-			else
-			{
-				color = debugBoundingBoxColorNotSolid;
-			}
-		}
-
+		final color = getDebugBoundingBoxColor(allowCollisions);
+		drawDebugBoundingBoxColor(gfx, rect, color);
+	}
+	
+	function getDebugBoundingBoxColor(allowCollisions:Int)
+	{
+		if (debugBoundingBoxColor != null)
+			return debugBoundingBoxColor;
+		
+		if (allowCollisions == FlxDirectionFlags.NONE)
+			return debugBoundingBoxColorNotSolid;
+		
+		if (allowCollisions == FlxDirectionFlags.ANY)
+			return debugBoundingBoxColorSolid;
+		
+		return debugBoundingBoxColorPartial;
+		
+	}
+	
+	function drawDebugBoundingBoxColor(gfx:Graphics, rect:FlxRect, color:FlxColor)
+	{
 		// fill static graphics object with square shape
 		gfx.lineStyle(1, color, 0.75);
 		gfx.drawRect(rect.x + 0.5, rect.y + 0.5, rect.width - 1.0, rect.height - 1.0);

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -212,15 +212,18 @@ class FlxRect implements IFlxPooled
 	}
 
 	/**
-	 * Checks to see if some FlxRect object overlaps this FlxRect object.
+	 * Checks to see if this rectangle overlaps another
 	 *
-	 * @param	Rect	The rectangle being tested.
-	 * @return	Whether or not the two rectangles overlap.
+	 * @param   rect  The other rectangle
+	 * @return  Whether the two rectangles overlap
 	 */
-	public inline function overlaps(Rect:FlxRect):Bool
+	public inline function overlaps(rect:FlxRect):Bool
 	{
-		var result = (Rect.x + Rect.width > x) && (Rect.x < x + width) && (Rect.y + Rect.height > y) && (Rect.y < y + height);
-		Rect.putWeak();
+		final result = rect.right > left
+			&& rect.left < right
+			&& rect.bottom > top
+			&& rect.top < bottom;
+		rect.putWeak();
 		return result;
 	}
 

--- a/flixel/path/FlxPathfinder.hx
+++ b/flixel/path/FlxPathfinder.hx
@@ -617,10 +617,8 @@ class FlxTypedPathfinderData<Tilemap:FlxBaseTilemap<FlxObject>>
 
 	public function hasValidStartEnd()
 	{
-		return startIndex >= 0
-			&& endIndex >= 0
-			&& startIndex < map.totalTiles
-			&& endIndex < map.totalTiles;
+		return map.tileExists(startIndex)
+			&& map.tileExists(endIndex);
 	}
 
 	public function destroy()
@@ -647,7 +645,7 @@ class FlxTypedPathfinderData<Tilemap:FlxBaseTilemap<FlxObject>>
 	 */
 	inline function getX(tile:Int)
 	{
-		return tile % map.widthInTiles;
+		return map.getColumn(tile);
 	}
 
 	/**
@@ -655,7 +653,7 @@ class FlxTypedPathfinderData<Tilemap:FlxBaseTilemap<FlxObject>>
 	 */
 	inline function getY(tile:Int)
 	{
-		return Std.int(tile / map.widthInTiles);
+		return map.getRow(tile);
 	}
 
 	/**
@@ -664,7 +662,7 @@ class FlxTypedPathfinderData<Tilemap:FlxBaseTilemap<FlxObject>>
 	inline function getTileCollisionsByIndex(tile:Int)
 	{
 		#if debug numChecks++; #end
-		return map.getTileCollisions(map.getTileByIndex(tile));
+		return map.getTileData(tile).allowCollisions;
 	}
 }
 

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -229,13 +229,19 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		return calcRayEntry(end, start, result);
 	}
-
-	public function overlapsWithCallback(object:FlxObject, ?callback:(FlxObject,FlxObject)->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
+	
+	@:deprecated("overlapsWithCallback is deprecated, use processOverlaps, instead")
+	public function overlapsWithCallback(object:FlxObject, ?callback:(FlxObject, FlxObject)->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
 	{
 		throw "overlapsWithCallback must be implemented";
 		return false;
 	}
-
+	
+	public function processOverlaps<TObj:FlxObject>(object:TObj, ?processCallback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
+	{
+		throw "processOverlaps must be implemented";
+	}
+	
 	public function setDirty(dirty:Bool = true):Void
 	{
 		throw "setDirty must be implemented";
@@ -804,7 +810,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Adjust collision settings and/or bind a callback function to a range of tiles.
-	 * This callback function, if present, is triggered by calls to overlap() or overlapsWithCallback().
+	 * This callback function, if present, is triggered by calls to `overlap` or `processOverlaps`.
 	 *
 	 * @param   tile             The tile or tiles you want to adjust.
 	 * @param   allowCollisions  Modify the tile or tiles to only allow collisions from certain directions, use FlxObject constants NONE, ANY, LEFT, RIGHT, etc. Default is "ANY".
@@ -982,7 +988,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		if (objectOrGroup.flixelType == OBJECT || objectOrGroup.flixelType == TILEMAP)
 		{
-			return overlapsWithCallback(cast objectOrGroup);
+			return processOverlaps(cast objectOrGroup);
 		}
 		else
 		{
@@ -1016,7 +1022,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		if (objectOrGroup.flixelType == OBJECT || objectOrGroup.flixelType == TILEMAP)
 		{
-			return overlapsWithCallback(cast objectOrGroup, null, false, _point.set(x, y));
+			return processOverlaps(cast objectOrGroup, null, _point.set(x, y));
 		}
 		else
 		{

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -285,6 +285,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   isCollision  If true, tiles where `allowCollisions` is `NONE` are excluded,
 	 *                       and the tiles' `onCollide` is dispatched
 	 * @return  Whether there were overlaps that resulted in a positive callback, if one was specified
+	 * @since 5.9.0
 	 */
 	public function processOverlaps<TObj:FlxObject>(object:TObj, ?processCallback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
 	{

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -864,10 +864,12 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * 
 	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
 	 * 
+	 * ##Soft Deprecation
+	 * You should use `getTileData(mapIndex).allowCollisions`, instead
+	 * 
 	 * @param   mapIndex  The desired location in the map
 	 * @return  The internal collision flag for the requested tile.
 	 */
-	@:deprecated("getTileCollisions is deprecated use getTileData(index).allowCollisions, instead")
 	public function getTileCollisions(mapIndex:Int):FlxDirectionFlags
 	{
 		return getTileData(mapIndex).allowCollisions;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -230,6 +230,37 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		return calcRayEntry(end, start, result);
 	}
 	
+	/**
+	 * Searches all tiles near the object for any that satisfy the given filter. Stops searching
+	 * when the first overlapping tile that satisfies the condition is found
+	 * 
+	 * @param   object    The object
+	 * @param   filter    Function that takes a tile and returns whether is satisfies the
+	 *                    disired condition, if `null`, any overlapping tile will satisfy
+	 * @param   position  Optional, specify a custom position for the tilemap
+	 * @return  Whether any overlapping tile satisfied the condition, if there was one
+	 * @since 5.9.0
+	 */
+	public function isOverlappingTile(object:FlxObject, ?filter:(tile:Tile)->Bool, ?position:FlxPoint):Bool
+	{
+		throw "overlapsWithCallback must be implemented";
+	}
+	
+	/**
+	 * Calls the given function on ever tile that is overlapping the target object
+	 * 
+	 * @param   object    The object
+	 * @param   filter    Function that takes a tile and returns whether is satisfies the
+	 *                    disired condition
+	 * @param   position  Optional, specify a custom position for the tilemap
+	 * @return  Whether any overlapping tile was found
+	 * @since 5.9.0
+	 */
+	public function forEachOverlappingTile(object:FlxObject, func:(tile:Tile)->Void, ?position:FlxPoint):Bool
+	{
+		throw "overlapsWithCallback must be implemented";
+	}
+	
 	@:deprecated("overlapsWithCallback is deprecated, use processOverlaps, instead")
 	public function overlapsWithCallback(object:FlxObject, ?callback:(FlxObject, FlxObject)->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
 	{
@@ -237,6 +268,24 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		return false;
 	}
 	
+	/**
+	 * Checks if the Object overlaps any tiles with any collision flags set,
+	 * and calls the specified callback function (if there is one).
+	 * Also calls the tile's registered callback if the filter matches.
+	 *
+	 * **Note:** To flip the callback params you can simply swap them in a arrow func, like so:
+	 * ```haxe
+	 final result = processOverlaps(obj, (tile, obj)->myProcessCallback(obj, tile));
+	 * ```
+	 *
+	 * @param   object       The FlxObject you are checking for overlaps against
+	 * @param   callback     An optional function that takes the overlapping tile and object
+	 *                       where `a` is a `FlxTile`, and `b` is the given `object` paaram
+	 * @param   position     Optional, specify a custom position for the tilemap (see `overlapsAt`)
+	 * @param   isCollision  If true, tiles where `allowCollisions` is `NONE` are excluded,
+	 *                       and the tiles' `onCollide` is dispatched
+	 * @return  Whether there were overlaps that resulted in a positive callback, if one was specified
+	 */
 	public function processOverlaps<TObj:FlxObject>(object:TObj, ?processCallback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
 	{
 		throw "processOverlaps must be implemented";
@@ -1009,7 +1058,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Whether or not the two objects overlap.
 	 */
 	@:access(flixel.group.FlxTypedGroup)
-	override public function overlapsAt(x:Float, y:Float, objectOrGroup:FlxBasic, inScreenSpace:Bool = false, ?camera:FlxCamera):Bool
+	override function overlapsAt(x:Float, y:Float, objectOrGroup:FlxBasic, inScreenSpace:Bool = false, ?camera:FlxCamera):Bool
 	{
 		final group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -135,17 +135,39 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		throw "computeDimensions must be implemented";
 	}
-
+	
+	/**
+	 * Finds the row number that overlaps the given Y in world space
+	 * @param   worldY  A Y coordinate in the world
+	 * @param   bind    If true, it will prevent out of range values
+	 * @return  A row index, where 0 is the top-most row
+	 * @since 5.9.0
+	 */
+	public function getRowAt(worldY:Float, bind = false):Int
+	{
+		throw "getRowAt must be implemented";
+	}
+	
+	/**
+	 * Finds the row number that overlaps the given X in world space
+	 * @param   worldX  A X coordinate in the world
+	 * @param   bind    If true, it will prevent out of range values
+	 * @return  A column index, where 0 is the left-most column
+	 * @since 5.9.0
+	 */
+	public function getColumnAt(worldX:Float, bind = false):Int
+	{
+		throw "getColumnAt must be implemented";
+	}
+	
 	public function getTileIndexByCoords(coord:FlxPoint):Int
 	{
 		throw "getTileIndexByCoords must be implemented";
-		return 0;
 	}
 
 	public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
 	{
 		throw "getTileCoordsByIndex must be implemented";
-		return null;
 	}
 
 	/**
@@ -762,7 +784,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 */
 	public overload extern inline function tileExists(column:Int, row:Int):Bool
 	{
-		return column >= 0 && row >= 0 && column < widthInTiles && row < heightInTiles;
+		return columnExists(column) && rowExists(row);
 	}
 	
 	/**
@@ -776,6 +798,28 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	public overload extern inline function tileExists(mapIndex:Int):Bool
 	{
 		return mapIndex >= 0 && mapIndex < _data.length;
+	}
+	
+	/**
+	 * Whether a row exists at the given map location
+	 *
+	 * @param   column  The desired location in the map
+	 * @since 5.9.0
+	 */
+	public overload extern inline function columnExists(column:Int):Bool
+	{
+		return column >= 0 && column < widthInTiles;
+	}
+	
+	/**
+	 * Whether a row exists at the given map location
+	 *
+	 * @param   row  The desired location in the map
+	 * @since 5.9.0
+	 */
+	public overload extern inline function rowExists(row:Int):Bool
+	{
+		return row >= 0 && row < heightInTiles;
 	}
 	
 	/**

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -724,6 +724,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * 
 	 * @param  column  the grid X location, in tiles
 	 * @param  row     the grid Y location, in tiles
+	 * @since 5.9.0
 	 */
 	public inline function getMapIndex(column:Int, row:Int):Int
 	{
@@ -734,6 +735,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * Calculates the column from a map location
 	 * 
 	 * @param  mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
+	 * @since 5.9.0
 	 */
 	public inline function getColumn(mapIndex:Int):Int
 	{
@@ -744,6 +746,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * Calculates the column from a map location
 	 * 
 	 * @param  mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
+	 * @since 5.9.0
 	 */
 	public inline function getRow(mapIndex:Int):Int
 	{

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -275,7 +275,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 *
 	 * **Note:** To flip the callback params you can simply swap them in a arrow func, like so:
 	 * ```haxe
-	 final result = processOverlaps(obj, (tile, obj)->myProcessCallback(obj, tile));
+	 * final result = processOverlaps(obj, (tile, obj)->myProcessCallback(obj, tile));
 	 * ```
 	 *
 	 * @param   object       The FlxObject you are checking for overlaps against

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -16,6 +16,7 @@ import openfl.display.BitmapData;
 
 using StringTools;
 
+@:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("overlapsWithCallback", "overlapsWithCallback is deprecated, use processOverlaps"))
 class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 {
 	/**
@@ -261,11 +262,10 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		throw "overlapsWithCallback must be implemented";
 	}
 	
-	@:deprecated("overlapsWithCallback is deprecated, use processOverlaps, instead")
+	@:deprecated("overlapsWithCallback is deprecated, use processOverlaps(object, callback, pos), instead")
 	public function overlapsWithCallback(object:FlxObject, ?callback:(FlxObject, FlxObject)->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
 	{
-		throw "overlapsWithCallback must be implemented";
-		return false;
+		return processOverlaps(object, (t, o)->{ return flipCallbackParams ? callback(o, t) : callback(t, o); }, position);
 	}
 	
 	/**

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -16,7 +16,7 @@ import openfl.display.BitmapData;
 
 using StringTools;
 
-@:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("overlapsWithCallback", "overlapsWithCallback is deprecated, use processOverlaps"))
+@:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("overlapsWithCallback", "overlapsWithCallback is deprecated, use objectOverlapsTiles"))
 class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 {
 	/**
@@ -284,10 +284,10 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		throw "overlapsWithCallback must be implemented";
 	}
 	
-	@:deprecated("overlapsWithCallback is deprecated, use processOverlaps(object, callback, pos), instead")
+	@:deprecated("overlapsWithCallback is deprecated, use objectOverlapsTiles(object, callback, pos), instead")
 	public function overlapsWithCallback(object:FlxObject, ?callback:(FlxObject, FlxObject)->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
 	{
-		return processOverlaps(object, (t, o)->{ return flipCallbackParams ? callback(o, t) : callback(t, o); }, position);
+		return objectOverlapsTiles(object, (t, o)->{ return flipCallbackParams ? callback(o, t) : callback(t, o); }, position);
 	}
 	
 	/**
@@ -297,7 +297,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 *
 	 * **Note:** To flip the callback params you can simply swap them in a arrow func, like so:
 	 * ```haxe
-	 * final result = processOverlaps(obj, (tile, obj)->myProcessCallback(obj, tile));
+	 * final result = objectOverlapsTiles(obj, (tile, obj)->myCallback(obj, tile));
 	 * ```
 	 *
 	 * @param   object       The FlxObject you are checking for overlaps against
@@ -309,9 +309,9 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Whether there were overlaps that resulted in a positive callback, if one was specified
 	 * @since 5.9.0
 	 */
-	public function processOverlaps<TObj:FlxObject>(object:TObj, ?processCallback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
+	public function objectOverlapsTiles<TObj:FlxObject>(object:TObj, ?callback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
 	{
-		throw "processOverlaps must be implemented";
+		throw "objectOverlapsTiles must be implemented";
 	}
 	
 	public function setDirty(dirty:Bool = true):Void
@@ -1074,7 +1074,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Adjust collision settings and/or bind a callback function to a range of tiles.
-	 * This callback function, if present, is triggered by calls to `overlap` or `processOverlaps`.
+	 * This callback function, if present, is triggered by calls to `overlap` or `objectOverlapsTiles`.
 	 *
 	 * @param   tile             The tile or tiles you want to adjust.
 	 * @param   allowCollisions  Modify the tile or tiles to only allow collisions from certain directions, use FlxObject constants NONE, ANY, LEFT, RIGHT, etc. Default is "ANY".
@@ -1243,7 +1243,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		if (objectOrGroup.flixelType == OBJECT || objectOrGroup.flixelType == TILEMAP)
 		{
-			return processOverlaps(cast objectOrGroup);
+			return objectOverlapsTiles(cast objectOrGroup);
 		}
 		else
 		{
@@ -1277,7 +1277,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	{
 		if (objectOrGroup.flixelType == OBJECT || objectOrGroup.flixelType == TILEMAP)
 		{
-			return processOverlaps(cast objectOrGroup, null, _point.set(x, y));
+			return objectOverlapsTiles(cast objectOrGroup, null, _point.set(x, y));
 		}
 		else
 		{

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -718,135 +718,300 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			throw "You must provide valid 'randomChoices' if you wish to randomize tilemap indices, please read documentation of 'setCustomTileMappings' function.";
 		}
 	}
-
+	
+	/**
+	 * Calculates a mapIndex via `row * widthInTiles + column`
+	 * 
+	 * @param  column  the grid X location, in tiles
+	 * @param  row     the grid Y location, in tiles
+	 */
+	public inline function getMapIndex(column:Int, row:Int):Int
+	{
+		return row * widthInTiles + column;
+	}
+	
+	/**
+	 * Calculates the column from a map location
+	 * 
+	 * @param  mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
+	 */
+	public inline function getColumn(mapIndex:Int):Int
+	{
+		return mapIndex % widthInTiles;
+	}
+	
+	/**
+	 * Calculates the column from a map location
+	 * 
+	 * @param  mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
+	 */
+	public inline function getRow(mapIndex:Int):Int
+	{
+		return Std.int(mapIndex / widthInTiles);
+	}
+	
+	/**
+	 * Whether a tile exists at the given map location
+	 *
+	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @since 5.9.0
+	 */
+	public overload extern inline function tileExists(column:Int, row:Int):Bool
+	{
+		return column >= 0 && row >= 0 && column < widthInTiles && row < heightInTiles;
+	}
+	
+	/**
+	 * Whether a tile exists at the given map location
+	 *
+	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
+	 *
+	 * @param   mapIndex  The desired location in the map
+	 * @since 5.9.0
+	 */
+	public overload extern inline function tileExists(mapIndex:Int):Bool
+	{
+		return mapIndex >= 0 && mapIndex < _data.length;
+	}
+	
+	/**
+	 * Finds the tile instance at a particular column and row
+	 *
+	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @return  The tile index of the tile at this location
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileData(column:Int, row:Int):Null<Tile>
+	{
+		return getTileData(getMapIndex(column, row));
+	}
+	
+	/**
+	 * Finds the tile instance with the given mapIndex
+	 *
+	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
+	 * 
+	 * **Note:** The reulting tile's `x`, `y`, `width` and `height` will not be accurate.
+	 * You can call `tile.orient` or similar methods
+	 *
+	 * @param   mapIndex  The desired location in the map
+	 * @return  An integer containing the value of the tile at this spot in the array.
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileData(mapIndex:Int):Null<Tile>
+	{
+		return _tileObjects[getTileIndex(mapIndex)];
+	}
+	
 	/**
 	 * Check the value of a particular tile.
 	 *
-	 * @param   x  The X coordinate of the tile (in tiles, not pixels).
-	 * @param   y  The Y coordinate of the tile (in tiles, not pixels).
+	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @return  The tile index of the tile at this location
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileIndex(column:Int, row:Int):Int
+	{
+		return getTileIndex(getMapIndex(column, row));
+	}
+	
+	/**
+	 * Get the `tileIndex` at the given map location
+	 * 
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
+	 *
+	 * @param   mapIndex  The desired location in the map
+	 * @return  The tileIndex of the tile with this `mapIndex`
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileIndex(mapIndex:Int):Int
+	{
+		return _data[mapIndex];
+	}
+	
+	/**
+	 * Check the value of a particular tile.
+	 *
+	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @return  The tile index of the tile at this location
+	 */
+	@:deprecated("getTile is deprecated use getTileIndex(column, row), instead")
+	public function getTile(column:Int, row:Int):Int
+	{
+		return getTileIndex(column, row);
+	}
+	
+	/**
+	 * Get the `tileIndex` at the given map location
+	 * 
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
+	 * 
+	 * @param   mapIndex  The desired location in the map
 	 * @return  An integer containing the value of the tile at this spot in the array.
 	 */
-	public function getTile(x:Int, y:Int):Int
+	@:deprecated("getTileByIndex is deprecated use getTileIndex(mapIndex), instead")
+	public function getTileByIndex(mapIndex:Int):Int
 	{
-		return _data[y * widthInTiles + x];
+		return getTileIndex(mapIndex);
 	}
-
+	
 	/**
-	 * Get the value of a tile in the tilemap by index.
-	 *
-	 * @param   index  The slot in the data array (Y * widthInTiles + X) where this tile is stored.
-	 * @return  An integer containing the value of the tile at this spot in the array.
-	 */
-	public function getTileByIndex(index:Int):Int
-	{
-		return _data[index];
-	}
-
-	/**
-	 * Gets the collision flags of tile by index.
-	 *
-	 * @param   index  Tile index returned by getTile or getTileByIndex
+	 * Gets the collision flags of the tile at the given location
+	 * 
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
+	 * 
+	 * @param   mapIndex  The desired location in the map
 	 * @return  The internal collision flag for the requested tile.
 	 */
-	public function getTileCollisions(index:Int):FlxDirectionFlags
+	@:deprecated("getTileCollisions is deprecated use getTileData(index).allowCollisions, instead")
+	public function getTileCollisions(mapIndex:Int):FlxDirectionFlags
 	{
-		return _tileObjects[index].allowCollisions;
+		return getTileData(mapIndex).allowCollisions;
 	}
-
+	
 	/**
-	 * Returns a new array full of every map index of the requested tile type.
+	 * Returns a new array full of every map index of the requested tile type
+	 * 
+	 * **Note:** Unlike `getAllMapIndices` this will return `null` if no tiles are found
 	 *
 	 * @param   index  The requested tile type.
 	 * @return  An Array with a list of all map indices of that tile type.
 	 */
-	public function getTileInstances(index:Int):Array<Int>
+	@:deprecated("getTileInstances is deprecated, use getTileIndices, instead")// 5.9.0
+	public inline function getTileInstances(tileIndex:Int):Array<Int>
 	{
-		var array:Array<Int> = null;
-		var i:Int = 0;
-		var l:Int = widthInTiles * heightInTiles;
-
-		while (i < l)
+		// for backwards compat, return `null` if none are found
+		final result = getAllMapIndices(tileIndex);
+		return result.length == 0 ? null : result;
+	}
+	
+	/**
+	 * Returns a new array full of every map index of the requested tile type.
+	 * 
+	 * **Note:** Unlike `getTileInstances` this will return `[]` if no tiles are found
+	 * 
+	 * @param   index  The requested tile type.
+	 * @return  An Array with a list of all map indices of that tile type.
+	 * @since 5.9.0
+	 */
+	public function getAllMapIndices(tileIndex:Int):Array<Int>
+	{
+		final result:Array<Int> = [];
+		var i:Int = widthInTiles * heightInTiles;
+		
+		while (i-- > 0)
 		{
-			if (_data[i] == index)
+			if (_data[i] == tileIndex)
 			{
-				if (array == null)
-				{
-					array = [];
-				}
-				array.push(i);
+				result.unshift(i);
 			}
-			i++;
 		}
-
-		return array;
+		
+		return result;
 	}
-
+	
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   x               The X coordinate of the tile (in tiles, not pixels).
-	 * @param   y               The Y coordinate of the tile (in tiles, not pixels).
-	 * @param   tile            The new integer data you wish to inject.
+	 * @param   mapIndex        The slot in the data array (Y * widthInTiles + X) where this tile is stored.
+	 * @param   tileIndex       The new tileIndex to place at the mapIndex
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 */
-	public function setTile(x:Int, y:Int, tile:Int, updateGraphics = true):Bool
+	public overload extern inline function setTileIndex(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
 	{
-		if ((x >= widthInTiles) || (y >= heightInTiles))
-		{
-			return false;
-		}
-
-		return setTileByIndex(y * widthInTiles + x, tile, updateGraphics);
+		return setTileHelper(mapIndex, tileIndex, updateGraphics);
 	}
-
+	
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   index           The slot in the data array (Y * widthInTiles + X) where this tile is stored.
-	 * @param   tile            The new integer data you wish to inject.
+	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @param   tileIndex       The new integer data you wish to inject.
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 */
-	public function setTileByIndex(index:Int, tile:Int, updateGraphics = true):Bool
+	public overload extern inline function setTileIndex(column:Int, row:Int, tileIndex:Int, updateGraphics = true):Bool
 	{
-		if (index >= _data.length)
-		{
+		return setTileHelper(getMapIndex(column, row), tileIndex, updateGraphics);
+	}
+	
+	/**
+	 * Change the data and graphic of a tile in the tilemap.
+	 *
+	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @param   tileIndex       The new integer data you wish to inject.
+	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
+	 * @return  Whether or not the tile was actually changed.
+	 */
+	@:deprecated("setTile is deprecated, use setTileIndex(column, row, tileIndex,...), instead")
+	public function setTile(column:Int, row:Int, tileIndex:Int, updateGraphics = true):Bool
+	{
+		return setTileIndex(getMapIndex(column, row), tileIndex, updateGraphics);
+	}
+	
+	/**
+	 * Change the data and graphic of a tile in the tilemap.
+	 *
+	 * @param   mapIndex        The slot in the data array (Y * widthInTiles + X) where this tile is stored.
+	 * @param   tileIndex       The new tileIndex to place at the mapIndex
+	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
+	 * @return  Whether or not the tile was actually changed.
+	 */
+	@:deprecated("setTileByIndex is deprecated, use setTileIndex(mapIndex, tileIndex,...), instead")
+	public function setTileByIndex(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
+	{
+		return setTileIndex(mapIndex, tileIndex, updateGraphics);
+	}
+	
+	function setTileHelper(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
+	{
+		if (!tileExists(mapIndex))
 			return false;
-		}
-
-		var ok:Bool = true;
-		_data[index] = tile;
-
+		
+		_data[mapIndex] = tileIndex;
+		
 		if (!updateGraphics)
 		{
-			return ok;
+			return true;
 		}
-
+		
 		setDirty();
-
-		if (auto == OFF)
+		
+		switch (auto)
 		{
-			updateTile(_data[index]);
-			return ok;
+			case OFF:
+				updateTile(_data[mapIndex]);
+			default:
+				updateTileWithAutoTile(mapIndex);
 		}
-
+		
+		return true;
+	}
+	
+	function updateTileWithAutoTile(mapIndex:Int)
+	{
 		// If this map is auto-tiled and it changes, locally update the arrangement
-		var i:Int;
-		var row:Int = Std.int(index / widthInTiles) - 1;
-		var rowLength:Int = row + 3;
-		var column:Int = index % widthInTiles - 1;
-		var columnHeight:Int = column + 3;
-
+		var row:Int = getRow(mapIndex) - 1;
+		var column:Int = getColumn(mapIndex) - 1;
+		final rowLength:Int = row + 3;
+		final columnHeight:Int = column + 3;
+		
 		while (row < rowLength)
 		{
 			column = columnHeight - 3;
-
+			
 			while (column < columnHeight)
 			{
-				if ((row >= 0) && (row < heightInTiles) && (column >= 0) && (column < widthInTiles))
+				if (tileExists(column, row))
 				{
-					i = row * widthInTiles + column;
+					final i = getMapIndex(column, row);
 					autoTile(i);
 					updateTile(_data[i]);
 				}
@@ -854,8 +1019,6 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 			}
 			row++;
 		}
-
-		return ok;
 	}
 
 	/**
@@ -911,22 +1074,13 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	public function getData(simple:Bool = false):Array<Int>
 	{
 		if (!simple)
-		{
 			return _data;
-		}
-
-		var i:Int = 0;
-		var l:Int = _data.length;
-		var data:Array<Int> = new Array();
-		FlxArrayUtil.setLength(data, l);
-
-		while (i < l)
-		{
-			data[i] = (_tileObjects[_data[i]].allowCollisions > 0) ? 1 : 0;
-			i++;
-		}
-
-		return data;
+		
+		return
+		[
+			for (i in 0..._data.length)
+				(getTileData(i).solid ? 1 : 0)
+		];
 	}
 
 	/**
@@ -1104,10 +1258,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	function tileAtPointAllowsCollisions(point:FlxPoint):Bool
 	{
-		var tileIndex = getTileIndexByCoords(point);
-		if (tileIndex < 0 || tileIndex >= _data.length)
-			return false;
-		return _tileObjects[_data[tileIndex]].allowCollisions > 0;
+		final mapIndex = getTileIndexByCoords(point);
+		return tileExists(mapIndex) && getTileData(mapIndex).solid;
 	}
 
 	/**

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -926,6 +926,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   tileIndex       The new tileIndex to place at the mapIndex
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
+	 * @since 5.9.0
 	 */
 	public overload extern inline function setTileIndex(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
 	{
@@ -940,6 +941,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   tileIndex       The new integer data you wish to inject.
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
+	 * @since 5.9.0
 	 */
 	public overload extern inline function setTileIndex(column:Int, row:Int, tileIndex:Int, updateGraphics = true):Bool
 	{

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -20,7 +20,10 @@ class FlxTile extends FlxObject
 	 */
 	public var callbackFunction:(FlxObject, FlxObject)->Void = null;
 	
-	/** Dispatched whenever FlxG.collide resolves a collision with a tile of this type */
+	/**
+	 * Dispatched whenever FlxG.collide resolves a collision with a tile of this type
+	 * @since 5.9.0
+	 */
 	public var onCollide = new FlxTypedSignal<(FlxTile, FlxObject)->Void>();
 	
 	/**
@@ -96,6 +99,7 @@ class FlxTile extends FlxObject
 	 * `orient` to ensure this tile is in the correct world space.
 	 * 
 	 * This method is dynamic, meaning you can set custom behavior per tile, without extension.
+	 * @since 5.9.0
 	 */
 	public dynamic function overlapsObject(object:FlxObject):Bool
 	{
@@ -116,6 +120,7 @@ class FlxTile extends FlxObject
 	 * @param   yPos    May be the true or a theoretical y of the map, based on what called this
 	 * @param   col     The tilemap column where this is being placed
 	 * @param   row     The tilemap row where this is being placed
+	 * @since 5.9.0
 	 */
 	public dynamic function orientAt(xPos:Float, yPos:Float, col:Int, row:Int)
 	{
@@ -136,6 +141,7 @@ class FlxTile extends FlxObject
 	 * 
 	 * @param   col     The tilemap column where this is being placed
 	 * @param   row     The tilemap row where this is being placed
+	 * @since 5.9.0
 	 */
 	public inline function orient(col:Int, row:Int)
 	{
@@ -151,6 +157,7 @@ class FlxTile extends FlxObject
 	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
 	 * 
 	 * @param   mapIndex  The desired location in the map
+	 * @since 5.9.0
 	 */
 	public inline function orientByIndex(mapIndex:Int)
 	{
@@ -166,6 +173,7 @@ class FlxTile extends FlxObject
 	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
 	 * 
 	 * @param   mapIndex  The desired location in the map
+	 * @since 5.9.0
 	 */
 	public inline function orientAtByIndex(xPos:Float, yPos:Float, mapIndex:Int)
 	{

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -21,7 +21,7 @@ class FlxTile extends FlxObject
 	public var callbackFunction:(FlxObject, FlxObject)->Void = null;
 	
 	/** Dispatched whenever FlxG.collide resolves a collision with a tile of this type */
-	public final onCollide = new FlxTypedSignal<(FlxTile, FlxObject)->Void>();
+	public var onCollide = new FlxTypedSignal<(FlxTile, FlxObject)->Void>();
 	
 	/**
 	 * Each tile can store its own filter class for their callback functions.

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -75,7 +75,7 @@ class FlxTile extends FlxObject
 	}
 	
 	/** Whether this tile overlaps the object */
-	dynamic public function overlapsObject(object:FlxObject):Bool
+	public dynamic function overlapsObject(object:FlxObject):Bool
 	{
 		return object.x + object.width > x
 			&& object.x < x + width

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -107,8 +107,8 @@ class FlxTile extends FlxObject
 	}
 	
 	/**
-	 * Places this tile in the world according to the map's location. often used before calling
-	 * `overlapsObject`
+	 * Places this tile in the world according to the desired map location. 
+	 * often used before calling `overlapsObject`
 	 * 
 	 * This method is dynamic, meaning you can set custom behavior per tile, without extension.
 	 * 
@@ -117,15 +117,58 @@ class FlxTile extends FlxObject
 	 * @param   col     The tilemap column where this is being placed
 	 * @param   row     The tilemap row where this is being placed
 	 */
-	public dynamic function orient(xPos:Float, yPos:Float, col:Int, row:Int)
+	public dynamic function orientAt(xPos:Float, yPos:Float, col:Int, row:Int)
 	{
-		final map = this.tilemap;
-		mapIndex = (row * map.widthInTiles) + col;
-		width = map.scaledTileWidth;
-		height = map.scaledTileHeight;
+		mapIndex = (row * tilemap.widthInTiles) + col;
+		width = tilemap.scaledTileWidth;
+		height = tilemap.scaledTileHeight;
 		x = xPos + col * width;
 		y = yPos + row * height;
-		last.x = x - xPos - map.last.x;
-		last.y = y - yPos - map.last.y;
+		last.x = x - xPos - tilemap.last.x;
+		last.y = y - yPos - tilemap.last.y;
+	}
+	
+	/**
+	 * Places this tile in the world according to the desired map location. 
+	 * often used before calling `overlapsObject`
+	 * 
+	 * Calls `orientAt` with the tilemap's current position
+	 * 
+	 * @param   col     The tilemap column where this is being placed
+	 * @param   row     The tilemap row where this is being placed
+	 */
+	public inline function orient(col:Int, row:Int)
+	{
+		orientAt(tilemap.x, tilemap.y, col, row);
+	}
+	
+	/**
+	 * Places this tile in the world according to the desired map location. 
+	 * often used before calling `overlapsObject`
+	 * 
+	 * Calls `orientAt` with the tilemap's current position
+	 * 
+	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
+	 * 
+	 * @param   mapIndex  The desired location in the map
+	 */
+	public inline function orientByIndex(mapIndex:Int)
+	{
+		orientAtByIndex(tilemap.x, tilemap.y, mapIndex);
+	}
+	
+	/**
+	 * Places this tile in the world according to the desired map location. 
+	 * often used before calling `overlapsObject`
+	 * 
+	 * Calls `orientAt` with the tilemap's current position
+	 * 
+	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
+	 * 
+	 * @param   mapIndex  The desired location in the map
+	 */
+	public inline function orientAtByIndex(xPos:Float, yPos:Float, mapIndex:Int)
+	{
+		orientAt(xPos, yPos, tilemap.getColumn(mapIndex), tilemap.getRow(mapIndex));
 	}
 }

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -74,13 +74,40 @@ class FlxTile extends FlxObject
 		this.allowCollisions = allowCollisions;
 	}
 	
-	/** Whether this tile overlaps the object */
+	/**
+	 * Whether this tile overlaps the object. this should be called directly after calling
+	 * `orient` to ensure this tile is in the correct world space.
+	 * 
+	 * This method is dynamic, meaning you can set custom behavior per tile, without extension.
+	 */
 	public dynamic function overlapsObject(object:FlxObject):Bool
 	{
 		return object.x + object.width > x
 			&& object.x < x + width
 			&& object.y + object.height > y
 			&& object.y < y + height;
+	}
+	
+	/**
+	 * Places this tile in the world according to the map's location. often used before calling
+	 * `overlapsObject`
+	 * 
+	 * This method is dynamic, meaning you can set custom behavior per tile, without extension.
+	 * 
+	 * @param   xPos    May be the true or a theoretical x of the map, based on what called this
+	 * @param   yPos    May be the true or a theoretical y of the map, based on what called this
+	 * @param   col     The tilemap column where this is being placed
+	 * @param   row     The tilemap row where this is being placed
+	 */
+	public dynamic function orient(xPos:Float, yPos:Float, col:Int, row:Int)
+	{
+		final map = this.tilemap;
+		width = map.scaledTileWidth;
+		height = map.scaledTileHeight;
+		x = xPos + col * width;
+		y = yPos + row * height;
+		last.x = x - xPos - map.last.x;
+		last.y = y - yPos - map.last.y;
 	}
 	
 	/**

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -75,7 +75,7 @@ class FlxTile extends FlxObject
 	}
 	
 	/** Whether this tile overlaps the object */
-	public function overlapsObject(object:FlxObject):Bool
+	dynamic public function overlapsObject(object:FlxObject):Bool
 	{
 		return object.x + object.width > x
 			&& object.x < x + width

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -73,7 +73,16 @@ class FlxTile extends FlxObject
 		this.visible = visible;
 		this.allowCollisions = allowCollisions;
 	}
-
+	
+	/** Whether this tile overlaps the object */
+	public function overlapsObject(object:FlxObject):Bool
+	{
+		return object.x + object.width > x
+			&& object.x < x + width
+			&& object.y + object.height > y
+			&& object.y < y + height;
+	}
+	
 	/**
 	 * Clean up memory.
 	 */

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -785,7 +785,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 				final dataIndex:Int = _data[mapIndex] < 0 ? 0 : _data[mapIndex];
 				
 				final tile = _tileObjects[dataIndex];
-				tile.orient(xPos, yPos, column, row);
+				tile.orientAt(xPos, yPos, column, row);
 				if (tile.overlapsObject(object))
 				{
 					if (filter == null || filter(tile))

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -785,7 +785,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 				
 				final tile = _tileObjects[tileIndex];
 				tile.orientAt(xPos, yPos, column, row);
-				if (tile.overlapsObject(object))
+				if (tile.overlapsObject(object) && (filter == null || filter(tile)))
 				{
 					if (stopAtFirst)
 						return true;

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1139,7 +1139,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			var tileX = Math.floor(curX / scaledTileWidth);
 			var tileY = Math.floor(curY / scaledTileHeight);
 			
-			if (getTileData(column, row).solid)
+			if (getTileData(tileX, tileY).solid)
 			{
 				// Some basic helper stuff
 				tileX *= Std.int(scaledTileWidth);

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -790,27 +790,16 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 				tile.y = yPos + row * tile.height;
 				tile.last.x = tile.x - deltaX;
 				tile.last.y = tile.y - deltaY;
-
-				var overlapFound = ((object.x + object.width) > tile.x)
-					&& (object.x < (tile.x + tile.width))
-					&& ((object.y + object.height) > tile.y)
-					&& (object.y < (tile.y + tile.height));
-
-				if (tile.allowCollisions != NONE)
+				
+				if (!tile.overlapsObject(object))
+					continue;
+				
+				var overlapFound = false;
+				if (tile.allowCollisions != NONE && callback != null)
 				{
-					if (callback != null)
-					{
-						if (flipCallbackParams)
-						{
-							overlapFound = callback(object, tile);
-						}
-						else
-						{
-							overlapFound = callback(tile, object);
-						}
-					}
+					overlapFound = flipCallbackParams ? callback(object, tile) : callback(tile, object);
 				}
-
+				
 				if (overlapFound)
 				{
 					if (tile.callbackFunction != null && (tile.filter == null || Std.isOfType(object, tile.filter)))

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -130,8 +130,10 @@ class FlxTilemap extends FlxTypedTilemap<FlxTile>
 		super();
 	}
 	
-	override function createTile(index, width, height, visible, allowCollisions):FlxTile
+	override function createTile(index:Int, width, height):FlxTile
 	{
+		final visible = index >= _drawIndex;
+		final allowCollisions = index >= _collideIndex ? this.allowCollisions : NONE;
 		return new FlxTile(this, index, width, height, visible, allowCollisions);
 	}
 }
@@ -380,7 +382,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		length += _startingIndex;
 
 		for (i in 0...length)
-			_tileObjects[i] = createTile(i, tileWidth, tileHeight, (i >= _drawIndex), (i >= _collideIndex) ? allowCollisions : NONE);
+			_tileObjects[i] = createTile(i, tileWidth, tileHeight);
 
 		// Create debug tiles for rendering bounding boxes on demand
 		#if FLX_DEBUG
@@ -390,7 +392,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		#end
 	}
 	
-	function createTile(index, width, height, visible, allowCollisions):Tile
+	function createTile(index, width, height):Tile
 	{
 		throw "createTile not implemented";
 	}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -780,7 +780,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		{
 			for (column in minTileX...maxTileX)
 			{
-				final mapIndex:Int = (row * widthInTiles) + column;
+				final mapIndex:Int = getMapIndex(column, row);
 				final tileIndex:Int = _data[mapIndex] < 0 ? 0 : _data[mapIndex];// TODO: still need to check -1?
 				
 				final tile = _tileObjects[tileIndex];
@@ -831,22 +831,22 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		return results;
 	}
 	
-	override function getRowAt(worldY:Float, bind = false):Int
-	{
-		final result = Math.floor(worldY / scaledTileHeight);
-		
-		if (bind)
-			return result < 0 ? 0 : (result > heightInTiles ? heightInTiles : result);
-		
-		return result;
-	}
-	
 	override function getColumnAt(worldX:Float, bind = false):Int
 	{
 		final result = Math.floor(worldX / scaledTileWidth);
 		
 		if (bind)
-			return result < 0 ? 0 : (result > widthInTiles ? widthInTiles : result);
+			return result < 0 ? 0 : (result >= widthInTiles ? widthInTiles - 1 : result);
+		
+		return result;
+	}
+	
+	override function getRowAt(worldY:Float, bind = false):Int
+	{
+		final result = Math.floor(worldY / scaledTileHeight);
+		
+		if (bind)
+			return result < 0 ? 0 : (result >= heightInTiles ? heightInTiles -1 : result);
 		
 		return result;
 	}

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -831,24 +831,24 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		return results;
 	}
 	
-	public function getRowAt(worldY:Float, bind = false):Int
+	override function getRowAt(worldY:Float, bind = false):Int
 	{
-		final unboundRow = Math.floor(worldY / scaledTileHeight);
+		final result = Math.floor(worldY / scaledTileHeight);
 		
 		if (bind)
-			return unboundRow < 0 ? 0 : (bind > heightInTiles ? heightInTiles : unboundRow);
+			return result < 0 ? 0 : (result > heightInTiles ? heightInTiles : result);
 		
-		return unbound;
+		return result;
 	}
 	
-	public function getColumnAt(worldX:Float, bind = false):Int
+	override function getColumnAt(worldX:Float, bind = false):Int
 	{
-		final unboundColumn = Math.floor(worldX / scaledTileWidth);
+		final result = Math.floor(worldX / scaledTileWidth);
 		
 		if (bind)
-			return unboundColumn < 0 ? 0 : (bind > widthInTiles ? widthInTiles : unboundColumn);
+			return result < 0 ? 0 : (result > widthInTiles ? widthInTiles : result);
 		
-		return unboundColumn;
+		return result;
 	}
 	
 	override public function getTileIndexByCoords(coord:FlxPoint):Int

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -875,6 +875,11 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 * and calls the specified callback function (if there is one).
 	 * Also calls the tile's registered callback if the filter matches.
 	 *
+	 * **Note:** To flip the callback params you can simply swap them in a arrow func, like so:
+	 * ```haxe
+	 final result = processOverlaps(obj, (tile, obj)->myProcessCallback(obj, tile));
+	 * ```
+	 *
 	 * @param   object       The FlxObject you are checking for overlaps against
 	 * @param   callback     An optional function that takes the overlapping tile and object
 	 *                       where `a` is a `FlxTile`, and `b` is the given `object` paaram

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -573,11 +573,9 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		// Copied from getScreenPosition()
 		_helperPoint.x = x - camera.scroll.x * scrollFactor.x;
 		_helperPoint.y = y - camera.scroll.y * scrollFactor.y;
-
-		var rectWidth:Float = scaledTileWidth;
-		var rectHeight:Float = scaledTileHeight;
-		var rect = FlxRect.get(0, 0, rectWidth, rectHeight);
-
+		
+		final rect = FlxRect.get(0, 0, scaledTileWidth, scaledTileHeight);
+		
 		// Copy tile images into the tile buffer
 		// Modified from getScreenPosition()
 		_point.x = (camera.scroll.x * scrollFactor.x) - x;
@@ -601,19 +599,28 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			{
 				final tile = _tileObjects[_data[columnIndex]];
 
-				if (tile != null && tile.visible)
+				if (tile != null && tile.visible && !tile.ignoreDrawDebug)
 				{
-					rect.x = _helperPoint.x + (columnIndex % widthInTiles) * rectWidth;
-					rect.y = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * rectHeight;
-					drawDebugBoundingBox(camera.debugLayer.graphics, rect, tile.allowCollisions, tile.allowCollisions != ANY);
+					rect.x = _helperPoint.x + (columnIndex % widthInTiles) * rect.width;
+					rect.y = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * rect.height;
+					
+						final color = tile.debugBoundingBoxColor != null
+							? tile.debugBoundingBoxColor
+							: getDebugBoundingBoxColor(tile.allowCollisions);
+						
+						if (color != null)
+						{
+							final colStr = color.toHexString();
+							drawDebugBoundingBoxColor(camera.debugLayer.graphics, rect, color);
+						}
 				}
 
 				columnIndex++;
 			}
-
+			
 			rowIndex += widthInTiles;
 		}
-
+		
 		rect.put();
 	}
 	#end

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -798,7 +798,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		return result;
 	}
 	
-	override function processOverlaps<TObj:FlxObject>(object:TObj, ?callback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
+	override function objectOverlapsTiles<TObj:FlxObject>(object:TObj, ?callback:(Tile, TObj)->Bool, ?position:FlxPoint, isCollision = true):Bool
 	{
 		var results = false;
 		

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -143,6 +143,7 @@ class FlxTilemap extends FlxTypedTilemap<FlxTile>
  * numbers and then associates those values with tiles from the sheet you pass in. It also includes
  * some handy static parsers that can convert arrays or images into strings that can be loaded.
  */
+@:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("overlapsWithCallback", "overlapsWithCallback is deprecated, use processOverlaps"))
 class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 {
 	/**

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1055,7 +1055,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		final endIndex = getTileIndexByCoords(end);
 
 		// If the starting tile is solid, return the starting position
-		if (getTileCollisions(getTileByIndex(startIndex)) != NONE)
+		if (getTileData(startIndex).allowCollisions != NONE)
 		{
 			if (result != null)
 				result.copyFrom(start);
@@ -1162,8 +1162,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		final step = startY <= endY ? 1 : -1;
 		while (true)
 		{
-			var index = y * widthInTiles + x;
-			if (getTileCollisions(getTileByIndex(index)) != NONE)
+			var index = getMapIndex(x, y);
+			if (getTileData(index).allowCollisions != NONE)
 				return index;
 			
 			if (y == endY)

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -781,19 +781,16 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			for (column in minTileX...maxTileX)
 			{
 				final mapIndex:Int = (row * widthInTiles) + column;
-				final dataIndex:Int = _data[mapIndex] < 0 ? 0 : _data[mapIndex];
+				final tileIndex:Int = _data[mapIndex] < 0 ? 0 : _data[mapIndex];// TODO: still need to check -1?
 				
-				final tile = _tileObjects[dataIndex];
+				final tile = _tileObjects[tileIndex];
 				tile.orientAt(xPos, yPos, column, row);
 				if (tile.overlapsObject(object))
 				{
-					if (filter == null || filter(tile))
-					{
-						if (stopAtFirst)
-							return true;
-						
-						result = true;
-					}
+					if (stopAtFirst)
+						return true;
+					
+					result = true;
 				}
 			}
 		}
@@ -833,7 +830,27 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		
 		return results;
 	}
-
+	
+	public function getRowAt(worldY:Float, bind = false):Int
+	{
+		final unboundRow = Math.floor(worldY / scaledTileHeight);
+		
+		if (bind)
+			return unboundRow < 0 ? 0 : (bind > heightInTiles ? heightInTiles : unboundRow);
+		
+		return unbound;
+	}
+	
+	public function getColumnAt(worldX:Float, bind = false):Int
+	{
+		final unboundColumn = Math.floor(worldX / scaledTileWidth);
+		
+		if (bind)
+			return unboundColumn < 0 ? 0 : (bind > widthInTiles ? widthInTiles : unboundColumn);
+		
+		return unboundColumn;
+	}
+	
 	override public function getTileIndexByCoords(coord:FlxPoint):Int
 	{
 		var localX = coord.x - x;

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1163,7 +1163,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		while (true)
 		{
 			var index = getMapIndex(x, y);
-			if (getTileData(index).allowCollisions != NONE)
+			if (getTileData(index).solid)
 				return index;
 			
 			if (y == endY)
@@ -1324,7 +1324,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		});
 
 		if (newTile >= 0)
-			setTile(tileX, tileY, newTile);
+			setTileIndex(tileX, tileY, newTile);
 
 		return tileSprite;
 	}

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"tags": ["game", "openfl", "flash", "html5", "neko", "cpp", "android", "ios", "cross"],
 	"description": "HaxeFlixel is a 2D game engine based on OpenFL that delivers cross-platform games.",
-	"version": "5.8.1",
+	"version": "5.9.0",
 	"releasenote": "TBD",
 	"contributors": ["haxeflixel", "Gama11", "GeoKureli"],
 	"dependencies": {}

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -53,6 +53,7 @@
 		<haxedef name="FLX_RENDER_TRIANGLE" />
 		<haxedef name="FLX_NO_SAVE" />
 		<haxedef name="FLX_NO_HEALTH" />
+		<haxedef name="FLX_4_LEGACY_COLLISION" />
 	</section>
 	<section if="coverage2">
 		<haxedef name="debug" />

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -1,14 +1,15 @@
 package flixel;
 
-import openfl.display.BitmapData;
+import flixel.FlxObject;
 import flixel.graphics.FlxGraphic;
 import flixel.math.FlxPoint;
 import flixel.math.FlxMath;
 import flixel.math.FlxRect;
 import flixel.tile.FlxTilemap;
 import flixel.util.FlxDirectionFlags;
-import massive.munit.Assert;
 import haxe.PosInfos;
+import massive.munit.Assert;
+import openfl.display.BitmapData;
 
 class FlxObjectTest extends FlxTest
 {
@@ -77,7 +78,92 @@ class FlxObjectTest extends FlxTest
 		step(60);
 		Assert.isFalse(FlxG.overlap(object1, object2));
 	}
-
+	
+	@Test
+	function testSeprateX():Void
+	{
+		final object1 = new FlxObject(5, 0, 10, 10);
+		object1.last.x = 10;
+		final object2 = new FlxObject(0, 0, 10, 10);
+		object2.last.x = -5;
+		
+		Assert.areEqual(-5, FlxObject.computeOverlapX(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapY(object1, object2));
+		Assert.isTrue(FlxG.overlap(object1, object2));
+		
+		Assert.isTrue(FlxObject.separateX(object1, object2));
+		
+		Assert.areEqual(0, FlxObject.computeOverlapX(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapY(object1, object2));
+		Assert.isFalse(FlxG.overlap(object1, object2));
+		Assert.isTrue(object1.x > object2.x);
+	}
+	
+	@Test
+	function testSeprateY():Void
+	{
+		final object1 = new FlxObject(0, 5, 10, 10);
+		object1.last.y = 10;
+		final object2 = new FlxObject(0, 0, 10, 10);
+		object2.last.y = -5;
+		
+		Assert.areEqual(-5, FlxObject.computeOverlapY(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapX(object1, object2));
+		
+		Assert.isTrue(FlxObject.separateY(object1, object2));
+		
+		Assert.areEqual(0, FlxObject.computeOverlapY(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapX(object1, object2));
+		Assert.isFalse(FlxG.overlap(object1, object2));
+		Assert.isTrue(object1.y > object2.y);
+	}
+	
+	@Test
+	function testSeprateXFromOpposite():Void
+	{
+		/*
+		 * NOTE: An odd y value on either may result in a rounding error where the second
+		 * computeOverlapY is 0 but FlxG.overlap returns true
+		 */
+		final object1 = new FlxObject(20, 0, 10, 10);
+		object1.last.x = object1.x - 30;
+		final object2 = new FlxObject(0, 0, 10, 10);
+		object2.last.x = object2.x + 30;
+		
+		Assert.areEqual(30, FlxObject.computeOverlapX(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapY(object1, object2));
+		
+		Assert.isTrue(FlxObject.separateX(object1, object2));
+		
+		Assert.areEqual(0, FlxObject.computeOverlapX(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapY(object1, object2));
+		Assert.isFalse(FlxG.overlap(object1, object2));
+		Assert.isTrue(object1.x < object2.x);
+	}
+	
+	@Test
+	function testSeprateYFromOpposite():Void
+	{
+		/*
+		 * NOTE: An odd y value on either may result in a rounding error where the second
+		 * computeOverlapY is 0 but FlxG.overlap returns true
+		 */
+		final object1 = new FlxObject(0, 20, 10, 10);
+		object1.last.y = object1.y - 30;
+		final object2 = new FlxObject(0, 0, 10, 10);
+		object2.last.y = object2.y + 30;
+		
+		Assert.areEqual(30, FlxObject.computeOverlapY(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapX(object1, object2));
+		
+		Assert.isTrue(FlxObject.separateY(object1, object2));
+		
+		Assert.areEqual(0, FlxObject.computeOverlapY(object1, object2));
+		Assert.areEqual(0, FlxObject.computeOverlapX(object1, object2));
+		Assert.isFalse(FlxG.overlap(object1, object2));
+		Assert.isTrue(object1.y < object2.y);
+	}
+	
 	@Test // closes #1564, tests #1561
 	function testSeparateYAfterX():Void
 	{

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -189,9 +189,14 @@ class FlxObjectTest extends FlxTest
 	}
 
 	@Test
-	function testOverlapsPoint()
+	function testOverlapsPointInScreenSpace()
 	{
 		overlapsPointInScreenSpace(true);
+	}
+	
+	@Test
+	function testOverlapsPointNotInScreenSpace()
+	{
 		overlapsPointInScreenSpace(false);
 	}
 

--- a/tests/unit/src/flixel/path/FlxPathTest.hx
+++ b/tests/unit/src/flixel/path/FlxPathTest.hx
@@ -42,6 +42,7 @@ class FlxPathTest extends FlxTest
 	}
 
 	@Test
+	@:haxe.warning("-WDeprecated")
 	function testCancelNoCallback()
 	{
 		startPath();

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -1,5 +1,6 @@
 package flixel.tile;
 
+import flixel.FlxObject;
 import openfl.display.BitmapData;
 import openfl.errors.ArgumentError;
 import flixel.math.FlxPoint;
@@ -224,7 +225,50 @@ class FlxTilemapTest extends FlxTest
 		Assert.isTrue(overlaps(0, 0));
 		Assert.isFalse(overlaps(1, 1));
 	}
-
+	
+	@Test // #3158
+	function testIsOverlappingTile()
+	{
+		final mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		
+		final obj = new FlxObject(4, 12, 8, 8);
+		var count = 0;
+		final result = tilemap.isOverlappingTile(obj, (tile)->{ count++; return tile.solid; } );
+		// should be touching bottom-left 4 tiles only
+		Assert.isTrue(result);
+		// wont need to check all 4 before finding
+		Assert.areEqual(2, count);
+		
+		// test position
+		count = 0;
+		final result = tilemap.isOverlappingTile(obj, (tile)->{ count++; return tile.solid; }, FlxPoint.get(0, 8));
+		// should be touching top-left 4 tiles only
+		Assert.isTrue(result);
+		Assert.areEqual(4, count);
+	}
+	
+	@Test // #3158
+	function testForEachOverlappingTile()
+	{
+		final mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		
+		final obj = new FlxObject(4, 12, 8, 8);
+		var count = 0;
+		final result = tilemap.forEachOverlappingTile(obj, (tile)->count++);
+		// should be touching bottom-left 4 tiles only
+		Assert.isTrue(result);
+		Assert.areEqual(4, count);
+		
+		// test position
+		count = 0;
+		final result = tilemap.forEachOverlappingTile(obj, (tile)->count++, FlxPoint.get(0, 12));
+		// should be touching top 2 left tiles
+		Assert.isTrue(result);
+		Assert.areEqual(2, count);
+	}
+	
 	function assertPixelHasColor(x:Int, color:UInt, ?info:PosInfos)
 	{
 		Assert.areEqual(FlxG.camera.buffer.getPixel(x, 0), color, info);

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -248,6 +248,8 @@ class FlxTilemapTest extends FlxTest
 	{
 		tilemap.loadMapFromCSV("-1,1", getBitmapData(), 8, 8);
 		FlxAssert.arraysEqual([0, 1], tilemap.getData());
+		
+		Assert.areEqual(0, tilemap.getTileIndex(0));
 	}
 
 	@Test // #1520

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -1,12 +1,13 @@
 package flixel.tile;
 
 import flixel.FlxObject;
-import openfl.display.BitmapData;
-import openfl.errors.ArgumentError;
 import flixel.math.FlxPoint;
 import flixel.util.FlxColor;
+import flixel.util.FlxDirectionFlags;
 import haxe.PosInfos;
 import massive.munit.Assert;
+import openfl.display.BitmapData;
+import openfl.errors.ArgumentError;
 
 using StringTools;
 
@@ -248,25 +249,112 @@ class FlxTilemapTest extends FlxTest
 		Assert.areEqual(4, count);
 	}
 	
-	@Test // #3158
-	function testForEachOverlappingTile()
+	@Test
+	function testWallLeft()
 	{
-		final mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
+		final mapData = [
+			1, 0, 0,
+			1, 0, 0,
+			1, 0, 0
+		];
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
 		
-		final obj = new FlxObject(4, 12, 8, 8);
-		var count = 0;
-		final result = tilemap.forEachOverlappingTile(obj, (tile)->count++);
-		// should be touching bottom-left 4 tiles only
-		Assert.isTrue(result);
-		Assert.areEqual(4, count);
+		final obj = new FlxObject(0, 0, 8, 8);
 		
-		// test position
-		count = 0;
-		final result = tilemap.forEachOverlappingTile(obj, (tile)->count++, FlxPoint.get(0, 12));
-		// should be touching top 2 left tiles
-		Assert.isTrue(result);
-		Assert.areEqual(2, count);
+		// move up-left towards a left wal, make sure we only separate on the X
+		for (i in 0...40)
+		{
+			// check a bunch of locations
+			obj.x = 4;
+			obj.y = 4 + (i / 10);
+			obj.touching = NONE;
+			obj.last.set(12, obj.y + 8);
+			FlxG.collide(tilemap, obj);
+			
+			final result = obj.touching.toString();
+			Assert.areEqual(LEFT.toString(), result, 'Value [$result] was not equal to expected value [L] on i=$i');
+		}
+	}
+	
+	@Test
+	function testWallRight()
+	{
+		final mapData = [
+			0, 0, 1,
+			0, 0, 1,
+			0, 0, 1
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		
+		final obj = new FlxObject(0, 0, 8, 8);
+		
+		// move up-right towards a right wall, make sure we only separate on the X
+		for (i in 0...40)
+		{
+			// check a bunch of locations
+			obj.x = 12;
+			obj.y = 4 + (i / 10);
+			obj.touching = NONE;
+			obj.last.set(4, obj.y + 8);
+			FlxG.collide(tilemap, obj);
+			
+			final result = obj.touching.toString();
+			Assert.areEqual(RIGHT.toString(), result, 'Value [$result] was not equal to expected value [R] on i=$i');
+		}
+	}
+	
+	@Test
+	function testWallTop()
+	{
+		final mapData = [
+			1, 1, 1,
+			0, 0, 0,
+			0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		
+		final obj = new FlxObject(0, 0, 8, 8);
+		
+		// move up-left towards a ceiling, make sure we only separate on the Y
+		for (i in 0...40)
+		{
+			// check a bunch of locations
+			obj.x = 4 + (i / 10);
+			obj.y = 4;
+			obj.touching = NONE;
+			obj.last.set(obj.x + 8, 12);
+			FlxG.collide(tilemap, obj);
+			
+			final result = obj.touching.toString();
+			Assert.areEqual(UP.toString(), result, 'Value [$result] was not equal to expected value [U] on i=$i');
+		}
+	}
+	
+	@Test
+	function testWallBottom()
+	{
+		final mapData = [
+			0, 0, 0,
+			0, 0, 0,
+			1, 1, 1
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		
+		final obj = new FlxObject(0, 0, 8, 8);
+		
+		// move down-right towards a floor, make sure we only separate on the Y
+		for (i in 0...40)
+		{
+			// check a bunch of locations
+			obj.x = 12 - (i / 10);
+			obj.y = 12;
+			obj.touching = NONE;
+			obj.last.set(obj.x - 8, 4);
+			FlxG.collide(tilemap, obj);
+			
+			final result = obj.touching.toString();
+			Assert.areEqual(DOWN.toString(), result, 'Value [$result] was not equal to expected value [D] on i=$i');
+		}
 	}
 	
 	function assertPixelHasColor(x:Int, color:UInt, ?info:PosInfos)

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -34,7 +34,7 @@ class FlxTilemapTest extends FlxTest
 	@Test
 	function test1x1Map()
 	{
-		tilemap.loadMapFromCSV("1", getBitmapData());
+		tilemap.loadMapFromCSV("1", getBitmapData(), 8, 8);
 
 		try
 		{
@@ -46,30 +46,93 @@ class FlxTilemapTest extends FlxTest
 		}
 
 		Assert.areEqual(1, tilemap.getData()[0]);
+		Assert.areEqual(1, tilemap.getData(true)[0]);
+		Assert.areEqual(1, tilemap.getTileIndex(0));
 	}
-
+	
 	@Test
 	function testLoadMapArray()
 	{
-		var mapData = [0, 1, 0, 1, 1, 1];
-		tilemap.loadMapFromArray(mapData, 3, 2, getBitmapData());
-
+		final mapData = 
+		[
+			0, 1, 0,
+			1, 1, 1
+		];
+		tilemap.loadMapFromArray(mapData, 3, 2, getBitmapData(), 8, 8);
+		
 		Assert.areEqual(3, tilemap.widthInTiles);
 		Assert.areEqual(2, tilemap.heightInTiles);
 		FlxAssert.arraysEqual([0, 1, 0, 1, 1, 1], tilemap.getData());
 	}
-
+	
 	@Test
 	function testLoadMap2DArray()
 	{
-		var mapData = [[0, 1, 0], [1, 1, 1]];
-		tilemap.loadMapFrom2DArray(mapData, getBitmapData());
-
+		final mapData =
+		[
+			[0, 1, 0],
+			[1, 1, 1]
+		];
+		tilemap.loadMapFrom2DArray(mapData, getBitmapData(), 8, 8);
+		
 		Assert.areEqual(3, tilemap.widthInTiles);
 		Assert.areEqual(2, tilemap.heightInTiles);
 		FlxAssert.arraysEqual([0, 1, 0, 1, 1, 1], tilemap.getData());
 	}
+	
+	@Test
+	function testAutoTiling()
+	{
+		final mapData = 
+		[
+			0, 0, 1, 0, 0,
+			0, 0, 1, 0, 0,
+			0, 1, 1, 1, 1,
+			0, 0, 0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 5, 3, getBitmapData(), 8, 8, AUTO);
 
+		Assert.areEqual(5, tilemap.widthInTiles);
+		Assert.areEqual(3, tilemap.heightInTiles);
+		
+		assertSolidData(mapData);
+		assertData
+		([
+			0, 0, 6,  0,  0,
+			0, 0, 6,  0,  0,
+			0, 3, 12, 11, 11,
+			0, 0, 0,  0,  0
+		]);
+		
+		tilemap.setTileIndex(2, 0);
+		
+		assertSolidData
+		([
+			0, 0, 0, 0, 0,
+			0, 0, 1, 0, 0,
+			0, 1, 1, 1, 1,
+			0, 0, 0, 0, 0
+		]);
+		
+		assertData
+		([
+			0, 0, 0,  0,  0,
+			0, 0, 5,  0,  0,
+			0, 3, 12, 11, 11,
+			0, 0, 0,  0,  0
+		]);
+	}
+	
+	function assertSolidData(expected:Array<Int>, ?msg:String, ?info:PosInfos)
+	{
+		FlxAssert.arraysEqual(expected, tilemap.getData(true), msg, info);
+	}
+	
+	function assertData(expected:Array<Int>, ?msg:String, ?info:PosInfos)
+	{
+		FlxAssert.arraysEqual(expected, tilemap.getData(false), msg, info);
+	}
+	
 	@Test
 	function testLoadMapFromGraphic()
 	{
@@ -111,7 +174,7 @@ class FlxTilemapTest extends FlxTest
 	@:haxe.warning("-WDeprecated")
 	function testOffMapOverlap()
 	{
-		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData());
+		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData(), 8, 8);
 		var sprite = new FlxSprite(-2, 10);
 		Assert.isFalse(tilemap.overlapsWithCallback(sprite));
 	}
@@ -120,7 +183,7 @@ class FlxTilemapTest extends FlxTest
 	// same as testOffMapOverlap but with processOverlaps
 	function testOffMapOverlap2()
 	{
-		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData());
+		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData(), 8, 8);
 		var sprite = new FlxSprite(-2, 10);
 		Assert.isFalse(tilemap.processOverlaps(sprite));
 	}
@@ -133,7 +196,7 @@ class FlxTilemapTest extends FlxTest
 
 	function testLoadMapFromCSVWithNewline(csv:String, newlines:String)
 	{
-		tilemap.loadMapFromCSV(csv.replace("[nl]", newlines), getBitmapData());
+		tilemap.loadMapFromCSV(csv.replace("[nl]", newlines), getBitmapData(), 8, 8);
 
 		Assert.areEqual(4, tilemap.widthInTiles);
 		Assert.areEqual(3, tilemap.heightInTiles);
@@ -144,7 +207,7 @@ class FlxTilemapTest extends FlxTest
 	function testRayEmpty()
 	{
 		var mapData = [0, 0, 0]; // 3x1
-		tilemap.loadMapFromArray(mapData, 3, 1, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 1, getBitmapData(), 8, 8);
 
 		Assert.isTrue(tilemap.ray(new FlxPoint(0, tilemap.height / 2), new FlxPoint(tilemap.width, tilemap.height / 2)));
 	}
@@ -153,7 +216,7 @@ class FlxTilemapTest extends FlxTest
 	function testRayStraight()
 	{
 		var mapData = [0, 1, 0]; // 3x1 with a solid block in the middle
-		tilemap.loadMapFromArray(mapData, 3, 1, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 1, getBitmapData(), 8, 8);
 
 		Assert.isFalse(tilemap.ray(new FlxPoint(0, tilemap.height / 2), new FlxPoint(tilemap.width, tilemap.height / 2)));
 	}
@@ -162,7 +225,7 @@ class FlxTilemapTest extends FlxTest
 	function testRayImperfectDiagonal()
 	{
 		var mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 
 		Assert.isFalse(tilemap.ray(new FlxPoint(0, 0), new FlxPoint(tilemap.width - tilemap.width / 8, tilemap.height)));
 	}
@@ -171,7 +234,7 @@ class FlxTilemapTest extends FlxTest
 	function testRayPerfectDiagonal()
 	{
 		var mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 
 		Assert.isFalse(tilemap.ray(new FlxPoint(0, 0), new FlxPoint(tilemap.width, tilemap.height)));
 	}
@@ -179,14 +242,14 @@ class FlxTilemapTest extends FlxTest
 	@Test
 	function testNegativeIndicesTreatedAsZero()
 	{
-		tilemap.loadMapFromCSV("-1,1", getBitmapData());
+		tilemap.loadMapFromCSV("-1,1", getBitmapData(), 8, 8);
 		FlxAssert.arraysEqual([0, 1], tilemap.getData());
 	}
 
 	@Test // #1520
 	function testLoadMapFromCSVTrailingComma()
 	{
-		tilemap.loadMapFromCSV("1,", getBitmapData());
+		tilemap.loadMapFromCSV("1,", getBitmapData(), 8, 8);
 		FlxAssert.arraysEqual([1], tilemap.getData());
 	}
 
@@ -196,7 +259,7 @@ class FlxTilemapTest extends FlxTest
 		var exceptionThrown = false;
 		try
 		{
-			tilemap.loadMapFromCSV("1,f,1", getBitmapData());
+			tilemap.loadMapFromCSV("1,f,1", getBitmapData(), 8, 8);
 		}
 		catch (e:Dynamic)
 		{
@@ -209,7 +272,7 @@ class FlxTilemapTest extends FlxTest
 	@Test // #1835
 	function testOverlapsPointCrash()
 	{
-		tilemap.loadMapFromCSV("1,", getBitmapData());
+		tilemap.loadMapFromCSV("1,", getBitmapData(), 8, 8);
 		var point = FlxPoint.get(1000, 1000);
 		Assert.isFalse(tilemap.overlapsPoint(point, false));
 		Assert.isFalse(tilemap.overlapsPoint(point, true));
@@ -231,7 +294,7 @@ class FlxTilemapTest extends FlxTest
 	function testIsOverlappingTile()
 	{
 		final mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
 		final obj = new FlxObject(4, 12, 8, 8);
 		var count = 0;
@@ -257,7 +320,7 @@ class FlxTilemapTest extends FlxTest
 			1, 0, 0,
 			1, 0, 0
 		];
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
 		final obj = new FlxObject(0, 0, 8, 8);
 		
@@ -284,7 +347,7 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 1,
 			0, 0, 1
 		];
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
 		final obj = new FlxObject(0, 0, 8, 8);
 		
@@ -311,7 +374,7 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 0,
 			0, 0, 0
 		];
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
 		final obj = new FlxObject(0, 0, 8, 8);
 		
@@ -338,7 +401,7 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 0,
 			1, 1, 1
 		];
-		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData());
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
 		final obj = new FlxObject(0, 0, 8, 8);
 		
@@ -357,6 +420,56 @@ class FlxTilemapTest extends FlxTest
 		}
 	}
 	
+	@Test
+	function testMapIndex()
+	{
+		final mapData = [
+			0, 0, 0,
+			0, 1, 0,
+			0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		
+		Assert.areEqual(tilemap.getTileIndex(4), tilemap.getTileIndex(1, 1));
+		Assert.areEqual(1, tilemap.getTileIndex(4));
+		Assert.areEqual(2, tilemap.getColumn(8));
+		Assert.areEqual(2, tilemap.getRow(8));
+		
+		Assert.areEqual(tilemap.getTileData(4), tilemap.getTileData(1, 1));
+	}
+	
+	@Test
+	function testTileExists()
+	{
+		final mapData = [
+			0, 0, 0,
+			0, 1, 0,
+			0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		
+		Assert.isTrue(tilemap.tileExists(4));
+		Assert.isTrue(tilemap.tileExists(1, 1));
+		Assert.isFalse(tilemap.tileExists(9));
+		Assert.isFalse(tilemap.tileExists(3, 1));
+		Assert.isFalse(tilemap.tileExists(1, 3));
+		Assert.isFalse(tilemap.tileExists(5, 5));
+	}
+	
+	@Test
+	function testGetAllMapIndices()
+	{
+		final mapData = [
+			0, 0, 0,
+			0, 1, 0,
+			0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		
+		FlxAssert.arraysEqual([4], tilemap.getAllMapIndices(1));
+		FlxAssert.arraysEqual([0,1,2,3,5,6,7,8], tilemap.getAllMapIndices(0));
+	}
+	
 	function assertPixelHasColor(x:Int, color:UInt, ?info:PosInfos)
 	{
 		Assert.areEqual(FlxG.camera.buffer.getPixel(x, 0), color, info);
@@ -364,6 +477,6 @@ class FlxTilemapTest extends FlxTest
 
 	function getBitmapData()
 	{
-		return new BitmapData(16, 8);
+		return new BitmapData(8*16, 8);
 	}
 }

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -184,8 +184,12 @@ class FlxTilemapTest extends FlxTest
 	function testOffMapOverlap2()
 	{
 		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData(), 8, 8);
-		var sprite = new FlxSprite(-2, 10);
-		Assert.isFalse(tilemap.objectOverlapsTiles(sprite));
+		final obj = new FlxObject(-10, 10, 8, 8);
+		Assert.isFalse(tilemap.objectOverlapsTiles(obj));
+		
+		obj.x = 8;
+		obj.y = 8;
+		Assert.isFalse(tilemap.objectOverlapsTiles(obj));
 	}
 
 	@Test // #1550
@@ -293,7 +297,12 @@ class FlxTilemapTest extends FlxTest
 	@Test // #3158
 	function testIsOverlappingTile()
 	{
-		final mapData = [0, 0, 0, 0, 1, 0, 0, 0, 0]; // 3x3 with a solid block in the middle
+		final mapData =
+		[
+			0, 0, 0,
+			0, 1, 0,
+			0, 0, 0
+		]; // 3x3 with a solid block in the middle
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
 		final obj = new FlxObject(4, 12, 8, 8);
@@ -451,12 +460,14 @@ class FlxTilemapTest extends FlxTest
 		Assert.areEqual(tilemap.getColumnAt(24, true), tilemap.getColumnAt(24, false));
 		Assert.areEqual(3, tilemap.getColumnAt(24));
 		Assert.areNotEqual(tilemap.getColumnAt(32, true), tilemap.getColumnAt(32, false));
-		Assert.areEqual(4, tilemap.getColumnAt(32));
+		Assert.areEqual(4, tilemap.getColumnAt(32, true));
+		Assert.areEqual(5, tilemap.getColumnAt(32, false));
 		
 		Assert.areEqual(tilemap.getRowAt(16, true), tilemap.getRowAt(16, false));
 		Assert.areEqual(2, tilemap.getRowAt(16));
 		Assert.areNotEqual(tilemap.getRowAt(24, true), tilemap.getRowAt(24, false));
-		Assert.areEqual(3, tilemap.getRowAt(24));
+		Assert.areEqual(3, tilemap.getRowAt(24, true));
+		Assert.areEqual(4, tilemap.getRowAt(24, false));
 	}
 	
 	@Test

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -106,11 +106,21 @@ class FlxTilemapTest extends FlxTest
 	}
 
 	@Test // #1546
+	@:haxe.warning("-WDeprecated")
 	function testOffMapOverlap()
 	{
 		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData());
 		var sprite = new FlxSprite(-2, 10);
 		Assert.isFalse(tilemap.overlapsWithCallback(sprite));
+	}
+	
+	@Test // #1546
+	// same as testOffMapOverlap but with processOverlaps
+	function testOffMapOverlap2()
+	{
+		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData());
+		var sprite = new FlxSprite(-2, 10);
+		Assert.isFalse(tilemap.processOverlaps(sprite));
 	}
 
 	@Test // #1550

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -180,12 +180,12 @@ class FlxTilemapTest extends FlxTest
 	}
 	
 	@Test // #1546
-	// same as testOffMapOverlap but with processOverlaps
+	// same as testOffMapOverlap but with objectOverlapsTiles
 	function testOffMapOverlap2()
 	{
 		tilemap.loadMapFrom2DArray([[1], [0]], getBitmapData(), 8, 8);
 		var sprite = new FlxSprite(-2, 10);
-		Assert.isFalse(tilemap.processOverlaps(sprite));
+		Assert.isFalse(tilemap.objectOverlapsTiles(sprite));
 	}
 
 	@Test // #1550
@@ -438,6 +438,27 @@ class FlxTilemapTest extends FlxTest
 		Assert.areEqual(tilemap.getTileData(4), tilemap.getTileData(1, 1));
 	}
 	
+	function testGetColumnRowAt()
+	{
+		
+		final mapData = [
+			0, 0, 0, 0,
+			0, 1, 0, 0,
+			0, 0, 0, 0,
+		];
+		tilemap.loadMapFromArray(mapData, 4, 3, getBitmapData(), 8, 8);
+		
+		Assert.areEqual(tilemap.getColumnAt(24, true), tilemap.getColumnAt(24, false));
+		Assert.areEqual(3, tilemap.getColumnAt(24));
+		Assert.areNotEqual(tilemap.getColumnAt(32, true), tilemap.getColumnAt(32, false));
+		Assert.areEqual(4, tilemap.getColumnAt(32));
+		
+		Assert.areEqual(tilemap.getRowAt(16, true), tilemap.getRowAt(16, false));
+		Assert.areEqual(2, tilemap.getRowAt(16));
+		Assert.areNotEqual(tilemap.getRowAt(24, true), tilemap.getRowAt(24, false));
+		Assert.areEqual(3, tilemap.getRowAt(24));
+	}
+	
 	@Test
 	function testTileExists()
 	{
@@ -454,6 +475,38 @@ class FlxTilemapTest extends FlxTest
 		Assert.isFalse(tilemap.tileExists(3, 1));
 		Assert.isFalse(tilemap.tileExists(1, 3));
 		Assert.isFalse(tilemap.tileExists(5, 5));
+	}
+	
+	@Test
+	function testColumnRowExists()
+	{
+		final mapData = [
+			0, 0, 0, 0,
+			0, 1, 0, 0,
+			0, 0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 4, 3, getBitmapData(), 8, 8);
+		
+		Assert.isFalse(tilemap.columnExists(5));
+		Assert.isFalse(tilemap.rowExists(5));
+		
+		Assert.isFalse(tilemap.columnExists(4));
+		Assert.isFalse(tilemap.rowExists(4));
+		
+		Assert.isTrue(tilemap.columnExists(3));
+		Assert.isFalse(tilemap.rowExists(3));
+		
+		Assert.isTrue(tilemap.columnExists(2));
+		Assert.isTrue(tilemap.rowExists(2));
+		
+		Assert.isTrue(tilemap.columnExists(1));
+		Assert.isTrue(tilemap.rowExists(1));
+		
+		Assert.isTrue(tilemap.columnExists(0));
+		Assert.isTrue(tilemap.rowExists(0));
+		
+		Assert.isFalse(tilemap.columnExists(-1));
+		Assert.isFalse(tilemap.rowExists(-1));
 	}
 	
 	@Test


### PR DESCRIPTION
## New features
### Tiles
- New dynamic `orient` method in FlxTile, used to position and resize the tile based on the grid location it is meant to represent in world space
- New dynamic `overlapsObject` method in FlxTile, can be extended or set to allow custom overlap detection for tiles whose hit shape is smaller than the tileGrid

### Tilemaps
- New `forEachOverlappingTile` method in FlxTilemap, to retrieve every tile that is overlapping the given object
- Using `forEachOverlappingTile` in `overlapsWithCallbacks`
- Alters the `createTile` method (also added in 5.9.0 and therefore not released) to remove the `allowCollisions` and `visible` args, it is recommended to simply reference the map's `drawIndex` and `collideIndex` in your override if you need these to your tile instances
- Added new `isOverlappingTile` method, allows you to check all tiles overlapping an object
- Added new `forEachOverlappingTile` calls a method with every tile that overlaps an object
- Added new `processOverlaps` to replace the now deprecated `overlapsWithCallbacks`
  - Eschews `flipCallbackParams` arg, allowing better typing of both callback params
  - Adds `isCollision` flag to control whether the Tiles' collision callbacks are fired and allows for processing non-solid tiles 
- Added new helpers: `getMapIndex`, `getRow`, `getColumn`, `getTileIndex`, `getTileData`, `tileExists`, `setTileIndex`, `getColumnAt`, `getRowAt`, `columnExists` and `rowExists`

### Objects
- Add internal helper `processCheckTilemap` for calling overlap checking utils between some combination of objects and tilemaps
- Add helper methods for `separate` and `updateTouchingFlags` 

### Debug Drawing
- Checks the previously unused `tile.ignoreDrawDebug` when debug drawing tiles
- Checks `tile.debugBoundingBoxColor` in debug drawing, if null, the map's debug drawing properties is used, as usual
- New `getDebugBoundingBoxColor` in FlxObject. Meant to replace `drawDebugBoundingBox`, will deprecate later

## (semi) Breaking changes
Previously, overlaps with callback would call the callback regardless of whether the tile overlapped the object. This change only effects objects placed **exactly** on the edge of a tile, and typically it was used to call separate, which would not do any separation in this case. this is technically a breaking change, but the case is so rare I'm going to add this on a minor release.

## TODO
 - ~~New unit tests~~