### PR TITLE
Fix FlxCamera.fill() blending

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1722,40 +1722,35 @@ class FlxCamera extends FlxBasic
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	function drawFX():Void
 	{
-		var fxColor:FlxColor;
-		var alphaComponent:Float;
-
 		// Draw the "flash" special effect onto the buffer
 		if (_fxFlashAlpha > 0.0)
 		{
-			fxColor = _fxFlashColor;
-			alphaComponent = fxColor.alphaFloat * _fxFlashAlpha;
-
 			if (FlxG.renderBlit)
 			{
-				fxColor.alphaFloat = alphaComponent;
-				fill(fxColor);
+				var color = _fxFlashColor;
+				color.alphaFloat *= _fxFlashAlpha;
+				fill(color);
 			}
 			else
 			{
-				fill(fxColor.rgb, true, alphaComponent, canvas.graphics);
+				final alpha = color.alphaFloat * _fxFlashAlpha;
+				fill(_fxFlashColor.rgb, true, alpha, canvas.graphics);
 			}
 		}
-
+		
 		// Draw the "fade" special effect onto the buffer
 		if (_fxFadeAlpha > 0.0)
 		{
-			fxColor = _fxFadeColor;
-			alphaComponent = fxColor.alphaFloat * _fxFadeAlpha;
-
 			if (FlxG.renderBlit)
 			{
-				fxColor.alphaFloat = alphaComponent;
-				fill(fxColor);
+				var color = _fxFadeColor;
+				color.alphaFloat *= _fxFadeAlpha;
+				fill(color);
 			}
 			else
 			{
-				fill(fxColor.rgb, true, alphaComponent, canvas.graphics);
+				final alpha = _fxFadeColor.alphaFloat * _fxFadeAlpha;
+				fill(_fxFadeColor.rgb, true, alpha, canvas.graphics);
 			}
 		}
 	}

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1545,6 +1545,8 @@ class FlxCamera extends FlxBasic
 			return;
 
 		_fxFlashColor = Color;
+		if (_fxFlashColor.alpha == 0)
+			_fxFlashColor.alpha = 0xff;
 		if (Duration <= 0)
 			Duration = 0.000001;
 		_fxFlashDuration = Duration;
@@ -1567,6 +1569,8 @@ class FlxCamera extends FlxBasic
 			return;
 
 		_fxFadeColor = Color;
+		if (_fxFadeColor.alpha == 0)
+			_fxFadeColor.alpha = 0xff;
 		if (Duration <= 0)
 			Duration = 0.000001;
 
@@ -1722,35 +1726,40 @@ class FlxCamera extends FlxBasic
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	function drawFX():Void
 	{
+		var fxColor:FlxColor;
 		var alphaComponent:Float;
 
 		// Draw the "flash" special effect onto the buffer
 		if (_fxFlashAlpha > 0.0)
 		{
-			alphaComponent = _fxFlashColor.alpha;
+			fxColor = _fxFlashColor;
+			alphaComponent = fxColor.alphaFloat * _fxFlashAlpha;
 
 			if (FlxG.renderBlit)
 			{
-				fill((Std.int(((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFlashAlpha) << 24) + (_fxFlashColor & 0x00ffffff));
+				fxColor.alphaFloat = alphaComponent;
+				fill(fxColor);
 			}
 			else
 			{
-				fill((_fxFlashColor & 0x00ffffff), true, ((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFlashAlpha / 255, canvas.graphics);
+				fill(fxColor.rgb, true, alphaComponent, canvas.graphics);
 			}
 		}
 
 		// Draw the "fade" special effect onto the buffer
 		if (_fxFadeAlpha > 0.0)
 		{
-			alphaComponent = _fxFadeColor.alpha;
+			fxColor = _fxFadeColor;
+			alphaComponent = fxColor.alphaFloat * _fxFadeAlpha;
 
 			if (FlxG.renderBlit)
 			{
-				fill((Std.int(((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFadeAlpha) << 24) + (_fxFadeColor & 0x00ffffff));
+				fxColor.alphaFloat = alphaComponent;
+				fill(fxColor);
 			}
 			else
 			{
-				fill((_fxFadeColor & 0x00ffffff), true, ((alphaComponent <= 0) ? 0xff : alphaComponent) * _fxFadeAlpha / 255, canvas.graphics);
+				fill(fxColor.rgb, true, alphaComponent, canvas.graphics);
 			}
 		}
 	}

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1703,8 +1703,11 @@ class FlxCamera extends FlxBasic
 			if (FxAlpha == 0)
 				return;
 
-			var targetGraphics:Graphics = (graphics == null) ? canvas.graphics : graphics;
+			final targetGraphics = (graphics == null) ? canvas.graphics : graphics;
 
+			#if (openfl > "8.7.0")
+			targetGraphics.overrideBlendMode(null);
+			#end
 			targetGraphics.beginFill(Color, FxAlpha);
 			// i'm drawing rect with these parameters to avoid light lines at the top and left of the camera,
 			// which could appear while cameras fading

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1545,8 +1545,6 @@ class FlxCamera extends FlxBasic
 			return;
 
 		_fxFlashColor = Color;
-		if (_fxFlashColor.alpha == 0)
-			_fxFlashColor.alpha = 0xff;
 		if (Duration <= 0)
 			Duration = 0.000001;
 		_fxFlashDuration = Duration;
@@ -1569,8 +1567,6 @@ class FlxCamera extends FlxBasic
 			return;
 
 		_fxFadeColor = Color;
-		if (_fxFadeColor.alpha == 0)
-			_fxFadeColor.alpha = 0xff;
 		if (Duration <= 0)
 			Duration = 0.000001;
 


### PR DESCRIPTION
Fixes #3203 by overriding the blend mode of target graphics in FlxCamera.fill() to null (BlendMode.NORMAL). Does not affect blitting targets since blend modes just doesn't work there.
Additionally makes drawFX more readable