### PR TITLE
Add support for custom border sizes to `FlxBar`

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -324,13 +324,14 @@ class FlxBar extends FlxSprite
 	}
 
 	/**
-	 * Creates a solid-colour filled health bar in the given colours, with optional 1px thick border.
+	 * Creates a solid-colour filled health bar in the given colours, with optional border.
 	 * All colour values are in 0xAARRGGBB format, so if you want a slightly transparent health bar give it lower AA values.
 	 *
 	 * @param	empty		The color of the bar when empty in 0xAARRGGBB format (the background colour)
 	 * @param	fill		The color of the bar when full in 0xAARRGGBB format (the foreground colour)
-	 * @param	showBorder	Should the bar be outlined with a 1px solid border?
+	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
+	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
 	 * @return	This FlxBar object with generated images for front and background.
 	 */
 	public function createFilledBar(empty:FlxColor, fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
@@ -341,11 +342,12 @@ class FlxBar extends FlxSprite
 	}
 
 	/**
-	 * Creates a solid-colour filled background for health bar in the given colour, with optional 1px thick border.
+	 * Creates a solid-colour filled background for health bar in the given colour, with optional border.
 	 *
 	 * @param	empty			The color of the bar when empty in 0xAARRGGBB format (the background colour)
-	 * @param	showBorder		Should the bar be outlined with a 1px solid border?
+	 * @param	showBorder		Should the bar be outlined with a solid border?
 	 * @param	border			The border colour in 0xAARRGGBB format
+	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
 	 * @return	This FlxBar object with generated image for rendering health bar background.
 	 */
 	public function createColoredEmptyBar(empty:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
@@ -401,10 +403,11 @@ class FlxBar extends FlxSprite
 	}
 
 	/**
-	 * Creates a solid-colour filled foreground for health bar in the given colour, with optional 1px thick border.
+	 * Creates a solid-colour filled foreground for health bar in the given colour, with optional border.
 	 * @param	fill		The color of the bar when full in 0xAARRGGBB format (the foreground colour)
-	 * @param	showBorder	Should the bar be outlined with a 1px solid border?
+	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
+	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
 	 * @return	This FlxBar object with generated image for rendering actual values.
 	 */
 	public function createColoredFilledBar(fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
@@ -459,15 +462,16 @@ class FlxBar extends FlxSprite
 	}
 
 	/**
-	 * Creates a gradient filled health bar using the given colour ranges, with optional 1px thick border.
+	 * Creates a gradient filled health bar using the given colour ranges, with optional border.
 	 * All colour values are in 0xAARRGGBB format, so if you want a slightly transparent health bar give it lower AA values.
 	 *
 	 * @param	empty		Array of colour values used to create the gradient of the health bar when empty, each colour must be in 0xAARRGGBB format (the background colour)
 	 * @param	fill		Array of colour values used to create the gradient of the health bar when full, each colour must be in 0xAARRGGBB format (the foreground colour)
 	 * @param	chunkSize	If you want a more old-skool looking chunky gradient, increase this value!
 	 * @param	rotation	Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
-	 * @param	showBorder	Should the bar be outlined with a 1px solid border?
+	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
+	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
 	 * @return 	This FlxBar object with generated images for front and background.
 	 */
 	public function createGradientBar(empty:Array<FlxColor>, fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
@@ -479,13 +483,14 @@ class FlxBar extends FlxSprite
 	}
 
 	/**
-	 * Creates a gradient filled background for health bar using the given colour range, with optional 1px thick border.
+	 * Creates a gradient filled background for health bar using the given colour range, with optional border.
 	 *
 	 * @param	empty			Array of colour values used to create the gradient of the health bar when empty, each colour must be in 0xAARRGGBB format (the background colour)
 	 * @param	chunkSize		If you want a more old-skool looking chunky gradient, increase this value!
 	 * @param	rotation		Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
-	 * @param	showBorder		Should the bar be outlined with a 1px solid border?
+	 * @param	showBorder		Should the bar be outlined with a solid border?
 	 * @param	border			The border colour in 0xAARRGGBB format
+	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
 	 * @return 	This FlxBar object with generated image for background rendering.
 	 */
 	public function createGradientEmptyBar(empty:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
@@ -550,13 +555,14 @@ class FlxBar extends FlxSprite
 	}
 
 	/**
-	 * Creates a gradient filled foreground for health bar using the given colour range, with optional 1px thick border.
+	 * Creates a gradient filled foreground for health bar using the given colour range, with optional border.
 	 *
 	 * @param	fill		Array of colour values used to create the gradient of the health bar when full, each colour must be in 0xAARRGGBB format (the foreground colour)
 	 * @param	chunkSize	If you want a more old-skool looking chunky gradient, increase this value!
 	 * @param	rotation	Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
-	 * @param	showBorder	Should the bar be outlined with a 1px solid border?
+	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
+	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
 	 * @return 	This FlxBar object with generated image for rendering actual values.
 	 */
 	public function createGradientFilledBar(fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -333,10 +333,10 @@ class FlxBar extends FlxSprite
 	 * @param	border		The border colour in 0xAARRGGBB format
 	 * @return	This FlxBar object with generated images for front and background.
 	 */
-	public function createFilledBar(empty:FlxColor, fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE):FlxBar
+	public function createFilledBar(empty:FlxColor, fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
 	{
-		createColoredEmptyBar(empty, showBorder, border);
-		createColoredFilledBar(fill, showBorder, border);
+		createColoredEmptyBar(empty, showBorder, border, borderSize);
+		createColoredFilledBar(fill, showBorder, border, borderSize);
 		return this;
 	}
 
@@ -348,7 +348,7 @@ class FlxBar extends FlxSprite
 	 * @param	border			The border colour in 0xAARRGGBB format
 	 * @return	This FlxBar object with generated image for rendering health bar background.
 	 */
-	public function createColoredEmptyBar(empty:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE):FlxBar
+	public function createColoredEmptyBar(empty:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -362,8 +362,11 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
+					if (borderSize == null)
+						borderSize = FlxPoint.get(1.0, 1.0);
+
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
-					emptyBar.fillRect(new Rectangle(1, 1, barWidth - 2, barHeight - 2), empty);
+					emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), empty);
 				}
 				else
 				{
@@ -379,8 +382,11 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
+				if (borderSize == null)
+					borderSize = FlxPoint.get(1.0, 1.0);
+
 				_emptyBar = new BitmapData(barWidth, barHeight, true, border);
-				_emptyBar.fillRect(new Rectangle(1, 1, barWidth - 2, barHeight - 2), empty);
+				_emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), empty);
 			}
 			else
 			{
@@ -401,7 +407,7 @@ class FlxBar extends FlxSprite
 	 * @param	border		The border colour in 0xAARRGGBB format
 	 * @return	This FlxBar object with generated image for rendering actual values.
 	 */
-	public function createColoredFilledBar(fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE):FlxBar
+	public function createColoredFilledBar(fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -415,8 +421,11 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
+					if (borderSize == null)
+						borderSize = FlxPoint.get(1.0, 1.0);
+
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
-					filledBar.fillRect(new Rectangle(1, 1, barWidth - 2, barHeight - 2), fill);
+					filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), fill);
 				}
 				else
 				{
@@ -432,8 +441,11 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
+				if (borderSize == null)
+					borderSize = FlxPoint.get(1.0, 1.0);
+
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				_filledBar.fillRect(new Rectangle(1, 1, barWidth - 2, barHeight - 2), fill);
+				_filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), fill);
 			}
 			else
 			{
@@ -459,10 +471,10 @@ class FlxBar extends FlxSprite
 	 * @return 	This FlxBar object with generated images for front and background.
 	 */
 	public function createGradientBar(empty:Array<FlxColor>, fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
-			border:FlxColor = FlxColor.WHITE):FlxBar
+			border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
 	{
-		createGradientEmptyBar(empty, chunkSize, rotation, showBorder, border);
-		createGradientFilledBar(fill, chunkSize, rotation, showBorder, border);
+		createGradientEmptyBar(empty, chunkSize, rotation, showBorder, border, borderSize);
+		createGradientFilledBar(fill, chunkSize, rotation, showBorder, border, borderSize);
 		return this;
 	}
 
@@ -477,7 +489,7 @@ class FlxBar extends FlxSprite
 	 * @return 	This FlxBar object with generated image for background rendering.
 	 */
 	public function createGradientEmptyBar(empty:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
-			border:FlxColor = FlxColor.WHITE):FlxBar
+			border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -499,8 +511,11 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
+					if (borderSize == null)
+						borderSize = FlxPoint.get(1.0, 1.0);
+
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
-					FlxGradient.overlayGradientOnBitmapData(emptyBar, barWidth - 2, barHeight - 2, empty, 1, 1, chunkSize, rotation);
+					FlxGradient.overlayGradientOnBitmapData(emptyBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, empty, 1, 1, chunkSize, rotation);
 				}
 				else
 				{
@@ -516,8 +531,11 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
+				if (borderSize == null)
+					borderSize = FlxPoint.get(1.0, 1.0);
+
 				_emptyBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_emptyBar, barWidth - 2, barHeight - 2, empty, 1, 1, chunkSize, rotation);
