### PR TITLE
Pointer

### DIFF
--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -20,32 +20,30 @@ class FlxPointer
 	public var screenY(default, never):Int = 0;
 	
 	/**
-	 * The world position relative to the main camera's scroll position, where `0` is `cam.scroll.x`,
-	 * `cam.viewMarginX` or `cam.viewMarginLeft` is the left edge of the camera and 
-	 * `cam.viewMarginRight` is the right edge of the camera
+	 * The world position relative to the main camera's scroll position, `cam.viewMarginX` or
+	 * `cam.viewMarginLeft` is the left edge of the camera and `cam.viewMarginRight` is the right
 	 * 
 	 * @since 5.9.0
 	 */
 	public var viewX(default, null):Int = 0;
 	/**
-	 * The world position relative to the main camera's scroll position, where `0` is `cam.scroll.x`,
-	 * `cam.viewMarginX` or `cam.viewMarginTop` is the top edge of the camera and 
-	 * `cam.viewMarginBottom` is the bottom edge of the camera
+	 * The world position relative to the main camera's scroll position, `cam.viewMarginY` or
+	 * `cam.viewMarginTop` is the top edge of the camera and `cam.viewMarginBottom` is the bottom
 	 * 
 	 * @since 5.9.0
 	 */
 	public var viewY(default, null):Int = 0;
 	
 	/**
-	 * The position relative to the `FlxGame`'s position in the window, where `0` is the left edge
-	 * of the game and `FlxG.scaleMode.gameSize.x` is the right edge of the game
+	 * The position relative to the `FlxGame`'s position in the window,
+	 * where `0` is the left edge of the game and `FlxG.width` is the right
 	 * 
 	 * @since 5.9.0
 	 */
 	public var gameX(default, null):Int = 0;
 	/**
-	 * The position relative to the `FlxGame`'s position in the window, where `0` is the top edge
-	 * of the game and `FlxG.scaleMode.gameSize.y` is the bottom edge of the game
+	 * The position relative to the `FlxGame`'s position in the window,
+	 * where `0` is the top edge of the game and `FlxG.height` is the bottom
 	 * 
 	 * @since 5.9.0
 	 */
@@ -68,8 +66,8 @@ class FlxPointer
 	 * 
 	 * **Note:** Fields `x` and `y` also store this result
 	 *
