### PR TITLE
Fnf 6

### DIFF
--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -23,7 +23,7 @@ class FlxGraphicsShader extends GraphicsShader
 				openfl_ColorOffsetv = colorOffset / 255.0;
 				openfl_ColorMultiplierv = colorMultiplier;
 			}
-		}")
+		}", true)
 	@:glFragmentHeader("
 		uniform bool hasTransform;
 		uniform bool hasColorTransform;
@@ -62,7 +62,7 @@ class FlxGraphicsShader extends GraphicsShader
 			}
 			return vec4(0.0, 0.0, 0.0, 0.0);
 		}
-	")
+	", true)
 	@:glFragmentSource("
 		#pragma header
 		


### PR DESCRIPTION
@EliteMasterEric This is the only remaining change between https://github.com/FunkinCrew/flixel/tree/dev-6.0.0 and release6. I can't find out what this change does, can you clarify, what does adding a true arg to `@:glVertexSource` and `@:glFragmentSource` do?

also you can update your dev-6.0.0 branch with https://github.com/FunkinCrew/flixel/compare/dev-6.0.0...Geokureli:fnf-6?expand=1