### PR TITLE
More new features and overloads to tilemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,17 +23,18 @@
 - `FlxCamera`: Improve doc ([#3161](https://github.com/HaxeFlixel/flixel/pull/3161))
 - `NextState`: Improve doc ([#3160](https://github.com/HaxeFlixel/flixel/pull/3160))
 - `FlxSprite`: Account for `scale`, `origin`, `offset`, `angle` and `pixelPerfectPosition` in `getGraphicMidpoint` ([#3125](https://github.com/HaxeFlixel/flixel/pull/3125))
-- Major change to `FlxTilemap` and `FlxTiles` collision ([#3158](https://github.com/HaxeFlixel/flixel/pull/3158))
+- Major change to `FlxTilemap` and `FlxTiles` collision ([#3158](https://github.com/HaxeFlixel/flixel/pull/3158)) ([#3189](https://github.com/HaxeFlixel/flixel/pull/3189))
   - `FlxTile`: Various features for allowing custom overlap/collision logic
     - Add dynamic methods `overlapsObject` and `orientAt` with helpers `orient`, `orientByIndex` and `orientAtByIndex`
     - Add `onCollide` signal, when overlaps are detected for collision purposes
   - Tilemaps: Add various new tools and helpers to `FlxTilemap` and `FlxBaseTilemap`
-    - Added new `forEachOverlappingTile` calls a method with every tile that overlaps an object
+    - Added new `forEachOverlappingTile` which calls a method with every tile that overlaps an object
+    - Added new `forEachMapIndex` which calls a method with every tile of a certain tile index
     - Added new `isOverlappingTile` method, allows you to check all tiles overlapping an object
     - Added new `objectOverlapsTiles` to replace the now deprecated `overlapsWithCallbacks`
       - Eschews `flipCallbackParams` arg, allowing better typing of both callback params
       - Adds `isCollision` flag to control whether the Tiles' collision callbacks are fired and allows for processing non-solid tiles 
-    - Added new helpers: `getMapIndex`, `getRow`, `getColumn`, `getTileIndex`, `getTileData`, `tileExists`, `setTileIndex`, `getColumnAt`, `getRowAt`, `columnExists` and `rowExists`
+    - Added new helpers: `getMapIndex`, `getMapIndexAt`, `getRow`, `getColumn`, `getTileIndex`, `getTileIndexAt`, `getTileData`, `getTileDataAt`, `tileExists`, `tileExistsAt`, `setTileIndex`, `setTileIndexAt`, `getColumnAt`, `getRowAt`, `columnExists`, `rowExists`, `columnExistsAt`, `rowExistsAt`, `getColumnPos`, `getRowPos`, `getColumnPosAt`, `getRowPosAt`, `getTilePos`, `getTilePosAt` and `getAllTilePos`
     - `FlxObject`: Add internal helpers for processing tilemaps in `separate`, `updateTouchingFlags` and similar functions
     - Debug Drawing: Various improvements to debug drawing tilemaps
       - Now honors tiles' `ignoreDrawDebug` and `debugBoundingBoxColor` fields

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -106,7 +106,7 @@ class FlxG
 	 * The HaxeFlixel version, in semantic versioning syntax. Use `Std.string()`
 	 * on it to get a `String` formatted like this: `"HaxeFlixel MAJOR.MINOR.PATCH-COMMIT_SHA"`.
 	 */
-	public static var VERSION(default, null):FlxVersion = new FlxVersion(5, 8, 1);
+	public static var VERSION(default, null):FlxVersion = new FlxVersion(5, 9, 0);
 
 	/**
 	 * Internal tracker for game object.

--- a/flixel/path/FlxPathfinder.hx
+++ b/flixel/path/FlxPathfinder.hx
@@ -60,8 +60,8 @@ class FlxTypedPathfinder<Tilemap:FlxBaseTilemap<FlxObject>, Data:FlxTypedPathfin
 	public function findPath(map:Tilemap, start:FlxPoint, end:FlxPoint, simplify:FlxPathSimplifier = LINE):Null<Array<FlxPoint>>
 	{
 		// Figure out what tile we are starting and ending on.
-		var startIndex = map.getTileIndexByCoords(start);
-		var endIndex = map.getTileIndexByCoords(end);
+		final startIndex = map.getMapIndex(start);
+		final endIndex = map.getMapIndex(end);
 
 		var data = createData(map, startIndex, endIndex);
 		var indices = findPathIndicesHelper(data);
@@ -119,7 +119,7 @@ class FlxTypedPathfinder<Tilemap:FlxBaseTilemap<FlxObject>, Data:FlxTypedPathfin
 	function getPathPointsFromIndices(data:Data, indices:Array<Int>)
 	{
 		// convert indices to world coordinates
-		return indices.map(data.map.getTileCoordsByIndex.bind(_, true));
+		return indices.map((i)->data.map.getTilePos(i, true));
 	}
 
 	/**

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -1241,69 +1241,98 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   mapIndex        The slot in the data array (Y * widthInTiles + X) where this tile is stored.
-	 * @param   tileIndex       The new tileIndex to place at the mapIndex
-	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
+	 * @param   mapIndex   The slot in the data array (Y * widthInTiles + X) where this tile is stored.
+	 * @param   tileIndex  The new tileIndex to place at the mapIndex
+	 * @param   redraw     Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 * @since 5.9.0
 	 */
-	public overload extern inline function setTileIndex(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
+	public overload extern inline function setTileIndex(mapIndex:Int, tileIndex:Int, redraw = true):Bool
 	{
-		return setTileHelper(mapIndex, tileIndex, updateGraphics);
+		return setTileHelper(mapIndex, tileIndex, redraw);
 	}
 	
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   column          The grid X location, in tiles
-	 * @param   row             The grid Y location, in tiles
-	 * @param   tileIndex       The new integer data you wish to inject.
-	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
+	 * @param   column     The grid X location, in tiles
+	 * @param   row        The grid Y location, in tiles
+	 * @param   tileIndex  The new integer data you wish to inject.
+	 * @param   redraw     Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 * @since 5.9.0
 	 */
-	public overload extern inline function setTileIndex(column:Int, row:Int, tileIndex:Int, updateGraphics = true):Bool
+	public overload extern inline function setTileIndex(column:Int, row:Int, tileIndex:Int, redraw = true):Bool
 	{
-		return setTileHelper(getMapIndex(column, row), tileIndex, updateGraphics);
+		return setTileHelper(getMapIndex(column, row), tileIndex, redraw);
 	}
 	
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   column          The grid X location, in tiles
-	 * @param   row             The grid Y location, in tiles
-	 * @param   tileIndex       The new integer data you wish to inject.
-	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
+	 * @param   worldPos   A location in the world
+	 * @param   tileIndex  The new integer data you wish to inject.
+	 * @param   redraw     Whether the graphical representation of this tile should change.
+	 * @return  Whether or not the tile was actually changed.
+	 * @since 5.9.0
+	 */
+	public overload extern inline function setTileIndex(worldPos:FlxPoint, tileIndex:Int, redraw = true):Bool
+	{
+		return setTileIndexAt(worldPos.x, worldPos.y, tileIndex, redraw);
+	}
+	
+	/**
+	 * Change the data and graphic of a tile in the tilemap.
+	 *
+	 * @param   worldX     An X coordinate in the world
+	 * @param   worldY     A Y coordinate in the world
+	 * @param   tileIndex  The new integer data you wish to inject.
+	 * @param   redraw     Whether the graphical representation of this tile should change.
+	 * @return  Whether or not the tile was actually changed.
+	 * @since 5.9.0
+	 */
+	public inline function setTileIndexAt(worldX:Float, worldY:Float, tileIndex:Int, redraw = true):Bool
+	{
+		return setTileHelper(getMapIndexAt(worldX, worldY), tileIndex, redraw);
+	}
+	
+	/**
+	 * Change the data and graphic of a tile in the tilemap.
+	 *
+	 * @param   column     The grid X location, in tiles
+	 * @param   row        The grid Y location, in tiles
+	 * @param   tileIndex  The new integer data you wish to inject.
+	 * @param   redraw     Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 */
 	@:deprecated("setTile is deprecated, use setTileIndex(column, row, tileIndex,...), instead") // 5.9.0
-	public function setTile(column:Int, row:Int, tileIndex:Int, updateGraphics = true):Bool
+	public function setTile(column:Int, row:Int, tileIndex:Int, redraw = true):Bool
 	{
-		return setTileIndex(getMapIndex(column, row), tileIndex, updateGraphics);
+		return setTileIndex(getMapIndex(column, row), tileIndex, redraw);
 	}
 	
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   mapIndex        The slot in the data array (Y * widthInTiles + X) where this tile is stored.
-	 * @param   tileIndex       The new tileIndex to place at the mapIndex
-	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
+	 * @param   mapIndex   The slot in the data array (Y * widthInTiles + X) where this tile is stored.
+	 * @param   tileIndex  The new tileIndex to place at the mapIndex
+	 * @param   redraw     Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 */
 	@:deprecated("setTileByIndex is deprecated, use setTileIndex(mapIndex, tileIndex,...), instead") // 5.9.0
-	public function setTileByIndex(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
+	public function setTileByIndex(mapIndex:Int, tileIndex:Int, redraw = true):Bool
 	{
-		return setTileIndex(mapIndex, tileIndex, updateGraphics);
+		return setTileIndex(mapIndex, tileIndex, redraw);
 	}
 	
-	function setTileHelper(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
+	function setTileHelper(mapIndex:Int, tileIndex:Int, redraw = true):Bool
 	{
 		if (!tileExists(mapIndex))
 			return false;
-		
+			
 		_data[mapIndex] = tileIndex;
 		
-		if (!updateGraphics)
+		if (!redraw)
 		{
 			return true;
 		}

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -4,11 +4,11 @@ import flixel.FlxObject;
 import flixel.group.FlxGroup;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
-import flixel.system.FlxAssets;
 import flixel.path.FlxPathfinder;
+import flixel.system.FlxAssets;
 import flixel.util.FlxArrayUtil;
-import flixel.util.FlxColor;
 import flixel.util.FlxCollision;
+import flixel.util.FlxColor;
 import flixel.util.FlxDirectionFlags;
 import flixel.util.FlxStringUtil;
 import openfl.Assets;
@@ -137,7 +137,21 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
+	 * Finds the column number that overlaps the given X in world space
+	 * 
+	 * @param   worldX  An X coordinate in the world
+	 * @param   bind    If true, it will prevent out of range values
+	 * @return  A column index, where 0 is the left-most column
+	 * @since 5.9.0
+	 */
+	public function getColumnAt(worldX:Float, bind = false):Int
+	{
+		throw "getColumnAt must be implemented";
+	}
+	
+	/**
 	 * Finds the row number that overlaps the given Y in world space
+	 * 
 	 * @param   worldY  A Y coordinate in the world
 	 * @param   bind    If true, it will prevent out of range values
 	 * @return  A row index, where 0 is the top-most row
@@ -149,31 +163,51 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
-	 * Finds the row number that overlaps the given X in world space
-	 * @param   worldX  A X coordinate in the world
-	 * @param   bind    If true, it will prevent out of range values
-	 * @return  A column index, where 0 is the left-most column
+	 * Get the world position of the specified column
+	 * 
+	 * @param   column    The grid X location, in tiles
+	 * @param   midpoint  Whether to use the tile's midpoint, or upper left corner
 	 * @since 5.9.0
 	 */
-	public function getColumnAt(worldX:Float, bind = false):Int
+	public function getColumnPos(column:Float, midPoint = false):Float
 	{
-		throw "getColumnAt must be implemented";
-	}
-	
-	public function getTileIndexByCoords(coord:FlxPoint):Int
-	{
-		throw "getTileIndexByCoords must be implemented";
+		throw "getColumnPos must be implemented";
 	}
 
-	public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
+	/**
+	 * Get the world position of the specified row
+	 * 
+	 * @param   row       The grid Y location, in tiles
+	 * @param   midpoint  Whether to use the tile's midpoint, or upper left corner
+	 * @since 5.9.0
+	 */
+	public function getRowPos(row:Int, midPoint = false):Float
 	{
-		throw "getTileCoordsByIndex must be implemented";
+		throw "getRowPos must be implemented";
+	}
+	
+	/**
+	 * **Note:** This method name is misleading! It does not return a `tileIndex`, it returns a `mapIndex`
+	 * 
+	 * @param   worldPos  A location in the world
+	 * @return  The `mapIndex` placed at the given world location
+	 */
+	@:deprecated("getTileIndexByCoords is deprecated, use getMapIndex, instead") // 5.9.0
+	public function getTileIndexByCoords(worldPos:FlxPoint):Int
+	{
+		return getMapIndex(worldPos);
+	}
+	@:deprecated("getTileCoordsByIndex is deprecated, use getTilePos, instead") // 5.9.0
+	public function getTileCoordsByIndex(mapIndex:Int, midpoint = true):FlxPoint
+	{
+		return getTilePos(mapIndex, midpoint);
 	}
 
 	/**
 	 * Shoots a ray from the start point to the end point.
 	 * If/when it passes through a tile, it stores that point and returns false.
-	 * Note: In flixel 5.0.0, this was redone, the old method is now `rayStep`
+	 * 
+	 * **Note:** In flixel 5.0.0, this was redone, the old method is now `rayStep`
 	 *
 	 * @param   start   The world coordinates of the start of the ray.
 	 * @param   end     The world coordinates of the end of the ray.
@@ -213,7 +247,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * If the line starts inside the tilemap, a copy of start is returned.
 	 * If the line never enters the tilemap, null is returned.
 	 *
-	 * Note: If a result vector is supplied and the line is outside the tilemap, null is returned
+	 * **Note:** If a result vector is supplied and the line is outside the tilemap, null is returned
 	 * and the supplied result is unchanged
 	 * @since 5.0.0
 	 *
@@ -238,7 +272,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * If the line ends inside the tilemap, a copy of end is returned.
 	 * If the line is never inside the tilemap, null is returned.
 	 *
-	 * Note: If a result vector is supplied and the line is outside the tilemap, null is returned
+	 * **Note:** If a result vector is supplied and the line is outside the tilemap, null is returned
 	 * and the supplied result is unchanged
 	 * @since 5.0.0
 	 *
@@ -284,7 +318,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		throw "overlapsWithCallback must be implemented";
 	}
 	
-	@:deprecated("overlapsWithCallback is deprecated, use objectOverlapsTiles(object, callback, pos), instead")
+	@:deprecated("overlapsWithCallback is deprecated, use objectOverlapsTiles(object, callback, pos), instead") // 5.9.0
 	public function overlapsWithCallback(object:FlxObject, ?callback:(FlxObject, FlxObject)->Bool, flipCallbackParams = false, ?position:FlxPoint):Bool
 	{
 		return objectOverlapsTiles(object, (t, o)->{ return flipCallbackParams ? callback(o, t) : callback(t, o); }, position);
@@ -328,7 +362,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		moves = false;
 	}
 
-	override public function destroy():Void
+	override function destroy():Void
 	{
 		_data = null;
 		super.destroy();
@@ -742,21 +776,50 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
-	 * Calculates a mapIndex via `row * widthInTiles + column`
+	 * Calculates a `mapIndex` via `row * widthInTiles + column`,
+	 * if the column or row is not valid, the result is `-1`
 	 * 
-	 * @param  column  the grid X location, in tiles
-	 * @param  row     the grid Y location, in tiles
+	 * @param   column  The grid X location, in tiles
+	 * @param   row     The grid Y location, in tiles
 	 * @since 5.9.0
 	 */
-	public inline function getMapIndex(column:Int, row:Int):Int
+	public overload extern inline function getMapIndex(column:Int, row:Int):Int
 	{
-		return row * widthInTiles + column;
+		return tileExists(column, row) ? (row * widthInTiles + column) : -1;
 	}
 	
 	/**
+	 * Calculates a `mapIndex` of the given location, if the coordinate
+	 * does not overlap the tilemap, the result is `-1`
+	 * 
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
+	 * 
+	 * @param   worldPos  A location in the world
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getMapIndex(worldPos:FlxPoint):Int
+	{
+		return getMapIndexAt(worldPos.x, worldPos.y);
+	}
+	
+	/**
+	 * Calculates a `mapIndex` of the given location, if the coordinate
+	 * does not overlap the tilemap, the result is `-1`
+	 *
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
+	 *
+	 * @param   worldX  An X coordinate in the world
+	 * @param   worldY  A Y coordinate in the world
+	 * @since 5.9.0
+	 */
+	public inline function getMapIndexAt(worldX:Float, worldY:Float):Int
+	{
+		return getMapIndex(getColumnAt(worldX), getRowAt(worldY));
+	}
+	/**
 	 * Calculates the column from a map location
 	 * 
-	 * @param  mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
+	 * @param   mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
 	 * @since 5.9.0
 	 */
 	public inline function getColumn(mapIndex:Int):Int
@@ -767,7 +830,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Calculates the column from a map location
 	 * 
-	 * @param  mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
+	 * @param   mapIndex  The location in the map where `mapIndex = row * widthInTiles + column`
 	 * @since 5.9.0
 	 */
 	public inline function getRow(mapIndex:Int):Int
@@ -778,8 +841,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Whether a tile exists at the given map location
 	 *
-	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
-	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid X location, in tiles
+	 * @param   row     The grid Y location, in tiles
 	 * @since 5.9.0
 	 */
 	public overload extern inline function tileExists(column:Int, row:Int):Bool
@@ -790,7 +853,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Whether a tile exists at the given map location
 	 *
-	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
 	 *
 	 * @param   mapIndex  The desired location in the map
 	 * @since 5.9.0
@@ -801,9 +864,32 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
+	 * Whether a tile exists at the given map location
+	 *
+	 * @param   worldPos  A location in the map
+	 * @since 5.9.0
+	 */
+	public overload extern inline function tileExists(worldPos:FlxPoint):Bool
+	{
+		return tileExistsAt(worldPos.x, worldPos.y);
+	}
+	
+	/**
+	 * Whether a tile exists at the given map location
+	 * 
+	 * @param   worldX  An X coordinate in the world
+	 * @param   worldY  A Y coordinate in the world
+	 * @since 5.9.0
+	 */
+	public inline function tileExistsAt(worldX:Float, worldY:Float):Bool
+	{
+		return columnExistsAt(worldX) && rowExistsAt(worldY);
+	}
+	
+	/**
 	 * Whether a row exists at the given map location
 	 *
-	 * @param   column  The desired location in the map
+	 * @param   column  The grid X location, in tiles
 	 * @since 5.9.0
 	 */
 	public overload extern inline function columnExists(column:Int):Bool
@@ -812,9 +898,20 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
+	 * Whether a column exists at the given map location
+	 *
+	 * @param   worldX  An X coordinate in the world
+	 * @since 5.9.0
+	 */
+	public inline function columnExistsAt(worldX:Float):Bool
+	{
+		return columnExists(getColumnAt(worldX));
+	}
+	
+	/**
 	 * Whether a row exists at the given map location
 	 *
-	 * @param   row  The desired location in the map
+	 * @param   row  The grid Y location, in tiles
 	 * @since 5.9.0
 	 */
 	public overload extern inline function rowExists(row:Int):Bool
@@ -823,11 +920,22 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
-	 * Finds the tile instance at a particular column and row
+	 * Whether a row exists at the given map location
 	 *
-	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
-	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
-	 * @return  The tile index of the tile at this location
+	 * @param   worldY  A Y coordinate in the world
+	 * @since 5.9.0
+	 */
+	public inline function rowExistsAt(worldY:Float):Bool
+	{
+		return rowExists(getRowAt(worldY));
+	}
+	
+	/**
+	 * Finds the tile instance at a particular column and row,
+	 * if the column or row is invalid, the result is `null`
+	 *
+	 * @param   column  The grid X location, in tiles
+	 * @param   row     The grid Y location, in tiles
 	 * @since 5.9.0
 	 */
 	public overload extern inline function getTileData(column:Int, row:Int):Null<Tile>
@@ -836,15 +944,15 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
-	 * Finds the tile instance with the given mapIndex
+	 * Finds the tile instance with the given `mapIndex`, 
+	 * if the `mapIndex` is invalid, the result is `null`
 	 *
-	 * **Note:** A tile's mapIndex can be calculated via `row * widthInTiles + column`
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
 	 * 
 	 * **Note:** The reulting tile's `x`, `y`, `width` and `height` will not be accurate.
 	 * You can call `tile.orient` or similar methods
 	 *
 	 * @param   mapIndex  The desired location in the map
-	 * @return  An integer containing the value of the tile at this spot in the array.
 	 * @since 5.9.0
 	 */
 	public overload extern inline function getTileData(mapIndex:Int):Null<Tile>
@@ -853,10 +961,42 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
-	 * Check the value of a particular tile.
+	 * Finds the tile instance with the given world location, if the
+	 * coordinate does not overlap the tilemap, the result is `null`
 	 *
-	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
-	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * **Note:** The reulting tile's `x`, `y`, `width` and `height` will not be accurate.
+	 * You can call `tile.orient` or similar methods
+	 *
+	 * @param   worldPos  A location in the world
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileData(worldPos:FlxPoint):Null<Tile>
+	{
+		return getTileDataAt(worldPos.x, worldPos.y);
+	}
+	
+	/**
+	 * Finds the tile instance with the given world location, if the
+	 * coordinate does not overlap the tilemap, the result is `null`
+	 *
+	 * **Note:** The reulting tile's `x`, `y`, `width` and `height` will not be accurate.
+	 * You can call `tile.orient` or similar methods
+	 *
+	 * @param   worldX  An X coordinate in the world
+	 * @param   worldY  A Y coordinate in the world
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileDataAt(worldX:Float, worldY:Float):Null<Tile>
+	{
+		return _tileObjects[getTileIndexAt(worldX, worldY)];
+	}
+	
+	/**
+	 * Check the value of a particular tile, if the
+	 * column or row is invalid, the result is `-1`
+	 *
+	 * @param   column  The grid X location, in tiles
+	 * @param   row     The grid Y location, in tiles
 	 * @return  The tile index of the tile at this location
 	 * @since 5.9.0
 	 */
@@ -866,7 +1006,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	}
 	
 	/**
-	 * Get the `tileIndex` at the given map location
+	 * Get the `tileIndex` at the given map location, 
+	 * if the `mapIndex` is invalid, the result is `-1`
 	 * 
 	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
 	 *
@@ -876,17 +1017,133 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 */
 	public overload extern inline function getTileIndex(mapIndex:Int):Int
 	{
-		return _data[mapIndex];
+		return tileExists(mapIndex) ? _data[mapIndex] : -1;
+	}
+	
+	/**
+	 * Get the `tileIndex` at the given location, if the coordinate
+	 * does not overlap the tilemap, the result is `-1`
+	 *
+	 * @param   worldPos  A location in the world
+	 * @return  The tileIndex of the tile at this location
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTileIndex(worldPos:FlxPoint):Int
+	{
+		return getTileIndexAt(worldPos.x, worldPos.y);
+	}
+	
+	/**
+	 * Get the `tileIndex` at the given location, if the coordinate
+	 * does not overlap the tilemap, the result is `-1`
+	 *
+	 * @param   worldX  An X coordinate in the world
+	 * @param   worldY  A Y coordinate in the world
+	 * @return  The tileIndex of the tile at this location
+	 * @since 5.9.0
+	 */
+	public inline function getTileIndexAt(worldX:Float, worldY:Float):Int
+	{
+		return getTileIndex(getColumnAt(worldX), getRowAt(worldY));
+	}
+	
+	/**
+	 * Get the world position of the specified tile, if the `mapIndex` is invalid,
+	 * the result is `null`
+	 * 
+	 * **Note:** A tile's `mapIndex` can be calculated via `row * widthInTiles + column`
+	 *
+	 * @param   mapIndex  The desired location in the map
+	 * @param   midpoint  Whether to use the tile's midpoint, or upper left corner
+	 * @return  The world position of the matching tile
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTilePos(mapIndex:Int, midpoint = false):Null<FlxPoint>
+	{
+		return tileExists(mapIndex) ? getTilePos(getColumn(mapIndex), getRow(mapIndex), midpoint) : null;
+	}
+	
+	/**
+	 * Get the world position of the specified tile
+	 * 
+	 * **Note:** The column or row does not need to be valid, to ensure a
+	 * valid tile, use `if (tileExists(column, row))`, first
+	 * 
+	 * @param   column    The grid X location, in tiles
+	 * @param   row       The grid Y location, in tiles
+	 * @param   midpoint  Whether to use the tile's midpoint, or upper left corner
+	 * @return  The world position of the matching tile
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTilePos(column:Int, row:Int, midpoint = false):FlxPoint
+	{
+		return FlxPoint.get(getColumnPos(column, midpoint), getRowPos(row, midpoint));
+	}
+	
+	/**
+	 * Get the world position of the tile overlapping the specified position
+	 * 
+	 * **Note:** The location does not need to overlap the tilemap, to ensure a
+	 * valid tile, use `if (tileExists(worldPos))`, first
+	 *
+	 * @param   worldPos  A location in the world
+	 * @param   midpoint  Whether to use the tile's midpoint, or upper left corner
+	 * @return  The world position of the overlapping tile
+	 * @since 5.9.0
+	 */
+	public overload extern inline function getTilePos(worldPos:FlxPoint, midpoint = false):FlxPoint
+	{
+		return getTilePosAt(worldPos.x, worldPos.y, midpoint);
+	}
+	
+	/**
+	 * Get the world position of the tile overlapping the specified position
+	 *
+	 * **Note:** The location does not need to overlap the tilemap, to ensure a
+	 * valid tile, use `if (tileExistsAt(worldX, worldY))`, first
+	 * 
+	 * @param   worldX    An X coordinate in the world
+	 * @param   worldY    A Y coordinate in the world
+	 * @param   midpoint  Whether to use the tile's midpoint, or upper left corner
+	 * @return  The world position of the overlapping tile
+	 * @since 5.9.0
+	 */
+	public inline function getTilePosAt(worldX:Float, worldY:Float, midpoint = false):FlxPoint
+	{
+		return getTilePos(getColumnAt(worldX), getRowAt(worldY), midpoint);
+	}
+	
+	/**
+	 * Returns a new array full of every coordinate of the requested tile type.
+	 *
+	 * @param   tileIndex  The requested tile type
+	 * @param   midpoint   Whether to use the tiles' midpoints, or upper left corner
+	 * @return  An Array with a list of all the coordinates of that tile type
+	 * @since 5.9.0
+	 */
+	public function getAllTilePos(tileIndex:Int, midpoint = false):Array<FlxPoint>
+	{
+		final result = [];
+		
+		final length = _data.length;
+		for (mapIndex in 0...length)
+		{
+			if (getTileIndex(mapIndex) == tileIndex)
+			{
+				result.push(getTilePos(mapIndex, midpoint));
+			}
+		}
+		return result;
 	}
 	
 	/**
 	 * Check the value of a particular tile.
 	 *
-	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
-	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @param   column  The grid X location, in tiles
+	 * @param   row     The grid Y location, in tiles
 	 * @return  The tile index of the tile at this location
 	 */
-	@:deprecated("getTile is deprecated use getTileIndex(column, row), instead")
+	@:deprecated("getTile is deprecated use getTileIndex(column, row), instead") // 5.9.0
 	public function getTile(column:Int, row:Int):Int
 	{
 		return getTileIndex(column, row);
@@ -900,7 +1157,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   mapIndex  The desired location in the map
 	 * @return  An integer containing the value of the tile at this spot in the array.
 	 */
-	@:deprecated("getTileByIndex is deprecated use getTileIndex(mapIndex), instead")
+	@:deprecated("getTileByIndex is deprecated use getTileIndex(mapIndex), instead") // 5.9.0
 	public function getTileByIndex(mapIndex:Int):Int
 	{
 		return getTileIndex(mapIndex);
@@ -950,17 +1207,35 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	public function getAllMapIndices(tileIndex:Int):Array<Int>
 	{
 		final result:Array<Int> = [];
-		var i:Int = widthInTiles * heightInTiles;
 		
-		while (i-- > 0)
+		final length = _data.length;
+		for (mapIndex in 0...length)
 		{
-			if (_data[i] == tileIndex)
+			if (getTileIndex(mapIndex) == tileIndex)
 			{
-				result.unshift(i);
+				result.push(mapIndex);
 			}
 		}
-		
 		return result;
+	}
+
+	/**
+	 * Calls the desired function with every `mapIndex` that uses the given `tileIndex`
+	 * 
+	 * @param   tileIndex  The desired tile type
+	 * @param   function   The function called with each mapIndex
+	 * @since 5.9.0
+	 */
+	public function forEachMapIndex(tileIndex:Int, f:(mapIndex:Int) -> Void)
+	{
+		final length = _data.length;
+		for (mapIndex in 0...length)
+		{
+			if (getTileIndex(mapIndex) == tileIndex)
+			{
+				f(mapIndex);
+			}
+		}
 	}
 	
 	/**
@@ -980,8 +1255,8 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
-	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @param   column          The grid X location, in tiles
+	 * @param   row             The grid Y location, in tiles
 	 * @param   tileIndex       The new integer data you wish to inject.
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
@@ -995,13 +1270,13 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Change the data and graphic of a tile in the tilemap.
 	 *
-	 * @param   row     The grid X coordinate of the tile (in tiles, not pixels)
-	 * @param   column  The grid Y coordinate of the tile (in tiles, not pixels)
+	 * @param   column          The grid X location, in tiles
+	 * @param   row             The grid Y location, in tiles
 	 * @param   tileIndex       The new integer data you wish to inject.
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 */
-	@:deprecated("setTile is deprecated, use setTileIndex(column, row, tileIndex,...), instead")
+	@:deprecated("setTile is deprecated, use setTileIndex(column, row, tileIndex,...), instead") // 5.9.0
 	public function setTile(column:Int, row:Int, tileIndex:Int, updateGraphics = true):Bool
 	{
 		return setTileIndex(getMapIndex(column, row), tileIndex, updateGraphics);
@@ -1015,7 +1290,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   updateGraphics  Whether the graphical representation of this tile should change.
 	 * @return  Whether or not the tile was actually changed.
 	 */
-	@:deprecated("setTileByIndex is deprecated, use setTileIndex(mapIndex, tileIndex,...), instead")
+	@:deprecated("setTileByIndex is deprecated, use setTileIndex(mapIndex, tileIndex,...), instead") // 5.9.0
 	public function setTileByIndex(mapIndex:Int, tileIndex:Int, updateGraphics = true):Bool
 	{
 		return setTileIndex(mapIndex, tileIndex, updateGraphics);
@@ -1179,7 +1454,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	/**
 	 * Pathfinding helper function, floods a grid with distance information until it finds the end point.
-	 * NOTE: Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
+	 * **Note:** Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
 	 *
 	 * @param   startIndex      The starting tile's map index.
 	 * @param   endIndex        The ending tile's map index.
@@ -1199,7 +1474,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	
 	/**
 	 * Pathfinding helper function, floods a grid with distance information until it finds the end point.
-	 * NOTE: Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
+	 * **Note:** Currently this process does NOT use any kind of fancy heuristic! It's pretty brute.
 	 * @since 5.0.0
 	 *
 	 * @param   startIndex  The starting tile's map index.
@@ -1222,7 +1497,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	/**
 	 * Checks to see if some FlxObject overlaps this FlxObject object in world space.
 	 * If the group has a LOT of things in it, it might be faster to use FlxG.overlaps().
-	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
+	 * **Warning:** Currently tilemaps do NOT support screen space overlap checks!
 	 *
 	 * @param   object         The object being tested.
 	 * @param   inScreenSpace  Whether to take scroll factors into account when checking for overlap.
@@ -1230,7 +1505,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Whether or not the two objects overlap.
 	 */
 	@:access(flixel.group.FlxTypedGroup)
-	override public function overlaps(objectOrGroup:FlxBasic, inScreenSpace = false, ?camera:FlxCamera):Bool
+	override function overlaps(objectOrGroup:FlxBasic, inScreenSpace = false, ?camera:FlxCamera):Bool
 	{
 		final group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null) // if it is a group
@@ -1293,7 +1568,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @param   camera         Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
 	 * @return  Whether or not the point overlaps this object.
 	 */
-	override public function overlapsPoint(worldPoint:FlxPoint, inScreenSpace = false, ?camera:FlxCamera):Bool
+	override function overlapsPoint(worldPoint:FlxPoint, inScreenSpace = false, ?camera:FlxCamera):Bool
 	{
 		if (inScreenSpace)
 		{
@@ -1309,7 +1584,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 
 	function tileAtPointAllowsCollisions(point:FlxPoint):Bool
 	{
-		final mapIndex = getTileIndexByCoords(point);
+		final mapIndex = getMapIndex(point);
 		return tileExists(mapIndex) && getTileData(mapIndex).solid;
 	}
 

--- a/flixel/tile/FlxTile.hx
+++ b/flixel/tile/FlxTile.hx
@@ -124,7 +124,7 @@ class FlxTile extends FlxObject
 	 */
 	public dynamic function orientAt(xPos:Float, yPos:Float, col:Int, row:Int)
 	{
-		mapIndex = (row * tilemap.widthInTiles) + col;
+		mapIndex = tilemap.getMapIndex(col, row);
 		width = tilemap.scaledTileWidth;
 		height = tilemap.scaledTileHeight;
 		x = xPos + col * width;

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -830,7 +830,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	
 	override function getColumnAt(worldX:Float, bind = false):Int
 	{
-		final result = Math.floor(worldX / scaledTileWidth);
+		final result = Math.floor((worldX - x) / scaledTileWidth);
 		
 		if (bind)
 			return result < 0 ? 0 : (result >= widthInTiles ? widthInTiles - 1 : result);
@@ -840,7 +840,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	
 	override function getRowAt(worldY:Float, bind = false):Int
 	{
-		final result = Math.floor(worldY / scaledTileHeight);
+		final result = Math.floor((worldY - y) / scaledTileHeight);
 		
 		if (bind)
 			return result < 0 ? 0 : (result >= heightInTiles ? heightInTiles -1 : result);
@@ -848,27 +848,14 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		return result;
 	}
 	
-	override public function getTileIndexByCoords(coord:FlxPoint):Int
+	override function getColumnPos(column:Float, midpoint = false):Float
 	{
-		var localX = coord.x - x;
-		var localY = coord.y - y;
-		coord.putWeak();
-
-		if ((localX < 0) || (localY < 0) || (localX >= scaledWidth) || (localY >= scaledHeight))
-			return -1;
-
-		return Std.int(localY / scaledTileHeight) * widthInTiles + Std.int(localX / scaledTileWidth);
+		return x + column * scaledTileWidth + (midpoint ? scaledTileWidth * 0.5 : 0);
 	}
 
-	override public function getTileCoordsByIndex(index:Int, midpoint = true):FlxPoint
+	override function getRowPos(row:Int, midpoint = false):Float
 	{
-		var point = FlxPoint.get(x + (index % widthInTiles) * scaledTileWidth, y + Std.int(index / widthInTiles) * scaledTileHeight);
-		if (midpoint)
-		{
-			point.x += scaledTileWidth * 0.5;
-			point.y += scaledTileHeight * 0.5;
-		}
-		return point;
+		return y + row * scaledTileHeight + (midpoint ? scaledTileHeight * 0.5 : 0);
 	}
 
 	/**
@@ -878,34 +865,10 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 * @param   midpoint  Whether to return the coordinates of the tile midpoint, or upper left corner. Default is true, return midpoint.
 	 * @return  An Array with a list of all the coordinates of that tile type.
 	 */
-	public function getTileCoords(index:Int, midpoint = true):Array<FlxPoint>
+	@:deprecated("getTileCoords is deprecated, use getAllTilePos, instead")
+	public function getTileCoords(tileIndex:Int, midpoint = true):Array<FlxPoint>
 	{
-		var array:Array<FlxPoint> = null;
-
-		var point:FlxPoint;
-		var l:Int = widthInTiles * heightInTiles;
-
-		for (i in 0...l)
-		{
-			if (_data[i] == index)
-			{
-				point = FlxPoint.get(x + (i % widthInTiles) * scaledTileWidth, y + Std.int(i / widthInTiles) * scaledTileHeight);
-
-				if (midpoint)
-				{
-					point.x += scaledTileWidth * 0.5;
-					point.y += scaledTileHeight * 0.5;
-				}
-
-				if (array == null)
-				{
-					array = new Array<FlxPoint>();
-				}
-				array.push(point);
-			}
-		}
-
-		return array;
+		return getAllTilePos(tileIndex, midpoint);
 	}
 
 	/**
@@ -966,11 +929,11 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			trimmedEnd.put();
 		}
 
-		final startIndex = getTileIndexByCoords(start);
-		final endIndex = getTileIndexByCoords(end);
+		final startIndex = getMapIndex(start);
+		final endIndex = getMapIndex(end);
 
 		// If the starting tile is solid, return the starting position
-		if (getTileData(startIndex).allowCollisions != NONE)
+		if (getTileData(startIndex).solid)
 		{
 			if (result != null)
 				result.copyFrom(start);
@@ -979,10 +942,10 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			return false;
 		}
 
-		final startTileX = startIndex % widthInTiles;
-		final startTileY = Std.int(startIndex / widthInTiles);
-		final endTileX = endIndex % widthInTiles;
-		final endTileY = Std.int(endIndex / widthInTiles);
+		final startTileX = getColumn(startIndex);
+		final startTileY = getRow(startIndex);
+		final endTileX = getColumn(endIndex);
+		final endTileY = getRow(endIndex);
 		var hitIndex = -1;
 
 		if (start.x == end.x)
@@ -991,7 +954,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			if (hitIndex != -1 && result != null)
 			{
 				// check the bottom
-				result.copyFrom(getTileCoordsByIndex(hitIndex, false));
+				result.copyFrom(getTilePos(hitIndex));
 				result.x = start.x;
 				if (start.y > end.y)
 					result.y += scaledTileHeight;
@@ -1015,9 +978,9 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 			while (tileX != endTileX)
 			{
-				xPos = x + (tileX + offset) * scaledTileWidth;
+				xPos = getColumnPos(tileX + offset);
 				yPos = m * xPos + b;
-				tileY = Math.floor((yPos - y) / scaledTileHeight);
+				tileY = getRowAt(yPos);
 				hitIndex = checkColumn(tileX, lastTileY, tileY);
 				if (hitIndex != -1)
 					break;
@@ -1030,7 +993,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 			if (hitIndex != -1 && result != null)
 			{
-				result.copyFrom(getTileCoordsByIndex(hitIndex, false));
+				result.copyFrom(getTilePos(hitIndex));
 				if (Std.int(hitIndex / widthInTiles) == lastTileY)
 				{
 					if (start.x > end.x)
@@ -1439,7 +1402,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	}
 	
 	/**
-	 * Internal function used in setTileByIndex() and the constructor to update the map.
+	 * Internal function used in setTileIndex() and the constructor to update the map.
 	 *
 	 * @param   index  The index of the tile object in _tileObjects internal array you want to update.
 	 */

--- a/tests/unit/src/flixel/path/FlxPathfinderTest.hx
+++ b/tests/unit/src/flixel/path/FlxPathfinderTest.hx
@@ -106,7 +106,7 @@ class FlxPathfinderTest extends FlxTest
 		var i = points.length;
 		while (i-- > 0)
 		{
-			indices.unshift(map.getTileIndexByCoords(points[i]));
+			indices.unshift(map.getMapIndex(points[i]));
 			if (put)
 				points.pop().put();
 		}

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -290,7 +290,7 @@ class FlxTilemapTest extends FlxTest
 		tilemap.loadMapFrom2DArray([[1]], new BitmapData(2, 1));
 		function overlaps(x, y)
 			return tilemap.overlapsPoint(FlxPoint.get(x, y));
-
+		
 		Assert.isFalse(overlaps(-1, -1));
 		Assert.isTrue(overlaps(0, 0));
 		Assert.isFalse(overlaps(1, 1));
@@ -440,13 +440,26 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 0
 		];
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		tilemap.x += 10;
+		tilemap.y += 20;
+		tilemap.scale.set(2, 2);
+		
+		final SIZE = 16;
+		final HALF = 8;
 		
 		Assert.areEqual(tilemap.getTileIndex(4), tilemap.getTileIndex(1, 1));
 		Assert.areEqual(1, tilemap.getTileIndex(4));
 		Assert.areEqual(2, tilemap.getColumn(8));
 		Assert.areEqual(2, tilemap.getRow(8));
 		
+		Assert.areEqual(-1, tilemap.getMapIndex(1000, 1));
+		Assert.areEqual(-1, tilemap.getTileIndex(1000, 1));
+		Assert.areEqual(8, tilemap.getMapIndexAt(10 + 2 * SIZE + HALF, 20 + 2 * SIZE + HALF));
+		Assert.areEqual(0, tilemap.getTileIndexAt(10 + 2 * SIZE + HALF, 20 + 2 * SIZE + HALF));
+		Assert.areEqual(-1, tilemap.getTileIndexAt(10 + 1000 * SIZE + HALF, 20 + 2 * SIZE + HALF));
+		
 		Assert.areEqual(tilemap.getTileData(4), tilemap.getTileData(1, 1));
+		Assert.areEqual(tilemap.getTileData(1, 1), tilemap.getTileDataAt(10 + 1 * SIZE + HALF, 20 + 1 * SIZE + HALF));
 	}
 	
 	function testGetColumnRowAt()
@@ -457,6 +470,7 @@ class FlxTilemapTest extends FlxTest
 			0, 1, 0, 0,
 			0, 0, 0, 0,
 		];
+		tilemap.y += 10;
 		tilemap.loadMapFromArray(mapData, 4, 3, getBitmapData(), 8, 8);
 		
 		Assert.areEqual(tilemap.getColumnAt(24, true), tilemap.getColumnAt(24, false));
@@ -465,11 +479,55 @@ class FlxTilemapTest extends FlxTest
 		Assert.areEqual(4, tilemap.getColumnAt(32, true));
 		Assert.areEqual(5, tilemap.getColumnAt(32, false));
 		
-		Assert.areEqual(tilemap.getRowAt(16, true), tilemap.getRowAt(16, false));
-		Assert.areEqual(2, tilemap.getRowAt(16));
-		Assert.areNotEqual(tilemap.getRowAt(24, true), tilemap.getRowAt(24, false));
-		Assert.areEqual(3, tilemap.getRowAt(24, true));
-		Assert.areEqual(4, tilemap.getRowAt(24, false));
+		Assert.areEqual(tilemap.getRowAt(10 + 16, true), tilemap.getRowAt(10 + 16, false));
+		Assert.areEqual(2, tilemap.getRowAt(10 + 16));
+		Assert.areNotEqual(tilemap.getRowAt(10 + 24, true), tilemap.getRowAt(10 + 24, false));
+		Assert.areEqual(3, tilemap.getRowAt(10 + 24, true));
+		Assert.areEqual(4, tilemap.getRowAt(10 + 24, false));
+	}
+	
+	@Test
+	function testColumnRowPos()
+	{
+		tilemap.loadMapFromArray(sampleMapArray, 4, 3, getBitmapData(), 8, 8);
+		tilemap.x = 10;
+		tilemap.y = 20;
+		tilemap.scale.set(2, 2);
+		
+		final SIZE = 16;
+		final HALF = 8;
+		
+		Assert.areEqual(0, tilemap.getColumnAt(tilemap.getColumnPos(0)));
+		Assert.areEqual(1, tilemap.getColumnAt(tilemap.getColumnPos(1)));
+		Assert.areEqual(2, tilemap.getColumnAt(tilemap.getColumnPos(2)));
+		Assert.areEqual(3, tilemap.getColumnAt(tilemap.getColumnPos(3)));
+		Assert.areEqual(1000, tilemap.getColumnAt(tilemap.getColumnPos(1000)));
+		Assert.areEqual(10 + 3 * SIZE, tilemap.getColumnPos(3));
+		Assert.areEqual(10 + 3 * SIZE + HALF, tilemap.getColumnPos(3, true));
+		Assert.areEqual(10 + 1000 * SIZE, tilemap.getColumnPos(1000));
+		
+		Assert.areEqual(0, tilemap.getRowAt(tilemap.getRowPos(0)));
+		Assert.areEqual(1, tilemap.getRowAt(tilemap.getRowPos(1)));
+		Assert.areEqual(2, tilemap.getRowAt(tilemap.getRowPos(2)));
+		Assert.areEqual(1000, tilemap.getRowAt(tilemap.getRowPos(1000)));
+		Assert.areEqual(20 + 2 * SIZE, tilemap.getRowPos(2));
+		Assert.areEqual(20 + 2 * SIZE + HALF, tilemap.getRowPos(2, true));
+		Assert.areEqual(20 + 1000 * SIZE, tilemap.getRowPos(1000));
+		
+		Assert.areEqual(null, tilemap.getTilePos(1000));
+		Assert.areEqual(null, tilemap.getTilePos(-1));
+		
+		
+		inline function assertPosEqual(expectedX:Float, expectedY:Float, actual:FlxPoint, ?infos:PosInfos)
+		{
+			Assert.areEqual(expectedX, actual.x, 'Point x [${actual.x}] was not equal to expected value [$expectedX]', infos);
+			Assert.areEqual(expectedY, actual.y, 'Point y [${actual.y}] was not equal to expected value [$expectedY]', infos);
+		}
+		
+		assertPosEqual(10 + -SIZE, 20 + -SIZE, tilemap.getTilePos(-1, -1));
+		assertPosEqual(10 + SIZE, 20 + SIZE, tilemap.getTilePos(1, 1));
+		assertPosEqual(10 + 1000 * SIZE, 20 + 1000 * SIZE, tilemap.getTilePos(1000, 1000));
+		assertPosEqual(10 + 1000 * SIZE, 20 + 1000 * SIZE, tilemap.getTilePosAt(10 + 1000 * SIZE, 20 + 1000 * SIZE));
 	}
 	
 	@Test
@@ -481,6 +539,11 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 0
 		];
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		tilemap.x = 10;
+		tilemap.y = 20;
+		tilemap.scale.set(2, 2);
+		
+		final SIZE = 16;
 		
 		Assert.isTrue(tilemap.tileExists(4));
 		Assert.isTrue(tilemap.tileExists(1, 1));
@@ -488,6 +551,11 @@ class FlxTilemapTest extends FlxTest
 		Assert.isFalse(tilemap.tileExists(3, 1));
 		Assert.isFalse(tilemap.tileExists(1, 3));
 		Assert.isFalse(tilemap.tileExists(5, 5));
+		
+		Assert.isTrue(tilemap.tileExistsAt(10 + 1 * SIZE, 20 + 1 * SIZE));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 3 * SIZE, 20 + 1 * SIZE));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 1 * SIZE, 20 + 3 * SIZE));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 5 * SIZE, 20 + 5 * SIZE));
 	}
 	
 	@Test
@@ -499,27 +567,59 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 0, 0
 		];
 		tilemap.loadMapFromArray(mapData, 4, 3, getBitmapData(), 8, 8);
+		tilemap.x = 10;
+		tilemap.y = 20;
+		tilemap.scale.set(2, 2);
+		
+		final SIZE = 16;
 		
 		Assert.isFalse(tilemap.columnExists(5));
 		Assert.isFalse(tilemap.rowExists(5));
+		Assert.isFalse(tilemap.tileExists(5, 5));
+		Assert.isFalse(tilemap.columnExistsAt(10 + 5 * SIZE));
+		Assert.isFalse(tilemap.rowExistsAt(20 + 5 * SIZE));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 5 * SIZE, 20 + 5 * SIZE));
 		
 		Assert.isFalse(tilemap.columnExists(4));
 		Assert.isFalse(tilemap.rowExists(4));
+		Assert.isFalse(tilemap.tileExists(4, 4));
+		Assert.isFalse(tilemap.columnExistsAt(10 + 4 * SIZE));
+		Assert.isFalse(tilemap.rowExistsAt(20 + 4 * SIZE));
 		
 		Assert.isTrue(tilemap.columnExists(3));
 		Assert.isFalse(tilemap.rowExists(3));
+		Assert.isFalse(tilemap.tileExists(3, 3));
+		Assert.isTrue(tilemap.columnExistsAt(10 + 3 * SIZE));
+		Assert.isFalse(tilemap.rowExistsAt(20 + 3 * SIZE));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 3 * SIZE, 20 + 3 * SIZE));
 		
 		Assert.isTrue(tilemap.columnExists(2));
 		Assert.isTrue(tilemap.rowExists(2));
+		Assert.isTrue(tilemap.tileExists(2, 2));
+		Assert.isTrue(tilemap.columnExistsAt(10 + 2 * SIZE));
+		Assert.isTrue(tilemap.rowExistsAt(20 + 2 * SIZE));
+		Assert.isTrue(tilemap.tileExistsAt(10 + 2 * SIZE, 20 + 2 * SIZE));
 		
 		Assert.isTrue(tilemap.columnExists(1));
 		Assert.isTrue(tilemap.rowExists(1));
+		Assert.isTrue(tilemap.tileExists(1, 1));
+		Assert.isTrue(tilemap.columnExistsAt(10 + 1 * SIZE));
+		Assert.isTrue(tilemap.rowExistsAt(20 + 1 * SIZE));
+		Assert.isTrue(tilemap.tileExistsAt(10 + 1 * SIZE, 20 + 1 * SIZE));
 		
 		Assert.isTrue(tilemap.columnExists(0));
 		Assert.isTrue(tilemap.rowExists(0));
+		Assert.isTrue(tilemap.tileExists(0, 0));
+		Assert.isTrue(tilemap.columnExistsAt(10));
+		Assert.isTrue(tilemap.rowExistsAt(20));
+		Assert.isTrue(tilemap.tileExistsAt(10, 20));
 		
 		Assert.isFalse(tilemap.columnExists(-1));
 		Assert.isFalse(tilemap.rowExists(-1));
+		Assert.isFalse(tilemap.tileExists(-1, -1));
+		Assert.isFalse(tilemap.columnExistsAt(10 - 1));
+		Assert.isFalse(tilemap.rowExistsAt(20 - 1));
+		Assert.isFalse(tilemap.tileExistsAt(10 - 1, 20 - 1));
 	}
 	
 	@Test
@@ -531,9 +631,23 @@ class FlxTilemapTest extends FlxTest
 			0, 0, 0
 		];
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		tilemap.x = 10;
+		tilemap.y = 20;
+		tilemap.scale.set(2, 2);
 		
 		FlxAssert.arraysEqual([4], tilemap.getAllMapIndices(1));
+		
+		final pos = tilemap.getAllTilePos(1);
+		Assert.areEqual(1, pos.length);
+		Assert.areEqual(10 + 16, pos[0].x);
+		Assert.areEqual(20 + 16, pos[0].y);
+		
 		FlxAssert.arraysEqual([0,1,2,3,5,6,7,8], tilemap.getAllMapIndices(0));
+		FlxAssert.arraysEqual([0,1,2,3,5,6,7,8], tilemap.getAllTilePos(0).map((p)->tilemap.getMapIndex(p)));
+		FlxAssert.arraysEqual([0,1,2,3,5,6,7,8], tilemap.getAllTilePos(0, true).map((p)->tilemap.getMapIndex(p)));
+		final all = new Array<Int>();
+		tilemap.forEachMapIndex(0, all.push);
+		FlxAssert.arraysEqual([0,1,2,3,5,6,7,8], all);
 	}
 	
 	@Test


### PR DESCRIPTION
- New helpers `getColumnPos`, `getRowPos`, `getColumnPosAt`, `getRowPosAt`, `getTilePos`, `getTilePosAt`, `getAllTilePos`, `forEachMapIndex`, `getMapIndexAt`, `tileExistsAt`, `columnExistsAt`, `rowExistsAt`, `getTileIndexAt`, `getTileDataAt` and `setTileIndexAt`
- New overloads with `worldPos` arg in `getMapIndex`, `tileExists`, `getTileIndex`, `getTileData` and `setTileIndex`
- deprecate `getTileCoordsByIndex`, `getTileIndexByCoords` and `getTileCoords`
- Fixes to `getColumnAt` and `getRowAt` to account for map position
- unit tests for all mentioned above