### PR TITLE
Use System.totalMemoryNumber in debugger

### DIFF
--- a/flixel/system/debug/stats/Stats.hx
+++ b/flixel/system/debug/stats/Stats.hx
@@ -333,7 +333,7 @@ class Stats extends Window
 	 */
 	public inline function currentMem():Float
 	{
-		return (System.totalMemory / 1024) / 1000;
+		return (#if (openfl >= "9.4.0") System.totalMemoryNumber #else System.totalMemory #end / 1024) / 1000;
 	}
 
 	/**


### PR DESCRIPTION
This is a redo of #3265 that uses the same fix but implemented directly into OpenFL (https://github.com/openfl/openfl/pull/2744)

The debugger will now use the more precise memory usage value when available (OpenFL version higher or equal to 9.4.0) and fallback to the old one if it's not. This conditional should be removed eventually when Flixel bumps up the minimum OpenFL version.