### PR TITLE
Fix `null` text alignment returning as CENTER on HashLink

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1273,6 +1273,9 @@ enum abstract FlxTextAlign(String) from String
 	{
 		return switch (align)
 		{
+			// This `null` check is needed for HashLink, otherwise it will cast
+			// a `null` alignment to 0 which results in returning `CENTER`
+			// instead of the default `LEFT`.
 			case null: LEFT;
 			case TextFormatAlign.LEFT: LEFT;
 			case TextFormatAlign.CENTER: CENTER;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1271,6 +1271,9 @@ enum abstract FlxTextAlign(String) from String
 
 	public static function fromOpenFL(align:TextFormatAlign):FlxTextAlign
 	{
+		if (align == null)
+			return LEFT;
+		
 		return switch (align)
 		{
 			case TextFormatAlign.LEFT: LEFT;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1271,11 +1271,9 @@ enum abstract FlxTextAlign(String) from String
 
 	public static function fromOpenFL(align:TextFormatAlign):FlxTextAlign
 	{
-		if (align == null)
-			return LEFT;
-		
 		return switch (align)
 		{
+			case null: LEFT;
 			case TextFormatAlign.LEFT: LEFT;
 			case TextFormatAlign.CENTER: CENTER;
 			case TextFormatAlign.RIGHT: RIGHT;


### PR DESCRIPTION
While working on the new text input, I found out that when compiling to HashLink, FlxText's `align` would return CENTER by default (not having changed it manually), instead of LEFT. This seems to be caused by the switch statement in `FlxTextAlign.fromOpenFL()` treating the `null` value as a 0, which corresponds to CENTER in OpenFL's text alignment enum (which is an abstract for Int).

This PR simply adds a null check in the function, which makes it automatically return LEFT if a null alignment was passed in.