-	 * @param   camera  If unspecified, `FlxG.camera` is used, instead.
-	 * @param   result  An existing point to store the results, if `null`, one is created
+	 * @param   camera  If unspecified, `FlxG.camera` is used, instead
+	 * @param   result  An existing point to store the results, if unspecified, one is created
 	 */
 	public function getWorldPosition(?camera:FlxCamera, ?result:FlxPoint):FlxPoint
 	{
@@ -83,11 +81,11 @@ class FlxPointer
 	
 	/**
 	 * The world position relative to the main camera's scroll position, where `(0, 0)` is the
-	 * top-left edge of the game and `(FlxG.width, FlxG.height)` is the bottom-right edge of the game
+	 * top-left edge of the game and `(FlxG.width, FlxG.height)` is the bottom-right
 	 * 
 	 * **Note:** Fields `gameX` and `gameY` also store this result
 	 * 
-	 * @param   result  An existing point to store the results, if `null`, one is created
+	 * @param   result  An existing point to store the results, if unspecified, one is created
 	 * @since 5.9.0
 	 */
 	public function getGamePosition(?result:FlxPoint):FlxPoint
@@ -101,12 +99,12 @@ class FlxPointer
 	/**
 	 * Fetch the position of the pointer relative to given camera's `scroll` position, where
 	 * `(cam.viewMarginLeft, cam.viewMarginTop)` is the top-left of the camera and
-	 * `(cam.viewMarginRight, cam.viewMarginBottom)` is the bottom right of the camera
+	 * `(cam.viewMarginRight, cam.viewMarginBottom)` is the bottom right
 	 * 
 	 * **Note:** Fields `viewX` and `viewY` also store this result
 	 *
-	 * @param   camera  If unspecified, `FlxG.camera` is used, instead.
-	 * @param   result  An existing point to store the results, if `null`, one is created
+	 * @param   camera  If unspecified, `FlxG.camera` is used, instead
+	 * @param   result  An existing point to store the results, if unspecified, one is created
 	 */
 	public function getViewPosition(?camera:FlxCamera, ?result:FlxPoint):FlxPoint
 	{
@@ -129,8 +127,8 @@ class FlxPointer
 	 * 
 	 * **Note:** Fields `viewX` and `viewY` also store this result for `FlxG.camera`
 	 * 
-	 * @param   camera  If unspecified, `FlxG.camera` is used, instead.
-	 * @param   result  An existing point to store the results, if `null`, one is created
+	 * @param   camera  If unspecified, `FlxG.camera` is used, instead
+	 * @param   result  An existing point to store the results, if unspecified, one is created
 	 */
 	@:deprecated("getScreenPosition is deprecated, use getViewPosition, instead") // 5.9.0
 	public function getScreenPosition(?camera:FlxCamera, ?result:FlxPoint):FlxPoint
@@ -155,7 +153,7 @@ class FlxPointer
 	 * **Note:** Fields `viewX` and `viewY` also store this result for `FlxG.camera`
 	 * 
 	 * @param   camera  If unspecified, `FlxG.camera` is used, instead.
-	 * @param   result  An existing point to store the results, if `null`, one is created
+	 * @param   result  An existing point to store the results, if unspecified, one is created
 	 * @return  The pointer's location relative to camera's viewport.
 	 */
 	@:deprecated("getPositionInCameraView is deprecated, use getViewPosition, instead") // 5.9.0
@@ -188,7 +186,7 @@ class FlxPointer
 	 * Checks to see if this pointer overlaps some `FlxObject` or `FlxGroup`.
 	 *
 	 * @param   objectOrGroup  The object or group being tested
-	 * @param   camera         Helps determine the world position. If `null`, `FlxG.camera` is used
+	 * @param   camera         Helps determine the world position. If unspecified, `FlxG.camera` is used
 	 */
 	@:access(flixel.group.FlxTypedGroup.resolveGroup)
 	public function overlaps(objectOrGroup:FlxBasic, ?camera:FlxCamera):Bool

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -52,9 +52,9 @@ class FlxPointer
 	public var gameY(default, null):Int = 0;
 
 	@:deprecated("_globalScreenX is deprecated, use gameX, instead") // 5.9.0
-	var _globalScreenX(get, never):Int;
+	var _globalScreenX(get, set):Int;
 	@:deprecated("_globalScreenY is deprecated, use gameY, instead") // 5.9.0
-	var _globalScreenY(get, never):Int;
+	var _globalScreenY(get, set):Int;
 	
 	var _rawX(default, null):Float = 0;
 	var _rawY(default, null):Float = 0;
@@ -179,8 +179,8 @@ class FlxPointer
 		if (result == null)
 			result = FlxPoint.get();
 
-		result.x = (_globalScreenX - camera.x) / camera.zoom + camera.viewMarginX;
-		result.y = (_globalScreenY - camera.y) / camera.zoom + camera.viewMarginY;
+		result.x = (gameX - camera.x) / camera.zoom + camera.viewMarginX;
+		result.y = (gameY - camera.y) / camera.zoom + camera.viewMarginY;
 
 		return result;
 	}
@@ -206,30 +206,25 @@ class FlxPointer
 	 * @return 	Whether or not the two objects overlap.
 	 */
 	@:access(flixel.group.FlxTypedGroup.resolveGroup)
-	public function overlaps(ObjectOrGroup:FlxBasic, ?Camera:FlxCamera):Bool
+	public function overlaps(objectOrGroup:FlxBasic, ?camera:FlxCamera):Bool
 	{
-		var result:Bool = false;
-		
-		var group = FlxTypedGroup.resolveGroup(ObjectOrGroup);
+		// check group
+		final group = FlxTypedGroup.resolveGroup(objectOrGroup);
 		if (group != null)
 		{
-			group.forEachExists(function(basic:FlxBasic)
+			for (basic in group.members)
 			{
-				if (overlaps(basic, Camera))
+				if (basic != null && overlaps(basic, camera))
 				{
-					result = true;
-					return;
+					return true;
 				}
-			});
+			}
+			return false;
 		}
-		else
-		{
-			getWorldPosition(Camera, _cachedPoint);
-			var object:FlxObject = cast ObjectOrGroup;
-			result = object.overlapsPoint(_cachedPoint, true, Camera);
-		}
-		
-		return result;
+		// check object
+		getWorldPosition(camera, _cachedPoint);
+		final object:FlxObject = cast objectOrGroup;
+		return object.overlapsPoint(_cachedPoint, true, camera);
 	}
 	
 	/**
@@ -298,5 +293,17 @@ class FlxPointer
 	inline function get__globalScreenY():Int
 	{
 		return gameY;
+	}
+	
+	inline function set__globalScreenX(value:Int):Int
+	{
+		_rawX = value * FlxG.scaleMode.scale.x;
+		return value;
+	}
+	
+	inline function set__globalScreenY(value:Int):Int
+	{
+		_rawY = value * FlxG.scaleMode.scale.y;
+		return value;
 	}
 }

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -99,9 +99,9 @@ class FlxPointer
 	}
 	
 	/**
-	 * Fetch the position of the pointer relative to given camera, where `(cam.viewLeft, cam.viewTop)`
-	 * is the top-left of the camera and `(cam.viewRight, cam.viewBottom)` is the bottom right of
-	 * the camera and `(0, 0)` is 
+	 * Fetch the position of the pointer relative to given camera's `scroll` position, where
+	 * `(cam.viewMarginLeft, cam.viewMarginTop)` is the top-left of the camera and
+	 * `(cam.viewMarginRight, cam.viewMarginBottom)` is the bottom right of the camera
 	 * 
 	 * **Note:** Fields `viewX` and `viewY` also store this result
 	 *
@@ -123,10 +123,12 @@ class FlxPointer
 	}
 	
 	/**
-	 * Fetch the position of the pointer relative to given camera, where `(cam.viewLeft, cam.viewTop)`
-	 * is the top-left of the camera and `(cam.viewRight, cam.viewBottom)` is the bottom right of
-	 * the camera and `(0, 0)` is 
-	 *
+	 * Fetch the position of the pointer relative to given camera's `scroll` position, where
+	 * `(cam.viewMarginLeft, cam.viewMarginTop)` is the top-left of the camera and
+	 * `(cam.viewMarginRight, cam.viewMarginBottom)` is the bottom right of the camera
+	 * 
+	 * **Note:** Fields `viewX` and `viewY` also store this result for `FlxG.camera`
+	 * 
 	 * @param   camera  If unspecified, `FlxG.camera` is used, instead.
 	 * @param   result  An existing point to store the results, if `null`, one is created
 	 */
