### PR TITLE
FlxG.camera.bgColor isn't reset on state switch

### DIFF
--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -143,6 +143,8 @@ class CameraFrontEnd
 	 */
 	public function reset(?NewCamera:FlxCamera):Void
 	{
+		FlxG.camera = null;
+		
 		while (list.length > 0)
 			remove(list[0]);
 


### PR DESCRIPTION
Closes: #3252

We need to reset `FlxG.camera` to `null` when `FlxG.cameras.reset` is called, otherwise when resetting the state, the newly generated camera will have the previous `FlxG.camera`'s `bgColor`.

This is a breaking change: [more information here](https://github.com/HaxeFlixel/flixel/issues/3252#issuecomment-2358954359).