### PR TITLE
Make `FlxSound#time` more precise

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -31,54 +31,54 @@ class FlxSound extends FlxBasic
 	 * Only really matters if you are doing proximity/panning stuff.
 	 */
 	public var x:Float;
-	
+
 	/**
 	 * The y position of this sound in world coordinates.
 	 * Only really matters if you are doing proximity/panning stuff.
 	 */
 	public var y:Float;
-	
+
 	/**
 	 * Whether or not this sound should be automatically destroyed when you switch states.
 	 */
 	public var persist:Bool;
-	
+
 	/**
 	 * The ID3 song name. Defaults to null. Currently only works for streamed sounds.
 	 */
 	public var name(default, null):String;
-	
+
 	/**
 	 * The ID3 artist name. Defaults to null. Currently only works for streamed sounds.
 	 */
 	public var artist(default, null):String;
-	
+
 	/**
 	 * Stores the average wave amplitude of both stereo channels
 	 */
 	public var amplitude(default, null):Float;
-	
+
 	/**
 	 * Just the amplitude of the left stereo channel
 	 */
 	public var amplitudeLeft(default, null):Float;
-	
+
 	/**
 	 * Just the amplitude of the right stereo channel
 	 */
 	public var amplitudeRight(default, null):Float;
-	
+
 	/**
 	 * Whether to call `destroy()` when the sound has finished playing.
 	 */
 	public var autoDestroy:Bool;
-	
+
 	/**
 	 * Tracker for sound complete callback. If assigned, will be called
 	 * each time when sound reaches its end.
 	 */
 	public var onComplete:Void->Void;
-	
+
 	/**
 	 * Pan amount. -1 = full left, 1 = full right. Proximity based panning overrides this.
 	 * 
@@ -86,134 +86,134 @@ class FlxSound extends FlxBasic
 	 * More info: [OpenFL Forums - SoundTransform.pan does not work](https://community.openfl.org/t/windows-legacy-soundtransform-pan-does-not-work/6616/2?u=geokureli)
 	 */
 	public var pan(get, set):Float;
-	
+
 	/**
 	 * Whether or not the sound is currently playing.
 	 */
 	public var playing(get, never):Bool;
-	
+
 	/**
 	 * Set volume to a value between 0 and 1 to change how this sound is.
 	 */
 	public var volume(get, set):Float;
-	
+
 	#if FLX_PITCH
 	/**
 	 * Set pitch, which also alters the playback speed. Default is 1.
 	 */
 	public var pitch(get, set):Float;
 	#end
-	
+
 	/**
 	 * The position in runtime of the music playback in milliseconds.
 	 * If set while paused, changes only come into effect after a `resume()` call.
 	 */
 	public var time(get, set):Float;
-	
+
 	/**
 	 * The length of the sound in milliseconds.
 	 * @since 4.2.0
 	 */
 	public var length(get, never):Float;
-	
+
 	/**
 	 * The sound group this sound belongs to, can only be in one group.
 	 * NOTE: This setter is deprecated, use `group.add(sound)` or `group.remove(sound)`.
 	 */
 	public var group(default, set):FlxSoundGroup;
-	
+
 	/**
 	 * Whether or not this sound should loop.
 	 */
 	public var looped:Bool;
-	
+
 	/**
 	 * In case of looping, the point (in milliseconds) from where to restart the sound when it loops back
 	 * @since 4.1.0
 	 */
 	public var loopTime:Float = 0;
-	
+
 	/**
 	 * At which point to stop playing the sound, in milliseconds.
 	 * If not set / `null`, the sound completes normally.
 	 * @since 4.2.0
 	 */
 	public var endTime:Null<Float>;
-	
+
 	/**
 	 * The tween used to fade this sound's volume in and out (set via `fadeIn()` and `fadeOut()`)
 	 * @since 4.1.0
 	 */
 	public var fadeTween:FlxTween;
-	
+
 	/**
 	 * Internal tracker for a Flash sound object.
 	 */
 	@:allow(flixel.system.frontEnds.SoundFrontEnd.load)
 	var _sound:Sound;