@@ -146,7 +148,9 @@ class FlxPointer
 	}
 	
 	/**
-	 * Fetch the screen position of the pointer on any given camera
+	 * Fetch the position of the pointer relative to given camera's `scroll` position, where
+	 * `(cam.viewMarginLeft, cam.viewMarginTop)` is the top-left of the camera and
+	 * `(cam.viewMarginRight, cam.viewMarginBottom)` is the bottom right of the camera
 	 * 
 	 * **Note:** Fields `viewX` and `viewY` also store this result for `FlxG.camera`
 	 * 
@@ -181,13 +185,10 @@ class FlxPointer
 	}
 	
 	/**
-	 * Checks to see if some FlxObject overlaps this FlxObject or FlxGroup.
-	 * If the group has a LOT of things in it, it might be faster to use FlxG.overlaps().
-	 * WARNING: Currently tilemaps do NOT support screen space overlap checks!
+	 * Checks to see if this pointer overlaps some `FlxObject` or `FlxGroup`.
 	 *
-	 * @param 	ObjectOrGroup The object or group being tested.
-	 * @param 	Camera Specify which game camera you want. If null getScreenPosition() will just grab the first global camera.
-	 * @return 	Whether or not the two objects overlap.
+	 * @param   objectOrGroup  The object or group being tested
+	 * @param   camera         Helps determine the world position. If `null`, `FlxG.camera` is used
 	 */
 	@:access(flixel.group.FlxTypedGroup.resolveGroup)
 	public function overlaps(objectOrGroup:FlxBasic, ?camera:FlxCamera):Bool
@@ -207,7 +208,7 @@ class FlxPointer
 		}
 		// check object
 		getWorldPosition(camera, _cachedPoint);
-		final object:FlxObject = cast objectOrGroup;
+		final object = cast (objectOrGroup, FlxObject);
 		return object.overlapsPoint(_cachedPoint, true, camera);
 	}
 	

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -80,7 +80,7 @@ class FlxPointer
 	}
 	
 	/**
-	 * The world position relative to the main camera's scroll position, where `(0, 0)` is the
+	 * The position relative to the game's position in the window, where `(0, 0)` is the
 	 * top-left edge of the game and `(FlxG.width, FlxG.height)` is the bottom-right
 	 * 
 	 * **Note:** Fields `gameX` and `gameY` also store this result
@@ -97,7 +97,7 @@ class FlxPointer
 	}
 	
 	/**
-	 * Fetch the position of the pointer relative to given camera's `scroll` position, where
+	 * Fetch the world position relative to the main camera's `scroll` position, where
 	 * `(cam.viewMarginLeft, cam.viewMarginTop)` is the top-left of the camera and
 	 * `(cam.viewMarginRight, cam.viewMarginBottom)` is the bottom right
 	 * 

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -82,22 +82,6 @@ class FlxPointer
 	}
 	
 	/**
-	 * Fetch the position of the pointer relative to the window, where `(0, 0)` is the top-left of
-	 * the window and `(stage.stageWidth, stage.stageHeight)` is the bottom right of the camera
-	 * 
-	 * **Note:** 
-	 * 
-	 * @param   result  An existing point to store the results, if `null`, one is created
-	 */
-	public function getWindowPosition(?result:FlxPoint):FlxPoint
-	{
-		if (result == null)
-			return FlxPoint.get();
-		
-		return result.set(_rawX + FlxG.game.x, _rawY + FlxG.game.y);
-	}
-	
-	/**
 	 * The world position relative to the main camera's scroll position, where `(0, 0)` is the
 	 * top-left edge of the game and `(FlxG.width, FlxG.height)` is the bottom-right edge of the game
 	 * 
@@ -111,7 +95,7 @@ class FlxPointer
 		if (result == null)
 			return FlxPoint.get();
 		
-		return result.set(Std.int(getRawGameX()), Std.int(getRawGameY()));
+		return result.set(Std.int(_rawX), Std.int(_rawY));
 	}
 	
 	/**
@@ -131,10 +115,10 @@ class FlxPointer
 		
 		if (result == null)
 			result = FlxPoint.get();
-
+		
 		result.x = Std.int((gameX - camera.x) / camera.zoom + camera.viewMarginX);
 		result.y = Std.int((gameY - camera.y) / camera.zoom + camera.viewMarginY);
-
+		
 		return result;
 	}
 	
@@ -154,10 +138,10 @@ class FlxPointer
 		
 		if (result == null)
 			result = FlxPoint.get();
-
+		
 		result.x = (gameX - camera.x + 0.5 * camera.width * (camera.zoom - camera.initialZoom)) / camera.zoom;
 		result.y = (gameY - camera.y + 0.5 * camera.height * (camera.zoom - camera.initialZoom)) / camera.zoom;
-
+		
 		return result;
 	}
 	
@@ -175,13 +159,13 @@ class FlxPointer
 	{
 		if (camera == null)
 			camera = FlxG.camera;
-
+		
 		if (result == null)
 			result = FlxPoint.get();
-
+		
 		result.x = (gameX - camera.x) / camera.zoom + camera.viewMarginX;
 		result.y = (gameY - camera.y) / camera.zoom + camera.viewMarginY;
-
+		
 		return result;
 	}
 	
@@ -245,8 +229,8 @@ class FlxPointer
 	@:haxe.warning("-WDeprecated")
 	public function setRawPositionUnsafe(x:Float, y:Float)
 	{
-		_rawX = x;
-		_rawY = y;
+		_rawX = x / FlxG.scaleMode.scale.x;
+		_rawY = y / FlxG.scaleMode.scale.y;
 		
 		updatePositions();
 	}
@@ -273,16 +257,6 @@ class FlxPointer
 	public function toString():String
 	{
 		return FlxStringUtil.getDebugString([LabelValuePair.weak("x", x), LabelValuePair.weak("y", y)]);
-	}
-	
-	inline function getRawGameX():Float
-	{
-		return _rawX / FlxG.scaleMode.scale.x;
-	}
-	
-	inline function getRawGameY():Float
-	{
-		return _rawY / FlxG.scaleMode.scale.y;
 	}
 	
 	inline function get__globalScreenX():Int

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -83,16 +83,30 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 * Distance in pixels the mouse has moved since the last frame in the Y direction.
 	 */
 	public var deltaY(get, never):Int;
