### PR TITLE
Stop dispatching onFocus event when closing debugger

### DIFF
--- a/flixel/system/frontEnds/DebuggerFrontEnd.hx
+++ b/flixel/system/frontEnds/DebuggerFrontEnd.hx
@@ -173,8 +173,6 @@ class DebuggerFrontEnd
 		if (!Value)
 		{
 			FlxG.stage.focus = null;
-			// setting focus to null will trigger a focus lost event, let's undo that
-			FlxG.game.onFocus(null);
 
 			#if FLX_MOUSE
 			FlxG.mouse.enabled = true;


### PR DESCRIPTION
This PR solves an issue where closing the debugger would dispatch an `onFocus` event.

One of the issues caused by this issue is sounds playing after the debugger gets closed. 
If you play a sound, pause it, open the debugger and then close it, the sound will get unpaused and continue playing.

This code seems to have been added for a reason but I can't reproduce what the comment is saying. setting `FlxG.stage.focus = null;` doesn't seem to dispatch any focus events. Maybe its an old OpenFL version thing? Or target specific?