### PR TITLE
FlxTextBorderStyle: Add SHADOW_CUSTOM, always draw full outline

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1145,20 +1145,20 @@ class FlxText extends FlxSprite
 					_matrix.ty = originY;
 				}
 			
-			case SHADOW_XY(offsetX, offsetY):
+			case SHADOW_XY(shadowX, shadowY):
 				// Render a shadow beneath the text with the specified offset
 				applyFormats(_formatAdjusted, true);
 				
 				final originX = _matrix.tx;
 				final originY = _matrix.ty;
 				
-				// Size is average of both, so (4, 4) has 4 iterations, just like SHADOW
-				final size = (Math.abs(offsetX) + Math.abs(offsetY)) / 2;
+				// Size is max of both, so (4, 4) has 4 iterations, just like SHADOW
+				final size = Math.max(shadowX, shadowY);
 				final iterations = borderQuality < 1 ? 1 : Std.int(size * borderQuality);
 				var i = iterations + 1;
 				while (i-- > 1)
 				{
-					copyTextWithOffset(offsetX / iterations * i, offsetY / iterations * i);
+					copyTextWithOffset(shadowX / iterations * i, shadowY / iterations * i);
 					// reset to origin
 					_matrix.tx = originX;
 					_matrix.ty = originY;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -161,12 +161,16 @@ class FlxText extends FlxSprite
 
 	var _autoHeight:Bool = true;
 	
+	/**
+	 * Internal handler for deprecated `shadowOffset` field
+	 */
 	var _shadowOffset:FlxPoint = FlxPoint.get(1, 1);
+	
 	/**
 	 * Offset that is applied to the shadow border style, if active.
 	 * `x` and `y` are multiplied by `borderSize`. Default is `(1, 1)`, or lower-right corner.
 	 */
-	@:deprecated("shadowOffset is deprecated, use setBorderStyle(SHADOW_XY(offsetX, offsetY)), instead")
+	@:deprecated("shadowOffset is deprecated, use setBorderStyle(SHADOW_XY(offsetX, offsetY)), instead") // 5.9.0
 	public var shadowOffset(get, never):FlxPoint;
 	
 	/**

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -166,7 +166,7 @@ class FlxText extends FlxSprite
 	 * Offset that is applied to the shadow border style, if active.
 	 * `x` and `y` are multiplied by `borderSize`. Default is `(1, 1)`, or lower-right corner.
 	 */
-	@:deprecated("shadowOffset is deprecated, use setBorderStyle(SHADOW_CUSTOM(offsetX, offsetY)), instead")
+	@:deprecated("shadowOffset is deprecated, use setBorderStyle(SHADOW_XY(offsetX, offsetY)), instead")
 	public var shadowOffset(get, never):FlxPoint;
 
 	var _defaultFormat:TextFormat;
@@ -891,7 +891,7 @@ class FlxText extends FlxSprite
 				borderWidth += Math.abs(borderSize);
 				borderHeight += Math.abs(borderSize);
 			
-			case SHADOW_CUSTOM(offsetX, offsetY):
+			case SHADOW_XY(offsetX, offsetY):
 				borderWidth += Math.abs(offsetX);
 				borderHeight += Math.abs(offsetY);
 			
@@ -1054,7 +1054,7 @@ class FlxText extends FlxSprite
 				if (borderSize < 0)
 					offset.set(-borderSize, -borderSize);
 			
-			case SHADOW_CUSTOM(offsetX, offsetY):
+			case SHADOW_XY(offsetX, offsetY):
 				offset.x = offsetX < 0 ? -offsetX : 0;
 				offset.y = offsetY < 0 ? -offsetY : 0;
 			
@@ -1097,7 +1097,7 @@ class FlxText extends FlxSprite
 					_matrix.ty = originY;
 				}
 			
-			case SHADOW_CUSTOM(offsetX, offsetY):
+			case SHADOW_XY(offsetX, offsetY):
 				// Render a shadow beneath the text with the specified offset
 				applyFormats(_formatAdjusted, true);
 				
@@ -1322,7 +1322,7 @@ enum FlxTextBorderStyle
 	 * A shadow that allows custom placement
 	 * **Note:** Ignores borderSize
 	 */