-
+	
 	/**
 	 * Distance in pixels the mouse has moved in screen space since the last frame in the X direction.
 	 */
+	@:deprecated("deltaScreenX is deprecated, use deltaViewX, instead") // 5.9.0
 	public var deltaScreenX(get, never):Int;
-
+	
 	/**
 	 * Distance in pixels the mouse has moved in screen space since the last frame in the Y direction.
 	 */
+	@:deprecated("deltaScreenY is deprecated, use deltaViewY, instead") // 5.9.0
 	public var deltaScreenY(get, never):Int;
+	
+	/**
+	 * Distance in pixels the mouse has moved in view space since the last frame in the X direction.
+	 * @since 5.9.0
+	 */
+	public var deltaViewX(get, never):Int;
+
+	/**
+	 * Distance in pixels the mouse has moved in view space since the last frame in the Y direction.
+	 * @since 5.9.0
+	 */
+	public var deltaViewY(get, never):Int;
 
 	/**
 	 * Check to see if the left mouse button is currently pressed.
@@ -217,8 +231,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	var _prevX:Int = 0;
 	var _prevY:Int = 0;
-	var _prevScreenX:Int = 0;
-	var _prevScreenY:Int = 0;
+	var _prevViewX:Int = 0;
+	var _prevViewY:Int = 0;
+	@:deprecated("_prevScreenX is deprecated, use _prevViewX, instead")
+	var _prevScreenX(get, never):Int;
+	@:deprecated("_prevScreenY is deprecated, use _prevViewY, instead")
+	var _prevScreenY(get, never):Int;
 
 	// Helper variable for cleaning up memory
 	var _stage:Stage;
@@ -493,11 +511,13 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	{
 		_prevX = x;
 		_prevY = y;
-		_prevScreenX = screenX;
-		_prevScreenY = screenY;
+		_prevViewX = viewX;
+		_prevViewY = viewY;
 
-		#if !FLX_UNIT_TEST // Travis segfaults when game.mouseX / Y is accessed
-		setGlobalScreenPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY);
+		#if FLX_UNIT_TEST // Travis segfaults when game.mouseX / Y is accessed
+		setRawPositionUnsafe(0, 0);
+		#else
+		setRawPositionUnsafe(FlxG.game.mouseX, FlxG.game.mouseY);
 
 		// actually position the flixel mouse cursor graphic
 		if (visible)
@@ -593,11 +613,23 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	inline function get_deltaY():Int
 		return y - _prevY;
 
+	inline function get_deltaViewX():Int
+		return viewX - _prevViewX;
+	
+	inline function get_deltaViewY():Int
+		return viewY - _prevViewY;
+		
+	inline function get__prevScreenX():Int
+		return _prevViewX;
+	
+	inline function get__prevScreenY():Int
+		return _prevViewY;
+		
 	inline function get_deltaScreenX():Int
-		return screenX - _prevScreenX;
-
+		return deltaViewX;
+	
 	inline function get_deltaScreenY():Int
-		return screenY - _prevScreenY;
+		return deltaViewY;
 
 	inline function get_pressed():Bool
 		return _leftButton.pressed;
@@ -726,16 +758,16 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	@:allow(flixel.system.replay.FlxReplay)
 	function record():MouseRecord
 	{
-		if ((_lastX == _globalScreenX)
-			&& (_lastY == _globalScreenY)
+		if ((_lastX == gameX)
+			&& (_lastY == gameY)
 			&& (_lastLeftButtonState == _leftButton.current)
 			&& (_lastWheel == wheel))
 		{
 			return null;
 		}
 
-		_lastX = _globalScreenX;
-		_lastY = _globalScreenY;
+		_lastX = gameX;
+		_lastY = gameY;
 		_lastLeftButtonState = _leftButton.current;
 		_lastWheel = wheel;
 		return new MouseRecord(_lastX, _lastY, _leftButton.current, _lastWheel);
@@ -754,19 +786,19 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		_lastLeftButtonState = _leftButton.current = record.button;
 		wheel = record.wheel;
-		_globalScreenX = record.x;
-		_globalScreenY = record.y;
+		// TODO: Store raw pos, instead, add versioning to recordings
+		setRawPositionUnsafe(record.x * FlxG.scaleMode.scale.x, record.y * FlxG.scaleMode.scale.y);
 		updatePositions();
 	}
 
 	inline function get__cursor()
 	{
-	    return cursor;
+		return cursor;
 	}
 	
 	inline function set__cursor(value:Bitmap)
 	{
-	    return cursor = value;
+		return cursor = value;
 	}
 }
 #end

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -786,8 +786,8 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		}
 		_lastLeftButtonState = _leftButton.current = record.button;
 		wheel = record.wheel;
-		// TODO: Store raw pos, instead, add versioning to recordings
-		setRawPositionUnsafe(record.x * FlxG.scaleMode.scale.x, record.y * FlxG.scaleMode.scale.y);
+		_rawX = record.x;
+		_rawY = record.y;
 		updatePositions();
 	}
 

--- a/flixel/input/mouse/FlxMouseButton.hx
+++ b/flixel/input/mouse/FlxMouseButton.hx
@@ -34,13 +34,13 @@ class FlxMouseButton extends FlxInput<Int> implements IFlxDestroyable
 
 		if (justPressed)
 		{
-			justPressedPosition.set(FlxG.mouse.screenX, FlxG.mouse.screenY);
+			justPressedPosition.set(FlxG.mouse.viewX, FlxG.mouse.viewY);
 			justPressedTimeInTicks = FlxG.game.ticks;
 		}
 		#if FLX_POINTER_INPUT
 		else if (justReleased)
 		{
-			FlxG.swipes.push(new FlxSwipe(ID, justPressedPosition.copyTo(), FlxG.mouse.getScreenPosition(), justPressedTimeInTicks));
+			FlxG.swipes.push(new FlxSwipe(ID, justPressedPosition.copyTo(), FlxG.mouse.getViewPosition(), justPressedTimeInTicks));
 		}
 		#end
 	}

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -635,7 +635,7 @@ class FlxMouseEventManager extends FlxBasic
 		for (camera in event.object.getCameras())
 		{
 			#if FLX_MOUSE
-			_point = FlxG.mouse.getPositionInCameraView(camera, _point);
+			_point = FlxG.mouse.getViewPosition(camera, _point);
 			if (camera.containsPoint(_point))
 			{
 				_point = FlxG.mouse.getWorldPosition(camera, _point);
@@ -650,7 +650,7 @@ class FlxMouseEventManager extends FlxBasic
 			#if FLX_TOUCH
 			for (touch in FlxG.touches.list)
 			{
-				_point = touch.getPositionInCameraView(camera, _point);
+				_point = touch.getViewPosition(camera, _point);
 				if (camera.containsPoint(_point))
 				{
 					_point = touch.getWorldPosition(camera, _point);

--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -81,13 +81,13 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 
 		if (justPressed)
 		{
-			justPressedPosition.set(screenX, screenY);
+			justPressedPosition.set(viewX, viewY);
 			justPressedTimeInTicks = FlxG.game.ticks;
 		}
 		#if FLX_POINTER_INPUT
 		else if (justReleased)
 		{
-			FlxG.swipes.push(new FlxSwipe(touchPointID, justPressedPosition.copyTo(), getScreenPosition(), justPressedTimeInTicks));
+			FlxG.swipes.push(new FlxSwipe(touchPointID, justPressedPosition.copyTo(), getViewPosition(), justPressedTimeInTicks));
 		}
 		#end
 	}
@@ -103,7 +103,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		flashPoint.setTo(X, Y);
 		flashPoint = FlxG.game.globalToLocal(flashPoint);
 
-		setGlobalScreenPositionUnsafe(flashPoint.x, flashPoint.y);
+		setRawPositionUnsafe(flashPoint.x, flashPoint.y);
 	}
 
 	inline function get_touchPointID():Int

--- a/flixel/math/FlxAngle.hx
+++ b/flixel/math/FlxAngle.hx
@@ -246,8 +246,8 @@ class FlxAngle
 
 		var p:FlxPoint = Object.getScreenPosition();
 
-		var dx:Float = FlxG.mouse.screenX - p.x;
-		var dy:Float = FlxG.mouse.screenY - p.y;
+		var dx:Float = FlxG.mouse.viewX - p.x;
+		var dy:Float = FlxG.mouse.viewY - p.y;
 
 		p.put();
 
@@ -296,8 +296,8 @@ class FlxAngle
 		// In order to get the angle between the object and mouse, we need the objects screen coordinates (rather than world coordinates)
 		var p:FlxPoint = Object.getScreenPosition();
 
-		var dx:Float = Touch.screenX - p.x;
-		var dy:Float = Touch.screenY - p.y;
+		var dx:Float = Touch.viewX - p.x;
+		var dy:Float = Touch.viewY - p.y;
 
 		p.put();
 

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -213,7 +213,7 @@ class FlxMath
 		}
 		else
 		{
-			return pointInFlxRect(FlxG.mouse.screenX, FlxG.mouse.screenY, rect);
+			return pointInFlxRect(FlxG.mouse.viewX, FlxG.mouse.viewY, rect);
 		}
 	}
 	#end
@@ -398,8 +398,8 @@ class FlxMath
 	 */
 	public static inline function distanceToMouse(Sprite:FlxSprite):Int
 	{
-		var dx:Float = (Sprite.x + Sprite.origin.x) - FlxG.mouse.screenX;
-		var dy:Float = (Sprite.y + Sprite.origin.y) - FlxG.mouse.screenY;
+		var dx:Float = (Sprite.x + Sprite.origin.x) - FlxG.mouse.viewX;
+		var dy:Float = (Sprite.y + Sprite.origin.y) - FlxG.mouse.viewY;
 		return Std.int(FlxMath.vectorLength(dx, dy));
 	}
 
