### PR TITLE
add FACE_ buttons

### DIFF
--- a/flixel/input/gamepad/FlxGamepadInputID.hx
+++ b/flixel/input/gamepad/FlxGamepadInputID.hx
@@ -16,18 +16,38 @@ enum abstract FlxGamepadInputID(Int) from Int to Int
 	// Button Indices
 	var ANY = -2;
 	var NONE = -1;
-
-	/**BOTTOM face button*/
+	
+	#if FLX_ABXY_BY_LABEL
+	/**
+	 * A face button, the BOTTOM on most controllers, or the RIGHT on Nintendo controllers. It
+	 * is recommended to use this for ## and `FACE_DOWN` or `FACE_RIGHT` for actions like jumping
+	 */
 	var A = 0;
 
-	/**RIGHT face button*/
+	/**
+	 * B face button, the RIGHT on most controllers, or the BOTTOM on Nintendo controllers. It
+	 * is recommended to use this for ## and `FACE_DOWN` or `FACE_RIGHT` for actions like jumping
+	 */
 	var B = 1;
 
-	/**LEFT face button*/
+	/** X face button, the LEFT on most controllers, or the TOP on Nintendo controllers */
 	var X = 2;
 
-	/**TOP face button*/
+	/** Y face button, the TOP on most controllers, or the LEFT on Nintendo controllers */
 	var Y = 3;
+	#else
+	/** BOTTOM face button */
+	var A = 0;
+
+	/** RIGHT face button */
+	var B = 1;
+
+	/** LEFT face button */
+	var X = 2;
+
+	/** TOP face button */
+	var Y = 3;
+	#end
 
 	/**left digital "bumper"*/
 	var LEFT_SHOULDER = 4;
@@ -127,6 +147,15 @@ enum abstract FlxGamepadInputID(Int) from Int to Int
 
 	/**left analog stick as a dpad, pushed left**/
 	var RIGHT_STICK_DIGITAL_LEFT = 41;
+
+	/** TOP face button */
+	var FACE_UP = 42;
+	/** BOTTOM face button */
+	var FACE_DOWN = 43;
+	/** LEFT face button */
+	var FACE_LEFT = 44;
+	/** RIGHT face button */
+	var FACE_RIGHT = 45;
 
 	@:from
 	public static inline function fromString(s:String)

--- a/flixel/input/gamepad/lists/FlxGamepadButtonList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadButtonList.hx
@@ -211,6 +211,26 @@ class FlxGamepadButtonList extends FlxBaseGamepadList
 	inline function get_RIGHT_STICK_DIGITAL_LEFT()
 		return check(FlxGamepadInputID.RIGHT_STICK_DIGITAL_LEFT);
 
