### PR TITLE
Don't attempt to retrieve frameCollections on a destroyed graphic.

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -514,8 +514,12 @@ class FlxGraphic implements IFlxDestroyable
 	 */
 	public inline function getFramesCollections(type:FlxFrameCollectionType):Array<Dynamic>
 	{
-		if (this.isDestroyed) return [];
-
+		if (this.isDestroyed)
+		{
+			FlxG.log.warn('Invalid call to getFramesCollections on a destroyed graphic');
+			return [];
+		}
+		
 		var collections:Array<Dynamic> = frameCollections.get(type);
 		if (collections == null)
 		{

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -514,6 +514,8 @@ class FlxGraphic implements IFlxDestroyable
 	 */
 	public inline function getFramesCollections(type:FlxFrameCollectionType):Array<Dynamic>
 	{
+		if (this.isDestroyed) return [];
+
 		var collections:Array<Dynamic> = frameCollections.get(type);
 		if (collections == null)
 		{


### PR DESCRIPTION
This fixes a crash bug I encountered while developing Funkin'.