### PR TITLE
Fix flxstrip color causing not rendering other flxstrips

### DIFF
--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -70,6 +70,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			shader.colorMultiplier.value = colorMultipliers;
 			shader.colorOffset.value = colorOffsets;
 		}
+		else
+		{
+			shader.colorMultiplier.value = null;
+			shader.colorOffset.value = null;
+		}
 
 		setParameterValue(shader.hasTransform, true);
 		setParameterValue(shader.hasColorTransform, colored || hasColorOffsets);
@@ -175,6 +180,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			i += 2;
 		}
 
+		var indicesLength:Int = indices.length;
 		if (!cameraBounds.overlaps(bounds))
 		{
 			this.vertices.splice(this.vertices.length - verticesLength, verticesLength);
@@ -187,7 +193,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 				this.uvtData[prevUVTDataLength + i] = uvtData[i];
 			}
 
-			var indicesLength:Int = indices.length;
 			for (i in 0...indicesLength)
 			{
 				this.indices[prevIndicesLength + i] = indices[i] + prevNumberOfVertices;
@@ -211,10 +216,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		cameraBounds.putWeak();
 
 		#if !flash
-		for (_ in 0...numTriangles)
+		for (_ in 0...indicesLength)
 		{
-			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
-			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
 			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
 		}
 
@@ -226,7 +229,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			if (colorOffsets == null)
 				colorOffsets = [];
 
-			for (_ in 0...(numTriangles * 3))
+			for (_ in 0...indicesLength)
 			{
 				if(transform != null)
 				{


### PR DESCRIPTION
When multiple FlxStrip are rendered using the same shader, if one of them uses the `color` property, it causes the other meshes to not be rendered.

Here an example:
```haxe
class BugExample extends FlxState {
	override public function create():Void {

	var graphic = FlxGraphic.fromRectangle(100, 100, 0xFFff40ff);
	var mesh1:FlxStrip = new FlxStrip(100, 100);
	mesh1.graphic = graphic;
        mesh1.indices = Vector.ofArray([0, 1, 2, 0, 2, 3]);
        mesh1.vertices = Vector.ofArray([0., 0., 300., 0., 300., 300., 0., 300.]);
        mesh1.uvtData = Vector.ofArray([0., 0., 1., 0., 1., 1., 0., 1.]);
        add(mesh1);

        var mesh2:FlxStrip = new FlxStrip(200, 150);
	mesh2.graphic = graphic;
        mesh2.indices = Vector.ofArray([0, 1, 2, 0, 2, 3]);
        mesh2.vertices = Vector.ofArray([0., 0., 300., 0., 300., 300., 0., 300.]);
        mesh2.uvtData = Vector.ofArray([0., 0., 1., 0., 1., 1., 0., 1.]);
        add(mesh2);

	var mesh3:FlxStrip = new FlxStrip(300, 50);
	mesh3.graphic = graphic;
        mesh3.indices = Vector.ofArray([0, 1, 2, 0, 2, 3]);
        mesh3.vertices = Vector.ofArray([0., 0., 300., 0., 300., 300., 0., 300.]);
        mesh3.uvtData = Vector.ofArray([0., 0., 1., 0., 1., 1., 0., 1.]);

	// mesh3.color = -9306137; // comment this line to enable the render bug

	add(mesh3);
	super.create();
	}
}
```

Commenting and uncommenting the `mesh3.color = -9306137;` line, it will trigger the bug.
In this example `mesh1` and `mesh2` are added to the same triangles batch. A second triangle batch is created for `mesh3`.

Here wath happens at the first render iteration:
- the first batch is selected and `shader.colorMultiplier.value` is `null`. The draw call happens and the two meshes are visible.
- the second batch is selected and `shader.colorMultiplier.value` is set using the `colorMultipliers` of the batch. The draw call happens and the third mesh is painted over the others two.

Then the second iteration happens. Canvas is cleared and:
- the first batch is selected and `shader.colorMultiplier.value` has the previous values set by the second batch. The draw call and I guess since there is a number of colors that does not match the number of vertices, nothing is rendered for this batch.
- the second batch does the same thing of first iteration.

Same occurs for the next iterations.

This PR reset `shader.colorMultiplier.value` and `shader.colorOffset.value` to `null`, if there is no color multipliers or offsets.

I'm not entirely sure if that is the right place to reset these values. There is the batch `reset` method, but the `shader` is already `null` in that context, even though I could acces the `graphic.shader`, before the `super.reset()` is called.

-----

Moreover, I've noticed that during the fill of color multipliers and offsets, the iteration occurs for all the indices in the batch, rather then the indices of the added triangle. This PR fix also that.

------

I'd like also to ask if there is any specific reason why color (and alpha) tinting, a new batch is initiated.

In my example, we need two draw call to render the three meshes. If we remove avoid to start a new batch when the mesh is colored through `color` or `alpha`, we can prevent to break batching. What do you think about this?