### PR TITLE
`FlxButton` labels don't work when `moves` is false - Update label position on status change

### DIFF
--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -615,6 +615,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		status = value;
 		updateLabelAlpha();
+		updateLabelPosition();
 		return status;
 	}
 


### PR DESCRIPTION
# Hello contributors, It'z Miles!
But that's enough about me. I'm here to patch up a problem with the labels on FlxButtons.
## The `FlxButton`'s label is being repositioned. Every. Single. Frame.
The setter for x and y are responsible for repositioning the FlxButton's label. FlxObject `updateMotion()` is updating the position and physics, which means it constantly repositions the label regardless of whether the button has moved or not!
## For a commonly static UI element, it makes sense for `moves` to be false.
FlxButtons (that generally don't move) can turn it off and skip the physics calculations, therefore repositioning the label only when we need it to. The small change I've introduced makes the label update whenever the state changes!
## Pros of calling `updateLabelPosition()` on a state change:
 * It happens only whenever the button is interacted with.
 * It doesn't introduce any breaking changes.
 * The button's label now works when `moves` is false.
 * The constant performance gains when `moves` is false are astronomical.
 * The occasional performance impact when `moves` is true is negligible and sparse.
 # Miles out! Feel free to suggest further improvements.