-	
+
 	/**
 	 * Internal tracker for a Flash sound channel object.
 	 */
 	var _channel:SoundChannel;
-	
+
 	/**
 	 * Internal tracker for a Flash sound transform object.
 	 */
 	var _transform:SoundTransform;
-	
+
 	/**
 	 * Internal tracker for whether the sound is paused or not (not the same as stopped).
 	 */
 	var _paused:Bool;
-	
+
 	/**
 	 * Internal tracker for volume.
 	 */
 	var _volume:Float;
-	
+
 	/**
 	 * Internal tracker for sound channel position.
 	 */
 	var _time:Float = 0;
-	
+
 	/**
 	 * Internal tracker for sound length, so that length can still be obtained while a sound is paused, because _sound becomes null.
 	 */
 	var _length:Float = 0;
-	
+
 	#if FLX_PITCH
 	/**
 	 * Internal tracker for pitch.
 	 */
 	var _pitch:Float = 1.0;
 	#end
-	
+
 	/**
 	 * Internal tracker for total volume adjustment.
 	 */
 	var _volumeAdjust:Float = 1.0;
-	
+
 	/**
 	 * Internal tracker for the sound's "target" (for proximity and panning).
 	 */
 	var _target:FlxObject;
-	
+
 	/**
 	 * Internal tracker for the maximum effective radius of this sound (for proximity and panning).
 	 */
 	var _radius:Float;
-	
+
 	/**
 	 * Internal tracker for whether to pan the sound left and right.  Default is false.
 	 */
 	var _proximityPan:Bool;
-	
+
 	/**
 	 * Helper var to prevent the sound from playing after focus was regained when it was already paused.
 	 */
 	var _alreadyPaused:Bool = false;
-	
+
 	/**
 	 * The FlxSound constructor gets all the variables initialized, but NOT ready to play a sound yet.
 	 */
@@ -222,17 +222,17 @@ class FlxSound extends FlxBasic
 		super();
 		reset();
 	}
-	
+
 	/**
 	 * An internal function for clearing all the variables used by sounds.
 	 */
 	function reset():Void
 	{
 		destroy();
-		
+
 		x = 0;
 		y = 0;
-		
+
 		_time = 0;
 		_paused = false;
 		_volume = 1.0;
@@ -248,43 +248,43 @@ class FlxSound extends FlxBasic
 		amplitudeLeft = 0;
 		amplitudeRight = 0;
 		autoDestroy = false;
-		
+
 		if (_transform == null)
 			_transform = new SoundTransform();
 		_transform.pan = 0;
 	}
