### PR TITLE
Attach `DEACTIVATE`/`ACTIVATE` events to `stage.nativeWindow`.

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -359,8 +359,8 @@ class FlxGame extends Sprite
 		stage.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		stage.addEventListener(FocusEvent.FOCUS_IN, onFocus);
 		#else
-		stage.addEventListener(Event.DEACTIVATE, onFocusLost);
-		stage.addEventListener(Event.ACTIVATE, onFocus);
+		stage.nativeWindow.addEventListener(Event.DEACTIVATE, onFocusLost);
+		stage.nativeWindow.addEventListener(Event.ACTIVATE, onFocus);
 		#end
 
 		// Instantiate the initial state

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -358,14 +358,12 @@ class FlxGame extends Sprite
 		#if (desktop && openfl <= "4.0.0")
 		stage.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		stage.addEventListener(FocusEvent.FOCUS_IN, onFocus);
-		#else
-		#if sys
+		#elseif (sys && openfl >= "9.3.0")
 		stage.nativeWindow.addEventListener(Event.DEACTIVATE, onFocusLost);
 		stage.nativeWindow.addEventListener(Event.ACTIVATE, onFocus);
 		#else
 		stage.addEventListener(Event.DEACTIVATE, onFocusLost);
 		stage.addEventListener(Event.ACTIVATE, onFocus);
-		#end
 		#end
 
 		// Instantiate the initial state

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -359,8 +359,13 @@ class FlxGame extends Sprite
 		stage.addEventListener(FocusEvent.FOCUS_OUT, onFocusLost);
 		stage.addEventListener(FocusEvent.FOCUS_IN, onFocus);
 		#else
+		#if sys
 		stage.nativeWindow.addEventListener(Event.DEACTIVATE, onFocusLost);
 		stage.nativeWindow.addEventListener(Event.ACTIVATE, onFocus);
+		#else
+		stage.addEventListener(Event.DEACTIVATE, onFocusLost);
+		stage.addEventListener(Event.ACTIVATE, onFocus);
+		#end
 		#end
 
 		// Instantiate the initial state


### PR DESCRIPTION
As of the recent changes to OpenFL's `NativeWindow` (https://github.com/openfl/openfl/commit/31e6f2e59b0faf0e10a4f4f229771b41e39c0aea and https://github.com/openfl/openfl/commit/48e150e584336f107ccc12f46ec988760af812ff), an issue on mobile has been fixed where `DEACTIVATE` and `ACTIVATE` events were not being called properly when user presses the power button, putting the phone into sleep mode.

This PR ensures that the events are now attached to `stage.nativeWindow` instead of the `stage` alone. The change doesn't affect other platforms (the events will continue to function as before). However, until the next OpenFL release, this fix won't take effect.
