### PR TITLE
Remove Matrix Math from default shader

### DIFF
--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -6,18 +6,18 @@ class FlxGraphicsShader extends GraphicsShader
 {
 	@:glVertexSource("
 		#pragma header
-		
+
 		attribute float alpha;
 		attribute vec4 colorMultiplier;
 		attribute vec4 colorOffset;
 		uniform bool hasColorTransform;
-		
+
 		void main(void)
 		{
 			#pragma body
-			
+
 			openfl_Alphav = openfl_Alpha * alpha;
-			
+
 			if (hasColorTransform)
 			{
 				openfl_ColorOffsetv = colorOffset / 255.0;
@@ -48,13 +48,7 @@ class FlxGraphicsShader extends GraphicsShader
 
 			color = vec4(color.rgb / color.a, color.a);
 
-			mat4 colorMultiplier = mat4(0);
-			colorMultiplier[0][0] = openfl_ColorMultiplierv.x;
-			colorMultiplier[1][1] = openfl_ColorMultiplierv.y;
-			colorMultiplier[2][2] = openfl_ColorMultiplierv.z;
-			colorMultiplier[3][3] = openfl_ColorMultiplierv.w;
-
-			color = clamp(openfl_ColorOffsetv + (color * colorMultiplier), 0.0, 1.0);
+			color = clamp(openfl_ColorOffsetv + (color * openfl_ColorMultiplierv), 0.0, 1.0);
 
 			if (color.a > 0.0)
 			{
@@ -65,7 +59,7 @@ class FlxGraphicsShader extends GraphicsShader
 	")
 	@:glFragmentSource("
 		#pragma header
-		
+
 		void main(void)
 		{
 			gl_FragColor = flixel_texture2D(bitmap, openfl_TextureCoordv);


### PR DESCRIPTION
Since the current matrix math can be simplified to a simple multiply