### PR TITLE
Implement FlxFlicker.pause() and FlxFlicker.resume()

### DIFF
--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -145,6 +145,22 @@ class FlxFlicker implements IFlxDestroyable
 	}
 
 	/**
+	 * Temporarily pause the flickering, so it can be resumed later.
+	 */
+	public function pause():Void {
+		if (timer == null) return;
+		timer.active = false;
+	}
+
+	/**
+	 * Resume the flickering after it has been temporarily paused.
+	 */
+	public function resume():Void {
+		if (timer == null) return;
+		timer.active = true;
+	}
+
+	/**
 	 * Prematurely ends flickering.
 	 */
 	public function stop():Void

--- a/flixel/effects/FlxFlicker.hx
+++ b/flixel/effects/FlxFlicker.hx
@@ -147,16 +147,22 @@ class FlxFlicker implements IFlxDestroyable
 	/**
 	 * Temporarily pause the flickering, so it can be resumed later.
 	 */
-	public function pause():Void {
-		if (timer == null) return;
+	public function pause():Void
+	{
+		if (timer == null)
+			return;
+		
 		timer.active = false;
 	}
 
 	/**
 	 * Resume the flickering after it has been temporarily paused.
 	 */
-	public function resume():Void {
-		if (timer == null) return;
+	public function resume():Void
+	{
+		if (timer == null)
+			return;
+		
 		timer.active = true;
 	}
 


### PR DESCRIPTION
During the development of Funkin', I found the need to pause an active FlxFlicker without actively destroying it and recreating it. This PR adds that functionality.