### PR TITLE
prevent draw calls to bgsprite when transparent

### DIFF
--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -45,17 +45,19 @@ class FlxSubState extends FlxState
 	var _created:Bool = false;
 
 	/**
-	 * @param   BGColor   background color for this substate
+	 * @param   bgColor   background color for this substate
 	 */
-	public function new(BGColor:FlxColor = FlxColor.TRANSPARENT)
+	public function new(bgColor = FlxColor.TRANSPARENT)
 	{
 		super();
 		closeCallback = null;
 		openCallback = null;
 
 		if (FlxG.renderTile)
+		{
 			_bgSprite = new FlxBGSprite();
-		bgColor = BGColor;
+		}
+		this.bgColor = bgColor;
 	}
 
 	override public function draw():Void
@@ -68,9 +70,10 @@ class FlxSubState extends FlxState
 				camera.fill(bgColor);
 			}
 		}
-		else
+		else // FlxG.renderTile
 		{
-			_bgSprite.draw();
+			if (_bgSprite != null && _bgsprite.visible)
+				_bgSprite.draw();
 		}
 
 		// Now draw all children
@@ -102,11 +105,15 @@ class FlxSubState extends FlxState
 	}
 
 	@:noCompletion
-	override function set_bgColor(Value:FlxColor):FlxColor
+	override function set_bgColor(value:FlxColor):FlxColor
 	{
 		if (FlxG.renderTile && _bgSprite != null)
-			_bgSprite.pixels.setPixel32(0, 0, Value);
+		{
+			_bgSprite.alpha = value.alphaFloat;
+			_bgsprite.visible = _bgSprite.alpha > 0;
+			_bgSprite.color = value.rgb;
+		}
 
-		return _bgColor = Value;
+		return _bgColor = value;
 	}
 }

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -72,7 +72,7 @@ class FlxSubState extends FlxState
 		}
 		else // FlxG.renderTile
 		{
-			if (_bgSprite != null && _bgsprite.visible)
+			if (_bgSprite != null && _bgSprite.visible)
 				_bgSprite.draw();
 		}
 
@@ -110,7 +110,7 @@ class FlxSubState extends FlxState
 		if (FlxG.renderTile && _bgSprite != null)
 		{
 			_bgSprite.alpha = value.alphaFloat;
-			_bgsprite.visible = _bgSprite.alpha > 0;
+			_bgSprite.visible = _bgSprite.alpha > 0;
 			_bgSprite.color = value.rgb;
 		}
 

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -10,7 +10,7 @@ class FlxBGSprite extends FlxSprite
 	public function new()
 	{
 		super();
-		// TODO: Use non-unique, now that we're not editing the pixels
+		// TODO: Use unique:false, now that we're not editing the pixels
 		makeGraphic(1, 1, FlxColor.WHITE, true, FlxG.bitmap.getUniqueKey("bg_graphic_"));
 		scrollFactor.set();
 	}

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -10,6 +10,7 @@ class FlxBGSprite extends FlxSprite
 	public function new()
 	{
 		super();
+		// TODO: Use non-unique, now that we're not editing the pixels
 		makeGraphic(1, 1, FlxColor.WHITE, true, FlxG.bitmap.getUniqueKey("bg_graphic_"));
 		scrollFactor.set();
 	}
@@ -29,6 +30,7 @@ class FlxBGSprite extends FlxSprite
 
 			_matrix.identity();
 			_matrix.scale(camera.viewWidth, camera.viewHeight);
+			_matrix.translate(camera.viewMarginLeft, camera.viewMarginTop);
 			camera.drawPixels(frame, _matrix, colorTransform);
 
 			#if FLX_DEBUG


### PR DESCRIPTION
An alpha of 0 is the default, so this should affect most cases

Inspired by @richTrash21 in https://github.com/HaxeFlixel/flixel/pull/3142 