### PR TITLE
Resize the debug watch window whenever something gets added / removed

### DIFF
--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -30,7 +30,7 @@ class Watch extends Window
 		entriesContainer.y = entriesContainerOffset.y;
 		addChild(entriesContainer);
 
-		FlxG.signals.preStateSwitch.add(removeAll);
+		FlxG.signals.preStateSwitch.add(clear);
 	}
 
 	public function add(displayName:String, data:WatchEntryData):Void
@@ -105,15 +105,23 @@ class Watch extends Window
 		updateSize();
 	}
 
-	public function removeAll():Void
+	/**
+	 * internal method to remove all without calling updateSize
+	 */
+	function clear():Void
 	{
-		for (i in 0...entries.length)
+		for (entry in entries)
 		{
-			var entry = entries[i];
 			entriesContainer.removeChild(entry);
 			entry.destroy();
 		}
-		entries.splice(0, entries.length);
+		
+		entries.resize(0);
+	}
+
+	public function removeAll():Void
+	{
+		clear();
 		updateSize();
 	}
 

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -87,7 +87,7 @@ class Watch extends Window
 		var entry = new WatchEntry(displayName, data, removeEntry);
 		entries.push(entry);
 		entriesContainer.addChild(entry);
-		resetEntries();
+		updateSize();
 	}
 
 	public function remove(displayName:String, data:WatchEntryData):Void
@@ -102,7 +102,7 @@ class Watch extends Window
 		entries.fastSplice(entry);
 		entriesContainer.removeChild(entry);
 		entry.destroy();
-		resetEntries();
+		updateSize();
 	}
 
 	public function removeAll():Void
@@ -114,7 +114,7 @@ class Watch extends Window
 			entry.destroy();
 		}
 		entries.splice(0, entries.length);
-		resetEntries();
+		updateSize();
 	}
 
 	override public function update():Void
@@ -125,9 +125,9 @@ class Watch extends Window
 
 	override function updateSize():Void
 	{
+		resetEntries();
 		minSize.setTo(getMaxMinWidth() + entriesContainerOffset.x, entriesContainer.height + entriesContainerOffset.y);
 		super.updateSize();
-		resetEntries();
 	}
 
 	function resetEntries():Void

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -136,6 +136,7 @@ class Watch extends Window
 		resetEntries();
 		minSize.setTo(getMaxMinWidth() + entriesContainerOffset.x, entriesContainer.height + entriesContainerOffset.y);
 		super.updateSize();
+		reposition(x, y);
 	}
 
 	function resetEntries():Void

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -128,6 +128,7 @@ class Watch extends Window
 		resetEntries();
 		minSize.setTo(getMaxMinWidth() + entriesContainerOffset.x, entriesContainer.height + entriesContainerOffset.y);
 		super.updateSize();
+		reposition(x, y);
 	}
 
 	function resetEntries():Void

--- a/flixel/system/debug/watch/Watch.hx
+++ b/flixel/system/debug/watch/Watch.hx
@@ -136,7 +136,6 @@ class Watch extends Window
 		resetEntries();
 		minSize.setTo(getMaxMinWidth() + entriesContainerOffset.x, entriesContainer.height + entriesContainerOffset.y);
 		super.updateSize();
-		reposition(x, y);
 	}
 
 	function resetEntries():Void


### PR DESCRIPTION
The debugger Watch window would overflow the contents and show offscreen until the user clicks+drags the window around (which then automatically resizes it properly) 

This PR makes it so that whenever something is added to the watch window, it will resize itself.

Using FNF (apologies for the .mov files!)
Before

https://github.com/user-attachments/assets/93446463-9837-4ddb-9dc5-668c16b38e99

After

https://github.com/user-attachments/assets/e766c59b-3cf0-4863-83f1-9d35414ef32f

