### PR TITLE
Fix FlxTextInput field border not being clipped correctly

### DIFF
--- a/flixel/text/FlxInputText.hx
+++ b/flixel/text/FlxInputText.hx
@@ -615,7 +615,7 @@ class FlxInputText extends FlxText implements IFlxInputText
 	 * Clips the sprite inside the bounds of the text field, taking
 	 * `clipRect` into account.
 	 */
-	function clipSprite(sprite:FlxSprite)
+	function clipSprite(sprite:FlxSprite, border:Bool = false)
 	{
 		if (sprite == null)
 			return;
@@ -625,7 +625,8 @@ class FlxInputText extends FlxText implements IFlxInputText
 			rect = FlxRect.get();
 		rect.set(0, 0, sprite.width, sprite.height);
 		
-		var bounds = FlxRect.get(0, 0, width, height);
+		var bounds = border ? FlxRect.get(-fieldBorderThickness, -fieldBorderThickness, width + (fieldBorderThickness * 2),
+			height + (fieldBorderThickness * 2)) : FlxRect.get(0, 0, width, height);
 		if (clipRect != null)
 		{
 			bounds = bounds.clipTo(clipRect);
@@ -1201,7 +1202,7 @@ class FlxInputText extends FlxText implements IFlxInputText
 			
 		_fieldBorderSprite.setPosition(x - fieldBorderThickness, y - fieldBorderThickness);
 		_backgroundSprite.setPosition(x, y);
-		clipSprite(_fieldBorderSprite);
+		clipSprite(_fieldBorderSprite, true);
 		clipSprite(_backgroundSprite);
 	}
 	
@@ -1747,7 +1748,7 @@ class FlxInputText extends FlxText implements IFlxInputText
 		super.set_clipRect(value);
 		
 		clipSprite(_backgroundSprite);
-		clipSprite(_fieldBorderSprite);
+		clipSprite(_fieldBorderSprite, true);
 		clipSprite(_caret);
 		for (box in _selectionBoxes)
 			clipSprite(box);


### PR DESCRIPTION
The FlxTextInput field border was not appearing at all, which turns out to have been from the clipping system not accounting for it being outside the bounds of the actual text field, and thus always making it invisible. This PR fixes that issue.

Closes #3258 