-	SHADOW_CUSTOM(offsetX:Float, offsetY:Float);
+	SHADOW_XY(offsetX:Float, offsetY:Float);
 	
 	/**
 	 * Outline on all 8 sides

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -883,13 +883,13 @@ class FlxText extends FlxSprite
 		var borderHeight:Float = 0;
 		switch(borderStyle)
 		{
-			case SHADOW if (_shadowOffset.x == 1 && _shadowOffset.y == 1):
-				borderWidth += Math.abs(borderSize);
-				borderHeight += Math.abs(borderSize);
-			
-			case SHADOW: // with non-default shadowOffset value
+			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
 				borderWidth += Math.abs(_shadowOffset.x);
 				borderHeight += Math.abs(_shadowOffset.y);
+			
+			case SHADOW: // With the default shadowOffset value
+				borderWidth += Math.abs(borderSize);
+				borderHeight += Math.abs(borderSize);
 			
 			case SHADOW_CUSTOM(offsetX, offsetY):
 				borderWidth += Math.abs(offsetX);
@@ -1046,13 +1046,13 @@ class FlxText extends FlxSprite
 		// offset entire image to fit the border
 		switch(borderStyle)
 		{
-			case SHADOW if (_shadowOffset.x == 1 && _shadowOffset.y == 1):
-				if (borderSize < 0)
-					offset.set(-borderSize, -borderSize);
-			
-			case SHADOW: // with non-default shadowOffset value
+			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
 				offset.x = _shadowOffset.x < 0 ? -_shadowOffset.x : 0;
 				offset.y = _shadowOffset.y < 0 ? -_shadowOffset.y : 0;
+			
+			case SHADOW: // With the default shadowOffset value
+				if (borderSize < 0)
+					offset.set(-borderSize, -borderSize);
 			
 			case SHADOW_CUSTOM(offsetX, offsetY):
 				offset.x = offsetX < 0 ? -offsetX : 0;
@@ -1067,7 +1067,20 @@ class FlxText extends FlxSprite
 		
 		switch (borderStyle)
 		{
-			case SHADOW if (_shadowOffset.x == 1 && _shadowOffset.y == 1):
+			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
+				// Render a shadow beneath the text using the shadowOffset property
+				applyFormats(_formatAdjusted, true);
+				
+				var iterations = borderQuality < 1 ? 1 : Std.int(Math.abs(borderSize) * borderQuality);
+				final delta = borderSize / iterations;
+				for (i in 0...iterations)
+				{
+					copyTextWithOffset(delta, delta);
+				}
+				
+				_matrix.translate(-_shadowOffset.x * borderSize, -_shadowOffset.y * borderSize);
+			
+			case SHADOW: // With the default shadowOffset value
 				// Render a shadow beneath the text
 				applyFormats(_formatAdjusted, true);
 				
@@ -1083,19 +1096,6 @@ class FlxText extends FlxSprite
 					_matrix.tx = originX;
 					_matrix.ty = originY;
 				}
-			
-			case SHADOW: // with non-default shadowOffset value
-				// Render a shadow beneath the text using the shadowOffset property
-				applyFormats(_formatAdjusted, true);
-				
-				var iterations = borderQuality < 1 ? 1 : Std.int(Math.abs(borderSize) * borderQuality);
-				final delta = borderSize / iterations;
-				for (i in 0...iterations)
-				{
-					copyTextWithOffset(delta, delta);
-				}
-				
-				_matrix.translate(-_shadowOffset.x * borderSize, -_shadowOffset.y * borderSize);
 			
 			case SHADOW_CUSTOM(offsetX, offsetY):
 				// Render a shadow beneath the text with the specified offset

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1047,8 +1047,8 @@ class FlxText extends FlxSprite
 		switch(borderStyle)
 		{
 			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
-				offset.x = _shadowOffset.x < 0 ? -_shadowOffset.x : 0;
-				offset.y = _shadowOffset.y < 0 ? -_shadowOffset.y : 0;
+				offset.x = _shadowOffset.x > 0 ? _shadowOffset.x : 0;
+				offset.y = _shadowOffset.y > 0 ? _shadowOffset.y : 0;
 			
 			case SHADOW: // With the default shadowOffset value
 				if (borderSize < 0)


### PR DESCRIPTION
Fixes https://github.com/HaxeFlixel/flixel/issues/3235

## Changes

- Adds new `FlxTextBorderStyle.SHADOW_XY`
- Deprecates `shadowOffset`
- Expands image size to fit outline (sets width, height and offset to keep text in the same position)

## Concerns
- ~~`offset` is now changed whenever the graphic is redrawn, this could be a breaking change, we should try to offset its draw position without affecting `offset`~~ - added _graphicOffset which offsets the position without using offset

Test State:
```hx
package states;

import flixel.system.debug.log.LogStyle;
import flixel.FlxG;
import flixel.text.FlxText;
import flixel.text.FlxBitmapText;

class TextShadowTestState extends flixel.FlxState
{
	final styles:Array<()->FlxTextBorderStyle> = [];
	
	var text:FlxText;
	var bmText:FlxBitmapText;
	var showBorder = true;
	var size = 4;
	var quality = 0;
	var styleIndex = 0;
	var offsetX = 1;
	var offsetY = 1;
	
	var instructions:FlxText;
	
	override public function create()
	{
		super.create();
		bgColor = 0xFF808080;
		
		styles.push(()->SHADOW);
		styles.push(()->SHADOW_XY(offsetX, offsetY));
		styles.push(()->OUTLINE);
		styles.push(()->OUTLINE_FAST);
		
		// text = new flixel.addons.ui.FlxInputText(0, 0, FlxG.width, "FlxText shadow clipping test lol", 8);
		text = new FlxText(0, 0, 0, "FlxText shadow clipping test lol", 8);
		text.screenCenter();
		add(text);
		
		bmText = new FlxBitmapText(0, 0, "FlxText shadow clipping test lol");
		bmText.screenCenter();
		add(bmText);
		
		final gap = (text.height + bmText.height) * 0.5;
		text.y -= gap;
		bmText.y += gap;
		
		applyShadow();
		
		// debug watch
		FlxG.watch.addFunction("bmd", function ()
		{
			final bmp = text.graphic.bitmap;
			return '( w: ${bmp.width} | h: ${bmp.height} )';
		});
		FlxG.watch.addFunction("shd.offset", ()->'( x: $offsetX | y: $offsetY )');
		FlxG.watch.addFunction("shd.size", ()->size);
		FlxG.watch.addFunction("shd.quality", ()->quality);
		FlxG.watch.addFunction("shd.style", ()->'$styleIndex : ${text.borderStyle}');
		FlxG.log.notice("LEFT RIGHT UP DOWN: change shadowOffset");
		FlxG.log.notice("SPACE: reset shadowOffset");
		FlxG.log.notice("< >: change borderSize");
		FlxG.log.notice("SHIFT + < >: change borderQuality");
		FlxG.log.notice("CLICK: toggle border");
		FlxG.log.notice("ENTER: change style");
		FlxG.debugger.visible = true;
		FlxG.debugger.drawDebug = true;
		
		LogStyle.WARNING.callbackFunction = function ()
		{
			trace("Warning");
		}
	}
	
	function applyShadow()
	{
		if (showBorder)
		{
			text.setBorderStyle(styles[styleIndex](), 0xFF000000, size, quality);
			bmText.setBorderStyle(styles[styleIndex](), 0xFF000000, size, quality);
		}
		else
		{
			text.setBorderStyle(NONE);
			bmText.setBorderStyle(NONE);
		}
		
		@:privateAccess text._regen = true;
		@:privateAccess text.regenGraphic();
		FlxG.bitmapLog.clear();
		FlxG.bitmapLog.add(text.graphic.bitmap);
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);
		
		var redraw = false;
		
		if (FlxG.keys.anyJustPressed([SPACE, RIGHT, LEFT, UP, DOWN]))
		{
			if (FlxG.keys.justPressed.SPACE) { offsetX = 1; offsetY = 1; }
			if (FlxG.keys.justPressed.RIGHT) offsetX += 1;
			if (FlxG.keys.justPressed.LEFT) offsetX -= 1;
			if (FlxG.keys.justPressed.UP) offsetY -= 1;
			if (FlxG.keys.justPressed.DOWN) offsetY += 1;
			text.shadowOffset.set(offsetX, offsetY);
			bmText.shadowOffset.set(offsetX, offsetY);
			
			redraw = true;
		}
		
		if (FlxG.keys.pressed.D) { text.x += 1; bmText.x += 1; }
		if (FlxG.keys.pressed.A) { text.x -= 1; bmText.x -= 1; }
		if (FlxG.keys.pressed.W) { text.y -= 1; bmText.y -= 1; }
		if (FlxG.keys.pressed.S) { text.y += 1; bmText.y += 1; }
		
		if (FlxG.keys.justPressed.ENTER)
		{
			styleIndex = (styleIndex + 1) % styles.length;
			redraw = true;
		}
		
		if (FlxG.keys.anyJustPressed([COMMA, PERIOD]))
		{
			if (FlxG.keys.pressed.SHIFT)
			{
				if (FlxG.keys.justPressed.PERIOD && quality < 2) quality++;
				if (FlxG.keys.justPressed.COMMA && quality > 0) quality--;
			}
			else
			{
				if (FlxG.keys.justPressed.PERIOD) size++;
				if (FlxG.keys.justPressed.COMMA) size--;
			}
			
			redraw = true;
		}
		
		if (FlxG.mouse.justPressed)
		{
			showBorder = !showBorder;
			redraw = true;
		}
		
		if (redraw)
			applyShadow();
		
		if (FlxG.keys.justPressed.BACKSPACE)
		{
			text.text = text.text == "" ? "FlxText shadow clipping test lol" : "";
			bmText.text = text.text;
		}
	}
}
```