@@ -414,8 +414,8 @@ class FlxMath
 	 */
 	public static inline function isDistanceToMouseWithin(Sprite:FlxSprite, Distance:Float, IncludeEqual:Bool = false):Bool
 	{
-		var dx:Float = (Sprite.x + Sprite.origin.x) - FlxG.mouse.screenX;
-		var dy:Float = (Sprite.y + Sprite.origin.y) - FlxG.mouse.screenY;
+		var dx:Float = (Sprite.x + Sprite.origin.x) - FlxG.mouse.viewX;
+		var dy:Float = (Sprite.y + Sprite.origin.y) - FlxG.mouse.viewY;
 
 		if (IncludeEqual)
 			return dx * dx + dy * dy <= Distance * Distance;
@@ -434,8 +434,8 @@ class FlxMath
 	 */
 	public static inline function distanceToTouch(Sprite:FlxSprite, Touch:FlxTouch):Int
 	{
-		var dx:Float = (Sprite.x + Sprite.origin.x) - Touch.screenX;
-		var dy:Float = (Sprite.y + Sprite.origin.y) - Touch.screenY;
+		var dx:Float = (Sprite.x + Sprite.origin.x) - Touch.viewX;
+		var dy:Float = (Sprite.y + Sprite.origin.y) - Touch.viewY;
 		return Std.int(FlxMath.vectorLength(dx, dy));
 	}
 
@@ -450,8 +450,8 @@ class FlxMath
 	 */
 	public static inline function isDistanceToTouchWithin(Sprite:FlxSprite, Touch:FlxTouch, Distance:Float, IncludeEqual:Bool = false):Bool
 	{
-		var dx:Float = (Sprite.x + Sprite.origin.x) - Touch.screenX;
-		var dy:Float = (Sprite.y + Sprite.origin.y) - Touch.screenY;
+		var dx:Float = (Sprite.x + Sprite.origin.x) - Touch.viewX;
+		var dy:Float = (Sprite.y + Sprite.origin.y) - Touch.viewY;
 
 		if (IncludeEqual)
 			return dx * dx + dy * dy <= Distance * Distance;

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -141,7 +141,7 @@ class Interaction extends Window
 
 		#if FLX_MOUSE
 		// Calculate in-game coordinates based on mouse position and camera.
-		_flixelPointer.setGlobalScreenPositionUnsafe(event.stageX, event.stageY);
+		_flixelPointer.setRawPositionUnsafe(event.stageX, event.stageY);
 
 		// Store Flixel mouse coordinates to speed up all
 		// internal calculations (overlap, etc)

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -141,7 +141,7 @@ class Interaction extends Window
 
 		#if FLX_MOUSE
 		// Calculate in-game coordinates based on mouse position and camera.
-		_flixelPointer.setRawPositionUnsafe(event.stageX, event.stageY);
+		_flixelPointer.setRawPositionUnsafe(Std.int(FlxG.game.mouseX), Std.int(FlxG.game.mouseY));
 
 		// Store Flixel mouse coordinates to speed up all
 		// internal calculations (overlap, etc)

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -472,7 +472,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	function checkInput(pointer:FlxPointer, input:IFlxInput, justPressedPosition:FlxPoint, camera:FlxCamera):Bool
 	{
 		if (maxInputMovement != Math.POSITIVE_INFINITY
-			&& justPressedPosition.distanceTo(pointer.getScreenPosition(FlxPoint.weak())) > maxInputMovement
+			&& justPressedPosition.distanceTo(pointer.getViewPosition(FlxPoint.weak())) > maxInputMovement
 			&& input == currentInput)
 		{
 			currentInput = null;

--- a/tests/unit/src/flixel/input/FlxPointerTest.hx
+++ b/tests/unit/src/flixel/input/FlxPointerTest.hx
@@ -1,0 +1,73 @@
+package flixel.input;
+
+import flixel.math.FlxPoint;
+import flixel.input.FlxPointer;
+import massive.munit.Assert;
+
+class FlxPointerTest
+{
+	var pointer:FlxPointer;
+	
+	@Before
+	function before()
+	{
+		pointer = new FlxPointer();
+		
+		FlxG.game.x = 0;
+		FlxG.game.y = 0;
+		FlxG.camera.zoom = 1;
+		FlxG.camera.scroll.set(0, 0);
+		FlxG.camera.setSize(640, 480);
+		FlxG.camera.setPosition(0, 0);
+	}
+	
+	@Test
+	function testZero()
+	{
+		final zero = FlxPoint.get(0, 0);
+		pointer.setRawPositionUnsafe(0, 0);
+		final p = FlxPoint.get();
+		FlxAssert.pointsEqual(zero, pointer.getWindowPosition(p));
+		FlxAssert.pointsEqual(zero, pointer.getGamePosition(p));
+		Assert.areEqual(0, pointer.gameX);
+		Assert.areEqual(0, pointer.gameY);
+		FlxAssert.pointsEqual(zero, pointer.getViewPosition(p));
+		Assert.areEqual(0, pointer.viewX);
+		Assert.areEqual(0, pointer.viewY);
+		FlxAssert.pointsEqual(zero, pointer.getWorldPosition(p));
+		Assert.areEqual(0, pointer.x);
+		Assert.areEqual(0, pointer.y);
+	}
+	
+	@Test
+	function testNonZero()
+	{
+		final result = FlxPoint.get();
+		final expected = FlxPoint.get();
+		inline function p(x, y) return expected.set(x, y);
+		
+		FlxG.game.x -= 10;
+		FlxG.camera.zoom = 2.0;
+		FlxG.camera.scroll.set(-5, -15);
+		Assert.areEqual(1, FlxG.camera.initialZoom);
+		Assert.areEqual(640, FlxG.camera.width);
+		Assert.areEqual(480, FlxG.camera.height);
+		FlxAssert.pointsEqual(p(1.25, 1.25), FlxG.scaleMode.scale);
+		FlxG.camera.setSize(560, 480);
+		FlxG.camera.setPosition(20, 0);
+		Assert.areEqual(140, FlxG.camera.viewMarginX);// 560/4
+		Assert.areEqual(120, FlxG.camera.viewMarginY);// 480/4
+		
+		pointer.setRawPositionUnsafe(50, 50);
+		FlxAssert.pointsEqual(p( 40,  50), pointer.getWindowPosition(result)); //  (50, 50) - (10, 0)
+		FlxAssert.pointsEqual(p( 40,  40), pointer.getGamePosition  (result)); //  (50, 50) / 1.25
+		FlxAssert.pointsEqual(p(150, 140), pointer.getViewPosition  (result)); // ((50, 50) / 1.25 - (20, 0)) / 2 + (140, 120)
+		FlxAssert.pointsEqual(p(145, 125), pointer.getWorldPosition (result)); // ((50, 50) / 1.25 - (20, 0)) / 2 + (140, 120) - (-5, -15)
+		Assert.areEqual(40, pointer.gameX);
+		Assert.areEqual(40, pointer.gameY);
+		Assert.areEqual(150, pointer.viewX);
+		Assert.areEqual(140, pointer.viewY);
+		Assert.areEqual(145, pointer.x);
+		Assert.areEqual(125, pointer.y);
+	}
+}

--- a/tests/unit/src/flixel/input/FlxPointerTest.hx
+++ b/tests/unit/src/flixel/input/FlxPointerTest.hx
@@ -46,28 +46,30 @@ class FlxPointerTest
 		final expected = FlxPoint.get();
 		inline function p(x, y) return expected.set(x, y);
 		
+		//Note: FlxG.scaleMode may be different on github actions compared to local
+		
 		FlxG.game.x -= 10;
 		FlxG.camera.zoom = 2.0;
 		FlxG.camera.scroll.set(-5, -15);
 		Assert.areEqual(1, FlxG.camera.initialZoom);
 		Assert.areEqual(640, FlxG.camera.width);
 		Assert.areEqual(480, FlxG.camera.height);
-		FlxAssert.pointsEqual(p(1.25, 1.25), FlxG.scaleMode.scale);
+		// FlxAssert.pointsEqual(p(1.25, 1.25), FlxG.scaleMode.scale);
 		FlxG.camera.setSize(560, 480);
-		FlxG.camera.setPosition(20, 0);
+		FlxG.camera.setPosition(20, 12);
 		Assert.areEqual(140, FlxG.camera.viewMarginX);// 560/4
 		Assert.areEqual(120, FlxG.camera.viewMarginY);// 480/4
 		
-		pointer.setRawPositionUnsafe(50, 50);
-		FlxAssert.pointsEqual(p( 40,  50), pointer.getWindowPosition(result)); //  (50, 50) - (10, 0)
-		FlxAssert.pointsEqual(p( 40,  40), pointer.getGamePosition  (result)); //  (50, 50) / 1.25
-		FlxAssert.pointsEqual(p(150, 140), pointer.getViewPosition  (result)); // ((50, 50) / 1.25 - (20, 0)) / 2 + (140, 120)
-		FlxAssert.pointsEqual(p(145, 125), pointer.getWorldPosition (result)); // ((50, 50) / 1.25 - (20, 0)) / 2 + (140, 120) - (-5, -15)
-		Assert.areEqual(40, pointer.gameX);
-		Assert.areEqual(40, pointer.gameY);
-		Assert.areEqual(150, pointer.viewX);
-		Assert.areEqual(140, pointer.viewY);
-		Assert.areEqual(145, pointer.x);
-		Assert.areEqual(125, pointer.y);
+		pointer.setRawPositionUnsafe(50 * FlxG.scaleMode.scale.x, 50 * FlxG.scaleMode.scale.y);
+		// FlxAssert.pointsEqual(p( 40,  50), pointer.getWindowPosition(result)); //  (50, 50) - (10, 0)
+		FlxAssert.pointsEqual(p( 50,  50), pointer.getGamePosition  (result)); //  (50, 50)
+		FlxAssert.pointsEqual(p(155, 139), pointer.getViewPosition  (result)); // ((50, 50) - (20, 12)) / 2 + (140, 120)
+		FlxAssert.pointsEqual(p(150, 124), pointer.getWorldPosition (result)); // ((50, 50) - (20, 12)) / 2 + (140, 120) - (-5, -15)
+		Assert.areEqual( 50, pointer.gameX);
+		Assert.areEqual( 50, pointer.gameY);
+		Assert.areEqual(155, pointer.viewX);
+		Assert.areEqual(139, pointer.viewY);
+		Assert.areEqual(150, pointer.x);
+		Assert.areEqual(124, pointer.y);
 	}
 }

--- a/tests/unit/src/flixel/input/FlxPointerTest.hx
+++ b/tests/unit/src/flixel/input/FlxPointerTest.hx
@@ -27,7 +27,6 @@ class FlxPointerTest
 		final zero = FlxPoint.get(0, 0);
 		pointer.setRawPositionUnsafe(0, 0);
 		final p = FlxPoint.get();
-		FlxAssert.pointsEqual(zero, pointer.getWindowPosition(p));
 		FlxAssert.pointsEqual(zero, pointer.getGamePosition(p));
 		Assert.areEqual(0, pointer.gameX);
 		Assert.areEqual(0, pointer.gameY);

--- a/tests/unit/src/flixel/input/FlxPointerTest.hx
+++ b/tests/unit/src/flixel/input/FlxPointerTest.hx
@@ -54,14 +54,12 @@ class FlxPointerTest
 		Assert.areEqual(1, FlxG.camera.initialZoom);
 		Assert.areEqual(640, FlxG.camera.width);
 		Assert.areEqual(480, FlxG.camera.height);
-		// FlxAssert.pointsEqual(p(1.25, 1.25), FlxG.scaleMode.scale);
 		FlxG.camera.setSize(560, 480);
 		FlxG.camera.setPosition(20, 12);
 		Assert.areEqual(140, FlxG.camera.viewMarginX);// 560/4
 		Assert.areEqual(120, FlxG.camera.viewMarginY);// 480/4
 		
 		pointer.setRawPositionUnsafe(50 * FlxG.scaleMode.scale.x, 50 * FlxG.scaleMode.scale.y);
-		// FlxAssert.pointsEqual(p( 40,  50), pointer.getWindowPosition(result)); //  (50, 50) - (10, 0)
 		FlxAssert.pointsEqual(p( 50,  50), pointer.getGamePosition  (result)); //  (50, 50)
 		FlxAssert.pointsEqual(p(155, 139), pointer.getViewPosition  (result)); // ((50, 50) - (20, 12)) / 2 + (140, 120)
 		FlxAssert.pointsEqual(p(150, 124), pointer.getWorldPosition (result)); // ((50, 50) - (20, 12)) / 2 + (140, 120) - (-5, -15)

--- a/tests/unit/src/flixel/input/actions/FlxActionInputAnalogTest.hx
+++ b/tests/unit/src/flixel/input/actions/FlxActionInputAnalogTest.hx
@@ -505,7 +505,7 @@ class FlxActionInputAnalogTest extends FlxTest
 	{
 		if (FlxG.mouse == null)
 			return;
-		FlxG.mouse.setGlobalScreenPositionUnsafe(0, 0);
+		FlxG.mouse.setRawPositionUnsafe(0, 0);
 
 		var left = @:privateAccess FlxG.mouse._leftButton;
 		var right = @:privateAccess FlxG.mouse._rightButton;
@@ -582,7 +582,7 @@ class FlxActionInputAnalogTest extends FlxTest
 	{
 		if (FlxG.mouse == null)
 			return;
-		FlxG.mouse.setGlobalScreenPositionUnsafe(0, 0);
+		FlxG.mouse.setRawPositionUnsafe(0, 0);
 		step();
 		step();
 	}
@@ -602,7 +602,7 @@ class FlxActionInputAnalogTest extends FlxTest
 		if (FlxG.mouse == null)
 			return;
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(X, Y);
+		FlxG.mouse.setRawPositionUnsafe(X, Y);
 		updateActions(arr);
 	}
 
@@ -629,7 +629,7 @@ class FlxActionInputAnalogTest extends FlxTest
 		if (FlxG.mouse == null)
 			return;
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(X, Y);
+		FlxG.mouse.setRawPositionUnsafe(X, Y);
 		updateActions(arr);
 	}
 

--- a/tests/unit/src/flixel/input/actions/FlxActionManagerTest.hx
+++ b/tests/unit/src/flixel/input/actions/FlxActionManagerTest.hx
@@ -981,7 +981,7 @@ class FlxActionManagerTest extends FlxTest
 		if (FlxG.mouse == null)
 			return;
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(X, Y);
+		FlxG.mouse.setRawPositionUnsafe(X, Y);
 		@:privateAccess manager.update();
 	}
 

