### PR TITLE
Fix rect.intersections, add rect.clipTo

### DIFF
--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -433,7 +433,7 @@ class FlxRect implements IFlxPooled
 		rect.putWeak();
 		return result;
 	}
-
+	
 	/**
 	 * Returns the area of intersection with specified rectangle.
 	 * If the rectangles do not intersect, this method returns an empty rectangle.
@@ -458,6 +458,18 @@ class FlxRect implements IFlxPooled
 		
 		return result.set(x0, y0, x1 - x0, y1 - y0);
 	}
+	
+	/**
+	 * Resizes `this` instance so that it fits within the intersection of the this and
+	 * the target rect. If there is no overlap between them, The result is an empty rect.
+	 *
+	 * @param   rect    Rectangle to check intersection against
+	 * @return  This rect, useful for chaining
+	 * @since 5.9.0
+	 */
+	public function clipTo(rect:FlxRect):FlxRect
+	{
+		return rect.intersection(this, this);
 	}
 	
 	/**

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -438,32 +438,26 @@ class FlxRect implements IFlxPooled
 	 * Returns the area of intersection with specified rectangle.
 	 * If the rectangles do not intersect, this method returns an empty rectangle.
 	 *
-	 * @param	rect	Rectangle to check intersection against.
-	 * @return	The area of intersection of two rectangles.
+	 * @param   rect    Rectangle to check intersection against
+	 * @param   result  The resulting instance, if `null`, a new one is created
+	 * @return  The area of intersection of two rectangles
 	 */
 	public function intersection(rect:FlxRect, ?result:FlxRect):FlxRect
 	{
 		if (result == null)
 			result = FlxRect.get();
-
-		var x0:Float = x < rect.x ? rect.x : x;
-		var x1:Float = right > rect.right ? rect.right : right;
-		if (x1 <= x0)
-		{
-			rect.putWeak();
-			return result;
-		}
-
-		var y0:Float = y < rect.y ? rect.y : y;
-		var y1:Float = bottom > rect.bottom ? rect.bottom : bottom;
-		if (y1 <= y0)
-		{
-			rect.putWeak();
-			return result;
-		}
-
+		
+		final x0:Float = x < rect.x ? rect.x : x;
+		final x1:Float = right > rect.right ? rect.right : right;
+		final y0:Float = y < rect.y ? rect.y : y;
+		final y1:Float = bottom > rect.bottom ? rect.bottom : bottom;
 		rect.putWeak();
+		
+		if (x1 <= x0 || y1 <= y0)
+			return result.set(0, 0, 0, 0);
+		
 		return result.set(x0, y0, x1 - x0, y1 - y0);
+	}
 	}
 	
 	/**

--- a/tests/unit/src/flixel/math/FlxRectTest.hx
+++ b/tests/unit/src/flixel/math/FlxRectTest.hx
@@ -124,4 +124,30 @@ class FlxRectTest extends FlxTest
 		expected.put();
 		result.put();
 	}
+	
+	@Test
+	function testClipTo()
+	{
+		rect1.set(0, 0, 100, 100);
+		rect2.set(50, 50, 100, 100);
+		
+		final expected = FlxRect.get(50, 50, 50, 50);
+		rect1.clipTo(rect2);
+		FlxAssert.rectsNear(expected, rect1, 0.0001);
+		
+		expected.put();
+	}
+	
+	@Test
+	function testClipToEmpty()
+	{
+		rect1.set(0, 0, 100, 100);
+		rect2.set(200, 200, 100, 100);
+		
+		final expected = FlxRect.get(0, 0, 0, 0);
+		rect1.clipTo(rect2);
+		FlxAssert.rectsNear(expected, rect1, 0.0001);
+		
+		expected.put();
+	}
 }

--- a/tests/unit/src/flixel/math/FlxRectTest.hx
+++ b/tests/unit/src/flixel/math/FlxRectTest.hx
@@ -94,4 +94,34 @@ class FlxRectTest extends FlxTest
 		pivot.put();
 		expected.put();
 	}
+	
+	@Test
+	function testIntersection()
+	{
+		rect1.set(0, 0, 100, 100);
+		rect2.set(50, 50, 100, 100);
+		
+		final expected = FlxRect.get(50, 50, 50, 50);
+		final result = FlxRect.get();
+		rect1.intersection(rect2, result);
+		FlxAssert.rectsNear(expected, result, 0.0001);
+		
+		expected.put();
+		result.put();
+	}
+	
+	@Test
+	function testIntersectionEmpty()
+	{
+		rect1.set(0, 0, 100, 100);
+		rect2.set(200, 200, 100, 100);
+		
+		final expected = FlxRect.get(0, 0, 0, 0);
+		final result = FlxRect.get(1000, 1000, 1000, 1000);
+		rect1.intersection(rect2, result);
+		FlxAssert.rectsNear(expected, result, 0.0001);
+		
+		expected.put();
+		result.put();
+	}
 }


### PR DESCRIPTION
- Adds `clipTo` to `FlxRect`, for resizing a rect to the intersection of it and another
- Fixes bug where an empty intersection result would not zero the resulting rect, if one was passed in
- Unit tests ensuring both