### PR TITLE
Modify FlxText to create a bitmap with an informative key.

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -890,7 +890,7 @@ class FlxText extends FlxSprite
 		if (oldWidth != newWidth || oldHeight != newHeight)
 		{
 			// Need to generate a new buffer to store the text graphic
-			var key:String = FlxG.bitmap.getUniqueKey("text");
+			var key:String = FlxG.bitmap.getUniqueKey('text(${this.text})');
 			makeGraphic(newWidth, newHeight, FlxColor.TRANSPARENT, false, key);
 
 			if (_hasBorderAlpha)


### PR DESCRIPTION
In the past, I've had to look over the list of graphics in the BitmapFrontEnd cache to determine the cause of memory issues.

In this circumstance, having readable keys is important; for example, if one bit of text appears in the cache a lot, there may be something forcing it to re-render too often.

This PR changes auto-generated graphics created by FlxText to include the actual text in their key (`text123` will instead be `text(Hello World)123`). This shouldn't have any negative impact but should improve debugging.