### PR TITLE
Little changes to `FlxDebugger` code completion.

### DIFF
--- a/flixel/system/debug/completion/CompletionHandler.hx
+++ b/flixel/system/debug/completion/CompletionHandler.hx
@@ -48,7 +48,7 @@ class CompletionHandler
 		var text = getTextUntilCaret();
 
 		// close completion so that enter works
-		if (text.endsWith(")") || text.endsWith("\"") || text.endsWith("'"))
+		if (text.endsWith(")") || text.endsWith("\"") || text.endsWith("'") || text.endsWith(";"))
 		{
 			completionList.close();
 			return;

--- a/flixel/system/debug/completion/CompletionList.hx
+++ b/flixel/system/debug/completion/CompletionList.hx
@@ -95,7 +95,7 @@ class CompletionList extends Sprite
 			case Keyboard.UP:
 				updateIndices(-1);
 
-			case Keyboard.ENTER:
+			case Keyboard.ENTER | Keyboard.TAB:
 				if (completed != null)
 					completed(items[selectedIndex]);
 				close();


### PR DESCRIPTION
Currently, typing out a simple line in the console, (e.g. `FlxG.state.exists = false;`) and pressing enter will result in code completion automatically adding a phrase to your command, instead of just running it. (resulting in e.g. `FlxG.state.exists = false;clearBitmapLog`)

To fix this I simply added a case to `CompletionHandler.hx` that closes the code completion if the current command ends with `;`.

This pull requests also makes a change to `CompletionList.hx` that allows you to press TAB (along with ENTER) in order to fill in the currently selected completion. This is a common bind in a lot of other programs.