+				FlxGradient.overlayGradientOnBitmapData(_emptyBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, empty, 1, 1, chunkSize, rotation);
 			}
 			else
 			{
@@ -542,7 +560,7 @@ class FlxBar extends FlxSprite
 	 * @return 	This FlxBar object with generated image for rendering actual values.
 	 */
 	public function createGradientFilledBar(fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
-			border:FlxColor = FlxColor.WHITE):FlxBar
+			border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -564,8 +582,11 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
+					if (borderSize == null)
+						borderSize = FlxPoint.get(1.0, 1.0);
+
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
-					FlxGradient.overlayGradientOnBitmapData(filledBar, barWidth - 2, barHeight - 2, fill, 1, 1, chunkSize, rotation);
+					FlxGradient.overlayGradientOnBitmapData(filledBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, fill, 1, 1, chunkSize, rotation);
 				}
 				else
 				{
@@ -581,8 +602,11 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
+				if (borderSize == null)
+					borderSize = FlxPoint.get(1.0, 1.0);
+
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_filledBar, barWidth - 2, barHeight - 2, fill, 1, 1, chunkSize, rotation);
+				FlxGradient.overlayGradientOnBitmapData(_filledBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, fill, 1, 1, chunkSize, rotation);
 			}
 			else
 			{

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -368,7 +368,7 @@ class FlxBar extends FlxSprite
 						borderSize = FlxPoint.get(1.0, 1.0);
 
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
-					emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), empty);
+					emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), empty);
 				}
 				else
 				{
@@ -388,7 +388,7 @@ class FlxBar extends FlxSprite
 					borderSize = FlxPoint.get(1.0, 1.0);
 
 				_emptyBar = new BitmapData(barWidth, barHeight, true, border);
-				_emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), empty);
+				_emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), empty);
 			}
 			else
 			{
@@ -428,7 +428,7 @@ class FlxBar extends FlxSprite
 						borderSize = FlxPoint.get(1.0, 1.0);
 
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
-					filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), fill);
+					filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), fill);
 				}
 				else
 				{
@@ -448,7 +448,7 @@ class FlxBar extends FlxSprite
 					borderSize = FlxPoint.get(1.0, 1.0);
 
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				_filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0), fill);
+				_filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), fill);
 			}
 			else
 			{
@@ -520,7 +520,8 @@ class FlxBar extends FlxSprite
 						borderSize = FlxPoint.get(1.0, 1.0);
 
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
-					FlxGradient.overlayGradientOnBitmapData(emptyBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, empty, 1, 1, chunkSize, rotation);
+					FlxGradient.overlayGradientOnBitmapData(emptyBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), empty, 1,
+						1, chunkSize, rotation);
 				}
 				else
 				{
@@ -540,7 +541,8 @@ class FlxBar extends FlxSprite
 					borderSize = FlxPoint.get(1.0, 1.0);
 
 				_emptyBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_emptyBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, empty, 1, 1, chunkSize, rotation);
