### PR TITLE
Use `FlxColorInt` instead of `Int` for RGBA to reduce variable size for CPP target

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -102,7 +102,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt #if cpp from cpp.UInt8 
 	 * @param Alpha	How opaque the color should be, from 0 to 255
 	 * @return The color as a FlxColor
 	 */
-	public static inline function fromRGB(Red:Int, Green:Int, Blue:Int, Alpha:Int = 255):FlxColor
+	public static inline function fromRGB(Red:FlxColorInt, Green:FlxColorInt, Blue:FlxColorInt, Alpha:FlxColorInt = 255):FlxColor
 	{
 		var color = new FlxColor();
 		return color.setRGB(Red, Green, Blue, Alpha);
@@ -456,7 +456,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt #if cpp from cpp.UInt8 
 	 * @param Alpha	How opaque the color should be, from 0 to 255
 	 * @return This color
 	 */
-	public inline function setRGB(Red:Int, Green:Int, Blue:Int, Alpha:Int = 255):FlxColor
+	public inline function setRGB(Red:FlxColorInt, Green:FlxColorInt, Blue:FlxColorInt, Alpha:FlxColorInt = 255):FlxColor
 	{
 		red = Red;
 		green = Green;

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -15,7 +15,7 @@ import flixel.system.macros.FlxMacroUtil;
  *
  * @author Joe Williamson (JoeCreates)
  */
-abstract FlxColor(Int) from Int from UInt to Int to UInt
+abstract FlxColor(Int) from Int from UInt to Int to UInt #if cpp from cpp.UInt8 to cpp.UInt8 #end
 {
 	public static inline var TRANSPARENT:FlxColor = 0x00000000;
 	public static inline var WHITE:FlxColor = 0xFFFFFFFF;
@@ -40,10 +40,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 */
 	public static var colorLookup(default, null):Map<String, Int> = FlxMacroUtil.buildMap("flixel.util.FlxColor");
 
-	public var red(get, set):Int;
-	public var blue(get, set):Int;
-	public var green(get, set):Int;
-	public var alpha(get, set):Int;
+	public var red(get, set):FlxColorInt;
+	public var blue(get, set):FlxColorInt;
+	public var green(get, set):FlxColorInt;
+	public var alpha(get, set):FlxColorInt;
 
 	public var redFloat(get, set):Float;
 	public var blueFloat(get, set):Float;
@@ -60,7 +60,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 */
 	public var rgb(get, set):FlxColor;
 
-	/** 
+	/**
 	 * The hue of the color in degrees (from 0 to 359)
 	 */
 	public var hue(get, set):Float;
@@ -584,22 +584,22 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		#end
 	}
 
-	inline function get_red():Int
+	inline function get_red():FlxColorInt
 	{
 		return (getThis() >> 16) & 0xff;
 	}
 
-	inline function get_green():Int
+	inline function get_green():FlxColorInt
 	{
 		return (getThis() >> 8) & 0xff;
 	}
 
-	inline function get_blue():Int
+	inline function get_blue():FlxColorInt
 	{
 		return getThis() & 0xff;
 	}
 
-	inline function get_alpha():Int
+	inline function get_alpha():FlxColorInt
 	{
 		return (getThis() >> 24) & 0xff;
 	}
@@ -624,7 +624,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return alpha / 255;
 	}
 
-	inline function set_red(Value:Int):Int
+	inline function set_red(Value:FlxColorInt):FlxColorInt
 	{
 		validate();
 		this &= 0xff00ffff;
@@ -632,7 +632,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return Value;
 	}
 
-	inline function set_green(Value:Int):Int
+	inline function set_green(Value:FlxColorInt):FlxColorInt
 	{
 		validate();
 		this &= 0xffff00ff;
@@ -640,7 +640,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return Value;
 	}
 
-	inline function set_blue(Value:Int):Int
+	inline function set_blue(Value:FlxColorInt):FlxColorInt
 	{
 		validate();
 		this &= 0xffffff00;
@@ -648,7 +648,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return Value;
 	}
 
-	inline function set_alpha(Value:Int):Int
+	inline function set_alpha(Value:FlxColorInt):FlxColorInt
 	{
 		validate();
 		this &= 0x00ffffff;
@@ -816,3 +816,9 @@ typedef TriadicHarmony =
 	color2:FlxColor,
 	color3:FlxColor
 }
+
+#if cpp
+private typedef FlxColorInt = cpp.UInt8;
+#else
+private typedef FlxColorInt = Int;
+#end


### PR DESCRIPTION
It is just an area for memory usage optimization for the CPP target. The main purpose is to use C's `uint8_t` instead of regular `int` to avoid wasting memory. 