### PR TITLE
Fix text clipping when applying a shadow to it

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -839,7 +839,7 @@ class FlxText extends FlxSprite
 	override function get_height():Float
 	{
 		regenGraphic();
-		return super.get_height() + shadowOffset.y;
+		return super.get_height();
 	}
 
 	override function updateColorTransform():Void

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -839,7 +839,7 @@ class FlxText extends FlxSprite
 	override function get_height():Float
 	{
 		regenGraphic();
-		return super.get_height();
+		return super.get_height() + shadowOffset.y;
 	}
 
 	override function updateColorTransform():Void
@@ -875,11 +875,11 @@ class FlxText extends FlxSprite
 			oldHeight = graphic.height;
 		}
 
-		var newWidth:Int = Math.ceil(textField.width);
+		var newWidth:Int = Math.ceil(textField.width) + Std.int(shadowOffset?.x);
 		var textfieldHeight = _autoHeight ? textField.textHeight : textField.height;
 		var vertGutter = _autoHeight ? VERTICAL_GUTTER : 0;
 		// Account for gutter
-		var newHeight:Int = Math.ceil(textfieldHeight) + vertGutter;
+		var newHeight:Int = Math.ceil(textfieldHeight) + vertGutter + Std.int(shadowOffset?.y);
 
 		// prevent text height from shrinking on flash if text == ""
 		if (textField.textHeight == 0)
@@ -1042,7 +1042,6 @@ class FlxText extends FlxSprite
 				}
 
 				_matrix.translate(-shadowOffset.x * borderSize, -shadowOffset.y * borderSize);
-
 			case OUTLINE:
 				// Render an outline around the text
 				// (do 8 offset draw calls)

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -875,11 +875,17 @@ class FlxText extends FlxSprite
 			oldHeight = graphic.height;
 		}
 
-		var newWidth:Int = Math.ceil(textField.width) + Std.int(shadowOffset?.x);
+		var newWidth:Int = Math.ceil(textField.width);
 		var textfieldHeight = _autoHeight ? textField.textHeight : textField.height;
 		var vertGutter = _autoHeight ? VERTICAL_GUTTER : 0;
 		// Account for gutter
-		var newHeight:Int = Math.ceil(textfieldHeight) + vertGutter + Std.int(shadowOffset?.y);
+		var newHeight:Int = Math.ceil(textfieldHeight) + vertGutter;
+
+		if (shadowOffset != null)
+		{
+			newWidth += Math.ceil(shadowOffset.x);
+			newHeight += Math.ceil(shadowOffset.y);
+		}
 
 		// prevent text height from shrinking on flash if text == ""
 		if (textField.textHeight == 0)

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1038,7 +1038,7 @@ class FlxText extends FlxSprite
 
 				for (i in 0...iterations)
 				{
-					copyTextWithOffset(delta, delta);
+					copyTextWithOffset(shadowOffset.x, shadowOffset.y);
 				}
 
 				_matrix.translate(-shadowOffset.x * borderSize, -shadowOffset.y * borderSize);

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -881,6 +881,7 @@ class FlxText extends FlxSprite
 		// Account for gutter
 		var newHeight:Int = Math.ceil(textfieldHeight) + vertGutter;
 
+		// Increase the dimensions of the bitmap to allow for the drawing of the shadow properly.
 		if (shadowOffset != null)
 		{
 			newWidth += Math.ceil(Math.abs(shadowOffset.x));

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -883,8 +883,8 @@ class FlxText extends FlxSprite
 
 		if (shadowOffset != null)
 		{
-			newWidth += Math.ceil(shadowOffset.x);
-			newHeight += Math.ceil(shadowOffset.y);
+			newWidth += Math.ceil(Math.abs(shadowOffset.x));
+			newHeight += Math.ceil(Math.abs(shadowOffset.y));
 		}
 
 		// prevent text height from shrinking on flash if text == ""
@@ -1044,7 +1044,9 @@ class FlxText extends FlxSprite
 
 				for (i in 0...iterations)
 				{
-					copyTextWithOffset(shadowOffset.x, shadowOffset.y);
+					copyTextWithOffset(shadowOffset.x >= 0 ?
+						 shadowOffset.x : delta, shadowOffset.y >= 0 ?
+						 shadowOffset.y : delta);
 				}
 
 				_matrix.translate(-shadowOffset.x * borderSize, -shadowOffset.y * borderSize);


### PR DESCRIPTION
Currently there seems to be an issue where applying a shadow to a FlxText, the text clips off by whatever the shadow offset is.
![image](https://github.com/user-attachments/assets/31bdf362-0579-428c-918a-aede1d8c63fb)
Here the shadow offset is 8 pixels and the text clips off by 8 pixels without the fix.

With the fix the text appears as it is supposed to be, the text does not clip off
![image](https://github.com/user-attachments/assets/70dea876-c7f7-4be4-9e1e-fdbab5f220e7)
Ive tested this on HashLink and C++ targets, it seems to just work(?) but I am unsure if there are any side effects.

I made a quick little test project [here](https://github.com/Vortex2Oblivion/flxtext-shadow-fixes)