### PR TITLE
FlxGamepadInputID: Add ACCEPT/CANCEL buttons

### DIFF
--- a/flixel/input/gamepad/FlxGamepadInputID.hx
+++ b/flixel/input/gamepad/FlxGamepadInputID.hx
@@ -35,7 +35,7 @@ enum abstract FlxGamepadInputID(Int) from Int to Int
 	/**right digital "bumper"*/
 	var RIGHT_SHOULDER = 5;
 
-	/**also known as "select", the leftmost center button*/
+	/**also known as "select", the left-most center button*/
 	var BACK = 6;
 
 	/**the rightmost center button*/
@@ -127,7 +127,19 @@ enum abstract FlxGamepadInputID(Int) from Int to Int
 
 	/**left analog stick as a dpad, pushed left**/
 	var RIGHT_STICK_DIGITAL_LEFT = 41;
-
+	
+	/**
+	 * Mapped to The bottom face button on most controllers, and the
+	 * right face button on Nintendo Switch controllers
+	**/
+	var ACCEPT = 42;
+	
+	/**
+	 * Mapped to The bottom face button on most controllers, and the
+	 * right face button on Nintendo Switch controllers
+	**/
+	var CANCEL = 43;
+	
 	@:from
 	public static inline function fromString(s:String)
 	{

--- a/flixel/input/gamepad/lists/FlxGamepadButtonList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadButtonList.hx
@@ -39,6 +39,10 @@ class FlxGamepadButtonList extends FlxBaseGamepadList
 	inline function get_RIGHT_SHOULDER()
 		return check(FlxGamepadInputID.RIGHT_SHOULDER);
 
+	/**
+	 * Also known as "select", the left-most center button.
+	 * Not to be confused with `CANCEL`, which is a face button (usually B)
+	 */
 	public var BACK(get, never):Bool;
 
 	inline function get_BACK()
@@ -210,6 +214,25 @@ class FlxGamepadButtonList extends FlxBaseGamepadList
 
 	inline function get_RIGHT_STICK_DIGITAL_LEFT()
 		return check(FlxGamepadInputID.RIGHT_STICK_DIGITAL_LEFT);
+	
+	/**
+	 * Mapped to The bottom face button on most controllers, and the
+	 * right face button on Nintendo Switch controllers
+	**/
+	public var ACCEPT(get, never):Bool;
+	
+	inline function get_ACCEPT()
+		return check(FlxGamepadInputID.ACCEPT);
+	
+	/**
+	 * Mapped to The right face button on most controllers, and the
+	 * bottom face button on Nintendo Switch controllers.
+	 * Not to be confused with `BACK` which is the XInput "select" button
+	**/
+	public var CANCEL(get, never):Bool;
+	
+	inline function get_CANCEL()
+		return check(FlxGamepadInputID.CANCEL);
 
 	public function new(status:FlxInputState, gamepad:FlxGamepad)
 	{

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -65,7 +65,12 @@ class FlxGamepadMapping
 	 */
 	public function getRawID(ID:FlxGamepadInputID):Int
 	{
-		return -1;
+		return switch ID
+		{
+			case ACCEPT: A;
+			case CANCEL: B;
+			default: -1;
+		}
 	}
 
 	/**
@@ -139,6 +144,8 @@ class FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: "rs-down";
 			case RIGHT_STICK_DIGITAL_LEFT: "rs-left";
 			case RIGHT_STICK_DIGITAL_RIGHT: "rs-right";
+			case ACCEPT: getInputLabel(cast getRawID(id));
+			case CANCEL: getInputLabel(cast getRawID(id));
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: "l2";
 			case RIGHT_TRIGGER_FAKE: "r2";

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -67,8 +67,8 @@ class FlxGamepadMapping
 	{
 		return switch ID
 		{
-			case ACCEPT: A;
-			case CANCEL: B;
+			case ACCEPT: getRawID(A);
+			case CANCEL: getRawID(B);
 			default: -1;
 		}
 	}

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -85,7 +85,7 @@ class LogitechMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LogitechID.SEVEN;
 			case RIGHT_TRIGGER_FAKE: LogitechID.EIGHT;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -75,7 +75,7 @@ class MFiMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER_FAKE: MFiID.RIGHT_TRIGGER;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -80,12 +80,11 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			default:
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp) LEFT_STICK_DIGITAL_UP;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown) LEFT_STICK_DIGITAL_DOWN;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft) LEFT_STICK_DIGITAL_LEFT;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight) LEFT_STICK_DIGITAL_RIGHT;
-				NONE;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			default: NONE;
 		}
 	}
 
@@ -174,7 +173,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -193,7 +192,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case BACK: MayflashWiiRemoteID.REMOTE_MINUS;
 			case GUIDE: MayflashWiiRemoteID.REMOTE_HOME;
 			case START: MayflashWiiRemoteID.REMOTE_PLUS;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -77,7 +77,7 @@ class OUYAMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -96,7 +96,7 @@ class PS4Mapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -63,7 +63,7 @@ class PSVitaMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: PSVitaID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: PSVitaID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: PSVitaID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -70,7 +70,9 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			case ACCEPT: SwitchJoyconLeftID.RIGHT;
+			case CANCEL: SwitchJoyconLeftID.DOWN;
+			default: super.getRawID(id);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -72,7 +72,9 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			case ACCEPT: SwitchJoyconRightID.A;
+			case CANCEL: SwitchJoyconRightID.B;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -95,7 +95,9 @@ class SwitchProMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			case ACCEPT: SwitchProID.A;
+			case CANCEL: SwitchProID.B;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -80,12 +80,11 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case WiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case WiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case WiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			default:
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawUp) LEFT_STICK_DIGITAL_UP;
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawDown) LEFT_STICK_DIGITAL_DOWN;
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft) LEFT_STICK_DIGITAL_LEFT;
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawRight) LEFT_STICK_DIGITAL_RIGHT;
-				NONE;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			default: super.getRawID(rawID);
 		}
 	}
 
@@ -147,7 +146,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: WiiRemoteID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: WiiRemoteID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: WiiRemoteID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -174,7 +173,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -195,7 +194,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case START: WiiRemoteID.REMOTE_PLUS;
 			case TILT_PITCH: WiiRemoteID.REMOTE_TILT_PITCH;
 			case TILT_ROLL: WiiRemoteID.REMOTE_TILT_ROLL;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -93,7 +93,7 @@ class XInputMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: XInputID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: XInputID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 


### PR DESCRIPTION
Untested

Adds gamepad buttons `ACCEPT` and `CANCEL`, which map to either A or B depending on the controller

Alternative to https://github.com/HaxeFlixel/flixel/pull/3275