-	
+
 	override public function destroy():Void
 	{
 		// Prevents double destroy
 		if (group != null)
 			group.remove(this);
-		
+
 		_transform = null;
 		exists = false;
 		active = false;
 		_target = null;
 		name = null;
 		artist = null;
-		
+
 		if (_channel != null)
 		{
 			_channel.removeEventListener(Event.SOUND_COMPLETE, stopped);
 			_channel.stop();
 			_channel = null;
 		}
-		
+
 		if (_sound != null)
 		{
 			_sound.removeEventListener(Event.ID3, gotID3);
 			_sound = null;
 		}
-		
+
 		onComplete = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Handles fade out, fade in, panning, proximity, and amplitude operations each frame.
 	 */
@@ -292,11 +292,11 @@ class FlxSound extends FlxBasic
 	{
 		if (!playing)
 			return;
-			
-		_time = _channel.position;
-		
+
+		// _time = _channel.position;
+
 		var radialMultiplier:Float = 1.0;
-		
+
 		// Distance-based volume control
 		if (_target != null)
 		{
@@ -304,17 +304,17 @@ class FlxSound extends FlxBasic
 			radialMultiplier = targetPosition.distanceTo(FlxPoint.weak(x, y)) / _radius;
 			targetPosition.put();
 			radialMultiplier = 1 - FlxMath.bound(radialMultiplier, 0, 1);
-			
+
 			if (_proximityPan)
 			{
 				var d:Float = (x - _target.x) / _radius;
 				_transform.pan = FlxMath.bound(d, -1, 1);
 			}
 		}
-		
+
 		_volumeAdjust = radialMultiplier;
 		updateTransform();
-		
+
 		if (_transform.volume > 0)
 		{
 			amplitudeLeft = _channel.leftPeak / _transform.volume;
@@ -327,17 +327,17 @@ class FlxSound extends FlxBasic
 			amplitudeRight = 0;
 			amplitude = 0;
 		}
-		
+
 		if (endTime != null && _time >= endTime)
 			stopped();
 	}
-	
+
 	override public function kill():Void
 	{
 		super.kill();
 		cleanup(false);
 	}
-	
+
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from an embedded MP3.
 	 *
@@ -352,9 +352,9 @@ class FlxSound extends FlxBasic
 	{
 		if (EmbeddedSound == null)
 			return this;
-			
+
 		cleanup(true);
-		
+
 		if ((EmbeddedSound is Sound))
 		{
 			_sound = EmbeddedSound;
@@ -370,11 +370,11 @@ class FlxSound extends FlxBasic
 			else
 				FlxG.log.error('Could not find a Sound asset with an ID of \'$EmbeddedSound\'.');
 		}
-		
+
 		// NOTE: can't pull ID3 info from embedded sound currently
 		return init(Looped, AutoDestroy, OnComplete);
 	}
-	
+
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a URL.
 	 *
@@ -389,7 +389,7 @@ class FlxSound extends FlxBasic
 	public function loadStream(SoundURL:String, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void, ?OnLoad:Void->Void):FlxSound
 	{
 		cleanup(true);
-		
+
 		_sound = new Sound();
 		_sound.addEventListener(Event.ID3, gotID3);
 		var loadCallback:Event->Void = null;
@@ -407,10 +407,10 @@ class FlxSound extends FlxBasic
 		// Use a weak reference so this can be garbage collected if destroyed before loading.
 		_sound.addEventListener(Event.COMPLETE, loadCallback, false, 0, true);
 		_sound.load(new URLRequest(SoundURL));
-		
+
 		return init(Looped, AutoDestroy, OnComplete);
 	}
-	
+
 	#if flash11
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a ByteArray.
@@ -424,15 +424,15 @@ class FlxSound extends FlxBasic
 	public function loadByteArray(Bytes:ByteArray, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{
 		cleanup(true);
-		
+
 		_sound = new Sound();
 		_sound.addEventListener(Event.ID3, gotID3);
 		_sound.loadCompressedDataFromByteArray(Bytes, Bytes.length);
-		
+
 		return init(Looped, AutoDestroy, OnComplete);
 	}
 	#end
-	
+
 	function init(Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{
 		looped = Looped;
@@ -447,7 +447,7 @@ class FlxSound extends FlxBasic
 		endTime = _length;
 		return this;
 	}
-	
+
 	/**
 	 * Call this function if you want this sound's volume to change
 	 * based on distance from a particular FlxObject.
@@ -468,7 +468,7 @@ class FlxSound extends FlxBasic
 		_proximityPan = Pan;
 		return this;
 	}
-	
+
 	/**
 	 * Call this function to play the sound - also works on paused sounds.
 	 *
@@ -484,21 +484,21 @@ class FlxSound extends FlxBasic
 	{
 		if (!exists)
 			return this;
-			
+
 		if (ForceRestart)
 			cleanup(false, true);
 		else if (playing) // Already playing sound
 			return this;
-			
+
 		if (_paused)
 			resume();
 		else
 			startSound(StartTime);
-			
+
 		endTime = EndTime;
 		return this;
 	}
-	
+
 	/**
 	 * Unpause a sound. Only works on sounds that have been paused.
 	 */
@@ -508,7 +508,7 @@ class FlxSound extends FlxBasic
 			startSound(_time);
 		return this;
 	}
-	
+
 	/**
 	 * Call this function to pause this sound.
 	 */
@@ -516,13 +516,13 @@ class FlxSound extends FlxBasic
 	{
 		if (!playing)
 			return this;
-			
+
 		_time = _channel.position;
 		_paused = true;
 		cleanup(false, false);
 		return this;
 	}
-	
+
 	/**
 	 * Call this function to stop this sound.
 	 */
@@ -531,7 +531,7 @@ class FlxSound extends FlxBasic
 		cleanup(autoDestroy, true);
 		return this;
 	}
-	
+
 	/**
 	 * Helper function that tweens this sound's volume.
 	 *
@@ -543,10 +543,10 @@ class FlxSound extends FlxBasic
 		if (fadeTween != null)
 			fadeTween.cancel();
 		fadeTween = FlxTween.num(volume, To, Duration, {onComplete: onComplete}, volumeTween);
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Helper function that tweens this sound's volume.
 	 *
@@ -558,19 +558,19 @@ class FlxSound extends FlxBasic
 	{
 		if (!playing)
 			play();
-			
+
 		if (fadeTween != null)
 			fadeTween.cancel();
-			
+
 		fadeTween = FlxTween.num(From, To, Duration, {onComplete: onComplete}, volumeTween);
 		return this;
 	}
-	
+
 	function volumeTween(f:Float):Void
 	{
 		volume = f;
 	}
-	
+
 	/**
 	 * Returns the currently selected "real" volume of the sound (takes fades and proximity into account).
 	 *
@@ -580,7 +580,7 @@ class FlxSound extends FlxBasic
 	{
 		return _volume * _volumeAdjust;
 	}
-	
+
 	/**
 	 * Helper function to set the coordinates of this object.
 	 * Sound positioning is used in conjunction with proximity/panning.
@@ -593,7 +593,7 @@ class FlxSound extends FlxBasic
 		x = X;
 		y = Y;
 	}
-	
+
 	/**
 	 * Call after adjusting the volume to update the sound channel's settings.
 	 */
@@ -602,11 +602,11 @@ class FlxSound extends FlxBasic
 	{
 		_transform.volume = #if FLX_SOUND_SYSTEM (FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume * #end
 			(group != null ? group.volume : 1) * _volume * _volumeAdjust;
-			
+
 		if (_channel != null)
 			_channel.soundTransform = _transform;
 	}
-	
+
 	/**
 	 * An internal helper function used to attempt to start playing
 	 * the sound and populate the _channel variable.
@@ -615,7 +615,7 @@ class FlxSound extends FlxBasic
 	{
 		if (_sound == null)
 			return;
-			
+
 		_time = StartTime;
 		_paused = false;
 		_channel = _sound.play(_time, 0, _transform);
@@ -633,7 +633,7 @@ class FlxSound extends FlxBasic
 			active = false;
 		}
 	}
-	
+
 	/**
 	 * An internal helper function used to help Flash
 	 * clean up finished sounds or restart looped sounds.
@@ -642,7 +642,7 @@ class FlxSound extends FlxBasic
 	{
 		if (onComplete != null)
 			onComplete();
-			
+
 		if (looped)
 		{
 			cleanup(false);
@@ -651,7 +651,7 @@ class FlxSound extends FlxBasic
 		else
 			cleanup(autoDestroy);
 	}
-	
+
 	/**
 	 * An internal helper function used to help Flash clean up (and potentially re-use) finished sounds.
 	 * Will stop the current sound and destroy the associated SoundChannel, plus,
@@ -668,23 +668,23 @@ class FlxSound extends FlxBasic
 			reset();
 			return;
 		}
-		
+
 		if (_channel != null)
 		{
 			_channel.removeEventListener(Event.SOUND_COMPLETE, stopped);
 			_channel.stop();
 			_channel = null;
 		}
-		
+
 		active = false;
-		
+
 		if (resetPosition)
 		{
 			_time = 0;
 			_paused = false;
 		}
 	}
-	
+
 	/**
 	 * Internal event handler for ID3 info (i.e. fetching the song name).
 	 */
@@ -694,7 +694,7 @@ class FlxSound extends FlxBasic
 		artist = _sound.id3.artist;
 		_sound.removeEventListener(Event.ID3, gotID3);
 	}
