### PR TITLE
Fixed a small issue with android config on lime 8.2.0.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -47,9 +47,9 @@
 		<sample path="${haxelib:flixel-demos}/User Interface" />
 	</section>
 
-	<section if="android">
+	<section if="${lime &ge; 8.2.0}">
 		<config:android>
-			<application android:appCategory="game" if="${lime &ge; 8.2.0}" />
+			<application android:appCategory="game" />
 		</config:android>
 	</section>
 </project>

--- a/include.xml
+++ b/include.xml
@@ -47,7 +47,7 @@
 		<sample path="${haxelib:flixel-demos}/User Interface" />
 	</section>
 
-	<section if="${lime &ge; 8.2.0}">
+	<section if="${lime >= 8.2.0}">
 		<config:android>
 			<application android:appCategory="game" />
 		</config:android>


### PR DESCRIPTION
This PR fixes a small were it adds `if="android"` on the outputed `AndroidManifest.xml` on `lime` (`8.2.0`).
![asd](https://github.com/user-attachments/assets/c59e1037-6b1b-46bf-824d-906a17820102)