--- a/tests/unit/src/flixel/input/actions/FlxActionSetTest.hx
+++ b/tests/unit/src/flixel/input/actions/FlxActionSetTest.hx
@@ -315,7 +315,7 @@ class FlxActionSetTest extends FlxTest
 		if (FlxG.mouse == null)
 			return;
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(X, Y);
+		FlxG.mouse.setRawPositionUnsafe(X, Y);
 		set.update();
 	}
 

--- a/tests/unit/src/flixel/input/actions/FlxActionTest.hx
+++ b/tests/unit/src/flixel/input/actions/FlxActionTest.hx
@@ -225,18 +225,18 @@ class FlxActionTest extends FlxTest
 	function clearAnalog()
 	{
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(0, 0);
+		FlxG.mouse.setRawPositionUnsafe(0, 0);
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(0, 0);
+		FlxG.mouse.setRawPositionUnsafe(0, 0);
 	}
 
 	@:access(flixel.input.mouse.FlxMouse)
 	function pulseAnalog(a:FlxActionAnalog, X:Float = 10.0, Y:Float = 10.0)
 	{
-		FlxG.mouse.setGlobalScreenPositionUnsafe(0, 0);
+		FlxG.mouse.setRawPositionUnsafe(0, 0);
 		step();
 		a.update();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(X, Y);
+		FlxG.mouse.setRawPositionUnsafe(X, Y);
 		step();
 		a.update();
 	}
