### PR TITLE
Fix crashes from negative tiles

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -974,16 +974,13 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			final inc = movesRight ? 1 : -1;
 			final offset = movesRight ? 1 : 0;
 			var tileX = startTileX;
-			var tileY = 0;
-			var xPos = 0.0;
-			var yPos = 0.0;
 			var lastTileY = startTileY;
 
 			while (tileX != endTileX)
 			{
-				xPos = getColumnPos(tileX + offset);
-				yPos = m * xPos + b;
-				tileY = getRowAt(yPos);
+				final xPos = getColumnPos(tileX + offset);
+				final yPos = m * getColumnPos(tileX + offset) + b;
+				final tileY = getRowAt(yPos);
 				hitIndex = checkColumn(tileX, lastTileY, tileY);
 				if (hitIndex != -1)
 					break;

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -781,6 +781,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			for (column in minTileX...maxTileX)
 			{
 				final tile = getTileData(column, row);
+				if (tile == null)
+					continue;
 				tile.orientAt(xPos, yPos, column, row);
 				if (tile.overlapsObject(object) && (filter == null || filter(tile)))
 				{
@@ -933,7 +935,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		final endIndex = getMapIndex(end);
 
 		// If the starting tile is solid, return the starting position
-		if (getTileData(startIndex).solid)
+		final tile = getTileData(startIndex);
+		if (tile != null && tile.solid)
 		{
 			if (result != null)
 				result.copyFrom(start);
@@ -1040,8 +1043,9 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		final step = startY <= endY ? 1 : -1;
 		while (true)
 		{
-			var index = getMapIndex(x, y);
-			if (getTileData(index).solid)
+			final index = getMapIndex(x, y);
+			final tile = getTileData(index);
+			if (tile != null && tile.solid)
 				return index;
 			
 			if (y == endY)
@@ -1102,7 +1106,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			var tileX = Math.floor(curX / scaledTileWidth);
 			var tileY = Math.floor(curY / scaledTileHeight);
 			
-			if (getTileData(tileX, tileY).solid)
+			final tile = getTileData(tileX, tileY);
+			if (tile != null && tile.solid)
 			{
 				// Some basic helper stuff
 				tileX *= Std.int(scaledTileWidth);
@@ -1394,12 +1399,6 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		setDirty();
 	}
 	#end
-	
-	/** Guards against -1 */
-	override function setTileHelper(mapIndex:Int, tileIndex:Int, updateGraphics:Bool = true):Bool
-	{
-		return super.setTileHelper(mapIndex, tileIndex < 0 ? 0 : tileIndex, updateGraphics);
-	}
 	
 	/**
 	 * Internal function used in setTileIndex() and the constructor to update the map.

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -673,6 +673,34 @@ class FlxTilemapTest extends FlxTest
 		Assert.areEqual(tile.x, tile.last.x);
 	}
 	
+	@Test
+	function testNegativeIndex()
+	{
+		final mapData = [
+			0, 0, 0,
+			0, 1, 0,
+			0, 0, 0
+		];
+		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
+		
+		tilemap.setTileIndex(4, -2);
+		Assert.areEqual(-2, tilemap.getTileIndex(4));
+		
+		// cover entire map
+		final object = new FlxObject(4, 4, 16, 16);
+		object.last.set(object.x, object.y);
+		
+		try
+		{
+			Assert.isFalse(tilemap.overlaps(object));
+			// TODO:test ray, rayStep and others
+		}
+		catch(e)
+		{
+			Assert.fail('tilemap.overlaps(object) threw exception: ' + e.toString());
+		}
+	}
+	
 	function getBitmapData()
 	{
 		return new BitmapData(8*16, 8);

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -683,8 +683,8 @@ class FlxTilemapTest extends FlxTest
 		];
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
-		tilemap.setTileIndex(1, -2);
-		Assert.areEqual(-2, tilemap.getTileIndex(1));
+		tilemap.setTileIndex(0, -2);
+		Assert.areEqual(-2, tilemap.getTileIndex(0));
 		
 		// cover entire map
 		final object = new FlxObject(4, 4, 16, 16);
@@ -693,20 +693,23 @@ class FlxTilemapTest extends FlxTest
 		var overlapResult = true;
 		var rayResult = false;
 		var rayStepResult = false;
+		var getIndexResult:FlxTile = null;
 		try
 		{
 			overlapResult = tilemap.overlaps(object);
 			rayResult = tilemap.ray(FlxPoint.weak(0, 0), new FlxPoint(tilemap.width, tilemap.height));
 			rayStepResult = tilemap.rayStep(FlxPoint.weak(0, 0), new FlxPoint(tilemap.width, tilemap.height));
+			getIndexResult = tilemap.getTileData(0);
 			// TODO: more tests?
 		}
 		catch(e)
 		{
-			Assert.fail('tilemap.overlaps(object) threw exception: ' + e.toString());
+			Assert.fail('Exception throw: ' + e.toString());
 		}
 		Assert.isTrue(overlapResult);
 		Assert.isFalse(rayResult);
 		Assert.isFalse(rayStepResult);
+		Assert.isNull(getIndexResult);
 	}
 	
 	function getBitmapData()

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -683,22 +683,30 @@ class FlxTilemapTest extends FlxTest
 		];
 		tilemap.loadMapFromArray(mapData, 3, 3, getBitmapData(), 8, 8);
 		
-		tilemap.setTileIndex(4, -2);
-		Assert.areEqual(-2, tilemap.getTileIndex(4));
+		tilemap.setTileIndex(1, -2);
+		Assert.areEqual(-2, tilemap.getTileIndex(1));
 		
 		// cover entire map
 		final object = new FlxObject(4, 4, 16, 16);
 		object.last.set(object.x, object.y);
 		
+		var overlapResult = true;
+		var rayResult = false;
+		var rayStepResult = false;
 		try
 		{
-			Assert.isFalse(tilemap.overlaps(object));
-			// TODO:test ray, rayStep and others
+			overlapResult = tilemap.overlaps(object);
+			rayResult = tilemap.ray(FlxPoint.weak(0, 0), new FlxPoint(tilemap.width, tilemap.height));
+			rayStepResult = tilemap.rayStep(FlxPoint.weak(0, 0), new FlxPoint(tilemap.width, tilemap.height));
+			// TODO: more tests?
 		}
 		catch(e)
 		{
 			Assert.fail('tilemap.overlaps(object) threw exception: ' + e.toString());
 		}
+		Assert.isTrue(overlapResult);
+		Assert.isFalse(rayResult);
+		Assert.isFalse(rayStepResult);
 	}
 	
 	function getBitmapData()


### PR DESCRIPTION
For 47Rooks in the discord server

This is a regression to earlier behavior, where setTileByIndex does not guard against 0, but overlap checks do