### PR TITLE
Add getGlobalScreenPosition to FlxPointer

### DIFF
--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -92,6 +92,16 @@ class FlxPointer
 	}
 
 	/**
+	 * Returns a FlxPoint with this input's global screen x and y
+	 */
+	public function getGlobalScreenPosition(?point:FlxPoint):FlxPoint
+	{
+		if (point == null)
+			point = FlxPoint.get();
+		return point.set(_globalScreenX, _globalScreenY);
+	}
+
+	/**
 	 * Returns a FlxPoint with this input's x and y.
 	 */
 	public function getPosition(?point:FlxPoint):FlxPoint


### PR DESCRIPTION
At the moment, FlxPointer does not have a publicly accessible way of getting it's global screen position. This change adds that.