@@ -244,7 +244,7 @@ class FlxActionTest extends FlxTest
 	function moveAnalog(a:FlxActionAnalog, X:Float, Y:Float)
 	{
 		step();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(X, Y);
+		FlxG.mouse.setRawPositionUnsafe(X, Y);
 		a.update();
 	}
 }

--- a/tests/unit/src/flixel/input/mouse/FlxMouseEventManagerTest.hx
+++ b/tests/unit/src/flixel/input/mouse/FlxMouseEventManagerTest.hx
@@ -12,7 +12,7 @@ class FlxMouseEventManagerTest extends FlxTest
 	function before()
 	{
 		FlxMouseEvent.removeAll();
-		FlxG.mouse.setGlobalScreenPositionUnsafe(75, 75); // causes a mouse over callback for each test
+		FlxG.mouse.setRawPositionUnsafe(75, 75); // causes a mouse over callback for each test
 
 		sprite0 = new FlxSprite(0, 0);
 		sprite0.makeGraphic(100, 100, 0xffffffff, false);


### PR DESCRIPTION
adds:
- `getGamePosition`: The position relative to the game's position in the window, where `(0, 0)` is the top-left edge of the game and `(FlxG.width, FlxG.height)` is the bottom-right
- `gameX` / `gameY`: The result of `getGamePosition()`
- `getViewPosition`: Fetch the world position of the pointer relative to given camera's `scroll` position
- `viewX` / `viewY`: The result of `getViewPosition(FlxG.camera)`
deprecates:
- `setGlobalScreenPositionUnsafe`, `getScreenPosition`, `screenX`, `screenY`, `getPoisitonInCameraView`, `_globalScreenX` and `_globalScreenY`