### PR TITLE
Prevent crash in FlxInputText when switching states

### DIFF
--- a/flixel/text/FlxInputText.hx
+++ b/flixel/text/FlxInputText.hx
@@ -482,6 +482,7 @@ class FlxInputText extends FlxText implements IFlxInputText
 	 */
 	override function destroy():Void
 	{
+		endFocus();
 		manager.unregisterInputText(this);
 
 		FlxDestroyUtil.destroy(onEnter);


### PR DESCRIPTION
Prevents null `textField` access in `FlxInputText` when switching between states. Resolves #3242.