### PR TITLE
fix for html5 arrow keys not working on the console

### DIFF
--- a/flixel/system/debug/console/Console.hx
+++ b/flixel/system/debug/console/Console.hx
@@ -218,6 +218,24 @@ class Console extends Window
 				if (!history.isEmpty)
 					setText(history.getPreviousCommand());
 
+			#if html5
+			// FlxKeyboard.preventDefaultKeys adds "preventDefault" on HTML5
+			// so it ends up not fully propegating our inputs to the stage/event listeners
+			// we do this small work around so we don't need to mess around with lime/openfl events
+			// todo: support the modifier keys
+			case Keyboard.RIGHT:
+				if (FlxG.keys.preventDefaultKeys.contains(Keyboard.RIGHT))
+				{
+					@:privateAccess
+					input.window_onKeyDown(RIGHT, 0);
+				}
+			case Keyboard.LEFT:
+				if (FlxG.keys.preventDefaultKeys.contains(Keyboard.LEFT))
+				{
+					@:privateAccess
+					input.window_onKeyDown(LEFT, 0);
+				}
+			#end
 			case Keyboard.DOWN:
 				if (!history.isEmpty)
 					setText(history.getNextCommand());


### PR DESCRIPTION
fixes #2190 and #3233 

on HTML5, `preventDefaultKeys` in `FlxKeyboard` also calls `preventDefault()` to the keyboard event. This is helpful for not tabbing or scrolling the page when arrow keys or tab is pressed, but side effect is that it cancels the event propegation from reaching our event listeners fully.

This is a bit of a workaround for that, we directly call the event listener ourselves 