### PR TITLE
Add blend mode support for FlxStrip

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -674,6 +674,7 @@ class FlxCamera extends FlxBasic
 			&& _headTriangles.antialiasing == smoothing
 			&& _headTriangles.colored == isColored
 			&& _headTriangles.blending == blendInt
+			&& _headTriangles.blend == blend
 			#if !flash
 			&& _headTriangles.hasColorOffsets == hasColorOffsets
 			&& _headTriangles.shader == shader
@@ -708,6 +709,7 @@ class FlxCamera extends FlxBasic
 		itemToReturn.antialiasing = smoothing;
 		itemToReturn.colored = isColored;
 		itemToReturn.blending = blendInt;
+		itemToReturn.blend = blend;
 		#if !flash
 		itemToReturn.hasColorOffsets = hasColorOffsets;
 		itemToReturn.shader = shader;


### PR DESCRIPTION
In the process of working with FlxStrip, I noticed blending modes are not working.
I saw that `startQuadBatch` assign the `blend` property to the current batch, while `startTrianglesBatch` isn't doing that.

Assinging the given blending mode to the current/new batch makes the blending mode working also for FlxStrip.

I guess #2199 just forgot to add that to the draw triangles case, or is any reason why drw triangles wasn't setting the blend property to the batch?