+				FlxGradient.overlayGradientOnBitmapData(_emptyBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), empty, 1, 1,
+					chunkSize, rotation);
 			}
 			else
 			{
@@ -592,7 +594,8 @@ class FlxBar extends FlxSprite
 						borderSize = FlxPoint.get(1.0, 1.0);
 
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
-					FlxGradient.overlayGradientOnBitmapData(filledBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, fill, 1, 1, chunkSize, rotation);
+					FlxGradient.overlayGradientOnBitmapData(filledBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), fill, 1,
+						1, chunkSize, rotation);
 				}
 				else
 				{
@@ -612,7 +615,8 @@ class FlxBar extends FlxSprite
 					borderSize = FlxPoint.get(1.0, 1.0);
 
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_filledBar, barWidth - borderSize.x * 2.0, barHeight - borderSize.y * 2.0, fill, 1, 1, chunkSize, rotation);
+				FlxGradient.overlayGradientOnBitmapData(_filledBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), fill, 1, 1,
+					chunkSize, rotation);
 			}
 			else
 			{

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -356,7 +356,7 @@ class FlxBar extends FlxSprite
 		{
 			var emptyKey:String = "empty: " + barWidth + "x" + barHeight + ":" + empty.toHexString();
 			if (showBorder)
-				emptyKey += ",border: " + border.toHexString();
+				emptyKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 
 			if (!FlxG.bitmap.checkCache(emptyKey))
 			{
@@ -410,7 +410,7 @@ class FlxBar extends FlxSprite
 		{
 			var filledKey:String = "filled: " + barWidth + "x" + barHeight + ":" + fill.toHexString();
 			if (showBorder)
-				filledKey += ",border: " + border.toHexString();
+				filledKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 
 			if (!FlxG.bitmap.checkCache(filledKey))
 			{
@@ -495,7 +495,7 @@ class FlxBar extends FlxSprite
 
 			if (showBorder)
 			{
-				emptyKey += ",border: " + border.toHexString();
+				emptyKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 			}
 
 			if (!FlxG.bitmap.checkCache(emptyKey))
@@ -563,7 +563,7 @@ class FlxBar extends FlxSprite
 
 			if (showBorder)
 			{
-				filledKey += ",border: " + border.toHexString();
+				filledKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 			}
 
 			if (!FlxG.bitmap.checkCache(filledKey))

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -158,7 +158,7 @@ class FlxBar extends FlxSprite
 	 * @param	variable	The variable of the object that is used to determine the bar position. For example if the parent was an FlxSprite this could be "health" to track the health value
 	 * @param	min			The minimum value. I.e. for a progress bar this would be zero (nothing loaded yet)
 	 * @param	max			The maximum value the bar can reach. I.e. for a progress bar this would typically be 100.
-	 * @param	showBorder	Include a 1px border around the bar? (if true it adds +2 to width and height to accommodate it)
+	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 */
 	public function new(x:Float = 0, y:Float = 0, ?direction:FlxBarFillDirection, width:Int = 100, height:Int = 10, ?parentRef:Dynamic, variable:String = "",
 			min:Float = 0, max:Float = 100, showBorder:Bool = false)
@@ -331,10 +331,10 @@ class FlxBar extends FlxSprite
 	 * @param	fill		The color of the bar when full in 0xAARRGGBB format (the foreground colour)
 	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
-	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
+	 * @param   borderSize  The size of the border, in pixels.
 	 * @return	This FlxBar object with generated images for front and background.
 	 */
-	public function createFilledBar(empty:FlxColor, fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
+	public function createFilledBar(empty:FlxColor, fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
 		createColoredEmptyBar(empty, showBorder, border, borderSize);
 		createColoredFilledBar(fill, showBorder, border, borderSize);
@@ -347,10 +347,10 @@ class FlxBar extends FlxSprite
 	 * @param	empty			The color of the bar when empty in 0xAARRGGBB format (the background colour)
 	 * @param	showBorder		Should the bar be outlined with a solid border?
 	 * @param	border			The border colour in 0xAARRGGBB format
-	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
+	 * @param   borderSize  The size of the border, in pixels.
 	 * @return	This FlxBar object with generated image for rendering health bar background.
 	 */
-	public function createColoredEmptyBar(empty:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
+	public function createColoredEmptyBar(empty:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -364,11 +364,8 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
-					if (borderSize == null)
-						borderSize = FlxPoint.get(1.0, 1.0);
-
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
-					emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), empty);
+					emptyBar.fillRect(new Rectangle(borderSize, borderSize, barWidth - borderSize * 2, barHeight - borderSize * 2), empty);
 				}
 				else
 				{
@@ -384,11 +381,8 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
-				if (borderSize == null)
-					borderSize = FlxPoint.get(1.0, 1.0);
-
 				_emptyBar = new BitmapData(barWidth, barHeight, true, border);
-				_emptyBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), empty);
+				_emptyBar.fillRect(new Rectangle(borderSize, borderSize, barWidth - borderSize * 2, barHeight - borderSize * 2), empty);
 			}
 			else
 			{
@@ -407,10 +401,10 @@ class FlxBar extends FlxSprite
 	 * @param	fill		The color of the bar when full in 0xAARRGGBB format (the foreground colour)
 	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
-	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
+	 * @param   borderSize  The size of the border, in pixels.
 	 * @return	This FlxBar object with generated image for rendering actual values.
 	 */
-	public function createColoredFilledBar(fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
+	public function createColoredFilledBar(fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -424,11 +418,8 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
-					if (borderSize == null)
-						borderSize = FlxPoint.get(1.0, 1.0);
-
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
-					filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), fill);
+					filledBar.fillRect(new Rectangle(borderSize, borderSize, barWidth - borderSize * 2, barHeight - borderSize * 2), fill);
 				}
 				else
 				{
@@ -444,11 +435,8 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
-				if (borderSize == null)
-					borderSize = FlxPoint.get(1.0, 1.0);
-
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				_filledBar.fillRect(new Rectangle(borderSize.x, borderSize.y, barWidth - borderSize.x * 2, barHeight - borderSize.y * 2), fill);
+				_filledBar.fillRect(new Rectangle(borderSize, borderSize, barWidth - borderSize * 2, barHeight - borderSize * 2), fill);
 			}
 			else
 			{
@@ -471,11 +459,11 @@ class FlxBar extends FlxSprite
 	 * @param	rotation	Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
 	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
-	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
+	 * @param   borderSize  The size of the border, in pixels.
 	 * @return 	This FlxBar object with generated images for front and background.
 	 */
 	public function createGradientBar(empty:Array<FlxColor>, fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
-			border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
+			border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
 		createGradientEmptyBar(empty, chunkSize, rotation, showBorder, border, borderSize);
 		createGradientFilledBar(fill, chunkSize, rotation, showBorder, border, borderSize);
@@ -490,11 +478,11 @@ class FlxBar extends FlxSprite
 	 * @param	rotation		Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
 	 * @param	showBorder		Should the bar be outlined with a solid border?
 	 * @param	border			The border colour in 0xAARRGGBB format
-	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
+	 * @param   borderSize  The size of the border, in pixels.
 	 * @return 	This FlxBar object with generated image for background rendering.
 	 */
 	public function createGradientEmptyBar(empty:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
-			border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
+			border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -516,12 +504,9 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
-					if (borderSize == null)
-						borderSize = FlxPoint.get(1.0, 1.0);
-
 					emptyBar = new BitmapData(barWidth, barHeight, true, border);
-					FlxGradient.overlayGradientOnBitmapData(emptyBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), empty, 1,
-						1, chunkSize, rotation);
+					FlxGradient.overlayGradientOnBitmapData(emptyBar, barWidth - borderSize * 2, barHeight - borderSize * 2, empty, borderSize, borderSize,
+						chunkSize, rotation);
 				}
 				else
 				{
@@ -537,11 +522,8 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
-				if (borderSize == null)
-					borderSize = FlxPoint.get(1.0, 1.0);
-
 				_emptyBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_emptyBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), empty, 1, 1,
+				FlxGradient.overlayGradientOnBitmapData(_emptyBar, barWidth - borderSize * 2, barHeight - borderSize * 2, empty, borderSize, borderSize,
 					chunkSize, rotation);
 			}
 			else
@@ -564,11 +546,11 @@ class FlxBar extends FlxSprite
 	 * @param	rotation	Angle of the gradient in degrees. 90 = top to bottom, 180 = left to right. Any angle is valid
 	 * @param	showBorder	Should the bar be outlined with a solid border?
 	 * @param	border		The border colour in 0xAARRGGBB format
-	 * @param   borderSize  An `FlxPoint` containing the dimensions of the border.
+	 * @param   borderSize  The size of the border, in pixels.
 	 * @return 	This FlxBar object with generated image for rendering actual values.
 	 */
 	public function createGradientFilledBar(fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
-			border:FlxColor = FlxColor.WHITE, ?borderSize:FlxPoint):FlxBar
+			border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
 		if (FlxG.renderTile)
 		{
@@ -590,12 +572,9 @@ class FlxBar extends FlxSprite
 
 				if (showBorder)
 				{
-					if (borderSize == null)
-						borderSize = FlxPoint.get(1.0, 1.0);
-
 					filledBar = new BitmapData(barWidth, barHeight, true, border);
-					FlxGradient.overlayGradientOnBitmapData(filledBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), fill, 1,
-						1, chunkSize, rotation);
+					FlxGradient.overlayGradientOnBitmapData(filledBar, barWidth - borderSize * 2, barHeight - borderSize * 2, fill, borderSize, borderSize,
+						chunkSize, rotation);
 				}
 				else
 				{
@@ -611,11 +590,8 @@ class FlxBar extends FlxSprite
 		{
 			if (showBorder)
 			{
-				if (borderSize == null)
-					borderSize = FlxPoint.get(1.0, 1.0);
-
 				_filledBar = new BitmapData(barWidth, barHeight, true, border);
-				FlxGradient.overlayGradientOnBitmapData(_filledBar, Std.int(barWidth - borderSize.x * 2), Std.int(barHeight - borderSize.y * 2), fill, 1, 1,
+				FlxGradient.overlayGradientOnBitmapData(_filledBar, barWidth - borderSize * 2, barHeight - borderSize * 2, fill, borderSize, borderSize,
 					chunkSize, rotation);
 			}
 			else


### PR DESCRIPTION
Adds support for custom border sizes to `FlxBar` by allowing the user to pass in an `Int` when calling functions such as `createFilledBar`.