### PR TITLE
Fix memory overflow in debugger for select targets

### DIFF
--- a/flixel/system/debug/stats/Stats.hx
+++ b/flixel/system/debug/stats/Stats.hx
@@ -333,7 +333,14 @@ class Stats extends Window
 	 */
 	public inline function currentMem():Float
 	{
-		return (System.totalMemory / 1024) / 1000;
+		#if cpp
+		var usage:Float = cpp.vm.Gc.memInfo64(cpp.vm.Gc.MEM_INFO_USAGE);
+		#elseif hl
+		var usage:Float = hl.Gc.stats().currentMemory;
+		#else
+		var usage:Float = System.totalMemory;
+		#end
+		return (usage / 1024) / 1000;
 	}
 
 	/**


### PR DESCRIPTION
Because `openfl.System.totalMemory` is an Int, after reaching ~2.14GB (32bit int limit) the memory usage will overflow and no longer display accurate values:
![Screenshot 2024-10-13 192013](https://github.com/user-attachments/assets/dbfe453d-ece3-4b7d-8791-9c8e467b574f)
On Hashlink and the C++ targets we can get a more precise 64bit memory usage value, which allows us to display *way* higher values (and this isn't even close to the limit):
![Screenshot 2024-10-13 193424](https://github.com/user-attachments/assets/c024cfb8-77e5-4684-aefa-f4191813b586)

Unrelated: I wonder if it'd be worth it to use `FlxStringUtil.formatBytes()` here
