### PR TITLE
Fix mouse wheel scrolling not working on FlxInputText

### DIFF
--- a/flixel/text/FlxInputText.hx
+++ b/flixel/text/FlxInputText.hx
@@ -507,8 +507,8 @@ class FlxInputText extends FlxText implements IFlxInputText
 
 	override function applyFormats(formatAdjusted:TextFormat, useBorderColor:Bool = false):Void
 	{
-		// scroll variables will be reset when `textField.setTextFormat()` is called,
-		// cache the current ones first
+		// Scroll variables will be reset when `textField.setTextFormat()` is called,
+		// cache the current ones first.
 		var cacheScrollH = scrollH;
 		var cacheScrollV = scrollV;
 		
@@ -517,9 +517,15 @@ class FlxInputText extends FlxText implements IFlxInputText
 		if (!useBorderColor && useSelectedTextFormat && selectionEndIndex > selectionBeginIndex)
 			textField.setTextFormat(_selectionFormat, selectionBeginIndex, selectionEndIndex);
 
-		// set the scroll back to how it was
-		scrollH = cacheScrollH;
-		scrollV = cacheScrollV;
+		// Set the scroll back to how it was.
+		// This changes the internal text field's scroll instead to make sure that
+		// `__updateLayout()` gets called even if the scroll hasn't changed.
+		// If it doesn't get called here, it will be called when the text field
+		// is being drawn to this sprite's graphic, which will reset the scroll
+		// to the current selection, effectively making scrolling with the mouse
+		// wheel not work.
+		textField.scrollH = cacheScrollH;
+		textField.scrollV = cacheScrollV;
 	}
 	
 	override function regenGraphic():Void


### PR DESCRIPTION
Like the title says, this fixes the input text not scrolling when using the mouse wheel on it. This can be seen with just a regular text input object with multiline enabled:

```haxe
var text = new FlxInputText(5, 5, FlxG.width - 20, "Hello world!", 16);
text.fieldHeight = 44;
text.multiline = true;
add(text);
```

I also added a comment with information on the fix.