-	
+
 	#if FLX_SOUND_SYSTEM
 	@:allow(flixel.system.frontEnds.SoundFrontEnd)
 	function onFocus():Void
@@ -702,7 +702,7 @@ class FlxSound extends FlxBasic
 		if (!_alreadyPaused)
 			resume();
 	}
-	
+
 	@:allow(flixel.system.frontEnds.SoundFrontEnd)
 	function onFocusLost():Void
 	{
@@ -710,7 +710,7 @@ class FlxSound extends FlxBasic
 		pause();
 	}
 	#end
-	
+
 	@:deprecated("sound.group = myGroup is deprecated, use myGroup.add(sound)") // 5.7.0
 	function set_group(value:FlxSoundGroup):FlxSoundGroup
 	{
@@ -726,30 +726,30 @@ class FlxSound extends FlxBasic
 		}
 		return value;
 	}
-	
+
 	inline function get_playing():Bool
 	{
 		return _channel != null;
 	}
-	
+
 	inline function get_volume():Float
 	{
 		return _volume;
 	}
-	
+
 	function set_volume(Volume:Float):Float
 	{
 		_volume = FlxMath.bound(Volume, 0, 1);
 		updateTransform();
 		return Volume;
 	}
-	
+
 	#if FLX_PITCH
 	inline function get_pitch():Float
 	{
 		return _pitch;
 	}
