### PR TITLE
Use `FlxColorInt` instead of `Int` for RGBA to reduce variable size for CPP target 

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -820,6 +820,9 @@ typedef TriadicHarmony =
 #if cpp
 private typedef FlxColorInt8 = cpp.UInt8;
 private typedef FlxColorInt16 = cpp.Int16;
+#elseif hl
+private typedef FlxColorInt8 = hl.UI8;
+private typedef FlxColorInt16 = hl.UI16;
 #else
 private typedef FlxColorInt8 = Int;
 private typedef FlxColorInt16 = Int;

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -820,9 +820,6 @@ typedef TriadicHarmony =
 #if cpp
 private typedef FlxColorInt8 = cpp.UInt8;
 private typedef FlxColorInt16 = cpp.Int16;
-#elseif hl
-private typedef FlxColorInt8 = hl.UI8;
-private typedef FlxColorInt16 = hl.UI16;
 #else
 private typedef FlxColorInt8 = Int;
 private typedef FlxColorInt16 = Int;


### PR DESCRIPTION
It is just an area for memory usage optimization for the CPP target. The primary purpose is to use `unsigned char` instead of regular int to avoid wasting memory. I wasn't able to reopen the previous branch because I was force-pushed.

This was the repo I made to do my testing and gathering of information:
https://github.com/Just-Feeshy/Draw

**Issue with the previous PR**
The reason why the `FlxColor.subtract` resulted in `FFFF8000` instead of the intended `FFFF0000` is that the test program tried to store the value `-255` into a byte-sized integer, which surpasses the 8-bit capacity because of the negative sign.

**What did I do to fix the PR?**
Since the variable is "connected to a setter," if that's the right way to phrase it, Haxe is a little weird regarding getters and setters. I just have the setter function data type instead be a 16-bit sized integer since 32-bit is still too much, so I can use at least 9 of those 16 bits to store the negative value. Since the getter doesn't deal with value manipulation, that means when retrieving the value of either red, green, blue, or alpha, the program retrieves the original 8-bit value of that variable. However, when setting a value to that variable, HXCPP is casting it to have the capacity of 16-bit for situations where a negative sign might be used.

**The performance change with this PR**
HXCPP usually uses static casting for the different types of integers. There are no performance hits due to the casting being done in compile time rather than run time, though I'm by no means an expert on how HXCPP works. There might be cases where dynamic casting is present, but even then, it wouldn't cause a massive delay. 

**How much memory do I save with this change**
Since the main focus of my "testing repo" is to store a large capacity of FlxColors to see a significant change in memory consumption, these are the screenshotted results. It took a lot of work to gather data on the constant fluctuation of memory usage, so these might not be 100% accurate; I timed both tests for 10 minutes with no user interaction. **This was tested, targeting the Arm64 processor using an M1 Pro Macbook.**

This was the latest version of HaxeFlixel (not including my commit).
<img width="956" alt="Test1" src="https://github.com/HaxeFlixel/flixel/assets/58647349/a0601eab-cd73-4787-9e3b-fc19a4797e45">

This was the test with the commits I made:
<img width="950" alt="Test2" src="https://github.com/HaxeFlixel/flixel/assets/58647349/65af45bb-22b2-4e62-8642-76153bb6b373">

I gained about 3MB saved for using less memory for creating a FlxColor per pixel on a fixed resolution of `800x600`.