### PR TITLE
Replace comments mentioning Std.is with Std.isOfType

### DIFF
--- a/flixel/system/debug/console/ConsoleUtil.hx
+++ b/flixel/system/debug/console/ConsoleUtil.hx
@@ -120,7 +120,7 @@ class ConsoleUtil
 		else if (Reflect.isObject(Object)) // get instance fields
 			fields = Type.getInstanceFields(Type.getClass(Object));
 
-		// on Flash, enums are classes, so Std.is(_, Enum) fails
+		// on Flash, enums are classes, so Std.isOfType(_, Enum) fails
 		fields.remove("__constructs__");
 
 		var filteredFields = [];

--- a/flixel/util/typeLimit/OneOfFour.hx
+++ b/flixel/util/typeLimit/OneOfFour.hx
@@ -3,7 +3,7 @@ package flixel.util.typeLimit;
 /**
  * Useful to limit a Dynamic function argument's type to the specified
  * type parameters. This does NOT make the use of Dynamic type-safe in
- * any way (the underlying type is still Dynamic and Std.is() checks +
+ * any way (the underlying type is still Dynamic and Std.isOfType() checks +
  * casts are necessary).
  */
 abstract OneOfFour<T1, T2, T3, T4>(Dynamic) from T1 from T2 from T3 from T4 to T1 to T2 to T3 to T4 {}

--- a/flixel/util/typeLimit/OneOfThree.hx
+++ b/flixel/util/typeLimit/OneOfThree.hx
@@ -3,7 +3,7 @@ package flixel.util.typeLimit;
 /**
  * Useful to limit a Dynamic function argument's type to the specified
  * type parameters. This does NOT make the use of Dynamic type-safe in
- * any way (the underlying type is still Dynamic and Std.is() checks +
+ * any way (the underlying type is still Dynamic and Std.isOfType() checks +
  * casts are necessary).
  */
 abstract OneOfThree<T1, T2, T3>(Dynamic) from T1 from T2 from T3 to T1 to T2 to T3 {}

--- a/flixel/util/typeLimit/OneOfTwo.hx
+++ b/flixel/util/typeLimit/OneOfTwo.hx
@@ -3,7 +3,7 @@ package flixel.util.typeLimit;
 /**
  * Useful to limit a Dynamic function argument's type to the specified
  * type parameters. This does NOT make the use of Dynamic type-safe in
- * any way (the underlying type is still Dynamic and Std.is() checks +
+ * any way (the underlying type is still Dynamic and Std.isOfType() checks +
  * casts are necessary).
  */
 abstract OneOfTwo<T1, T2>(Dynamic) from T1 from T2 to T1 to T2 {}


### PR DESCRIPTION
Found some comments that mention a deprecated function, this updates them to the newer function 