-	
+
 	function set_pitch(v:Float):Float
 	{
 		if (_channel != null)
@@ -764,28 +764,28 @@ class FlxSound extends FlxBasic
 				_channel.__audioSource.pitch = v;
 			#end
 		}
-			
+
 		return _pitch = v;
 	}
 	#end
-	
+
 	inline function get_pan():Float
 	{
 		return _transform.pan;
 	}
-	
+
 	inline function set_pan(pan:Float):Float
 	{
 		_transform.pan = pan;
 		updateTransform();
 		return pan;
 	}
-	
+
 	inline function get_time():Float
 	{
-		return _time;
+		return (playing) ? _channel.position : _time;
 	}
-	
+
 	function set_time(time:Float):Float
 	{
 		if (playing)
@@ -795,12 +795,12 @@ class FlxSound extends FlxBasic
 		}
 		return _time = time;
 	}
-	
+
 	inline function get_length():Float
 	{
 		return _length;
 	}
-	
+
 	override public function toString():String
 	{
 		return FlxStringUtil.getDebugString([


### PR DESCRIPTION
It seems that directly seeking for `channel.position` is less prone to errors when seeking for `sound.time`.
Not sure where the issue actually comes from yet, but this fixed bunch of issues related to music syncing for me.

```haxe
import flixel.FlxG;
import flixel.FlxState;
import flixel.sound.FlxSound;
import flixel.text.FlxText;

class PlayState extends FlxState
{
	var _instrumental:FlxSound;
	var _voices:Array<FlxSound> = [];

	var _resyncText:FlxText;
	var _resyncs:Int = 0;

	override public function create()
	{
		super.create();

		FlxG.fixedTimestep = false;

		_instrumental = FlxG.sound.load(AssetPaths.Inst__ogg).play();
		_voices.push(FlxG.sound.load(AssetPaths.Voices_Opponent__ogg).play());
		_voices.push(FlxG.sound.load(AssetPaths.Voices_Player__ogg).play());

		_resyncText = new FlxText(10, 10, 0, "0", 16);
		add(_resyncText);
	}

	override public function update(elapsed:Float)
	{
		for (voice in _voices)
		{
			if (Math.abs(voice.time - _instrumental.time) > 5)
			{
				voice.time = _instrumental.time;
				_resyncText.text = Std.string(++_resyncs);
			}
		}
	}
}
```
Here, the voices would resync often, causing audio stutters. The changes made by this PR seems to fix it, as well as other issues in my other project
Pr in draft as it may be better to fix the root issue instead

NOTE: this PR introduces behaviour change, originally sounds that aren't updated won't have their `time` value changing during playback. Here it changes regardless.