### PR TITLE
fix crash in getWorldPos

### DIFF
--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -74,7 +74,7 @@ class FlxPointer
 		if (camera == null)
 			camera = FlxG.camera;
 		
-		getViewPosition(camera, result);
+		result = getViewPosition(camera, result);
 		result.addPoint(camera.scroll);
 		return result;
 	}

--- a/tests/unit/src/flixel/input/FlxPointerTest.hx
+++ b/tests/unit/src/flixel/input/FlxPointerTest.hx
@@ -69,4 +69,48 @@ class FlxPointerTest
 		Assert.areEqual(150, pointer.x);
 		Assert.areEqual(124, pointer.y);
 	}
+	
+	@Test
+	function testNullResult()
+	{
+		try
+		{
+			final result = pointer.getPosition();
+			Assert.areEqual(0, result.x);
+		}
+		catch(e)
+		{
+			Assert.fail('Exception thrown from "getPosition", message: "${e.message}"');
+		}
+		
+		try
+		{
+			final result = pointer.getWorldPosition();
+			Assert.areEqual(0, result.x);
+		}
+		catch(e)
+		{
+			Assert.fail('Exception thrown from "getWorldPosition", message: "${e.message}"');
+		}
+		
+		try
+		{
+			final result = pointer.getViewPosition();
+			Assert.areEqual(0, result.x);
+		}
+		catch(e)
+		{
+			Assert.fail('Exception thrown from "getViewPosition", message: "${e.message}"');
+		}
+		
+		try
+		{
+			final result = pointer.getGamePosition();
+			Assert.areEqual(0, result.x);
+		}
+		catch(e)
+		{
+			Assert.fail('Exception thrown from "getGamePosition", message: "${e.message}"');
+		}
+	}
 }


### PR DESCRIPTION
The following would cause a null crash:
```hx
final mouse = FlxG.mouse.getWorldPosition();
```