+	public var FACE_UP(get, never):Bool;
+	
+	inline function get_FACE_UP()
+		return check(FlxGamepadInputID.FACE_UP);
+
+	public var FACE_DOWN(get, never):Bool;
+	
+	inline function get_FACE_DOWN()
+		return check(FlxGamepadInputID.FACE_DOWN);
+
+	public var FACE_LEFT(get, never):Bool;
+	
+	inline function get_FACE_LEFT()
+		return check(FlxGamepadInputID.FACE_LEFT);
+
+	public var FACE_RIGHT(get, never):Bool;
+	
+	inline function get_FACE_RIGHT()
+		return check(FlxGamepadInputID.FACE_RIGHT);
+
 	public function new(status:FlxInputState, gamepad:FlxGamepad)
 	{
 		super(status, gamepad);

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -65,7 +65,14 @@ class FlxGamepadMapping
 	 */
 	public function getRawID(ID:FlxGamepadInputID):Int
 	{
-		return -1;
+		return switch ID
+		{
+			case FACE_UP: getRawID(Y);
+			case FACE_DOWN: getRawID(A);
+			case FACE_LEFT: getRawID(X);
+			case FACE_RIGHT: getRawID(B);
+			default: -1;
+		}
 	}
 
 	/**
@@ -139,6 +146,8 @@ class FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: "rs-down";
 			case RIGHT_STICK_DIGITAL_LEFT: "rs-left";
 			case RIGHT_STICK_DIGITAL_RIGHT: "rs-right";
+			case FACE_UP | FACE_DOWN | FACE_LEFT| FACE_RIGHT:
+				getInputLabel(getRawID(id));
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: "l2";
 			case RIGHT_TRIGGER_FAKE: "r2";

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -85,7 +85,7 @@ class LogitechMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LogitechID.SEVEN;
 			case RIGHT_TRIGGER_FAKE: LogitechID.EIGHT;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -75,7 +75,7 @@ class MFiMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER_FAKE: MFiID.RIGHT_TRIGGER;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -80,12 +80,12 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			default:
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp) LEFT_STICK_DIGITAL_UP;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown) LEFT_STICK_DIGITAL_DOWN;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft) LEFT_STICK_DIGITAL_LEFT;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight) LEFT_STICK_DIGITAL_RIGHT;
-				NONE;
+			case id if(id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if(id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if(id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if(id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+				
+			default: NONE;
 		}
 	}
 
@@ -174,7 +174,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -193,7 +193,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case BACK: MayflashWiiRemoteID.REMOTE_MINUS;
 			case GUIDE: MayflashWiiRemoteID.REMOTE_HOME;
 			case START: MayflashWiiRemoteID.REMOTE_PLUS;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -77,7 +77,7 @@ class OUYAMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -96,7 +96,7 @@ class PS4Mapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -63,7 +63,7 @@ class PSVitaMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: PSVitaID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: PSVitaID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: PSVitaID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -52,10 +52,17 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 	{
 		return switch (id)
 		{
+			#if FLX_ABXY_BY_LABEL
+			case A: SwitchJoyconLeftID.RIGHT;
+			case B: SwitchJoyconLeftID.DOWN;
+			case X: SwitchJoyconLeftID.UP;
+			case Y: SwitchJoyconLeftID.LEFT;
+			#else
 			case A: SwitchJoyconLeftID.DOWN;
 			case B: SwitchJoyconLeftID.RIGHT;
 			case X: SwitchJoyconLeftID.LEFT;
 			case Y: SwitchJoyconLeftID.UP;
+			#end
 			case START: SwitchJoyconLeftID.MINUS;
 			case LEFT_STICK_CLICK: SwitchJoyconLeftID.LEFT_STICK_CLICK;
 			case LEFT_SHOULDER: SwitchJoyconLeftID.SL;
@@ -66,11 +73,15 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawRight;
+			case FACE_UP: SwitchJoyconLeftID.UP;
+			case FACE_DOWN: SwitchJoyconLeftID.DOWN;
+			case FACE_LEFT: SwitchJoyconLeftID.LEFT;
+			case FACE_RIGHT: SwitchJoyconLeftID.RIGHT;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			default: super.getRawID(id);
 		}
 	}
 
@@ -78,15 +89,26 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 	{
 		return switch (id)
 		{
+			#if FLX_ABXY_BY_LABEL
+			case A: "right";
+			case B: "down";
+			case X: "up";
+			case Y: "left";
+			#else
 			case A: "down";
 			case B: "right";
 			case X: "left";
 			case Y: "up";
+			#end
 			case START: "minus";
 			case EXTRA_0: "l";
 			case LEFT_SHOULDER: "sl";
 			case RIGHT_SHOULDER: "sr";
 			case LEFT_TRIGGER: "zl";
+			case FACE_UP: "up";
+			case FACE_DOWN: "down";
+			case FACE_LEFT: "left";
+			case FACE_RIGHT: "right";
 			case _: super.getInputLabel(id);
 		}
 	}

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -30,10 +30,17 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 	{
 		return switch (rawID)
 		{
+			#if FLX_ABXY_BY_LABEL
+			case SwitchJoyconRightID.A: X;
+			case SwitchJoyconRightID.B: A;
+			case SwitchJoyconRightID.X: Y;
+			case SwitchJoyconRightID.Y: B;
+			#else
 			case SwitchJoyconRightID.A: A;
 			case SwitchJoyconRightID.B: X;
 			case SwitchJoyconRightID.X: B;
 			case SwitchJoyconRightID.Y: Y;
+			#end
 			case SwitchJoyconRightID.HOME: GUIDE;
 			case SwitchJoyconRightID.PLUS: START;
 			case SwitchJoyconRightID.LEFT_STICK_CLICK: LEFT_STICK_CLICK;
@@ -53,10 +60,17 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 	{
 		return switch (ID)
 		{
+			#if FLX_ABXY_BY_LABEL
+			case A: SwitchJoyconRightID.X;
+			case B: SwitchJoyconRightID.A;
+			case X: SwitchJoyconRightID.Y;
+			case Y: SwitchJoyconRightID.B;
+			#else
 			case A: SwitchJoyconRightID.A;
 			case B: SwitchJoyconRightID.X;
 			case X: SwitchJoyconRightID.B;
 			case Y: SwitchJoyconRightID.Y;
+			#end
 			case GUIDE: SwitchJoyconRightID.HOME;
 			case START: SwitchJoyconRightID.PLUS;
 			case LEFT_STICK_CLICK: SwitchJoyconRightID.LEFT_STICK_CLICK;
@@ -68,11 +82,15 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawRight;
+			case FACE_UP: SwitchJoyconRightID.Y;
+			case FACE_DOWN: SwitchJoyconRightID.A;
+			case FACE_LEFT: SwitchJoyconRightID.B;
+			case FACE_RIGHT: SwitchJoyconRightID.X;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -65,10 +65,17 @@ class SwitchProMapping extends FlxGamepadMapping
 	{
 		return switch (ID)
 		{
+			#if FLX_ABXY_BY_LABEL
+			case A: SwitchProID.A;
+			case B: SwitchProID.B;
+			case X: SwitchProID.X;
+			case Y: SwitchProID.Y;
+			#else
 			case A: SwitchProID.B;
 			case B: SwitchProID.A;
 			case X: SwitchProID.Y;
 			case Y: SwitchProID.X;
+			#end
 			case BACK: SwitchProID.MINUS;
 			case EXTRA_0: SwitchProID.CAPTURE;
 			case GUIDE: SwitchProID.HOME;
@@ -91,11 +98,15 @@ class SwitchProMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: SwitchProID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: SwitchProID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: SwitchProID.RIGHT_ANALOG_STICK.rawRight;
+			case FACE_UP: SwitchProID.X;
+			case FACE_DOWN: SwitchProID.B;
+			case FACE_LEFT: SwitchProID.Y;
+			case FACE_RIGHT: SwitchProID.A;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -43,6 +43,8 @@ private enum UserDefines
 	FLX_TRACK_POOLS;
 	/** Adds `creationInfo` to FlxGraphic instances, automatically defined with FLX_DEBUG */
 	FLX_TRACK_GRAPHICS;
+	/** Whether ABXY refer to switch gamepad buttons by name rather than XInput locations */
+	FLX_ABXY_BY_LABEL;
 }
 
 /**
@@ -86,6 +88,8 @@ private enum HelperDefines
 	FLX_HEALTH;
 	FLX_NO_TRACK_POOLS;
 	FLX_NO_TRACK_GRAPHICS;
+	/** Whether ABXY refer to switch gamepad buttons by XInput locations rather than name */
+	FLX_ABXY_BY_LOCATION;
 }
 
 class FlxDefines
@@ -186,6 +190,7 @@ class FlxDefines
 		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
 		defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
 		defineInversion(FLX_TRACK_POOLS, FLX_NO_TRACK_POOLS);
+		defineInversion(FLX_ABXY_BY_LABEL, FLX_ABXY_BY_LOCATION);
 		// defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS); // special case
 	}
 


### PR DESCRIPTION
Adds FACE_UP, FACE_DOWN, FACE_LEFT and FACE_RIGHT gamepad buttons. Enabled via FLX_ABXY_BY_LABEL
Note: FLX_NO_SWITCH_ABXY caused errors, I'm not sure why, it happened with FLX_NO_SWITCH as well but not FLX_NO_SWITC, making me think that flag is used somewhere (repo searches found nothing)

I'm having doubts about this, now that I've used it, it may just be better to add `ACCEPT`(A) and `CANCEL` (B) buttons.

Pros of adding ACCEPT/CANCEL: 
- Not a breaking change
- Don't need new defines, enabled by default
- X and Y actions are rarely swapped in switch versions of games
Cons:
- BACK and CANCEL might get confused