### PR TITLE
FlxGamepadManager: Add FlxG.gamepads.acceptMode

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -830,19 +830,19 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return switch (model)
 		{
-			case LOGITECH: cast new LogitechMapping(attachment);
-			case OUYA: cast new OUYAMapping(attachment);
-			case PS4: cast new PS4Mapping(attachment);
-			case PSVITA: cast new PSVitaMapping(attachment);
-			case XINPUT: cast new XInputMapping(attachment);
-			case MAYFLASH_WII_REMOTE: cast new MayflashWiiRemoteMapping(attachment);
-			case WII_REMOTE: cast new WiiRemoteMapping(attachment);
-			case MFI: cast new MFiMapping(attachment);
-			case SWITCH_PRO: cast new SwitchProMapping(attachment);
-			case SWITCH_JOYCON_LEFT: cast new SwitchJoyconLeftMapping(attachment);
-			case SWITCH_JOYCON_RIGHT: cast new SwitchJoyconRightMapping(attachment);
+			case LOGITECH: new LogitechMapping(attachment);
+			case OUYA: new OUYAMapping(attachment);
+			case PS4: new PS4Mapping(attachment);
+			case PSVITA: new PSVitaMapping(attachment);
+			case XINPUT: new XInputMapping(attachment);
+			case MAYFLASH_WII_REMOTE: new MayflashWiiRemoteMapping(attachment);
+			case WII_REMOTE: new WiiRemoteMapping(attachment);
+			case MFI: new MFiMapping(attachment);
+			case SWITCH_PRO: new SwitchProMapping(attachment);
+			case SWITCH_JOYCON_LEFT: new SwitchJoyconLeftMapping(attachment);
+			case SWITCH_JOYCON_RIGHT: new SwitchJoyconRightMapping(attachment);
 			// default to XInput if we don't have a mapping for this
-			case _: cast new XInputMapping(attachment);
+			case _: new XInputMapping(attachment);
 		}
 	}
 

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -892,7 +892,7 @@ class FlxGamepad implements IFlxDestroyable
 	
 	/** 
 	 * The value of the target gamepad input. For instance, on a PS4 gamepad `A` is `PS4(PS4ID.X)`,
-	 * while Xbox is `XInput(XInputID.A)` and the Switch pro controller is `SwitchPro(SwitchProID.B)`
+	 * while Xbox is `X_INPUT(XInputID.A)` and the Switch pro controller is `SWITCH_PRO(SwitchProID.B)`
 	 * @since 5.9.0
 	 */
 	public function getMappedInput(id:FlxGamepadInputID):FlxGamepadMappedInput

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -880,7 +880,9 @@ class FlxGamepad implements IFlxDestroyable
 		return _deadZone = deadZone;
 	}
 	
-	/** 
+	/**
+	 * A string representing the label of the target input. For instance, on a PS4 gamepad
+	 * `A` is "x", while Xbox is "a" and the Switch pro controller is "B"
 	 * @since 4.8.0
 	 */
 	public inline function getInputLabel(id:FlxGamepadInputID)
@@ -889,6 +891,8 @@ class FlxGamepad implements IFlxDestroyable
 	}
 	
 	/** 
+	 * The value of the target gamepad input. For instance, on a PS4 gamepad `A` is `PS4(PS4ID.X)`,
+	 * while Xbox is `XInput(XInputID.A)` and the Switch pro controller is `SwitchPro(SwitchProID.B)`
 	 * @since 5.9.0
 	 */
 	public function getMappedInput(id:FlxGamepadInputID):FlxGamepadMappedInput

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -1,6 +1,7 @@
 package flixel.input.gamepad;
 
 import flixel.input.FlxInput.FlxInputState;
+import flixel.input.gamepad.FlxGamepadMappedInput;
 import flixel.input.gamepad.lists.FlxGamepadAnalogList;
 import flixel.input.gamepad.lists.FlxGamepadButtonList;
 import flixel.input.gamepad.lists.FlxGamepadMotionValueList;
@@ -829,19 +830,19 @@ class FlxGamepad implements IFlxDestroyable
 	{
 		return switch (model)
 		{
-			case LOGITECH: new LogitechMapping(attachment);
-			case OUYA: new OUYAMapping(attachment);
-			case PS4: new PS4Mapping(attachment);
-			case PSVITA: new PSVitaMapping(attachment);
-			case XINPUT: new XInputMapping(attachment);
-			case MAYFLASH_WII_REMOTE: new MayflashWiiRemoteMapping(attachment);
-			case WII_REMOTE: new WiiRemoteMapping(attachment);
-			case MFI: new MFiMapping(attachment);
-			case SWITCH_PRO: new SwitchProMapping(attachment);
-			case SWITCH_JOYCON_LEFT: new SwitchJoyconLeftMapping(attachment);
-			case SWITCH_JOYCON_RIGHT: new SwitchJoyconRightMapping(attachment);
+			case LOGITECH: cast new LogitechMapping(attachment);
+			case OUYA: cast new OUYAMapping(attachment);
+			case PS4: cast new PS4Mapping(attachment);
+			case PSVITA: cast new PSVitaMapping(attachment);
+			case XINPUT: cast new XInputMapping(attachment);
+			case MAYFLASH_WII_REMOTE: cast new MayflashWiiRemoteMapping(attachment);
+			case WII_REMOTE: cast new WiiRemoteMapping(attachment);
+			case MFI: cast new MFiMapping(attachment);
+			case SWITCH_PRO: cast new SwitchProMapping(attachment);
+			case SWITCH_JOYCON_LEFT: cast new SwitchJoyconLeftMapping(attachment);
+			case SWITCH_JOYCON_RIGHT: cast new SwitchJoyconRightMapping(attachment);
 			// default to XInput if we don't have a mapping for this
-			case _: new XInputMapping(attachment);
+			case _: cast new XInputMapping(attachment);
 		}
 	}
 
@@ -885,6 +886,14 @@ class FlxGamepad implements IFlxDestroyable
 	public inline function getInputLabel(id:FlxGamepadInputID)
 	{
 		return mapping.getInputLabel(id);
+	}
+	
+	/** 
+	 * @since 5.9.0
+	 */
+	public function getMappedInput(id:FlxGamepadInputID):FlxGamepadMappedInput
+	{
+		return mapping.getMappedInput(id);
 	}
 
 	public function toString():String

--- a/flixel/input/gamepad/FlxGamepadAnalogStick.hx
+++ b/flixel/input/gamepad/FlxGamepadAnalogStick.hx
@@ -6,8 +6,8 @@ typedef FlxGamepadAnalogStick = FlxTypedGamepadAnalogStick<Int>;
 
 class FlxTypedGamepadAnalogStick<TInputID:Int>
 {
-	public var x(default, null):TInputID;
-	public var y(default, null):TInputID;
+	public var x(default, null):Int;
+	public var y(default, null):Int;
 
 	/**
 	 * a raw button input ID, for sending a digital event for "up" alongside the analog event
@@ -39,20 +39,31 @@ class FlxTypedGamepadAnalogStick<TInputID:Int>
 	 */
 	public var mode(default, null):FlxAnalogToDigitalMode = BOTH;
 
-	public function new(x:Int, y:Int, ?settings:FlxGamepadAnalogStickSettings)
+	public function new(x:Int, y:Int, ?settings:FlxGamepadAnalogStickSettings<TInputID>)
 	{
-		this.x = cast x;
-		this.y = cast y;
+		this.x = x;
+		this.y = y;
 
-		if (settings == null)
-			return;
-
-		mode = (settings.mode != null) ? settings.mode : BOTH;
-		rawUp = cast (settings.up != null) ? settings.up : -1;
-		rawDown = cast (settings.down != null) ? settings.down : -1;
-		rawLeft = cast (settings.left != null) ? settings.left : -1;
-		rawRight = cast (settings.right != null) ? settings.right : -1;
-		digitalThreshold = (settings.threshold != null) ? settings.threshold : 0.5;
+		if (settings != null)
+		{
+			if (settings.mode != null)
+				mode = settings.mode;
+			
+			if (settings.up != null)
+				rawUp = settings.up;
+			
+			if (settings.down != null)
+				rawDown = settings.down;
+			
+			if (settings.left != null)
+				rawLeft = settings.left;
+			
+			if (settings.right != null)
+				rawRight = settings.right;
+			
+			if (settings.threshold != null)
+				digitalThreshold = settings.threshold;
+		}
 	}
 
 	public function toString():String
@@ -70,12 +81,12 @@ class FlxTypedGamepadAnalogStick<TInputID:Int>
 	}
 }
 
-typedef FlxGamepadAnalogStickSettings =
+typedef FlxGamepadAnalogStickSettings<TInputID:Int> =
 {
-	?up:Int,
-	?down:Int,
-	?left:Int,
-	?right:Int,
+	?up:TInputID,
+	?down:TInputID,
+	?left:TInputID,
+	?right:TInputID,
 	?threshold:Float,
 	?mode:FlxAnalogToDigitalMode
 }

--- a/flixel/input/gamepad/FlxGamepadAnalogStick.hx
+++ b/flixel/input/gamepad/FlxGamepadAnalogStick.hx
@@ -2,30 +2,32 @@ package flixel.input.gamepad;
 
 import flixel.util.FlxStringUtil;
 
-class FlxGamepadAnalogStick
+typedef FlxGamepadAnalogStick = FlxTypedGamepadAnalogStick<Int>;
+
+class FlxTypedGamepadAnalogStick<TInputID:Int>
 {
-	public var x(default, null):Int;
-	public var y(default, null):Int;
+	public var x(default, null):TInputID;
+	public var y(default, null):TInputID;
 
 	/**
 	 * a raw button input ID, for sending a digital event for "up" alongside the analog event
 	 */
-	public var rawUp(default, null):Int = -1;
+	public var rawUp(default, null):TInputID = cast -1;
 
 	/**
 	 * a raw button input ID, for sending a digital event for "down" alongside the analog event
 	 */
-	public var rawDown(default, null):Int = -1;
+	public var rawDown(default, null):TInputID = cast -1;
 
 	/**
 	 * a raw button input ID, for sending a digital event for "left" alongside the analog event
 	 */
-	public var rawLeft(default, null):Int = -1;
+	public var rawLeft(default, null):TInputID = cast -1;
 
 	/**
 	 * a raw button input ID, for sending a digital event for "right" alongside the analog event
 	 */
-	public var rawRight(default, null):Int = -1;
+	public var rawRight(default, null):TInputID = cast -1;
 
 	/**
 	 * the absolute value the dpad must be greater than before digital inputs are sent
@@ -39,17 +41,17 @@ class FlxGamepadAnalogStick
 
 	public function new(x:Int, y:Int, ?settings:FlxGamepadAnalogStickSettings)
 	{
-		this.x = x;
-		this.y = y;
+		this.x = cast x;
+		this.y = cast y;
 
 		if (settings == null)
 			return;
 
 		mode = (settings.mode != null) ? settings.mode : BOTH;
-		rawUp = (settings.up != null) ? settings.up : -1;
-		rawDown = (settings.down != null) ? settings.down : -1;
-		rawLeft = (settings.left != null) ? settings.left : -1;
-		rawRight = (settings.right != null) ? settings.right : -1;
+		rawUp = cast (settings.up != null) ? settings.up : -1;
+		rawDown = cast (settings.down != null) ? settings.down : -1;
+		rawLeft = cast (settings.left != null) ? settings.left : -1;
+		rawRight = cast (settings.right != null) ? settings.right : -1;
 		digitalThreshold = (settings.threshold != null) ? settings.threshold : 0.5;
 	}
 

--- a/flixel/input/gamepad/FlxGamepadInputID.hx
+++ b/flixel/input/gamepad/FlxGamepadInputID.hx
@@ -35,7 +35,7 @@ enum abstract FlxGamepadInputID(Int) from Int to Int
 	/**right digital "bumper"*/
 	var RIGHT_SHOULDER = 5;
 
-	/**also known as "select", the leftmost center button*/
+	/**also known as "select", the left-most center button*/
 	var BACK = 6;
 
 	/**the rightmost center button*/
@@ -127,7 +127,19 @@ enum abstract FlxGamepadInputID(Int) from Int to Int
 
 	/**left analog stick as a dpad, pushed left**/
 	var RIGHT_STICK_DIGITAL_LEFT = 41;
-
+	
+	/**
+	 * Mapped to The bottom face button on most controllers, and the
+	 * right face button on Nintendo Switch controllers
+	**/
+	var ACCEPT = 42;
+	
+	/**
+	 * Mapped to The bottom face button on most controllers, and the
+	 * right face button on Nintendo Switch controllers
+	**/
+	var CANCEL = 43;
+	
 	@:from
 	public static inline function fromString(s:String)
 	{

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -53,6 +53,7 @@ class FlxGamepadManager implements IFlxInputManager
 	
 	/**
 	 * Whether the bottom or right face button is ACCEPT
+	 * @since 5.9.0
 	 */
 	public var acceptMode:FlxGamepadAcceptMode = BOTTOM;
 	
@@ -601,6 +602,9 @@ class FlxGamepadManager implements IFlxInputManager
 	}
 }
 
+/**
+ * @since 5.9.0
+ */
 enum FlxGamepadAcceptMode
 {
 	/**

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -50,7 +50,12 @@ class FlxGamepadManager implements IFlxInputManager
 	 * @since 4.6.0
 	 */
 	public var deviceDisconnected(default, null):FlxTypedSignal<FlxGamepad->Void>;
-
+	
+	/**
+	 * Whether the bottom or right face button is ACCEPT
+	 */
+	public var acceptMode:FlxGamepadAcceptMode = BOTTOM;
+	
 	/**
 	 * Stores all gamepads - can have null entries, but index matches event.device
 	 */
@@ -594,4 +599,25 @@ class FlxGamepadManager implements IFlxInputManager
 				count++;
 		return count;
 	}
+}
+
+enum FlxGamepadAcceptMode
+{
+	/**
+	 * The bottom face button is `ACCEPT` and the right face button is `CANCEL`.
+	 * This is common on western-style consoles, like XBox or American PS4/5
+	 */
+	BOTTOM;
+	
+	/**
+	 * The right face button is `ACCEPT` and the bottom face button is `CANCEL`.
+	 * This is common in Japanese PS4/5 consoles, and Nintendo consoles
+	 */
+	RIGHT;
+	
+	/**
+	 * Behavies like `BOTTOM` for nearly all gamepads, but `RIGHT` for Nintendo
+	 * Switch gamepads
+	 */
+	ADAPTIVE;
 }

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -616,8 +616,8 @@ enum FlxGamepadAcceptMode
 	RIGHT;
 	
 	/**
-	 * Behavies like `BOTTOM` for nearly all gamepads, but `RIGHT` for Nintendo
-	 * Switch gamepads
+	 * Behaves like `BOTTOM` for nearly all gamepads, but `RIGHT` for specific mappings,
+	 * namely Nintendo Switch gamepads
 	 */
-	ADAPTIVE;
+	USE_MAPPING;
 }

--- a/flixel/input/gamepad/FlxGamepadMappedInput.hx
+++ b/flixel/input/gamepad/FlxGamepadMappedInput.hx
@@ -32,7 +32,7 @@ enum FlxGamepadMappedInput
 
 class FlxGamepadMappedInputTools
 {
-	static inline public function toModel(input:FlxGamepadMappedInput):FlxGamepadModel
+	static public inline function toModel(input:FlxGamepadMappedInput):FlxGamepadModel
 	{
 		return switch input
 		{

--- a/flixel/input/gamepad/FlxGamepadMappedInput.hx
+++ b/flixel/input/gamepad/FlxGamepadMappedInput.hx
@@ -13,6 +13,10 @@ import flixel.input.gamepad.id.SwitchProID;
 import flixel.input.gamepad.id.WiiRemoteID;
 import flixel.input.gamepad.id.XInputID;
 
+/**
+ * A list of every possible gamepad input from every known device
+ * @since 5.9.0
+ */
 @:using(flixel.input.gamepad.FlxGamepadMappedInput.FlxGamepadMappedInputTools)
 enum FlxGamepadMappedInput
 {
@@ -30,7 +34,7 @@ enum FlxGamepadMappedInput
 	UNKNOWN(id:FlxGamepadInputID);
 }
 
-class FlxGamepadMappedInputTools
+private class FlxGamepadMappedInputTools
 {
 	public static inline function toModel(input:FlxGamepadMappedInput):FlxGamepadModel
 	{

--- a/flixel/input/gamepad/FlxGamepadMappedInput.hx
+++ b/flixel/input/gamepad/FlxGamepadMappedInput.hx
@@ -1,19 +1,29 @@
 package flixel.input.gamepad;
 
-import flixel.input.gamepad.id.*;
+import flixel.input.gamepad.id.LogitechID;
+import flixel.input.gamepad.id.MayflashWiiRemoteID;
+import flixel.input.gamepad.id.MFiID;
+import flixel.input.gamepad.id.OUYAID;
+import flixel.input.gamepad.id.PS4ID;
+import flixel.input.gamepad.id.PSVitaID;
+import flixel.input.gamepad.id.SwitchJoyconLeftID;
+import flixel.input.gamepad.id.SwitchJoyconRightID;
+import flixel.input.gamepad.id.SwitchProID;
+import flixel.input.gamepad.id.WiiRemoteID;
+import flixel.input.gamepad.id.XInputID;
 
 enum FlxGamepadMappedInput
 {
-	Logitech(id:LogitechID);
-	MayflashWiiRemote(id:MayflashWiiRemoteID);
-	MFi(id:MFiID);
+	LOGITECH(id:LogitechID);
+	MAYFLASH_WII(id:MayflashWiiRemoteID);
+	MFI(id:MFiID);
 	OUYA(id:OUYAID);
 	PS4(id:PS4ID);
-	PSVita(id:PSVitaID);
-	SwitchJoyconLeft(id:SwitchJoyconLeftID);
-	SwitchJoyconRight(id:SwitchJoyconRightID);
-	SwitchPro(id:SwitchProID);
-	WiiRemote(id:WiiRemoteID);
-	XInput(id:XInputID);
-	Unknown(id:FlxGamepadInputID);
+	PS_VITA(id:PSVitaID);
+	SWITCH_JOYCON_LEFT(id:SwitchJoyconLeftID);
+	SWITCH_JOYCON_RIGHT(id:SwitchJoyconRightID);
+	SWITCH_PRO(id:SwitchProID);
+	WII(id:WiiRemoteID);
+	X_INPUT(id:XInputID);
+	UNKNOWN(id:FlxGamepadInputID);
 }

--- a/flixel/input/gamepad/FlxGamepadMappedInput.hx
+++ b/flixel/input/gamepad/FlxGamepadMappedInput.hx
@@ -1,0 +1,19 @@
+package flixel.input.gamepad;
+
+import flixel.input.gamepad.id.*;
+
+enum FlxGamepadMappedInput
+{
+	Logitech(id:LogitechID);
+	MayflashWiiRemote(id:MayflashWiiRemoteID);
+	MFi(id:MFiID);
+	OUYA(id:OUYAID);
+	PS4(id:PS4ID);
+	PSVita(id:PSVitaID);
+	SwitchJoyconLeft(id:SwitchJoyconLeftID);
+	SwitchJoyconRight(id:SwitchJoyconRightID);
+	SwitchPro(id:SwitchProID);
+	WiiRemote(id:WiiRemoteID);
+	XInput(id:XInputID);
+	Unknown(id:FlxGamepadInputID);
+}

--- a/flixel/input/gamepad/FlxGamepadMappedInput.hx
+++ b/flixel/input/gamepad/FlxGamepadMappedInput.hx
@@ -32,7 +32,7 @@ enum FlxGamepadMappedInput
 
 class FlxGamepadMappedInputTools
 {
-	static public inline function toModel(input:FlxGamepadMappedInput):FlxGamepadModel
+	public static inline function toModel(input:FlxGamepadMappedInput):FlxGamepadModel
 	{
 		return switch input
 		{

--- a/flixel/input/gamepad/FlxGamepadMappedInput.hx
+++ b/flixel/input/gamepad/FlxGamepadMappedInput.hx
@@ -1,5 +1,6 @@
 package flixel.input.gamepad;
 
+import flixel.input.gamepad.FlxGamepad;
 import flixel.input.gamepad.id.LogitechID;
 import flixel.input.gamepad.id.MayflashWiiRemoteID;
 import flixel.input.gamepad.id.MFiID;
@@ -12,6 +13,7 @@ import flixel.input.gamepad.id.SwitchProID;
 import flixel.input.gamepad.id.WiiRemoteID;
 import flixel.input.gamepad.id.XInputID;
 
+@:using(flixel.input.gamepad.FlxGamepadMappedInput.FlxGamepadMappedInputTools)
 enum FlxGamepadMappedInput
 {
 	LOGITECH(id:LogitechID);
@@ -26,4 +28,26 @@ enum FlxGamepadMappedInput
 	WII(id:WiiRemoteID);
 	X_INPUT(id:XInputID);
 	UNKNOWN(id:FlxGamepadInputID);
+}
+
+class FlxGamepadMappedInputTools
+{
+	static inline public function toModel(input:FlxGamepadMappedInput):FlxGamepadModel
+	{
+		return switch input
+		{
+			case FlxGamepadMappedInput.OUYA(_): FlxGamepadModel.OUYA;
+			case FlxGamepadMappedInput.PS4(_): FlxGamepadModel.PS4;
+			case FlxGamepadMappedInput.PS_VITA(_): FlxGamepadModel.PSVITA;
+			case FlxGamepadMappedInput.LOGITECH(_): FlxGamepadModel.LOGITECH;
+			case FlxGamepadMappedInput.X_INPUT(_): FlxGamepadModel.XINPUT;
+			case FlxGamepadMappedInput.WII(_): FlxGamepadModel.WII_REMOTE;
+			case FlxGamepadMappedInput.MAYFLASH_WII(_): FlxGamepadModel.MAYFLASH_WII_REMOTE;
+			case FlxGamepadMappedInput.SWITCH_PRO(_): FlxGamepadModel.SWITCH_PRO;
+			case FlxGamepadMappedInput.SWITCH_JOYCON_LEFT(_): FlxGamepadModel.SWITCH_JOYCON_LEFT;
+			case FlxGamepadMappedInput.SWITCH_JOYCON_RIGHT(_): FlxGamepadModel.SWITCH_JOYCON_RIGHT;
+			case FlxGamepadMappedInput.MFI(_): FlxGamepadModel.MFI;
+			case FlxGamepadMappedInput.UNKNOWN(_): FlxGamepadModel.UNKNOWN;
+		}
+	}
 }

--- a/flixel/input/gamepad/id/LogitechID.hx
+++ b/flixel/input/gamepad/id/LogitechID.hx
@@ -27,7 +27,7 @@ enum abstract LogitechID(Int) to Int
 	var DPAD_RIGHT = 7;
 
 	// TODO: Someone needs to look this up and define it! (NOTE: not all logitech controllers have this)
-	var LOGITECH:Int = -1;
+	var LOGITECH = -1;
 	#else // native and html5
 	var ONE = 0;
 	var TWO = 1;

--- a/flixel/input/gamepad/id/LogitechID.hx
+++ b/flixel/input/gamepad/id/LogitechID.hx
@@ -51,17 +51,27 @@ enum abstract LogitechID(Int) to Int
 	// TODO: Someone needs to look this up and define it! (NOTE: not all logitech controllers have this)
 	var LOGITECH = -5;
 	#end
-
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<LogitechID>(0, 1, {
-		up: 24,
-		down: 25,
-		left: 26,
-		right: 27
+	
+	var LEFT_STICK_UP = 24;
+	var LEFT_STICK_DOWN = 25;
+	var LEFT_STICK_LEFT = 26;
+	var LEFT_STICK_RIGHT = 27;
+	
+	var RIGHT_STICK_UP = 28;
+	var RIGHT_STICK_DOWN = 29;
+	var RIGHT_STICK_LEFT = 30;
+	var RIGHT_STICK_RIGHT = 31;
+		
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<LogitechID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<LogitechID>(2, 3, {
-		up: 28,
-		down: 29,
-		left: 30,
-		right: 31
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<LogitechID>(2, 3, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
 	});
 }

--- a/flixel/input/gamepad/id/LogitechID.hx
+++ b/flixel/input/gamepad/id/LogitechID.hx
@@ -5,60 +5,60 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
 /**
  * IDs for Logitech controllers (key codes based on Cordless Rumblepad 2)
  */
-class LogitechID
+enum abstract LogitechID(Int) to Int
 {
 	#if flash
-	public static inline var ONE:Int = 8;
-	public static inline var TWO:Int = 9;
-	public static inline var THREE:Int = 10;
-	public static inline var FOUR:Int = 11;
-	public static inline var FIVE:Int = 12;
-	public static inline var SIX:Int = 13;
-	public static inline var SEVEN:Int = 14;
-	public static inline var EIGHT:Int = 15;
-	public static inline var NINE:Int = 16;
-	public static inline var TEN:Int = 17;
-	public static inline var LEFT_STICK_CLICK:Int = 18;
-	public static inline var RIGHT_STICK_CLICK:Int = 19;
+	var ONE = 8;
+	var TWO = 9;
+	var THREE = 10;
+	var FOUR = 11;
+	var FIVE = 12;
+	var SIX = 13;
+	var SEVEN = 14;
+	var EIGHT = 15;
+	var NINE = 16;
+	var TEN = 17;
+	var LEFT_STICK_CLICK = 18;
+	var RIGHT_STICK_CLICK = 19;
 
-	public static inline var DPAD_UP:Int = 4;
-	public static inline var DPAD_DOWN:Int = 5;
-	public static inline var DPAD_LEFT:Int = 6;
-	public static inline var DPAD_RIGHT:Int = 7;
+	var DPAD_UP = 4;
+	var DPAD_DOWN = 5;
+	var DPAD_LEFT = 6;
+	var DPAD_RIGHT = 7;
 
 	// TODO: Someone needs to look this up and define it! (NOTE: not all logitech controllers have this)
-	public static inline var LOGITECH:Int = -1;
+	var LOGITECH:Int = -1;
 	#else // native and html5
-	public static inline var ONE:Int = 0;
-	public static inline var TWO:Int = 1;
-	public static inline var THREE:Int = 2;
-	public static inline var FOUR:Int = 3;
-	public static inline var FIVE:Int = 4;
-	public static inline var SIX:Int = 5;
-	public static inline var SEVEN:Int = 6;
-	public static inline var EIGHT:Int = 7;
-	public static inline var NINE:Int = 8;
-	public static inline var TEN:Int = 9;
-	public static inline var LEFT_STICK_CLICK:Int = 10;
-	public static inline var RIGHT_STICK_CLICK:Int = 11;
+	var ONE = 0;
+	var TWO = 1;
+	var THREE = 2;
+	var FOUR = 3;
+	var FIVE = 4;
+	var SIX = 5;
+	var SEVEN = 6;
+	var EIGHT = 7;
+	var NINE = 8;
+	var TEN = 9;
+	var LEFT_STICK_CLICK = 10;
+	var RIGHT_STICK_CLICK = 11;
 
 	// "fake" IDs, we manually watch for hat axis changes and then send events using these otherwise unused joystick button codes
-	public static inline var DPAD_UP:Int = 16;
-	public static inline var DPAD_DOWN:Int = 17;
-	public static inline var DPAD_LEFT:Int = 18;
-	public static inline var DPAD_RIGHT:Int = 19;
+	var DPAD_UP = 16;
+	var DPAD_DOWN = 17;
+	var DPAD_LEFT = 18;
+	var DPAD_RIGHT = 19;
 
 	// TODO: Someone needs to look this up and define it! (NOTE: not all logitech controllers have this)
-	public static inline var LOGITECH:Int = -5;
+	var LOGITECH = -5;
 	#end
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<LogitechID>(0, 1, {
 		up: 24,
 		down: 25,
 		left: 26,
 		right: 27
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<LogitechID>(2, 3, {
 		up: 28,
 		down: 29,
 		left: 30,

--- a/flixel/input/gamepad/id/LogitechID.hx
+++ b/flixel/input/gamepad/id/LogitechID.hx
@@ -62,13 +62,13 @@ enum abstract LogitechID(Int) to Int
 	var RIGHT_STICK_LEFT = 30;
 	var RIGHT_STICK_RIGHT = 31;
 		
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<LogitechID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<LogitechID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<LogitechID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<LogitechID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/MFiID.hx
+++ b/flixel/input/gamepad/id/MFiID.hx
@@ -1,41 +1,43 @@
 package flixel.input.gamepad.id;
 
+import flixel.input.gamepad.FlxGamepadAnalogStick;
+
 /**
  * IDs for MFi controllers
  */
-class MFiID
+enum abstract MFiID(Int) to Int
 {
-	public static inline var A:Int = 6;
-	public static inline var B:Int = 7;
-	public static inline var X:Int = 8;
-	public static inline var Y:Int = 9;
-	public static inline var LB:Int = 15;
-	public static inline var RB:Int = 16;
-	public static inline var BACK:Int = 10;
-	public static inline var START:Int = 12;
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var RIGHT_STICK_CLICK:Int = 14;
+	var A = 6;
+	var B = 7;
+	var X = 8;
+	var Y = 9;
+	var LB = 15;
+	var RB = 16;
+	var BACK = 10;
+	var START = 12;
+	var LEFT_STICK_CLICK = 13;
+	var RIGHT_STICK_CLICK = 14;
 
-	public static inline var GUIDE:Int = 11;
+	var GUIDE = 11;
 
-	public static inline var DPAD_UP:Int = 17;
-	public static inline var DPAD_DOWN:Int = 18;
-	public static inline var DPAD_LEFT:Int = 19;
-	public static inline var DPAD_RIGHT:Int = 20;
+	var DPAD_UP = 17;
+	var DPAD_DOWN = 18;
+	var DPAD_LEFT = 19;
+	var DPAD_RIGHT = 20;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MFiID>(0, 1, {
 		up: 21,
 		down: 22,
 		left: 23,
 		right: 24
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MFiID>(2, 3, {
 		up: 25,
 		down: 26,
 		left: 27,
 		right: 28
 	});
 
-	public static inline var LEFT_TRIGGER:Int = 4;
-	public static inline var RIGHT_TRIGGER:Int = 5;
+	var LEFT_TRIGGER = 4;
+	var RIGHT_TRIGGER = 5;
 }

--- a/flixel/input/gamepad/id/MFiID.hx
+++ b/flixel/input/gamepad/id/MFiID.hx
@@ -37,13 +37,13 @@ enum abstract MFiID(Int) to Int
 	var RIGHT_STICK_LEFT = 27;
 	var RIGHT_STICK_RIGHT = 28;
 	
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<MFiID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<MFiID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<MFiID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<MFiID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/MFiID.hx
+++ b/flixel/input/gamepad/id/MFiID.hx
@@ -7,6 +7,9 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  */
 enum abstract MFiID(Int) to Int
 {
+	var LEFT_TRIGGER = 4;
+	var RIGHT_TRIGGER = 5;
+	
 	var A = 6;
 	var B = 7;
 	var X = 8;
@@ -14,30 +17,36 @@ enum abstract MFiID(Int) to Int
 	var LB = 15;
 	var RB = 16;
 	var BACK = 10;
+	var GUIDE = 11;
 	var START = 12;
 	var LEFT_STICK_CLICK = 13;
 	var RIGHT_STICK_CLICK = 14;
-
-	var GUIDE = 11;
-
+	
 	var DPAD_UP = 17;
 	var DPAD_DOWN = 18;
 	var DPAD_LEFT = 19;
 	var DPAD_RIGHT = 20;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MFiID>(0, 1, {
-		up: 21,
-		down: 22,
-		left: 23,
-		right: 24
+	var LEFT_STICK_UP = 21;
+	var LEFT_STICK_DOWN = 22;
+	var LEFT_STICK_LEFT = 23;
+	var LEFT_STICK_RIGHT = 24;
+		
+	var RIGHT_STICK_UP = 25;
+	var RIGHT_STICK_DOWN = 26;
+	var RIGHT_STICK_LEFT = 27;
+	var RIGHT_STICK_RIGHT = 28;
+	
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<MFiID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MFiID>(2, 3, {
-		up: 25,
-		down: 26,
-		left: 27,
-		right: 28
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<MFiID>(2, 3, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
 	});
-
-	var LEFT_TRIGGER = 4;
-	var RIGHT_TRIGGER = 5;
 }

--- a/flixel/input/gamepad/id/MayflashWiiRemoteID.hx
+++ b/flixel/input/gamepad/id/MayflashWiiRemoteID.hx
@@ -7,7 +7,7 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  *
  * @author larsiusprime
  */
-class MayflashWiiRemoteID
+enum abstract MayflashWiiRemoteID(Int) to Int
 {
 	/**
 	 * Things to add:
@@ -19,65 +19,65 @@ class MayflashWiiRemoteID
 	 */
 	#if FLX_JOYSTICK_API
 	// Standard Wii Remote inputs:
-	public static inline var REMOTE_ONE:Int = 0;
-	public static inline var REMOTE_TWO:Int = 1;
-	public static inline var REMOTE_A:Int = 2;
-	public static inline var REMOTE_B:Int = 3;
+	var REMOTE_ONE = 0;
+	var REMOTE_TWO = 1;
+	var REMOTE_A = 2;
+	var REMOTE_B = 3;
 
-	public static inline var REMOTE_MINUS:Int = 4;
-	public static inline var REMOTE_PLUS:Int = 5;
+	var REMOTE_MINUS = 4;
+	var REMOTE_PLUS = 5;
 
-	public static inline var REMOTE_HOME:Int = 11;
+	var REMOTE_HOME = 11;
 
 	// Nunchuk attachment:
-	public static inline var NUNCHUK_Z:Int = 6;
-	public static inline var NUNCHUK_C:Int = 7;
+	var NUNCHUK_Z = 6;
+	var NUNCHUK_C = 7;
 
-	public static inline var NUNCHUK_DPAD_DOWN:Int = 12;
-	public static inline var NUNCHUK_DPAD_UP:Int = 13;
-	public static inline var NUNCHUK_DPAD_LEFT:Int = 14;
-	public static inline var NUNCHUK_DPAD_RIGHT:Int = 15;
+	var NUNCHUK_DPAD_DOWN = 12;
+	var NUNCHUK_DPAD_UP = 13;
+	var NUNCHUK_DPAD_LEFT = 14;
+	var NUNCHUK_DPAD_RIGHT = 15;
 
-	public static inline var NUNCHUK_MINUS:Int = 4;
-	public static inline var NUNCHUK_PLUS:Int = 5;
+	var NUNCHUK_MINUS = 4;
+	var NUNCHUK_PLUS = 5;
 
-	public static inline var NUNCHUK_HOME:Int = 11;
+	var NUNCHUK_HOME = 11;
 
-	public static inline var NUNCHUK_ONE:Int = 0;
-	public static inline var NUNCHUK_TWO:Int = 1;
-	public static inline var NUNCHUK_A:Int = 2;
-	public static inline var NUNCHUK_B:Int = 3;
+	var NUNCHUK_ONE = 0;
+	var NUNCHUK_TWO = 1;
+	var NUNCHUK_A = 2;
+	var NUNCHUK_B = 3;
 
 	// classic controller attachment:
-	public static inline var CLASSIC_Y:Int = 0; // Identical to WiiRemote 1
-	public static inline var CLASSIC_X:Int = 1; // Identical to WiiRemote 2
-	public static inline var CLASSIC_B:Int = 2; // Identical to WiiRemote A
-	public static inline var CLASSIC_A:Int = 3; // Identical to WiiRemote B
+	var CLASSIC_Y = 0; // Identical to WiiRemote 1
+	var CLASSIC_X = 1; // Identical to WiiRemote 2
+	var CLASSIC_B = 2; // Identical to WiiRemote A
+	var CLASSIC_A = 3; // Identical to WiiRemote B
 
-	public static inline var CLASSIC_L:Int = 4; // Identical to MINUS and PLUS
-	public static inline var CLASSIC_R:Int = 5;
-	public static inline var CLASSIC_ZL:Int = 6; // Identical to C and Z
-	public static inline var CLASSIC_ZR:Int = 7;
+	var CLASSIC_L = 4; // Identical to MINUS and PLUS
+	var CLASSIC_R = 5;
+	var CLASSIC_ZL = 6; // Identical to C and Z
+	var CLASSIC_ZR = 7;
 
-	public static inline var CLASSIC_SELECT:Int = 8;
-	public static inline var CLASSIC_START:Int = 9;
+	var CLASSIC_SELECT = 8;
+	var CLASSIC_START = 9;
 
-	public static inline var CLASSIC_HOME:Int = 11;
+	var CLASSIC_HOME = 11;
 
-	public static inline var CLASSIC_DPAD_DOWN:Int = 12;
-	public static inline var CLASSIC_DPAD_UP:Int = 13;
-	public static inline var CLASSIC_DPAD_LEFT:Int = 14;
-	public static inline var CLASSIC_DPAD_RIGHT:Int = 15;
+	var CLASSIC_DPAD_DOWN = 12;
+	var CLASSIC_DPAD_UP = 13;
+	var CLASSIC_DPAD_LEFT = 14;
+	var CLASSIC_DPAD_RIGHT = 15;
 
-	public static inline var CLASSIC_ONE:Int = -1;
-	public static inline var CLASSIC_TWO:Int = -1;
+	var CLASSIC_ONE = -1;
+	var CLASSIC_TWO = -1;
 
 	// Axis indices
-	public static inline var NUNCHUK_POINTER_X:Int = 2;
-	public static inline var NUNCHUK_POINTER_Y:Int = 3;
+	var NUNCHUK_POINTER_X = 2;
+	var NUNCHUK_POINTER_Y = 3;
 
 	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
 		up: REMOTE_DPAD_UP,
 		down: REMOTE_DPAD_DOWN,
 		left: REMOTE_DPAD_LEFT,
@@ -86,13 +86,13 @@ class MayflashWiiRemoteID
 		mode: ONLY_DIGITAL
 	});
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
 		up: 26,
 		down: 27,
 		left: 28,
 		right: 29
 	}); // the nunchuk only has the "left" analog stick
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
 		up: 30,
 		down: 31,
 		left: 32,
@@ -100,92 +100,93 @@ class MayflashWiiRemoteID
 	}); // the classic controller has both the "left" and "right" analog sticks
 
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
-	public static inline var LEFT_TRIGGER_FAKE:Int = 4;
-	public static inline var RIGHT_TRIGGER_FAKE:Int = 5;
+	var LEFT_TRIGGER_FAKE = 4;
+	var RIGHT_TRIGGER_FAKE = 5;
 
 	// "fake" IDs
-	public static inline var REMOTE_DPAD_UP:Int = 22;
-	public static inline var REMOTE_DPAD_DOWN:Int = 23;
-	public static inline var REMOTE_DPAD_LEFT:Int = 24;
-	public static inline var REMOTE_DPAD_RIGHT:Int = 25;
+	var REMOTE_DPAD_UP = 22;
+	var REMOTE_DPAD_DOWN = 23;
+	var REMOTE_DPAD_LEFT = 24;
+	var REMOTE_DPAD_RIGHT = 25;
 	#else // gamepad API
 	// Standard Wii Remote inputs:
-	public static inline var REMOTE_ONE:Int = 8;
-	public static inline var REMOTE_TWO:Int = 9;
-	public static inline var REMOTE_A:Int = 10;
-	public static inline var REMOTE_B:Int = 11;
+	var REMOTE_ONE = 8;
+	var REMOTE_TWO = 9;
+	var REMOTE_A = 10;
+	var REMOTE_B = 11;
 
-	public static inline var REMOTE_MINUS:Int = 12;
-	public static inline var REMOTE_PLUS:Int = 13;
+	var REMOTE_MINUS = 12;
+	var REMOTE_PLUS = 13;
 
-	public static inline var REMOTE_HOME:Int = 19;
+	var REMOTE_HOME = 19;
 
 	// Nunchuk attachment:
-	public static inline var NUNCHUK_Z:Int = 14;
-	public static inline var NUNCHUK_C:Int = 15;
+	var NUNCHUK_Z = 14;
+	var NUNCHUK_C = 15;
 
-	public static inline var NUNCHUK_DPAD_UP:Int = 4;
-	public static inline var NUNCHUK_DPAD_DOWN:Int = 5;
-	public static inline var NUNCHUK_DPAD_LEFT:Int = 6;
-	public static inline var NUNCHUK_DPAD_RIGHT:Int = 7;
+	var NUNCHUK_DPAD_UP = 4;
+	var NUNCHUK_DPAD_DOWN = 5;
+	var NUNCHUK_DPAD_LEFT = 6;
+	var NUNCHUK_DPAD_RIGHT = 7;
 
-	public static inline var NUNCHUK_MINUS:Int = 12;
-	public static inline var NUNCHUK_PLUS:Int = 13;
+	var NUNCHUK_MINUS = 12;
+	var NUNCHUK_PLUS = 13;
 
-	public static inline var NUNCHUK_HOME:Int = 19;
+	var NUNCHUK_HOME = 19;
 
-	public static inline var NUNCHUK_A:Int = 10;
-	public static inline var NUNCHUK_B:Int = 11;
+	var NUNCHUK_A = 10;
+	var NUNCHUK_B = 11;
 
-	public static inline var NUNCHUK_ONE:Int = 8;
-	public static inline var NUNCHUK_TWO:Int = 9;
+	var NUNCHUK_ONE = 8;
+	var NUNCHUK_TWO = 9;
 
 	// classic controller attachment:
-	public static inline var CLASSIC_Y:Int = 8;
-	public static inline var CLASSIC_X:Int = 9;
-	public static inline var CLASSIC_B:Int = 10;
-	public static inline var CLASSIC_A:Int = 11;
+	var CLASSIC_Y = 8;
+	var CLASSIC_X = 9;
+	var CLASSIC_B = 10;
+	var CLASSIC_A = 11;
 
-	public static inline var CLASSIC_L:Int = 12;
-	public static inline var CLASSIC_R:Int = 13;
-	public static inline var CLASSIC_ZL:Int = 14;
-	public static inline var CLASSIC_ZR:Int = 15;
+	var CLASSIC_L = 12;
+	var CLASSIC_R = 13;
+	var CLASSIC_ZL = 14;
+	var CLASSIC_ZR = 15;
 
-	public static inline var CLASSIC_SELECT:Int = 16;
-	public static inline var CLASSIC_START:Int = 17;
+	var CLASSIC_SELECT = 16;
+	var CLASSIC_START = 17;
 
-	public static inline var CLASSIC_HOME:Int = 19;
+	var CLASSIC_HOME = 19;
 
-	public static inline var CLASSIC_ONE:Int = -1;
-	public static inline var CLASSIC_TWO:Int = -1;
+	var CLASSIC_ONE = -1;
+	var CLASSIC_TWO = -1;
 
 	// (input "10" does not seem to be defined)
-	public static inline var CLASSIC_DPAD_UP:Int = 4;
-	public static inline var CLASSIC_DPAD_DOWN:Int = 5;
-	public static inline var CLASSIC_DPAD_LEFT:Int = 6;
-	public static inline var CLASSIC_DPAD_RIGHT:Int = 7;
+	var CLASSIC_DPAD_UP = 4;
+	var CLASSIC_DPAD_DOWN = 5;
+	var CLASSIC_DPAD_LEFT = 6;
+	var CLASSIC_DPAD_RIGHT = 7;
 
 	// Axis indices
-	public static inline var NUNCHUK_POINTER_X:Int = 2;
-	public static inline var NUNCHUK_POINTER_Y:Int = 3;
+	var NUNCHUK_POINTER_X = 2;
+	var NUNCHUK_POINTER_Y = 3;
 
 	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxGamepadAnalogStick(0, 1, {
-		up: REMOTE_DPAD_UP,
-		down: REMOTE_DPAD_DOWN,
-		left: REMOTE_DPAD_LEFT,
-		right: REMOTE_DPAD_RIGHT,
+	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>
+	(0, 1, {
+		up: (cast REMOTE_DPAD_UP:Int),
+		down: (cast REMOTE_DPAD_DOWN:Int),
+		left: (cast REMOTE_DPAD_LEFT:Int),
+		right: (cast REMOTE_DPAD_RIGHT:Int),
 		threshold: 0.5,
 		mode: ONLY_DIGITAL
 	});
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
 		up: 26,
 		down: 27,
 		left: 28,
 		right: 29
 	}); // the nunchuk only has the "left" analog stick
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
 		up: 26,
 		down: 27,
 		left: 28,
@@ -193,13 +194,13 @@ class MayflashWiiRemoteID
 	}); // the classic controller has both the "left" and "right" analog sticks
 
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
-	public static inline var LEFT_TRIGGER_FAKE:Int = 4;
-	public static inline var RIGHT_TRIGGER_FAKE:Int = 5;
+	var LEFT_TRIGGER_FAKE = 4;
+	var RIGHT_TRIGGER_FAKE = 5;
 
 	// "fake" IDs
-	public static inline var REMOTE_DPAD_UP:Int = 22;
-	public static inline var REMOTE_DPAD_DOWN:Int = 23;
-	public static inline var REMOTE_DPAD_LEFT:Int = 24;
-	public static inline var REMOTE_DPAD_RIGHT:Int = 25;
+	var REMOTE_DPAD_UP = 22;
+	var REMOTE_DPAD_DOWN = 23;
+	var REMOTE_DPAD_LEFT = 24;
+	var REMOTE_DPAD_RIGHT = 25;
 	#end
 }

--- a/flixel/input/gamepad/id/MayflashWiiRemoteID.hx
+++ b/flixel/input/gamepad/id/MayflashWiiRemoteID.hx
@@ -71,43 +71,6 @@ enum abstract MayflashWiiRemoteID(Int) to Int
 
 	var CLASSIC_ONE = -1;
 	var CLASSIC_TWO = -1;
-
-	// Axis indices
-	var NUNCHUK_POINTER_X = 2;
-	var NUNCHUK_POINTER_Y = 3;
-
-	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
-		up: REMOTE_DPAD_UP,
-		down: REMOTE_DPAD_DOWN,
-		left: REMOTE_DPAD_LEFT,
-		right: REMOTE_DPAD_RIGHT,
-		threshold: 0.5,
-		mode: ONLY_DIGITAL
-	});
-
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
-		up: 26,
-		down: 27,
-		left: 28,
-		right: 29
-	}); // the nunchuk only has the "left" analog stick
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
-		up: 30,
-		down: 31,
-		left: 32,
-		right: 33
-	}); // the classic controller has both the "left" and "right" analog sticks
-
-	// these aren't real axes, they're simulated when the right digital buttons are pushed
-	var LEFT_TRIGGER_FAKE = 4;
-	var RIGHT_TRIGGER_FAKE = 5;
-
-	// "fake" IDs
-	var REMOTE_DPAD_UP = 22;
-	var REMOTE_DPAD_DOWN = 23;
-	var REMOTE_DPAD_LEFT = 24;
-	var REMOTE_DPAD_RIGHT = 25;
 	#else // gamepad API
 	// Standard Wii Remote inputs:
 	var REMOTE_ONE = 8;
@@ -164,35 +127,21 @@ enum abstract MayflashWiiRemoteID(Int) to Int
 	var CLASSIC_DPAD_DOWN = 5;
 	var CLASSIC_DPAD_LEFT = 6;
 	var CLASSIC_DPAD_RIGHT = 7;
-
+	#end
 	// Axis indices
 	var NUNCHUK_POINTER_X = 2;
 	var NUNCHUK_POINTER_Y = 3;
 
-	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>
-	(0, 1, {
-		up: (cast REMOTE_DPAD_UP:Int),
-		down: (cast REMOTE_DPAD_DOWN:Int),
-		left: (cast REMOTE_DPAD_LEFT:Int),
-		right: (cast REMOTE_DPAD_RIGHT:Int),
-		threshold: 0.5,
-		mode: ONLY_DIGITAL
-	});
-
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
-		up: 26,
-		down: 27,
-		left: 28,
-		right: 29
-	}); // the nunchuk only has the "left" analog stick
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
-		up: 26,
-		down: 27,
-		left: 28,
-		right: 29
-	}); // the classic controller has both the "left" and "right" analog sticks
-
+	var LEFT_STICK_UP = 26;
+	var LEFT_STICK_DOWN = 27;
+	var LEFT_STICK_LEFT = 28;
+	var LEFT_STICK_RIGHT = 29;
+	
+	var RIGHT_STICK_UP = 30;
+	var RIGHT_STICK_DOWN = 31;
+	var RIGHT_STICK_LEFT = 32;
+	var RIGHT_STICK_RIGHT = 33;
+	
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
 	var LEFT_TRIGGER_FAKE = 4;
 	var RIGHT_TRIGGER_FAKE = 5;
@@ -202,5 +151,29 @@ enum abstract MayflashWiiRemoteID(Int) to Int
 	var REMOTE_DPAD_DOWN = 23;
 	var REMOTE_DPAD_LEFT = 24;
 	var REMOTE_DPAD_RIGHT = 25;
-	#end
+	
+	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
+	public static final remoteDPad = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>
+	(0, 1, {
+		up: REMOTE_DPAD_UP,
+		down: REMOTE_DPAD_DOWN,
+		left: REMOTE_DPAD_LEFT,
+		right: REMOTE_DPAD_RIGHT,
+		threshold: 0.5,
+		mode: ONLY_DIGITAL
+	});
+	
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	}); // the nunchuk only has the "left" analog stick
+	
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
+	}); // the classic controller has both the "left" and "right" analog sticks
 }

--- a/flixel/input/gamepad/id/MayflashWiiRemoteID.hx
+++ b/flixel/input/gamepad/id/MayflashWiiRemoteID.hx
@@ -153,8 +153,7 @@ enum abstract MayflashWiiRemoteID(Int) to Int
 	var REMOTE_DPAD_RIGHT = 25;
 	
 	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static final remoteDPad = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>
-	(0, 1, {
+	public static final REMOTE_DPAD = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
 		up: REMOTE_DPAD_UP,
 		down: REMOTE_DPAD_DOWN,
 		left: REMOTE_DPAD_LEFT,
@@ -163,14 +162,14 @@ enum abstract MayflashWiiRemoteID(Int) to Int
 		mode: ONLY_DIGITAL
 	});
 	
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	}); // the nunchuk only has the "left" analog stick
 	
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<MayflashWiiRemoteID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/OUYAID.hx
+++ b/flixel/input/gamepad/id/OUYAID.hx
@@ -36,13 +36,13 @@ enum abstract OUYAID(Int) to Int
 	var RIGHT_STICK_RIGHT = 30;
 	
 	// If TRIGGER axis returns value > 0 then LT is being pressed, and if it's < 0 then RT is being pressed
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<OUYAID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<OUYAID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<OUYAID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<OUYAID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/OUYAID.hx
+++ b/flixel/input/gamepad/id/OUYAID.hx
@@ -5,34 +5,34 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
 /**
  * IDs for OUYA controllers
  */
-class OUYAID
+enum abstract OUYAID(Int) to Int
 {
-	public static inline var O:Int = 6;
-	public static inline var U:Int = 8;
-	public static inline var Y:Int = 9;
-	public static inline var A:Int = 7;
-	public static inline var LB:Int = 15;
-	public static inline var RB:Int = 16;
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var RIGHT_STICK_CLICK:Int = 14;
-	public static inline var HOME:Int = 0x01000012;	// Not sure if press HOME is taken in account on OUYA
-	public static inline var LEFT_TRIGGER:Int = 4;
-	public static inline var RIGHT_TRIGGER:Int = 5;
+	var O = 6;
+	var U = 8;
+	var Y = 9;
+	var A = 7;
+	var LB = 15;
+	var RB = 16;
+	var LEFT_STICK_CLICK = 13;
+	var RIGHT_STICK_CLICK = 14;
+	var HOME = 0x01000012;	// Not sure if press HOME is taken in account on OUYA
+	var LEFT_TRIGGER = 4;
+	var RIGHT_TRIGGER = 5;
 
 	// "fake" IDs, we manually watch for hat axis changes and then send events using these otherwise unused joystick button codes
-	public static inline var DPAD_LEFT:Int = 19;
-	public static inline var DPAD_RIGHT:Int = 20;
-	public static inline var DPAD_DOWN:Int = 18;
-	public static inline var DPAD_UP:Int = 17;
+	var DPAD_LEFT = 19;
+	var DPAD_RIGHT = 20;
+	var DPAD_DOWN = 18;
+	var DPAD_UP = 17;
 
 	// If TRIGGER axis returns value > 0 then LT is being pressed, and if it's < 0 then RT is being pressed
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<OUYAID>(0, 1, {
 		up: 23,
 		down: 24,
 		left: 25,
 		right: 26
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<OUYAID>(2, 3, {
 		up: 27,
 		down: 28,
 		left: 29,

--- a/flixel/input/gamepad/id/OUYAID.hx
+++ b/flixel/input/gamepad/id/OUYAID.hx
@@ -24,18 +24,28 @@ enum abstract OUYAID(Int) to Int
 	var DPAD_RIGHT = 20;
 	var DPAD_DOWN = 18;
 	var DPAD_UP = 17;
-
+	
+	var LEFT_STICK_UP = 23;
+	var LEFT_STICK_DOWN = 24;
+	var LEFT_STICK_LEFT = 25;
+	var LEFT_STICK_RIGHT = 26;
+	
+	var RIGHT_STICK_UP = 27;
+	var RIGHT_STICK_DOWN = 28;
+	var RIGHT_STICK_LEFT = 29;
+	var RIGHT_STICK_RIGHT = 30;
+	
 	// If TRIGGER axis returns value > 0 then LT is being pressed, and if it's < 0 then RT is being pressed
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<OUYAID>(0, 1, {
-		up: 23,
-		down: 24,
-		left: 25,
-		right: 26
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<OUYAID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<OUYAID>(2, 3, {
-		up: 27,
-		down: 28,
-		left: 29,
-		right: 30
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<OUYAID>(2, 3, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
 	});
 }

--- a/flixel/input/gamepad/id/PS4ID.hx
+++ b/flixel/input/gamepad/id/PS4ID.hx
@@ -36,10 +36,10 @@ enum abstract PS4ID(Int) to Int
 	var PS = 22;
 	var TOUCHPAD_CLICK = 23;
 	
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 2;
-	static var rightY = 5;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 2;
+	inline static final RIGHT_Y = 5;
 	
 	var LEFT_STICK_UP = 24;
 	var LEFT_STICK_DOWN = 25;
@@ -71,10 +71,10 @@ enum abstract PS4ID(Int) to Int
 	#if ps4
 	var TOUCHPAD_CLICK = 10; // On an actual PS4, share is reserved by the system, and the touchpad click can serve more or less as a replacement for the "back/select" button
 	
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 2;
-	static var rightY = 3;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 2;
+	inline static final RIGHT_Y = 3;
 	
 	var LEFT_STICK_UP = 32;
 	var LEFT_STICK_DOWN = 33;
@@ -90,10 +90,10 @@ enum abstract PS4ID(Int) to Int
 	#else
 	var SHARE = 10; // This is only accessible when not using an actual Playstation 4, otherwise it's reserved by the system
 
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 2;
-	static var rightY = 3;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 2;
+	inline static final RIGHT_Y = 3;
 	
 	var LEFT_STICK_UP = 22;
 	var LEFT_STICK_DOWN = 23;
@@ -136,10 +136,10 @@ enum abstract PS4ID(Int) to Int
 	var L2 = 3;
 	var R2 = 4;
 
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 2;
-	static var rightY = 5;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 2;
+	inline static final RIGHT_Y = 5;
 	
 	var LEFT_STICK_UP = 27;
 	var LEFT_STICK_DOWN = 28;
@@ -158,13 +158,13 @@ enum abstract PS4ID(Int) to Int
 	var DPAD_UP = 18;
 	#end
 	
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<PS4ID>(leftX, leftY, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<PS4ID>(LEFT_X, LEFT_Y, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<PS4ID>(rightX, rightY, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<PS4ID>(RIGHT_X, RIGHT_Y, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/PS4ID.hx
+++ b/flixel/input/gamepad/id/PS4ID.hx
@@ -18,56 +18,56 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
 	* MAC: the PS4 controller seemed to work perfectly without anything special installed, and was not detected in the 360Controller
 	* control panel, so it might just work right out of the box!
  */
-class PS4ID
+enum abstract PS4ID(Int) to Int
 {
 	#if flash
-	public static inline var SQUARE:Int = 10;
-	public static inline var X:Int = 11;
-	public static inline var CIRCLE:Int = 12;
-	public static inline var TRIANGLE:Int = 13;
-	public static inline var L1:Int = 14;
-	public static inline var R1:Int = 15;
-	public static inline var L2:Int = 16;
-	public static inline var R2:Int = 17;
-	public static inline var SHARE:Int = 18;
-	public static inline var OPTIONS:Int = 19;
-	public static inline var LEFT_STICK_CLICK:Int = 20;
-	public static inline var RIGHT_STICK_CLICK:Int = 21;
-	public static inline var PS:Int = 22;
-	public static inline var TOUCHPAD_CLICK:Int = 23;
+	var SQUARE = 10;
+	var X = 11;
+	var CIRCLE = 12;
+	var TRIANGLE = 13;
+	var L1 = 14;
+	var R1 = 15;
+	var L2 = 16;
+	var R2 = 17;
+	var SHARE = 18;
+	var OPTIONS = 19;
+	var LEFT_STICK_CLICK = 20;
+	var RIGHT_STICK_CLICK = 21;
+	var PS = 22;
+	var TOUCHPAD_CLICK = 23;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(0, 1, {
 		up: 24,
 		down: 25,
 		left: 26,
 		right: 27
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 5, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(2, 5, {
 		up: 28,
 		down: 29,
 		left: 30,
 		right: 31
 	});
 
-	public static inline var DPAD_UP:Int = 6;
-	public static inline var DPAD_DOWN:Int = 7;
-	public static inline var DPAD_LEFT:Int = 8;
-	public static inline var DPAD_RIGHT:Int = 9;
+	var DPAD_UP = 6;
+	var DPAD_DOWN = 7;
+	var DPAD_LEFT = 8;
+	var DPAD_RIGHT = 9;
 	#elseif FLX_GAMEINPUT_API
 	// #if (html5 || windows || mac || linux)
-	public static inline var X:Int = 6;
-	public static inline var CIRCLE:Int = 7;
-	public static inline var SQUARE:Int = 8;
-	public static inline var TRIANGLE:Int = 9;
-	public static inline var PS:Int = 11;
-	public static inline var OPTIONS:Int = 12;
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var RIGHT_STICK_CLICK:Int = 14;
-	public static inline var L1:Int = 15;
-	public static inline var R1:Int = 16;
+	var X = 6;
+	var CIRCLE = 7;
+	var SQUARE = 8;
+	var TRIANGLE = 9;
+	var PS = 11;
+	var OPTIONS = 12;
+	var LEFT_STICK_CLICK = 13;
+	var RIGHT_STICK_CLICK = 14;
+	var L1 = 15;
+	var R1 = 16;
 
 	#if ps4
-	public static inline var TOUCHPAD_CLICK:Int = 10; // On an actual PS4, share is reserved by the system, and the touchpad click can serve more or less as a replacement for the "back/select" button
+	var TOUCHPAD_CLICK = 10; // On an actual PS4, share is reserved by the system, and the touchpad click can serve more or less as a replacement for the "back/select" button
 
 	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
 		up: 32,
@@ -82,62 +82,62 @@ class PS4ID
 		right: 39
 	});
 
-	public static inline var SHARE:Int = 40; // Not accessible on an actual PS4, just setting it to a dummy value
+	var SHARE = 40; // Not accessible on an actual PS4, just setting it to a dummy value
 	#else
-	public static inline var SHARE:Int = 10; // This is only accessible when not using an actual Playstation 4, otherwise it's reserved by the system
+	var SHARE = 10; // This is only accessible when not using an actual Playstation 4, otherwise it's reserved by the system
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(0, 1, {
 		up: 22,
 		down: 23,
 		left: 24,
 		right: 25
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(2, 3, {
 		up: 26,
 		down: 27,
 		left: 28,
 		right: 29
 	});
 
-	public static inline var TOUCHPAD_CLICK:Int = 30; // I don't believe this is normally accessible on PC, just setting it to a dummy value
+	var TOUCHPAD_CLICK = 30; // I don't believe this is normally accessible on PC, just setting it to a dummy value
 
 	#end
-	public static inline var L2:Int = 4;
-	public static inline var R2:Int = 5;
+	var L2 = 4;
+	var R2 = 5;
 
-	public static inline var DPAD_UP:Int = 17;
-	public static inline var DPAD_DOWN:Int = 18;
-	public static inline var DPAD_LEFT:Int = 19;
-	public static inline var DPAD_RIGHT:Int = 20;
+	var DPAD_UP = 17;
+	var DPAD_DOWN = 18;
+	var DPAD_LEFT = 19;
+	var DPAD_RIGHT = 20;
 
 	// On linux the drivers we're testing with just make the PS4 controller look like an XInput device,
 	// So strictly speaking these ID's will probably not be used, but the compiler needs something or
 	// else it will not compile on Linux
 	#else // "legacy"
-	public static inline var SQUARE:Int = 0;
-	public static inline var X:Int = 1;
-	public static inline var CIRCLE:Int = 2;
-	public static inline var TRIANGLE:Int = 3;
-	public static inline var L1:Int = 4;
-	public static inline var R1:Int = 5;
+	var SQUARE = 0;
+	var X = 1;
+	var CIRCLE = 2;
+	var TRIANGLE = 3;
+	var L1 = 4;
+	var R1 = 5;
 
-	public static inline var SHARE:Int = 8;
-	public static inline var OPTIONS:Int = 9;
-	public static inline var LEFT_STICK_CLICK:Int = 10;
-	public static inline var RIGHT_STICK_CLICK:Int = 11;
-	public static inline var PS:Int = 12;
-	public static inline var TOUCHPAD_CLICK:Int = 13;
+	var SHARE = 8;
+	var OPTIONS = 9;
+	var LEFT_STICK_CLICK = 10;
+	var RIGHT_STICK_CLICK = 11;
+	var PS = 12;
+	var TOUCHPAD_CLICK = 13;
 
-	public static inline var L2:Int = 3;
-	public static inline var R2:Int = 4;
+	var L2 = 3;
+	var R2 = 4;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(0, 1, {
 		up: 27,
 		down: 28,
 		left: 29,
 		right: 30
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 5, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(2, 5, {
 		up: 31,
 		down: 32,
 		left: 33,
@@ -145,9 +145,9 @@ class PS4ID
 	});
 
 	// "fake" IDs, we manually watch for hat axis changes and then send events using these otherwise unused joystick button codes
-	public static inline var DPAD_LEFT:Int = 15;
-	public static inline var DPAD_RIGHT:Int = 16;
-	public static inline var DPAD_DOWN:Int = 17;
-	public static inline var DPAD_UP:Int = 18;
+	var DPAD_LEFT = 15;
+	var DPAD_RIGHT = 16;
+	var DPAD_DOWN = 17;
+	var DPAD_UP = 18;
 	#end
 }

--- a/flixel/input/gamepad/id/PS4ID.hx
+++ b/flixel/input/gamepad/id/PS4ID.hx
@@ -36,10 +36,10 @@ enum abstract PS4ID(Int) to Int
 	var PS = 22;
 	var TOUCHPAD_CLICK = 23;
 	
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 2;
-	inline static final RIGHT_Y = 5;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 2;
+	static inline final RIGHT_Y = 5;
 	
 	var LEFT_STICK_UP = 24;
 	var LEFT_STICK_DOWN = 25;
@@ -71,10 +71,10 @@ enum abstract PS4ID(Int) to Int
 	#if ps4
 	var TOUCHPAD_CLICK = 10; // On an actual PS4, share is reserved by the system, and the touchpad click can serve more or less as a replacement for the "back/select" button
 	
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 2;
-	inline static final RIGHT_Y = 3;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 2;
+	static inline final RIGHT_Y = 3;
 	
 	var LEFT_STICK_UP = 32;
 	var LEFT_STICK_DOWN = 33;
@@ -90,10 +90,10 @@ enum abstract PS4ID(Int) to Int
 	#else
 	var SHARE = 10; // This is only accessible when not using an actual Playstation 4, otherwise it's reserved by the system
 
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 2;
-	inline static final RIGHT_Y = 3;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 2;
+	static inline final RIGHT_Y = 3;
 	
 	var LEFT_STICK_UP = 22;
 	var LEFT_STICK_DOWN = 23;
@@ -136,10 +136,10 @@ enum abstract PS4ID(Int) to Int
 	var L2 = 3;
 	var R2 = 4;
 
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 2;
-	inline static final RIGHT_Y = 5;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 2;
+	static inline final RIGHT_Y = 5;
 	
 	var LEFT_STICK_UP = 27;
 	var LEFT_STICK_DOWN = 28;

--- a/flixel/input/gamepad/id/PS4ID.hx
+++ b/flixel/input/gamepad/id/PS4ID.hx
@@ -35,20 +35,22 @@ enum abstract PS4ID(Int) to Int
 	var RIGHT_STICK_CLICK = 21;
 	var PS = 22;
 	var TOUCHPAD_CLICK = 23;
-
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(0, 1, {
-		up: 24,
-		down: 25,
-		left: 26,
-		right: 27
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(2, 5, {
-		up: 28,
-		down: 29,
-		left: 30,
-		right: 31
-	});
-
+	
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 2;
+	static var rightY = 5;
+	
+	var LEFT_STICK_UP = 24;
+	var LEFT_STICK_DOWN = 25;
+	var LEFT_STICK_LEFT = 26;
+	var LEFT_STICK_RIGHT = 27;
+	
+	var RIGHT_STICK_UP = 28;
+	var RIGHT_STICK_DOWN = 29;
+	var RIGHT_STICK_LEFT = 30;
+	var RIGHT_STICK_RIGHT = 31;
+	
 	var DPAD_UP = 6;
 	var DPAD_DOWN = 7;
 	var DPAD_LEFT = 8;
@@ -68,39 +70,42 @@ enum abstract PS4ID(Int) to Int
 
 	#if ps4
 	var TOUCHPAD_CLICK = 10; // On an actual PS4, share is reserved by the system, and the touchpad click can serve more or less as a replacement for the "back/select" button
-
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
-		up: 32,
-		down: 33,
-		left: 34,
-		right: 35
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
-		up: 36,
-		down: 37,
-		left: 38,
-		right: 39
-	});
-
+	
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 2;
+	static var rightY = 3;
+	
+	var LEFT_STICK_UP = 32;
+	var LEFT_STICK_DOWN = 33;
+	var LEFT_STICK_LEFT = 34;
+	var LEFT_STICK_RIGHT = 35;
+	
+	var RIGHT_STICK_UP = 36;
+	var RIGHT_STICK_DOWN = 37;
+	var RIGHT_STICK_LEFT = 38;
+	var RIGHT_STICK_RIGHT = 39;
+	
 	var SHARE = 40; // Not accessible on an actual PS4, just setting it to a dummy value
 	#else
 	var SHARE = 10; // This is only accessible when not using an actual Playstation 4, otherwise it's reserved by the system
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(0, 1, {
-		up: 22,
-		down: 23,
-		left: 24,
-		right: 25
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(2, 3, {
-		up: 26,
-		down: 27,
-		left: 28,
-		right: 29
-	});
-
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 2;
+	static var rightY = 3;
+	
+	var LEFT_STICK_UP = 22;
+	var LEFT_STICK_DOWN = 23;
+	var LEFT_STICK_LEFT = 24;
+	var LEFT_STICK_RIGHT = 25;
+	
+	var RIGHT_STICK_UP = 26;
+	var RIGHT_STICK_DOWN = 27;
+	var RIGHT_STICK_LEFT = 28;
+	var RIGHT_STICK_RIGHT = 29;
+	
 	var TOUCHPAD_CLICK = 30; // I don't believe this is normally accessible on PC, just setting it to a dummy value
-
 	#end
 	var L2 = 4;
 	var R2 = 5;
@@ -131,23 +136,38 @@ enum abstract PS4ID(Int) to Int
 	var L2 = 3;
 	var R2 = 4;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(0, 1, {
-		up: 27,
-		down: 28,
-		left: 29,
-		right: 30
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PS4ID>(2, 5, {
-		up: 31,
-		down: 32,
-		left: 33,
-		right: 34
-	});
-
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 2;
+	static var rightY = 5;
+	
+	var LEFT_STICK_UP = 27;
+	var LEFT_STICK_DOWN = 28;
+	var LEFT_STICK_LEFT = 29;
+	var LEFT_STICK_RIGHT = 30;
+	
+	var RIGHT_STICK_UP = 31;
+	var RIGHT_STICK_DOWN = 32;
+	var RIGHT_STICK_LEFT = 33;
+	var RIGHT_STICK_RIGHT = 34;
+	
 	// "fake" IDs, we manually watch for hat axis changes and then send events using these otherwise unused joystick button codes
 	var DPAD_LEFT = 15;
 	var DPAD_RIGHT = 16;
 	var DPAD_DOWN = 17;
 	var DPAD_UP = 18;
 	#end
+	
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<PS4ID>(leftX, leftY, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	});
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<PS4ID>(rightX, rightY, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
+	});
 }

--- a/flixel/input/gamepad/id/PSVitaID.hx
+++ b/flixel/input/gamepad/id/PSVitaID.hx
@@ -23,17 +23,27 @@ enum abstract PSVitaID(Int) to Int
 	var DPAD_DOWN = 18;
 	var DPAD_LEFT = 19;
 	var DPAD_RIGHT = 20;
-
+	
+	var LEFT_STICK_UP = 21;
+	var LEFT_STICK_DOWN = 22;
+	var LEFT_STICK_LEFT = 23;
+	var LEFT_STICK_RIGHT = 24;
+	
+	var RIGHT_STICK_UP = 25;
+	var RIGHT_STICK_DOWN = 26;
+	var RIGHT_STICK_LEFT = 27;
+	var RIGHT_STICK_RIGHT = 28;
+	
 	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PSVitaID>(0, 1, {
-		up: 21,
-		down: 22,
-		left: 23,
-		right: 24
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
 	});
 	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PSVitaID>(2, 3, {
-		up: 25,
-		down: 26,
-		left: 27,
-		right: 28
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
 	});
 }

--- a/flixel/input/gamepad/id/PSVitaID.hx
+++ b/flixel/input/gamepad/id/PSVitaID.hx
@@ -34,13 +34,13 @@ enum abstract PSVitaID(Int) to Int
 	var RIGHT_STICK_LEFT = 27;
 	var RIGHT_STICK_RIGHT = 28;
 	
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PSVitaID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<PSVitaID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PSVitaID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<PSVitaID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/PSVitaID.hx
+++ b/flixel/input/gamepad/id/PSVitaID.hx
@@ -8,29 +8,29 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  *
  * This will ONLY work with the gamepad API (available only in OpenFL "next", not "legacy") and will NOT work with the joystick API
  */
-class PSVitaID
+enum abstract PSVitaID(Int) to Int
 {
-	public static inline var X:Int = 6;
-	public static inline var CIRCLE:Int = 7;
-	public static inline var SQUARE:Int = 8;
-	public static inline var TRIANGLE:Int = 9;
-	public static inline var SELECT:Int = 10;
-	public static inline var START:Int = 12;
-	public static inline var L:Int = 15;
-	public static inline var R:Int = 16;
+	var X = 6;
+	var CIRCLE = 7;
+	var SQUARE = 8;
+	var TRIANGLE = 9;
+	var SELECT = 10;
+	var START = 12;
+	var L = 15;
+	var R = 16;
 
-	public static inline var DPAD_UP:Int = 17;
-	public static inline var DPAD_DOWN:Int = 18;
-	public static inline var DPAD_LEFT:Int = 19;
-	public static inline var DPAD_RIGHT:Int = 20;
+	var DPAD_UP = 17;
+	var DPAD_DOWN = 18;
+	var DPAD_LEFT = 19;
+	var DPAD_RIGHT = 20;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PSVitaID>(0, 1, {
 		up: 21,
 		down: 22,
 		left: 23,
 		right: 24
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<PSVitaID>(2, 3, {
 		up: 25,
 		down: 26,
 		left: 27,

--- a/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
@@ -33,12 +33,11 @@ enum abstract SwitchJoyconLeftID(Int) to Int
 	var MINUS = 17;
 	var CAPTURE = 21;
 	var LEFT_STICK_CLICK = 22;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
-		up: 24,
-		down: 25,
-		left: 26,
-		right: 27
-	});
+	
+	var LEFT_STICK_UP = 24;
+	var LEFT_STICK_DOWN = 25;
+	var LEFT_STICK_LEFT = 26;
+	var LEFT_STICK_RIGHT = 27;
 	#else
 	var ZL = 4;
 	var DOWN = 6;
@@ -51,12 +50,17 @@ enum abstract SwitchJoyconLeftID(Int) to Int
 	var SL = 15;
 	var SR = 16;
 	var CAPTURE = 21;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
-		up: 22,
-		down: 23,
-		left: 24,
-		right: 25
-	});
+	
+	var LEFT_STICK_UP = 22;
+	var LEFT_STICK_DOWN = 23;
+	var LEFT_STICK_LEFT = 24;
+	var LEFT_STICK_RIGHT = 25;
 	#end
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	});
 	
 }

--- a/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
@@ -19,39 +19,39 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  * 
  * @since 4.8.0
  */
-class SwitchJoyconLeftID
+enum abstract SwitchJoyconLeftID(Int) to Int
 {
 	#if flash
-	public static inline var UP:Int = 8;
-	public static inline var LEFT:Int = 9;
-	public static inline var DOWN:Int = 10;
-	public static inline var RIGHT:Int = 11;
-	public static inline var SL:Int = 12;
-	public static inline var SR:Int = 13;
-	public static inline var ZL:Int = 14;
-	public static inline var L:Int = 15;
-	public static inline var MINUS:Int = 17;
-	public static inline var CAPTURE:Int = 21;
-	public static inline var LEFT_STICK_CLICK:Int = 22;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	var UP = 8;
+	var LEFT = 9;
+	var DOWN = 10;
+	var RIGHT = 11;
+	var SL = 12;
+	var SR = 13;
+	var ZL = 14;
+	var L = 15;
+	var MINUS = 17;
+	var CAPTURE = 21;
+	var LEFT_STICK_CLICK = 22;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
 		up: 24,
 		down: 25,
 		left: 26,
 		right: 27
 	});
 	#else
-	public static inline var ZL:Int = 4;
-	public static inline var DOWN:Int = 6;
-	public static inline var RIGHT:Int = 7;
-	public static inline var LEFT:Int = 8;
-	public static inline var UP:Int = 9;
-	public static inline var L:Int = 10;
-	public static inline var MINUS:Int = 12;
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var SL:Int = 15;
-	public static inline var SR:Int = 16;
-	public static inline var CAPTURE:Int = 21;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	var ZL = 4;
+	var DOWN = 6;
+	var RIGHT = 7;
+	var LEFT = 8;
+	var UP = 9;
+	var L = 10;
+	var MINUS = 12;
+	var LEFT_STICK_CLICK = 13;
+	var SL = 15;
+	var SR = 16;
+	var CAPTURE = 21;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
 		up: 22,
 		down: 23,
 		left: 24,

--- a/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconLeftID.hx
@@ -56,7 +56,7 @@ enum abstract SwitchJoyconLeftID(Int) to Int
 	var LEFT_STICK_LEFT = 24;
 	var LEFT_STICK_RIGHT = 25;
 	#end
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<SwitchJoyconLeftID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,

--- a/flixel/input/gamepad/id/SwitchJoyconRightID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconRightID.hx
@@ -35,18 +35,11 @@ enum abstract SwitchJoyconRightID(Int) to Int
 	var HOME = 20;
 	var CAPTURE = 21;
 	var LEFT_STICK_CLICK = 22;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
-		up: 24,
-		down: 25,
-		left: 26,
-		right: 27
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(2, 3, {
-		up: 28,
-		down: 29,
-		left: 30,
-		right: 31
-	});
+	
+	var LEFT_STICK_UP = 24;
+	var LEFT_STICK_DOWN = 25;
+	var LEFT_STICK_LEFT = 26;
+	var LEFT_STICK_RIGHT = 27;
 	#else
 	var ZR = 5;
 	var A = 6;
@@ -59,12 +52,16 @@ enum abstract SwitchJoyconRightID(Int) to Int
 	var LEFT_STICK_CLICK = 13;
 	var SL = 15;
 	var SR = 16;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
-		up: 22,
-		down: 23,
-		left: 24,
-		right: 25
-	});
-	#end
 	
+	var LEFT_STICK_UP = 22;
+	var LEFT_STICK_DOWN = 23;
+	var LEFT_STICK_LEFT = 24;
+	var LEFT_STICK_RIGHT = 25;
+	#end
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	});
 }

--- a/flixel/input/gamepad/id/SwitchJoyconRightID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconRightID.hx
@@ -58,7 +58,7 @@ enum abstract SwitchJoyconRightID(Int) to Int
 	var LEFT_STICK_LEFT = 24;
 	var LEFT_STICK_RIGHT = 25;
 	#end
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,

--- a/flixel/input/gamepad/id/SwitchJoyconRightID.hx
+++ b/flixel/input/gamepad/id/SwitchJoyconRightID.hx
@@ -19,46 +19,47 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  * 
  * @since 4.8.0
  */
-class SwitchJoyconRightID
+
+enum abstract SwitchJoyconRightID(Int) to Int
 {
 	#if flash
-	public static inline var A:Int = 8;
-	public static inline var B:Int = 9;
-	public static inline var X:Int = 10;
-	public static inline var Y:Int = 11;
-	public static inline var SL:Int = 12;
-	public static inline var SR:Int = 13;
-	public static inline var ZR:Int = 15;
-	public static inline var R:Int = 16;
-	public static inline var PLUS:Int = 17;
-	public static inline var HOME:Int = 20;
-	public static inline var CAPTURE:Int = 21;
-	public static inline var LEFT_STICK_CLICK:Int = 22;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	var A = 8;
+	var B = 9;
+	var X = 10;
+	var Y = 11;
+	var SL = 12;
+	var SR = 13;
+	var ZR = 15;
+	var R = 16;
+	var PLUS = 17;
+	var HOME = 20;
+	var CAPTURE = 21;
+	var LEFT_STICK_CLICK = 22;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
 		up: 24,
 		down: 25,
 		left: 26,
 		right: 27
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(2, 3, {
 		up: 28,
 		down: 29,
 		left: 30,
 		right: 31
 	});
 	#else
-	public static inline var ZR:Int = 5;
-	public static inline var A:Int = 6;
-	public static inline var X:Int = 7;
-	public static inline var B:Int = 8;
-	public static inline var Y:Int = 9;
-	public static inline var R:Int = 10;
-	public static inline var HOME:Int = 11;
-	public static inline var PLUS:Int = 12;
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var SL:Int = 15;
-	public static inline var SR:Int = 16;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	var ZR = 5;
+	var A = 6;
+	var X = 7;
+	var B = 8;
+	var Y = 9;
+	var R = 10;
+	var HOME = 11;
+	var PLUS = 12;
+	var LEFT_STICK_CLICK = 13;
+	var SL = 15;
+	var SR = 16;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchJoyconRightID>(0, 1, {
 		up: 22,
 		down: 23,
 		left: 24,

--- a/flixel/input/gamepad/id/SwitchProID.hx
+++ b/flixel/input/gamepad/id/SwitchProID.hx
@@ -38,18 +38,17 @@ enum abstract SwitchProID(Int) to Int
 	var CAPTURE = 21;
 	var LEFT_STICK_CLICK = 22;
 	var RIGHT_STICK_CLICK = 23;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
-		up: 24,
-		down: 25,
-		left: 26,
-		right: 27
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
-		up: 28,
-		down: 29,
-		left: 30,
-		right: 31
-	});
+	
+	var LEFT_STICK_UP = 24;
+	var LEFT_STICK_DOWN = 25;
+	var LEFT_STICK_LEFT = 26;
+	var LEFT_STICK_RIGHT = 27;
+	
+	var RIGHT_STICK_UP = 28;
+	var RIGHT_STICK_DOWN = 29;
+	var RIGHT_STICK_LEFT = 30;
+	var RIGHT_STICK_RIGHT = 31;
+	
 	#else
 	var ZL = 4;
 	var ZR = 5;
@@ -69,18 +68,29 @@ enum abstract SwitchProID(Int) to Int
 	var DPAD_LEFT = 19;
 	var DPAD_RIGHT = 20;
 	var CAPTURE = 21;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
-		up: 22,
-		down: 23,
-		left: 24,
-		right: 25
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
-		up: 26,
-		down: 27,
-		left: 28,
-		right: 29
-	});
+	
+	var LEFT_STICK_UP = 22;
+	var LEFT_STICK_DOWN = 23;
+	var LEFT_STICK_LEFT = 24;
+	var LEFT_STICK_RIGHT = 25;
+	
+	var RIGHT_STICK_UP = 26;
+	var RIGHT_STICK_DOWN = 27;
+	var RIGHT_STICK_LEFT = 28;
+	var RIGHT_STICK_RIGHT = 29;
 	#end
+	
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	});
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
+	});
 	
 }

--- a/flixel/input/gamepad/id/SwitchProID.hx
+++ b/flixel/input/gamepad/id/SwitchProID.hx
@@ -17,65 +17,65 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  * 
  * @since 4.8.0
  */
-class SwitchProID
+enum abstract SwitchProID(Int) to Int
 {
 	#if flash
-	public static inline var DPAD_UP:Int = 4;
-	public static inline var DPAD_DOWN:Int = 5;
-	public static inline var DPAD_LEFT:Int = 6;
-	public static inline var DPAD_RIGHT:Int = 7;
-	public static inline var A:Int = 8;
-	public static inline var B:Int = 9;
-	public static inline var X:Int = 10;
-	public static inline var Y:Int = 11;
-	public static inline var L:Int = 12;
-	public static inline var R:Int = 13;
-	public static inline var ZL:Int = 14;
-	public static inline var ZR:Int = 15;
-	public static inline var MINUS:Int = 16;
-	public static inline var PLUS:Int = 17;
-	public static inline var HOME:Int = 20;
-	public static inline var CAPTURE:Int = 21;
-	public static inline var LEFT_STICK_CLICK:Int = 22;
-	public static inline var RIGHT_STICK_CLICK:Int = 23;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	var DPAD_UP = 4;
+	var DPAD_DOWN = 5;
+	var DPAD_LEFT = 6;
+	var DPAD_RIGHT = 7;
+	var A = 8;
+	var B = 9;
+	var X = 10;
+	var Y = 11;
+	var L = 12;
+	var R = 13;
+	var ZL = 14;
+	var ZR = 15;
+	var MINUS = 16;
+	var PLUS = 17;
+	var HOME = 20;
+	var CAPTURE = 21;
+	var LEFT_STICK_CLICK = 22;
+	var RIGHT_STICK_CLICK = 23;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
 		up: 24,
 		down: 25,
 		left: 26,
 		right: 27
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
 		up: 28,
 		down: 29,
 		left: 30,
 		right: 31
 	});
 	#else
-	public static inline var ZL:Int = 4;
-	public static inline var ZR:Int = 5;
-	public static inline var B:Int = 6;
-	public static inline var A:Int = 7;
-	public static inline var Y:Int = 8;
-	public static inline var X:Int = 9;
-	public static inline var MINUS:Int = 10;
-	public static inline var HOME:Int = 11;
-	public static inline var PLUS:Int = 12;
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var RIGHT_STICK_CLICK:Int = 14;
-	public static inline var L:Int = 15;
-	public static inline var R:Int = 16;
-	public static inline var DPAD_UP:Int = 17;
-	public static inline var DPAD_DOWN:Int = 18;
-	public static inline var DPAD_LEFT:Int = 19;
-	public static inline var DPAD_RIGHT:Int = 20;
-	public static inline var CAPTURE:Int = 21;
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	var ZL = 4;
+	var ZR = 5;
+	var B = 6;
+	var A = 7;
+	var Y = 8;
+	var X = 9;
+	var MINUS = 10;
+	var HOME = 11;
+	var PLUS = 12;
+	var LEFT_STICK_CLICK = 13;
+	var RIGHT_STICK_CLICK = 14;
+	var L = 15;
+	var R = 16;
+	var DPAD_UP = 17;
+	var DPAD_DOWN = 18;
+	var DPAD_LEFT = 19;
+	var DPAD_RIGHT = 20;
+	var CAPTURE = 21;
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
 		up: 22,
 		down: 23,
 		left: 24,
 		right: 25
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
 		up: 26,
 		down: 27,
 		left: 28,

--- a/flixel/input/gamepad/id/SwitchProID.hx
+++ b/flixel/input/gamepad/id/SwitchProID.hx
@@ -80,13 +80,13 @@ enum abstract SwitchProID(Int) to Int
 	var RIGHT_STICK_RIGHT = 29;
 	#end
 	
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<SwitchProID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<SwitchProID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/WiiRemoteID.hx
+++ b/flixel/input/gamepad/id/WiiRemoteID.hx
@@ -191,7 +191,7 @@ enum abstract WiiRemoteID(Int) to Int
 	/**
 	 * the nunchuk only has the "left" analog stick
 	 */
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
@@ -201,7 +201,7 @@ enum abstract WiiRemoteID(Int) to Int
 	/**
 	 * the classic controller has both the "left" and "right" analog sticks
 	 */
-	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
+	public static final RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/id/WiiRemoteID.hx
+++ b/flixel/input/gamepad/id/WiiRemoteID.hx
@@ -11,7 +11,7 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
  *
  * @author larsiusprime
  */
-class WiiRemoteID
+enum abstract WiiRemoteID(Int) to Int
 {
 	/**
 	 * Things to add:
@@ -23,52 +23,52 @@ class WiiRemoteID
 	 */
 	#if FLX_JOYSTICK_API
 	// Standard Wii Remote inputs:
-	public static inline var REMOTE_ONE:Int = 0;
-	public static inline var REMOTE_TWO:Int = 1;
-	public static inline var REMOTE_A:Int = 2;
-	public static inline var REMOTE_B:Int = 3;
-	public static inline var REMOTE_PLUS:Int = 4;
-	public static inline var REMOTE_MINUS:Int = 5;
-	public static inline var REMOTE_HOME:Int = 6;
+	var REMOTE_ONE = 0;
+	var REMOTE_TWO = 1;
+	var REMOTE_A = 2;
+	var REMOTE_B = 3;
+	var REMOTE_PLUS = 4;
+	var REMOTE_MINUS = 5;
+	var REMOTE_HOME = 6;
 
 	// Nunchuk attachment:
-	public static inline var NUNCHUK_A:Int = 0;
-	public static inline var NUNCHUK_B:Int = 1;
-	public static inline var NUNCHUK_C:Int = 2;
-	public static inline var NUNCHUK_Z:Int = 3;
-	public static inline var NUNCHUK_ONE:Int = 4;
-	public static inline var NUNCHUK_TWO:Int = 5;
-	public static inline var NUNCHUK_PLUS:Int = 6;
-	public static inline var NUNCHUK_MINUS:Int = 7;
-	public static inline var NUNCHUK_HOME:Int = 8;
+	var NUNCHUK_A = 0;
+	var NUNCHUK_B = 1;
+	var NUNCHUK_C = 2;
+	var NUNCHUK_Z = 3;
+	var NUNCHUK_ONE = 4;
+	var NUNCHUK_TWO = 5;
+	var NUNCHUK_PLUS = 6;
+	var NUNCHUK_MINUS = 7;
+	var NUNCHUK_HOME = 8;
 
 	// classic controller attachment:
-	public static inline var CLASSIC_A:Int = 0;
-	public static inline var CLASSIC_B:Int = 1;
-	public static inline var CLASSIC_Y:Int = 2;
-	public static inline var CLASSIC_X:Int = 3;
-	public static inline var CLASSIC_L:Int = 4;
-	public static inline var CLASSIC_R:Int = 5;
-	public static inline var CLASSIC_ZL:Int = 6;
-	public static inline var CLASSIC_ZR:Int = 7;
-	public static inline var CLASSIC_START:Int = 8;
-	public static inline var CLASSIC_SELECT:Int = 9;
-	public static inline var CLASSIC_HOME:Int = 10;
-	public static inline var CLASSIC_ONE:Int = 11;
-	public static inline var CLASSIC_TWO:Int = 12;
+	var CLASSIC_A = 0;
+	var CLASSIC_B = 1;
+	var CLASSIC_Y = 2;
+	var CLASSIC_X = 3;
+	var CLASSIC_L = 4;
+	var CLASSIC_R = 5;
+	var CLASSIC_ZL = 6;
+	var CLASSIC_ZR = 7;
+	var CLASSIC_START = 8;
+	var CLASSIC_SELECT = 9;
+	var CLASSIC_HOME = 10;
+	var CLASSIC_ONE = 11;
+	var CLASSIC_TWO = 12;
 
-	public static inline var REMOTE_TILT_PITCH:Int = 2;
-	public static inline var REMOTE_TILT_ROLL:Int = 3;
+	var REMOTE_TILT_PITCH = 2;
+	var REMOTE_TILT_ROLL = 3;
 
-	public static inline var NUNCHUK_TILT_PITCH:Int = 3;
-	public static inline var NUNCHUK_TILT_ROLL:Int = 2;
+	var NUNCHUK_TILT_PITCH = 3;
+	var NUNCHUK_TILT_ROLL = 2;
 
-	public static inline var REMOTE_NULL_AXIS:Int = 4;
-	public static inline var NUNCHUK_NULL_AXIS:Int = 4;
+	var REMOTE_NULL_AXIS = 4;
+	var NUNCHUK_NULL_AXIS = 4;
 
 	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...
 	// so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
 		up: REMOTE_DPAD_UP,
 		down: REMOTE_DPAD_DOWN,
 		left: REMOTE_DPAD_LEFT,
@@ -78,14 +78,14 @@ class WiiRemoteID
 	});
 
 	// the nunchuk only has the "left" analog stick
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
 		up: 32,
 		down: 33,
 		left: 34,
 		right: 35
 	});
 	// the classic controller has both the "left" and "right" analog sticks
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
 		up: 36,
 		down: 37,
 		left: 38,
@@ -93,88 +93,88 @@ class WiiRemoteID
 	});
 
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
-	public static inline var LEFT_TRIGGER_FAKE:Int = 4;
-	public static inline var RIGHT_TRIGGER_FAKE:Int = 5;
+	var LEFT_TRIGGER_FAKE = 4;
+	var RIGHT_TRIGGER_FAKE = 5;
 
 	// "fake" ID's
-	public static inline var REMOTE_DPAD_UP:Int = 14;
-	public static inline var REMOTE_DPAD_DOWN:Int = 15;
-	public static inline var REMOTE_DPAD_LEFT:Int = 16;
-	public static inline var REMOTE_DPAD_RIGHT:Int = 17;
+	var REMOTE_DPAD_UP = 14;
+	var REMOTE_DPAD_DOWN = 15;
+	var REMOTE_DPAD_LEFT = 16;
+	var REMOTE_DPAD_RIGHT = 17;
 
-	public static inline var REMOTE_DPAD_X:Int = 18;
-	public static inline var REMOTE_DPAD_Y:Int = 19;
+	var REMOTE_DPAD_X = 18;
+	var REMOTE_DPAD_Y = 19;
 
-	public static inline var CLASSIC_DPAD_DOWN:Int = 24;
-	public static inline var CLASSIC_DPAD_UP:Int = 25;
-	public static inline var CLASSIC_DPAD_LEFT:Int = 26;
-	public static inline var CLASSIC_DPAD_RIGHT:Int = 27;
+	var CLASSIC_DPAD_DOWN = 24;
+	var CLASSIC_DPAD_UP = 25;
+	var CLASSIC_DPAD_LEFT = 26;
+	var CLASSIC_DPAD_RIGHT = 27;
 
-	public static inline var NUNCHUK_DPAD_DOWN:Int = 28;
-	public static inline var NUNCHUK_DPAD_UP:Int = 29;
-	public static inline var NUNCHUK_DPAD_LEFT:Int = 30;
-	public static inline var NUNCHUK_DPAD_RIGHT:Int = 31;
+	var NUNCHUK_DPAD_DOWN = 28;
+	var NUNCHUK_DPAD_UP = 29;
+	var NUNCHUK_DPAD_LEFT = 30;
+	var NUNCHUK_DPAD_RIGHT = 31;
 	#else // gamepad API
 	// Standard Wii Remote inputs:
-	public static inline var REMOTE_ONE:Int = 9;
-	public static inline var REMOTE_TWO:Int = 10;
-	public static inline var REMOTE_A:Int = 11;
-	public static inline var REMOTE_B:Int = 12;
-	public static inline var REMOTE_PLUS:Int = 13;
-	public static inline var REMOTE_MINUS:Int = 14;
-	public static inline var REMOTE_HOME:Int = 15;
+	var REMOTE_ONE = 9;
+	var REMOTE_TWO = 10;
+	var REMOTE_A = 11;
+	var REMOTE_B = 12;
+	var REMOTE_PLUS = 13;
+	var REMOTE_MINUS = 14;
+	var REMOTE_HOME = 15;
 
 	// Nunchuk attachment:
-	public static inline var NUNCHUK_A:Int = 9;
-	public static inline var NUNCHUK_B:Int = 10;
-	public static inline var NUNCHUK_C:Int = 11;
-	public static inline var NUNCHUK_Z:Int = 12;
-	public static inline var NUNCHUK_ONE:Int = 13;
-	public static inline var NUNCHUK_TWO:Int = 14;
-	public static inline var NUNCHUK_PLUS:Int = 15;
-	public static inline var NUNCHUK_MINUS:Int = 16;
-	public static inline var NUNCHUK_HOME:Int = 17;
+	var NUNCHUK_A = 9;
+	var NUNCHUK_B = 10;
+	var NUNCHUK_C = 11;
+	var NUNCHUK_Z = 12;
+	var NUNCHUK_ONE = 13;
+	var NUNCHUK_TWO = 14;
+	var NUNCHUK_PLUS = 15;
+	var NUNCHUK_MINUS = 16;
+	var NUNCHUK_HOME = 17;
 
-	public static inline var NUNCHUK_DPAD_UP:Int = 5;
-	public static inline var NUNCHUK_DPAD_DOWN:Int = 6;
-	public static inline var NUNCHUK_DPAD_LEFT:Int = 7;
-	public static inline var NUNCHUK_DPAD_RIGHT:Int = 8;
+	var NUNCHUK_DPAD_UP = 5;
+	var NUNCHUK_DPAD_DOWN = 6;
+	var NUNCHUK_DPAD_LEFT = 7;
+	var NUNCHUK_DPAD_RIGHT = 8;
 
 	// classic controller attachment:
-	public static inline var CLASSIC_A:Int = 9;
-	public static inline var CLASSIC_B:Int = 10;
-	public static inline var CLASSIC_Y:Int = 11;
-	public static inline var CLASSIC_X:Int = 12;
-	public static inline var CLASSIC_L:Int = 13;
-	public static inline var CLASSIC_R:Int = 14;
-	public static inline var CLASSIC_ZL:Int = 15;
-	public static inline var CLASSIC_ZR:Int = 16;
-	public static inline var CLASSIC_START:Int = 17;
-	public static inline var CLASSIC_SELECT:Int = 18;
-	public static inline var CLASSIC_HOME:Int = 19;
-	public static inline var CLASSIC_ONE:Int = 20;
-	public static inline var CLASSIC_TWO:Int = 21;
+	var CLASSIC_A = 9;
+	var CLASSIC_B = 10;
+	var CLASSIC_Y = 11;
+	var CLASSIC_X = 12;
+	var CLASSIC_L = 13;
+	var CLASSIC_R = 14;
+	var CLASSIC_ZL = 15;
+	var CLASSIC_ZR = 16;
+	var CLASSIC_START = 17;
+	var CLASSIC_SELECT = 18;
+	var CLASSIC_HOME = 19;
+	var CLASSIC_ONE = 20;
+	var CLASSIC_TWO = 21;
 
-	public static inline var CLASSIC_DPAD_UP:Int = 5;
-	public static inline var CLASSIC_DPAD_DOWN:Int = 6;
-	public static inline var CLASSIC_DPAD_LEFT:Int = 7;
-	public static inline var CLASSIC_DPAD_RIGHT:Int = 8;
+	var CLASSIC_DPAD_UP = 5;
+	var CLASSIC_DPAD_DOWN = 6;
+	var CLASSIC_DPAD_LEFT = 7;
+	var CLASSIC_DPAD_RIGHT = 8;
 
-	public static inline var REMOTE_TILT_PITCH:Int = 2;
-	public static inline var REMOTE_TILT_ROLL:Int = 3;
+	var REMOTE_TILT_PITCH = 2;
+	var REMOTE_TILT_ROLL = 3;
 
-	public static inline var NUNCHUK_TILT_PITCH:Int = 3;
-	public static inline var NUNCHUK_TILT_ROLL:Int = 2;
+	var NUNCHUK_TILT_PITCH = 3;
+	var NUNCHUK_TILT_ROLL = 2;
 
-	public static inline var REMOTE_NULL_AXIS:Int = 4;
-	public static inline var NUNCHUK_NULL_AXIS:Int = 4;
+	var REMOTE_NULL_AXIS = 4;
+	var NUNCHUK_NULL_AXIS = 4;
 
 	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxGamepadAnalogStick(0, 1, {
-		up: REMOTE_DPAD_UP,
-		down: REMOTE_DPAD_DOWN,
-		left: REMOTE_DPAD_LEFT,
-		right: REMOTE_DPAD_RIGHT,
+	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
+		up: (cast REMOTE_DPAD_UP:Int),
+		down: (cast REMOTE_DPAD_DOWN:Int),
+		left: (cast REMOTE_DPAD_LEFT:Int),
+		right: (cast REMOTE_DPAD_RIGHT:Int),
 		threshold: 0.5,
 		mode: ONLY_DIGITAL
 	});
@@ -182,7 +182,7 @@ class WiiRemoteID
 	/**
 	 * the nunchuk only has the "left" analog stick
 	 */
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
 		up: 28,
 		down: 29,
 		left: 30,
@@ -192,7 +192,7 @@ class WiiRemoteID
 	/**
 	 * the classic controller has both the "left" and "right" analog sticks
 	 */
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
 		up: 32,
 		down: 33,
 		left: 34,
@@ -200,16 +200,16 @@ class WiiRemoteID
 	});
 
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
-	public static inline var LEFT_TRIGGER_FAKE:Int = 4;
-	public static inline var RIGHT_TRIGGER_FAKE:Int = 5;
+	var LEFT_TRIGGER_FAKE = 4;
+	var RIGHT_TRIGGER_FAKE = 5;
 
 	// "fake" ID's
-	public static inline var REMOTE_DPAD_UP:Int = 22;
-	public static inline var REMOTE_DPAD_DOWN:Int = 23;
-	public static inline var REMOTE_DPAD_LEFT:Int = 24;
-	public static inline var REMOTE_DPAD_RIGHT:Int = 25;
+	var REMOTE_DPAD_UP = 22;
+	var REMOTE_DPAD_DOWN = 23;
+	var REMOTE_DPAD_LEFT = 24;
+	var REMOTE_DPAD_RIGHT = 25;
 
-	public static inline var REMOTE_DPAD_X:Int = 26;
-	public static inline var REMOTE_DPAD_Y:Int = 27;
+	var REMOTE_DPAD_X = 26;
+	var REMOTE_DPAD_Y = 27;
 	#end
 }

--- a/flixel/input/gamepad/id/WiiRemoteID.hx
+++ b/flixel/input/gamepad/id/WiiRemoteID.hx
@@ -179,7 +179,7 @@ enum abstract WiiRemoteID(Int) to Int
 	
 	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...
 	// so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static final remoteDPad = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
+	public static final REMOTE_DPAD = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
 		up: REMOTE_DPAD_UP,
 		down: REMOTE_DPAD_DOWN,
 		left: REMOTE_DPAD_LEFT,

--- a/flixel/input/gamepad/id/WiiRemoteID.hx
+++ b/flixel/input/gamepad/id/WiiRemoteID.hx
@@ -66,32 +66,16 @@ enum abstract WiiRemoteID(Int) to Int
 	var REMOTE_NULL_AXIS = 4;
 	var NUNCHUK_NULL_AXIS = 4;
 
-	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...
-	// so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
-		up: REMOTE_DPAD_UP,
-		down: REMOTE_DPAD_DOWN,
-		left: REMOTE_DPAD_LEFT,
-		right: REMOTE_DPAD_RIGHT,
-		threshold: 0.5,
-		mode: ONLY_DIGITAL
-	});
-
-	// the nunchuk only has the "left" analog stick
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
-		up: 32,
-		down: 33,
-		left: 34,
-		right: 35
-	});
-	// the classic controller has both the "left" and "right" analog sticks
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
-		up: 36,
-		down: 37,
-		left: 38,
-		right: 39
-	});
-
+	var LEFT_STICK_UP = 32;
+	var LEFT_STICK_DOWN = 33;
+	var LEFT_STICK_LEFT = 34;
+	var LEFT_STICK_RIGHT = 35;
+	
+	var RIGHT_STICK_UP = 36;
+	var RIGHT_STICK_DOWN = 37;
+	var RIGHT_STICK_LEFT = 38;
+	var RIGHT_STICK_RIGHT = 39;
+	
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
 	var LEFT_TRIGGER_FAKE = 4;
 	var RIGHT_TRIGGER_FAKE = 5;
@@ -169,36 +153,16 @@ enum abstract WiiRemoteID(Int) to Int
 	var REMOTE_NULL_AXIS = 4;
 	var NUNCHUK_NULL_AXIS = 4;
 
-	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...so we have to pass in some "fake" ID's to get simulated digital inputs
-	public static var REMOTE_DPAD(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
-		up: (cast REMOTE_DPAD_UP:Int),
-		down: (cast REMOTE_DPAD_DOWN:Int),
-		left: (cast REMOTE_DPAD_LEFT:Int),
-		right: (cast REMOTE_DPAD_RIGHT:Int),
-		threshold: 0.5,
-		mode: ONLY_DIGITAL
-	});
-
-	/**
-	 * the nunchuk only has the "left" analog stick
-	 */
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
-		up: 28,
-		down: 29,
-		left: 30,
-		right: 31
-	});
-
-	/**
-	 * the classic controller has both the "left" and "right" analog sticks
-	 */
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
-		up: 32,
-		down: 33,
-		left: 34,
-		right: 35
-	});
-
+	var LEFT_STICK_UP = 28;
+	var LEFT_STICK_DOWN = 29;
+	var LEFT_STICK_LEFT = 30;
+	var LEFT_STICK_RIGHT = 31;
+	
+	var RIGHT_STICK_UP = 32;
+	var RIGHT_STICK_DOWN = 33;
+	var RIGHT_STICK_LEFT = 34;
+	var RIGHT_STICK_RIGHT = 35;
+	
 	// these aren't real axes, they're simulated when the right digital buttons are pushed
 	var LEFT_TRIGGER_FAKE = 4;
 	var RIGHT_TRIGGER_FAKE = 5;
@@ -212,4 +176,36 @@ enum abstract WiiRemoteID(Int) to Int
 	var REMOTE_DPAD_X = 26;
 	var REMOTE_DPAD_Y = 27;
 	#end
+	
+	// Yes, the WiiRemote DPAD is treated as ANALOG for some reason...
+	// so we have to pass in some "fake" ID's to get simulated digital inputs
+	public static final remoteDPad = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
+		up: REMOTE_DPAD_UP,
+		down: REMOTE_DPAD_DOWN,
+		left: REMOTE_DPAD_LEFT,
+		right: REMOTE_DPAD_RIGHT,
+		threshold: 0.5,
+		mode: ONLY_DIGITAL
+	});
+	
+	/**
+	 * the nunchuk only has the "left" analog stick
+	 */
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<WiiRemoteID>(0, 1, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	});
+
+	/**
+	 * the classic controller has both the "left" and "right" analog sticks
+	 */
+	public static final rightAnalogStick = new FlxTypedGamepadAnalogStick<WiiRemoteID>(2, 3, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
+	});
+
 }

--- a/flixel/input/gamepad/id/XInputID.hx
+++ b/flixel/input/gamepad/id/XInputID.hx
@@ -81,10 +81,10 @@ enum abstract XInputID(Int) to Int
 	var DPAD_LEFT = 19;
 	var DPAD_RIGHT = 20;
 	
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 2;
-	inline static final RIGHT_Y = 3;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 2;
+	static inline final RIGHT_Y = 3;
 
 	var LEFT_STICK_UP = 21;
 	var LEFT_STICK_DOWN = 22;
@@ -131,10 +131,10 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 2;
 	var RIGHT_TRIGGER = 5;
 
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 3;
-	inline static final RIGHT_Y = 4;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 3;
+	static inline final RIGHT_Y = 4;
 
 	var LEFT_STICK_UP = 21;
 	var LEFT_STICK_DOWN = 22;
@@ -170,10 +170,10 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 2;
 	var RIGHT_TRIGGER = 5;
 
-	inline static final LEFT_X = 0;
-	inline static final LEFT_Y = 1;
-	inline static final RIGHT_X = 3;
-	inline static final RIGHT_Y = 4;
+	static inline final LEFT_X = 0;
+	static inline final LEFT_Y = 1;
+	static inline final RIGHT_X = 3;
+	static inline final RIGHT_Y = 4;
 
 	var LEFT_STICK_UP = 21;
 	var LEFT_STICK_DOWN = 22;

--- a/flixel/input/gamepad/id/XInputID.hx
+++ b/flixel/input/gamepad/id/XInputID.hx
@@ -45,18 +45,21 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 10;
 	var RIGHT_TRIGGER = 11;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
-		up: 20,
-		down: 21,
-		left: 22,
-		right: 23
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(2, 3, {
-		up: 24,
-		down: 25,
-		left: 26,
-		right: 27
-	});
+	
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 2;
+	static var rightY = 3;
+	
+	var LEFT_STICK_UP = 20;
+	var LEFT_STICK_DOWN = 21;
+	var LEFT_STICK_LEFT = 22;
+	var LEFT_STICK_RIGHT = 23;
+	
+	var RIGHT_STICK_UP = 24;
+	var RIGHT_STICK_DOWN = 25;
+	var RIGHT_STICK_LEFT = 26;
+	var RIGHT_STICK_RIGHT = 27;
 	#elseif FLX_GAMEINPUT_API
 	var A = 6;
 	var B = 7;
@@ -77,19 +80,21 @@ enum abstract XInputID(Int) to Int
 	var DPAD_DOWN = 18;
 	var DPAD_LEFT = 19;
 	var DPAD_RIGHT = 20;
+	
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 2;
+	static var rightY = 3;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
-		up: 21,
-		down: 22,
-		left: 23,
-		right: 24
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(2, 3, {
-		up: 25,
-		down: 26,
-		left: 27,
-		right: 28
-	});
+	var LEFT_STICK_UP = 21;
+	var LEFT_STICK_DOWN = 22;
+	var LEFT_STICK_LEFT = 23;
+	var LEFT_STICK_RIGHT = 24;
+	
+	var RIGHT_STICK_UP = 25;
+	var RIGHT_STICK_DOWN = 26;
+	var RIGHT_STICK_LEFT = 27;
+	var RIGHT_STICK_RIGHT = 28;
 
 	var LEFT_TRIGGER = 4;
 	var RIGHT_TRIGGER = 5;
@@ -126,18 +131,20 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 2;
 	var RIGHT_TRIGGER = 5;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
-		up: 21,
-		down: 22,
-		left: 23,
-		right: 24
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(3, 4, {
-		up: 25,
-		down: 26,
-		left: 27,
-		right: 28
-	});
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 3;
+	static var rightY = 4;
+
+	var LEFT_STICK_UP = 21;
+	var LEFT_STICK_DOWN = 22;
+	var LEFT_STICK_LEFT = 23;
+	var LEFT_STICK_RIGHT = 24;
+	
+	var RIGHT_STICK_UP = 25;
+	var RIGHT_STICK_DOWN = 26;
+	var RIGHT_STICK_LEFT = 27;
+	var RIGHT_STICK_RIGHT = 28;
 	#else // mac
 	var A = 0;
 	var B = 1;
@@ -163,18 +170,34 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 2;
 	var RIGHT_TRIGGER = 5;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
-		up: 21,
-		down: 22,
-		left: 23,
-		right: 24
-	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(3, 4, {
-		up: 25,
-		down: 26,
-		left: 27,
-		right: 28
-	});
+	static var leftX = 0;
+	static var leftY = 1;
+	static var rightX = 3;
+	static var rightY = 4;
+
+	var LEFT_STICK_UP = 21;
+	var LEFT_STICK_DOWN = 22;
+	var LEFT_STICK_LEFT = 23;
+	var LEFT_STICK_RIGHT = 24;
+	
+	var RIGHT_STICK_UP = 25;
+	var RIGHT_STICK_DOWN = 26;
+	var RIGHT_STICK_LEFT = 27;
+	var RIGHT_STICK_RIGHT = 28;
 	#end
 	#end
+	
+	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<XInputID>(leftX, leftY, {
+		up: LEFT_STICK_UP,
+		down: LEFT_STICK_DOWN,
+		left: LEFT_STICK_LEFT,
+		right: LEFT_STICK_RIGHT
+	});
+	
+	public static var rightAnalogStick = new FlxTypedGamepadAnalogStick<XInputID>(rightX, rightY, {
+		up: RIGHT_STICK_UP,
+		down: RIGHT_STICK_DOWN,
+		left: RIGHT_STICK_LEFT,
+		right: RIGHT_STICK_RIGHT
+	});
 }

--- a/flixel/input/gamepad/id/XInputID.hx
+++ b/flixel/input/gamepad/id/XInputID.hx
@@ -20,156 +20,156 @@ import flixel.input.gamepad.FlxGamepadAnalogStick;
 	* MAC: we assume the user is using the 360 Controller driver, specifically this one:
 	* https://github.com/360Controller/360Controller/releases
  */
-class XInputID
+enum abstract XInputID(Int) to Int
 {
 	#if flash
-	public static inline var A:Int = 4;
-	public static inline var B:Int = 5;
-	public static inline var X:Int = 6;
-	public static inline var Y:Int = 7;
-	public static inline var LB:Int = 8;
-	public static inline var RB:Int = 9;
+	var A = 4;
+	var B = 5;
+	var X = 6;
+	var Y = 7;
+	var LB = 8;
+	var RB = 9;
 
-	public static inline var BACK:Int = 12;
-	public static inline var GUIDE:Int = -1;
-	public static inline var START:Int = 13;
+	var BACK = 12;
+	var GUIDE = -1;
+	var START = 13;
 
-	public static inline var LEFT_STICK_CLICK:Int = 14;
-	public static inline var RIGHT_STICK_CLICK:Int = 15;
+	var LEFT_STICK_CLICK = 14;
+	var RIGHT_STICK_CLICK = 15;
 
-	public static inline var DPAD_UP:Int = 16;
-	public static inline var DPAD_DOWN:Int = 17;
-	public static inline var DPAD_LEFT:Int = 18;
-	public static inline var DPAD_RIGHT:Int = 19;
+	var DPAD_UP = 16;
+	var DPAD_DOWN = 17;
+	var DPAD_LEFT = 18;
+	var DPAD_RIGHT = 19;
 
-	public static inline var LEFT_TRIGGER:Int = 10;
-	public static inline var RIGHT_TRIGGER:Int = 11;
+	var LEFT_TRIGGER = 10;
+	var RIGHT_TRIGGER = 11;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
 		up: 20,
 		down: 21,
 		left: 22,
 		right: 23
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(2, 3, {
 		up: 24,
 		down: 25,
 		left: 26,
 		right: 27
 	});
 	#elseif FLX_GAMEINPUT_API
-	public static inline var A:Int = 6;
-	public static inline var B:Int = 7;
-	public static inline var X:Int = 8;
-	public static inline var Y:Int = 9;
+	var A = 6;
+	var B = 7;
+	var X = 8;
+	var Y = 9;
 
-	public static inline var BACK:Int = 10;
-	public static inline var GUIDE:Int = #if mac 11 #else - 1 #end;
-	public static inline var START:Int = 12;
+	var BACK = 10;
+	var GUIDE = #if mac 11 #else - 1 #end;
+	var START = 12;
 
-	public static inline var LEFT_STICK_CLICK:Int = 13;
-	public static inline var RIGHT_STICK_CLICK:Int = 14;
+	var LEFT_STICK_CLICK = 13;
+	var RIGHT_STICK_CLICK = 14;
 
-	public static inline var LB:Int = 15;
-	public static inline var RB:Int = 16;
+	var LB = 15;
+	var RB = 16;
 
-	public static inline var DPAD_UP:Int = 17;
-	public static inline var DPAD_DOWN:Int = 18;
-	public static inline var DPAD_LEFT:Int = 19;
-	public static inline var DPAD_RIGHT:Int = 20;
+	var DPAD_UP = 17;
+	var DPAD_DOWN = 18;
+	var DPAD_LEFT = 19;
+	var DPAD_RIGHT = 20;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
 		up: 21,
 		down: 22,
 		left: 23,
 		right: 24
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(2, 3, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(2, 3, {
 		up: 25,
 		down: 26,
 		left: 27,
 		right: 28
 	});
 
-	public static inline var LEFT_TRIGGER:Int = 4;
-	public static inline var RIGHT_TRIGGER:Int = 5;
+	var LEFT_TRIGGER = 4;
+	var RIGHT_TRIGGER = 5;
 	#elseif FLX_JOYSTICK_API
 	#if (windows || linux)
-	public static inline var A:Int = 0;
-	public static inline var B:Int = 1;
-	public static inline var X:Int = 2;
-	public static inline var Y:Int = 3;
+	var A = 0;
+	var B = 1;
+	var X = 2;
+	var Y = 3;
 
-	public static inline var LB:Int = 4;
-	public static inline var RB:Int = 5;
+	var LB = 4;
+	var RB = 5;
 
-	public static inline var BACK:Int = 6;
-	public static inline var START:Int = 7;
+	var BACK = 6;
+	var START = 7;
 
 	#if linux
-	public static inline var LEFT_STICK_CLICK:Int = 9;
-	public static inline var RIGHT_STICK_CLICK:Int = 10;
-	public static inline var GUIDE:Int = 8;
+	var LEFT_STICK_CLICK = 9;
+	var RIGHT_STICK_CLICK = 10;
+	var GUIDE = 8;
 	#elseif windows
-	public static inline var LEFT_STICK_CLICK:Int = 8;
-	public static inline var RIGHT_STICK_CLICK:Int = 9;
-	public static inline var GUIDE:Int = 10;
+	var LEFT_STICK_CLICK = 8;
+	var RIGHT_STICK_CLICK = 9;
+	var GUIDE = 10;
 	#end
 
 	// "fake" IDs, we manually watch for hat axis changes and then send events using
 	// these otherwise unused joystick button codes
-	public static inline var DPAD_UP:Int = 11;
-	public static inline var DPAD_DOWN:Int = 12;
-	public static inline var DPAD_LEFT:Int = 13;
-	public static inline var DPAD_RIGHT:Int = 14;
+	var DPAD_UP = 11;
+	var DPAD_DOWN = 12;
+	var DPAD_LEFT = 13;
+	var DPAD_RIGHT = 14;
 
-	public static inline var LEFT_TRIGGER:Int = 2;
-	public static inline var RIGHT_TRIGGER:Int = 5;
+	var LEFT_TRIGGER = 2;
+	var RIGHT_TRIGGER = 5;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
 		up: 21,
 		down: 22,
 		left: 23,
 		right: 24
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(3, 4, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(3, 4, {
 		up: 25,
 		down: 26,
 		left: 27,
 		right: 28
 	});
 	#else // mac
-	public static inline var A:Int = 0;
-	public static inline var B:Int = 1;
-	public static inline var X:Int = 2;
-	public static inline var Y:Int = 3;
+	var A = 0;
+	var B = 1;
+	var X = 2;
+	var Y = 3;
 
-	public static inline var LB:Int = 4;
-	public static inline var RB:Int = 5;
+	var LB = 4;
+	var RB = 5;
 
-	public static inline var LEFT_STICK_CLICK:Int = 6;
-	public static inline var RIGHT_STICK_CLICK:Int = 7;
+	var LEFT_STICK_CLICK = 6;
+	var RIGHT_STICK_CLICK = 7;
 
-	public static inline var BACK:Int = 9;
-	public static inline var START:Int = 8;
+	var BACK = 9;
+	var START = 8;
 
-	public static inline var GUIDE:Int = 10;
+	var GUIDE = 10;
 
-	public static inline var DPAD_UP:Int = 11;
-	public static inline var DPAD_DOWN:Int = 12;
-	public static inline var DPAD_LEFT:Int = 13;
-	public static inline var DPAD_RIGHT:Int = 14;
+	var DPAD_UP = 11;
+	var DPAD_DOWN = 12;
+	var DPAD_LEFT = 13;
+	var DPAD_RIGHT = 14;
 
-	public static inline var LEFT_TRIGGER:Int = 2;
-	public static inline var RIGHT_TRIGGER:Int = 5;
+	var LEFT_TRIGGER = 2;
+	var RIGHT_TRIGGER = 5;
 
-	public static var LEFT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(0, 1, {
+	public static var LEFT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(0, 1, {
 		up: 21,
 		down: 22,
 		left: 23,
 		right: 24
 	});
-	public static var RIGHT_ANALOG_STICK(default, null) = new FlxGamepadAnalogStick(3, 4, {
+	public static var RIGHT_ANALOG_STICK(default, null) = new FlxTypedGamepadAnalogStick<XInputID>(3, 4, {
 		up: 25,
 		down: 26,
 		left: 27,

--- a/flixel/input/gamepad/id/XInputID.hx
+++ b/flixel/input/gamepad/id/XInputID.hx
@@ -46,10 +46,10 @@ enum abstract XInputID(Int) to Int
 	var RIGHT_TRIGGER = 11;
 
 	
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 2;
-	static var rightY = 3;
+	static final LEFT_X = 0;
+	static final LEFT_Y = 1;
+	static final RIGHT_X = 2;
+	static final RIGHT_Y = 3;
 	
 	var LEFT_STICK_UP = 20;
 	var LEFT_STICK_DOWN = 21;
@@ -81,10 +81,10 @@ enum abstract XInputID(Int) to Int
 	var DPAD_LEFT = 19;
 	var DPAD_RIGHT = 20;
 	
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 2;
-	static var rightY = 3;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 2;
+	inline static final RIGHT_Y = 3;
 
 	var LEFT_STICK_UP = 21;
 	var LEFT_STICK_DOWN = 22;
@@ -131,10 +131,10 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 2;
 	var RIGHT_TRIGGER = 5;
 
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 3;
-	static var rightY = 4;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 3;
+	inline static final RIGHT_Y = 4;
 
 	var LEFT_STICK_UP = 21;
 	var LEFT_STICK_DOWN = 22;
@@ -170,10 +170,10 @@ enum abstract XInputID(Int) to Int
 	var LEFT_TRIGGER = 2;
 	var RIGHT_TRIGGER = 5;
 
-	static var leftX = 0;
-	static var leftY = 1;
-	static var rightX = 3;
-	static var rightY = 4;
+	inline static final LEFT_X = 0;
+	inline static final LEFT_Y = 1;
+	inline static final RIGHT_X = 3;
+	inline static final RIGHT_Y = 4;
 
 	var LEFT_STICK_UP = 21;
 	var LEFT_STICK_DOWN = 22;
@@ -187,14 +187,14 @@ enum abstract XInputID(Int) to Int
 	#end
 	#end
 	
-	public static final leftAnalogStick = new FlxTypedGamepadAnalogStick<XInputID>(leftX, leftY, {
+	public static final LEFT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<XInputID>(LEFT_X, LEFT_Y, {
 		up: LEFT_STICK_UP,
 		down: LEFT_STICK_DOWN,
 		left: LEFT_STICK_LEFT,
 		right: LEFT_STICK_RIGHT
 	});
 	
-	public static var rightAnalogStick = new FlxTypedGamepadAnalogStick<XInputID>(rightX, rightY, {
+	public static var RIGHT_ANALOG_STICK = new FlxTypedGamepadAnalogStick<XInputID>(RIGHT_X, RIGHT_Y, {
 		up: RIGHT_STICK_UP,
 		down: RIGHT_STICK_DOWN,
 		left: RIGHT_STICK_LEFT,

--- a/flixel/input/gamepad/lists/FlxGamepadButtonList.hx
+++ b/flixel/input/gamepad/lists/FlxGamepadButtonList.hx
@@ -39,6 +39,10 @@ class FlxGamepadButtonList extends FlxBaseGamepadList
 	inline function get_RIGHT_SHOULDER()
 		return check(FlxGamepadInputID.RIGHT_SHOULDER);
 
+	/**
+	 * Also known as "select", the left-most center button.
+	 * Not to be confused with `CANCEL`, which is a face button (usually B)
+	 */
 	public var BACK(get, never):Bool;
 
 	inline function get_BACK()
@@ -210,6 +214,25 @@ class FlxGamepadButtonList extends FlxBaseGamepadList
 
 	inline function get_RIGHT_STICK_DIGITAL_LEFT()
 		return check(FlxGamepadInputID.RIGHT_STICK_DIGITAL_LEFT);
+	
+	/**
+	 * Mapped to The bottom face button on most controllers, and the
+	 * right face button on Nintendo Switch controllers
+	**/
+	public var ACCEPT(get, never):Bool;
+	
+	inline function get_ACCEPT()
+		return check(FlxGamepadInputID.ACCEPT);
+	
+	/**
+	 * Mapped to The right face button on most controllers, and the
+	 * bottom face button on Nintendo Switch controllers.
+	 * Not to be confused with `BACK` which is the XInput "select" button
+	**/
+	public var CANCEL(get, never):Bool;
+	
+	inline function get_CANCEL()
+		return check(FlxGamepadInputID.CANCEL);
 
 	public function new(status:FlxInputState, gamepad:FlxGamepad)
 	{

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -65,7 +65,12 @@ class FlxGamepadMapping
 	 */
 	public function getRawID(ID:FlxGamepadInputID):Int
 	{
-		return -1;
+		return switch ID
+		{
+			case ACCEPT: A;
+			case CANCEL: B;
+			default: -1;
+		}
 	}
 
 	/**
@@ -139,6 +144,8 @@ class FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: "rs-down";
 			case RIGHT_STICK_DIGITAL_LEFT: "rs-left";
 			case RIGHT_STICK_DIGITAL_RIGHT: "rs-right";
+			case ACCEPT: getInputLabel(cast getRawID(id));
+			case CANCEL: getInputLabel(cast getRawID(id));
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: "l2";
 			case RIGHT_TRIGGER_FAKE: "r2";

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -19,6 +19,11 @@ class FlxGamepadMapping
 	var attachment(default, set):FlxGamepadAttachment = NONE;
 
 	var manufacturer:Manufacturer;
+	
+	/**
+	 * Whether to treat `A` or `B` as `ACCEPT` or `CANCEL`, when `FlxG.gamepads.acceptMode` is `ADAPTIVE`
+	 */
+	var bottomIsAccept:Bool = true;
 
 	public function new(?attachment:FlxGamepadAttachment)
 	{
@@ -67,9 +72,24 @@ class FlxGamepadMapping
 	{
 		return switch ID
 		{
-			case ACCEPT: getRawID(A);
-			case CANCEL: getRawID(B);
+			case ACCEPT if (getGlobalBottomIsAccept()): getRawID(A);
+			case CANCEL if (getGlobalBottomIsAccept()): getRawID(B);
+			case ACCEPT: getRawID(B);
+			case CANCEL: getRawID(A);
 			default: -1;
+		}
+	}
+	
+	function getGlobalBottomIsAccept()
+	{
+		if (FlxG.gamepads == null)
+			return bottomIsAccept;
+		
+		return switch FlxG.gamepads.acceptMode
+		{
+			case BOTTOM: true;
+			case RIGHT: false;
+			case ADAPTIVE: bottomIsAccept;
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -7,13 +7,15 @@ import flixel.input.gamepad.FlxGamepadInputID;
 import openfl.system.Capabilities;
 #end
 
-class FlxGamepadMapping
+typedef FlxGamepadMapping = FlxTypedGamepadMapping<Int>;
+
+class FlxTypedGamepadMapping<TInputID:Int>
 {
 	public var supportsMotion:Bool = false;
 	public var supportsPointer:Bool = false;
 
-	public var leftStick:FlxGamepadAnalogStick;
-	public var rightStick:FlxGamepadAnalogStick;
+	public var leftStick:FlxTypedGamepadAnalogStick<TInputID>;
+	public var rightStick:FlxTypedGamepadAnalogStick<TInputID>;
 
 	@:allow(flixel.input.gamepad.FlxGamepad)
 	var attachment(default, set):FlxGamepadAttachment = NONE;
@@ -44,7 +46,7 @@ class FlxGamepadMapping
 
 	function initValues():Void {}
 
-	public function getAnalogStick(ID:FlxGamepadInputID):FlxGamepadAnalogStick
+	public function getAnalogStick(ID:FlxGamepadInputID):FlxTypedGamepadAnalogStick<TInputID>
 	{
 		return switch (ID)
 		{
@@ -60,7 +62,7 @@ class FlxGamepadMapping
 	/**
 	 * Given a raw hardware code, return the "universal" ID
 	 */
-	public function getID(rawID:Int):FlxGamepadInputID
+	public function getID(rawID:TInputID):FlxGamepadInputID
 	{
 		return FlxGamepadInputID.NONE;
 	}
@@ -68,7 +70,7 @@ class FlxGamepadMapping
 	/**
 	 * Given an ID, return the raw hardware code
 	 */
-	public function getRawID(ID:FlxGamepadInputID):Int
+	public function getRawID(ID:FlxGamepadInputID):TInputID
 	{
 		return switch ID
 		{
@@ -76,32 +78,36 @@ class FlxGamepadMapping
 			case CANCEL if (getGlobalBottomIsAccept()): getRawID(B);
 			case ACCEPT: getRawID(B);
 			case CANCEL: getRawID(A);
-			default: -1;
+			default: cast -1;
 		}
 	}
 	
 	function getGlobalBottomIsAccept()
 	{
-		if (FlxG.gamepads == null)
-			return bottomIsAccept;
-		
-		return switch FlxG.gamepads.acceptMode
+		#if FLX_GAMEPAD
+		if (FlxG.gamepads != null)
 		{
-			case BOTTOM: true;
-			case RIGHT: false;
-			case USE_MAPPING: bottomIsAccept;
+			return switch FlxG.gamepads.acceptMode
+			{
+				case BOTTOM: true;
+				case RIGHT: false;
+				case USE_MAPPING: bottomIsAccept;
+			}
 		}
+		#end
+		
+		return bottomIsAccept;
 	}
 
 	/**
 	 * Whether this axis needs to be flipped
 	 */
-	public function isAxisFlipped(axisID:Int):Bool
+	public function isAxisFlipped(axisID:TInputID):Bool
 	{
 		return false;
 	}
 
-	public function isAxisForMotion(ID:FlxGamepadInputID):Bool
+	public function isAxisForMotion(ID:TInputID):Bool
 	{
 		return false;
 	}
@@ -111,20 +117,25 @@ class FlxGamepadMapping
 	 * Given an axis index value like 0-6, figures out which input that
 	 * corresponds to and returns a "fake" ButtonID for that input
 	 */
-	public function axisIndexToRawID(axisID:Int):Int
+	public function axisIndexToRawID(axisID:TInputID):Int
 	{
 		return -1;
 	}
 
 	public function checkForFakeAxis(ID:FlxGamepadInputID):Int
 	{
-		return -1;
+		return cast -1;
 	}
 	#end
 
 	function set_attachment(attachment:FlxGamepadAttachment):FlxGamepadAttachment
 	{
 		return this.attachment = attachment;
+	}
+	
+	public function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.Unknown(id);
 	}
 	
 	public function getInputLabel(id:FlxGamepadInputID):Null<String>

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -78,7 +78,7 @@ class FlxTypedGamepadMapping<TInputID:Int>
 			case CANCEL if (getGlobalBottomIsAccept()): getRawID(B);
 			case ACCEPT: getRawID(B);
 			case CANCEL: getRawID(A);
-			default: cast -1;
+			default: cast -1;// TODO: Throw error
 		}
 	}
 	
@@ -124,7 +124,7 @@ class FlxTypedGamepadMapping<TInputID:Int>
 
 	public function checkForFakeAxis(ID:FlxGamepadInputID):Int
 	{
-		return cast -1;
+		return -1;
 	}
 	#end
 

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -164,8 +164,10 @@ class FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: "rs-down";
 			case RIGHT_STICK_DIGITAL_LEFT: "rs-left";
 			case RIGHT_STICK_DIGITAL_RIGHT: "rs-right";
-			case ACCEPT: getInputLabel(cast getRawID(id));
-			case CANCEL: getInputLabel(cast getRawID(id));
+			case ACCEPT if (getGlobalBottomIsAccept()): getInputLabel(A);
+			case CANCEL if (getGlobalBottomIsAccept()): getInputLabel(B);
+			case ACCEPT: getInputLabel(B);
+			case CANCEL: getInputLabel(A);
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: "l2";
 			case RIGHT_TRIGGER_FAKE: "r2";

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -67,8 +67,8 @@ class FlxGamepadMapping
 	{
 		return switch ID
 		{
-			case ACCEPT: A;
-			case CANCEL: B;
+			case ACCEPT: getRawID(A);
+			case CANCEL: getRawID(B);
 			default: -1;
 		}
 	}

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -89,7 +89,7 @@ class FlxGamepadMapping
 		{
 			case BOTTOM: true;
 			case RIGHT: false;
-			case ADAPTIVE: bottomIsAccept;
+			case USE_MAPPING: bottomIsAccept;
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -24,6 +24,7 @@ class FlxTypedGamepadMapping<TInputID:Int>
 	
 	/**
 	 * Whether to treat `A` or `B` as `ACCEPT` or `CANCEL`, when `FlxG.gamepads.acceptMode` is `ADAPTIVE`
+	 * @since 5.9.0
 	 */
 	var bottomIsAccept:Bool = true;
 

--- a/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
+++ b/flixel/input/gamepad/mappings/FlxGamepadMapping.hx
@@ -135,7 +135,7 @@ class FlxTypedGamepadMapping<TInputID:Int>
 	
 	public function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.Unknown(id);
+		return FlxGamepadMappedInput.UNKNOWN(id);
 	}
 	
 	public function getInputLabel(id:FlxGamepadInputID):Null<String>

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -85,7 +85,7 @@ class LogitechMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LogitechID.SEVEN;
 			case RIGHT_TRIGGER_FAKE: LogitechID.EIGHT;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -7,11 +7,11 @@ import flixel.input.gamepad.mappings.FlxGamepadMapping;
 class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 {
 	#if FLX_JOYSTICK_API
-	var LEFT_ANALOG_STICK_FAKE_X = 20;
-	var LEFT_ANALOG_STICK_FAKE_Y = 21;
+	static inline var LEFT_ANALOG_STICK_FAKE_X = 20;
+	static inline var LEFT_ANALOG_STICK_FAKE_Y = 21;
 
-	var RIGHT_ANALOG_STICK_FAKE_X = 22;
-	var RIGHT_ANALOG_STICK_FAKE_Y = 23;
+	static inline var RIGHT_ANALOG_STICK_FAKE_X = 22;
+	static inline var RIGHT_ANALOG_STICK_FAKE_Y = 23;
 	#end
 
 	override function initValues():Void
@@ -92,7 +92,7 @@ class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.Logitech(getRawID(id));
+		return FlxGamepadMappedInput.LOGITECH(getRawID(id));
 	}
 	
 	override function getInputLabel(id:FlxGamepadInputID)

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -16,8 +16,8 @@ class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 
 	override function initValues():Void
 	{
-		leftStick = LogitechID.LEFT_ANALOG_STICK;
-		rightStick = LogitechID.RIGHT_ANALOG_STICK;
+		leftStick = LogitechID.leftAnalogStick;
+		rightStick = LogitechID.rightAnalogStick;
 	}
 
 	override function getID(rawID:LogitechID):FlxGamepadInputID
@@ -74,14 +74,14 @@ class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 			case DPAD_RIGHT: LogitechID.DPAD_RIGHT;
 			case LEFT_TRIGGER: LogitechID.SEVEN;
 			case RIGHT_TRIGGER: LogitechID.EIGHT;
-			case LEFT_STICK_DIGITAL_UP: LogitechID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: LogitechID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: LogitechID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: LogitechID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: LogitechID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: LogitechID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: LogitechID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: LogitechID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: LogitechID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: LogitechID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: LogitechID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: LogitechID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: LogitechID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: LogitechID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: LogitechID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: LogitechID.rightAnalogStick.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LogitechID.SEVEN;
 			case RIGHT_TRIGGER_FAKE: LogitechID.EIGHT;

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -16,8 +16,8 @@ class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 
 	override function initValues():Void
 	{
-		leftStick = LogitechID.leftAnalogStick;
-		rightStick = LogitechID.rightAnalogStick;
+		leftStick = LogitechID.LEFT_ANALOG_STICK;
+		rightStick = LogitechID.RIGHT_ANALOG_STICK;
 	}
 
 	override function getID(rawID:LogitechID):FlxGamepadInputID
@@ -74,14 +74,14 @@ class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 			case DPAD_RIGHT: LogitechID.DPAD_RIGHT;
 			case LEFT_TRIGGER: LogitechID.SEVEN;
 			case RIGHT_TRIGGER: LogitechID.EIGHT;
-			case LEFT_STICK_DIGITAL_UP: LogitechID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: LogitechID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: LogitechID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: LogitechID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: LogitechID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: LogitechID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: LogitechID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: LogitechID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: LogitechID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: LogitechID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: LogitechID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: LogitechID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: LogitechID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: LogitechID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: LogitechID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: LogitechID.RIGHT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LogitechID.SEVEN;
 			case RIGHT_TRIGGER_FAKE: LogitechID.EIGHT;

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -2,15 +2,16 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.LogitechID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class LogitechMapping extends FlxGamepadMapping
+class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 {
 	#if FLX_JOYSTICK_API
-	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 20;
-	static inline var LEFT_ANALOG_STICK_FAKE_Y:Int = 21;
+	var LEFT_ANALOG_STICK_FAKE_X = 20;
+	var LEFT_ANALOG_STICK_FAKE_Y = 21;
 
-	static inline var RIGHT_ANALOG_STICK_FAKE_X:Int = 22;
-	static inline var RIGHT_ANALOG_STICK_FAKE_Y:Int = 23;
+	var RIGHT_ANALOG_STICK_FAKE_X = 22;
+	var RIGHT_ANALOG_STICK_FAKE_Y = 23;
 	#end
 
 	override function initValues():Void
@@ -19,7 +20,7 @@ class LogitechMapping extends FlxGamepadMapping
 		rightStick = LogitechID.RIGHT_ANALOG_STICK;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:LogitechID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -52,7 +53,7 @@ class LogitechMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):LogitechID
 	{
 		return switch (ID)
 		{
@@ -89,6 +90,11 @@ class LogitechMapping extends FlxGamepadMapping
 		}
 	}
 	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.Logitech(getRawID(id));
+	}
+	
 	override function getInputLabel(id:FlxGamepadInputID)
 	{
 		return switch (id)
@@ -113,7 +119,7 @@ class LogitechMapping extends FlxGamepadMapping
 	}
 
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:MFiID):Int
 	{
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X; else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y; else if (axisID == rightStick.x)
 			RIGHT_ANALOG_STICK_FAKE_X;

--- a/flixel/input/gamepad/mappings/LogitechMapping.hx
+++ b/flixel/input/gamepad/mappings/LogitechMapping.hx
@@ -119,7 +119,7 @@ class LogitechMapping extends FlxTypedGamepadMapping<LogitechID>
 	}
 
 	#if FLX_JOYSTICK_API
-	override function axisIndexToRawID(axisID:MFiID):Int
+	override function axisIndexToRawID(axisID:LogitechID):Int
 	{
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X; else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y; else if (axisID == rightStick.x)
 			RIGHT_ANALOG_STICK_FAKE_X;

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -75,7 +75,7 @@ class MFiMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER_FAKE: MFiID.RIGHT_TRIGGER;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -82,7 +82,7 @@ class MFiMapping extends FlxTypedGamepadMapping<MFiID>
 
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.MFi(getRawID(id));
+		return FlxGamepadMappedInput.MFI(getRawID(id));
 	}
 	
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -8,8 +8,8 @@ class MFiMapping extends FlxTypedGamepadMapping<MFiID>
 {
 	override function initValues():Void
 	{
-		leftStick = MFiID.leftAnalogStick;
-		rightStick = MFiID.rightAnalogStick;
+		leftStick = MFiID.LEFT_ANALOG_STICK;
+		rightStick = MFiID.RIGHT_ANALOG_STICK;
 	}
 
 	override function getID(rawID:MFiID):FlxGamepadInputID
@@ -64,14 +64,14 @@ class MFiMapping extends FlxTypedGamepadMapping<MFiID>
 			case DPAD_RIGHT: MFiID.DPAD_RIGHT;
 			case LEFT_TRIGGER: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER: MFiID.RIGHT_TRIGGER;
-			case LEFT_STICK_DIGITAL_UP: MFiID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: MFiID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: MFiID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: MFiID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: MFiID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: MFiID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: MFiID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: MFiID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: MFiID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: MFiID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: MFiID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: MFiID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: MFiID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: MFiID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: MFiID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: MFiID.RIGHT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER_FAKE: MFiID.RIGHT_TRIGGER;

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -8,8 +8,8 @@ class MFiMapping extends FlxTypedGamepadMapping<MFiID>
 {
 	override function initValues():Void
 	{
-		leftStick = MFiID.LEFT_ANALOG_STICK;
-		rightStick = MFiID.RIGHT_ANALOG_STICK;
+		leftStick = MFiID.leftAnalogStick;
+		rightStick = MFiID.rightAnalogStick;
 	}
 
 	override function getID(rawID:MFiID):FlxGamepadInputID
@@ -64,14 +64,14 @@ class MFiMapping extends FlxTypedGamepadMapping<MFiID>
 			case DPAD_RIGHT: MFiID.DPAD_RIGHT;
 			case LEFT_TRIGGER: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER: MFiID.RIGHT_TRIGGER;
-			case LEFT_STICK_DIGITAL_UP: MFiID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: MFiID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: MFiID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: MFiID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: MFiID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: MFiID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: MFiID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: MFiID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: MFiID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: MFiID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: MFiID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: MFiID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: MFiID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: MFiID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: MFiID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: MFiID.rightAnalogStick.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: MFiID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER_FAKE: MFiID.RIGHT_TRIGGER;

--- a/flixel/input/gamepad/mappings/MFiMapping.hx
+++ b/flixel/input/gamepad/mappings/MFiMapping.hx
@@ -2,8 +2,9 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.MFiID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class MFiMapping extends FlxGamepadMapping
+class MFiMapping extends FlxTypedGamepadMapping<MFiID>
 {
 	override function initValues():Void
 	{
@@ -11,7 +12,7 @@ class MFiMapping extends FlxGamepadMapping
 		rightStick = MFiID.RIGHT_ANALOG_STICK;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:MFiID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -42,7 +43,7 @@ class MFiMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):MFiID
 	{
 		return switch (ID)
 		{
@@ -79,8 +80,13 @@ class MFiMapping extends FlxGamepadMapping
 		}
 	}
 
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.MFi(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:MFiID):Int
 	{
 		// the axis index values for this don't overlap with anything so we can just return the original values!
 		return axisID;

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -80,12 +80,11 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			default:
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp) LEFT_STICK_DIGITAL_UP;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown) LEFT_STICK_DIGITAL_DOWN;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft) LEFT_STICK_DIGITAL_LEFT;
-				if (rawID == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight) LEFT_STICK_DIGITAL_RIGHT;
-				NONE;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			default: NONE;
 		}
 	}
 
@@ -174,7 +173,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -193,7 +192,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 			case BACK: MayflashWiiRemoteID.REMOTE_MINUS;
 			case GUIDE: MayflashWiiRemoteID.REMOTE_HOME;
 			case START: MayflashWiiRemoteID.REMOTE_PLUS;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -81,10 +81,10 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
-			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
-			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
-			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
 			default: NONE;
 		}
 	}
@@ -139,14 +139,14 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 			case RIGHT_TRIGGER: MayflashWiiRemoteID.CLASSIC_R;
 			case EXTRA_0: MayflashWiiRemoteID.CLASSIC_ONE;
 			case EXTRA_1: MayflashWiiRemoteID.CLASSIC_TWO;
-			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: MayflashWiiRemoteID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.rightAnalogStick.rawRight;
 			default: getRawDefault(ID);
 		}
 	}
@@ -170,10 +170,10 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 			case DPAD_RIGHT: MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT;
 			case POINTER_X: MayflashWiiRemoteID.NUNCHUK_POINTER_X;
 			case POINTER_Y: MayflashWiiRemoteID.NUNCHUK_POINTER_Y;
-			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.leftAnalogStick.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -245,13 +245,13 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 	{
 		leftStick = switch (attachment)
 		{
-			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.LEFT_ANALOG_STICK;
-			case NONE: MayflashWiiRemoteID.REMOTE_DPAD;
+			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.leftAnalogStick;
+			case NONE: MayflashWiiRemoteID.remoteDPad;
 		}
 
 		rightStick = switch (attachment)
 		{
-			case WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.RIGHT_ANALOG_STICK;
+			case WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.rightAnalogStick;
 			default: null;
 		}
 

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -260,7 +260,7 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.MayflashWiiRemote(getRawID(id));
+		return FlxGamepadMappedInput.MAYFLASH_WII(getRawID(id));
 	}
 	
 	override function getInputLabel(id:FlxGamepadInputID)

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -3,8 +3,9 @@ package flixel.input.gamepad.mappings;
 import flixel.input.gamepad.FlxGamepad.FlxGamepadAttachment;
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.MayflashWiiRemoteID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class MayflashWiiRemoteMapping extends FlxGamepadMapping
+class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var REMOTE_DPAD_X:Int = 16;
@@ -22,7 +23,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		supportsPointer = true;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:MayflashWiiRemoteID):FlxGamepadInputID
 	{
 		return switch (attachment)
 		{
@@ -32,7 +33,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getIDClassicController(rawID:Int):FlxGamepadInputID
+	function getIDClassicController(rawID:MayflashWiiRemoteID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -63,7 +64,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getIDNunchuk(rawID:Int):FlxGamepadInputID
+	function getIDNunchuk(rawID:MayflashWiiRemoteID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -88,7 +89,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getIDDefault(rawID:Int):FlxGamepadInputID
+	function getIDDefault(rawID:MayflashWiiRemoteID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -107,7 +108,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):MayflashWiiRemoteID
 	{
 		return switch (attachment)
 		{
@@ -117,7 +118,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getRawClassicController(ID:FlxGamepadInputID):Int
+	function getRawClassicController(ID:FlxGamepadInputID):MayflashWiiRemoteID
 	{
 		return switch (ID)
 		{
@@ -150,7 +151,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getRawNunchuk(ID:FlxGamepadInputID):Int
+	function getRawNunchuk(ID:FlxGamepadInputID):MayflashWiiRemoteID
 	{
 		return switch (ID)
 		{
@@ -177,7 +178,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getRawDefault(ID:FlxGamepadInputID):Int
+	function getRawDefault(ID:FlxGamepadInputID):MayflashWiiRemoteID
 	{
 		return switch (ID)
 		{
@@ -197,7 +198,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 	}
 
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:TInputID):Int
 	{
 		if (attachment == WII_NUNCHUCK || attachment == WII_CLASSIC_CONTROLLER)
 		{
@@ -222,7 +223,7 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		return axisID;
 	}
 
-	override public function checkForFakeAxis(ID:FlxGamepadInputID):Int
+	override function checkForFakeAxis(ID:FlxGamepadInputID):Int
 	{
 		if (attachment == WII_NUNCHUCK)
 		{
@@ -255,6 +256,11 @@ class MayflashWiiRemoteMapping extends FlxGamepadMapping
 		}
 
 		return super.set_attachment(attachment);
+	}
+	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.MayflashWiiRemote(getRawID(id));
 	}
 	
 	override function getInputLabel(id:FlxGamepadInputID)

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -81,10 +81,10 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawUp): LEFT_STICK_DIGITAL_UP;
-			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
-			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
-			case id if (id == MayflashWiiRemoteID.leftAnalogStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
 			default: NONE;
 		}
 	}
@@ -139,14 +139,14 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 			case RIGHT_TRIGGER: MayflashWiiRemoteID.CLASSIC_R;
 			case EXTRA_0: MayflashWiiRemoteID.CLASSIC_ONE;
 			case EXTRA_1: MayflashWiiRemoteID.CLASSIC_TWO;
-			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: MayflashWiiRemoteID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.RIGHT_ANALOG_STICK.rawRight;
 			default: getRawDefault(ID);
 		}
 	}
@@ -170,10 +170,10 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 			case DPAD_RIGHT: MayflashWiiRemoteID.NUNCHUK_DPAD_RIGHT;
 			case POINTER_X: MayflashWiiRemoteID.NUNCHUK_POINTER_X;
 			case POINTER_Y: MayflashWiiRemoteID.NUNCHUK_POINTER_Y;
-			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.leftAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: MayflashWiiRemoteID.LEFT_ANALOG_STICK.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -245,13 +245,13 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 	{
 		leftStick = switch (attachment)
 		{
-			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.leftAnalogStick;
-			case NONE: MayflashWiiRemoteID.remoteDPad;
+			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.LEFT_ANALOG_STICK;
+			case NONE: MayflashWiiRemoteID.REMOTE_DPAD;
 		}
 
 		rightStick = switch (attachment)
 		{
-			case WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.rightAnalogStick;
+			case WII_CLASSIC_CONTROLLER: MayflashWiiRemoteID.RIGHT_ANALOG_STICK;
 			default: null;
 		}
 

--- a/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/MayflashWiiRemoteMapping.hx
@@ -198,7 +198,7 @@ class MayflashWiiRemoteMapping extends FlxTypedGamepadMapping<MayflashWiiRemoteI
 	}
 
 	#if FLX_JOYSTICK_API
-	override function axisIndexToRawID(axisID:TInputID):Int
+	override function axisIndexToRawID(axisID:MayflashWiiRemoteID):Int
 	{
 		if (attachment == WII_NUNCHUCK || attachment == WII_CLASSIC_CONTROLLER)
 		{

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -77,7 +77,7 @@ class OUYAMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -16,8 +16,8 @@ class OUYAMapping extends FlxTypedGamepadMapping<OUYAID>
 
 	override function initValues():Void
 	{
-		leftStick = OUYAID.LEFT_ANALOG_STICK;
-		rightStick = OUYAID.RIGHT_ANALOG_STICK;
+		leftStick = OUYAID.leftAnalogStick;
+		rightStick = OUYAID.rightAnalogStick;
 	}
 
 	override function getID(rawID:OUYAID):FlxGamepadInputID
@@ -70,14 +70,14 @@ class OUYAMapping extends FlxTypedGamepadMapping<OUYAID>
 			case DPAD_RIGHT: OUYAID.DPAD_RIGHT;
 			case LEFT_TRIGGER: OUYAID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER: OUYAID.RIGHT_TRIGGER;
-			case LEFT_STICK_DIGITAL_UP: OUYAID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: OUYAID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: OUYAID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: OUYAID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: OUYAID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: OUYAID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: OUYAID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: OUYAID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: OUYAID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: OUYAID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.rightAnalogStick.rawRight;
 			default: super.getRawID(ID);
 		}
 	}

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -16,8 +16,8 @@ class OUYAMapping extends FlxTypedGamepadMapping<OUYAID>
 
 	override function initValues():Void
 	{
-		leftStick = OUYAID.leftAnalogStick;
-		rightStick = OUYAID.rightAnalogStick;
+		leftStick = OUYAID.LEFT_ANALOG_STICK;
+		rightStick = OUYAID.RIGHT_ANALOG_STICK;
 	}
 
 	override function getID(rawID:OUYAID):FlxGamepadInputID
@@ -70,14 +70,14 @@ class OUYAMapping extends FlxTypedGamepadMapping<OUYAID>
 			case DPAD_RIGHT: OUYAID.DPAD_RIGHT;
 			case LEFT_TRIGGER: OUYAID.LEFT_TRIGGER;
 			case RIGHT_TRIGGER: OUYAID.RIGHT_TRIGGER;
-			case LEFT_STICK_DIGITAL_UP: OUYAID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: OUYAID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: OUYAID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: OUYAID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: OUYAID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: OUYAID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: OUYAID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: OUYAID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: OUYAID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: OUYAID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: OUYAID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: OUYAID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: OUYAID.RIGHT_ANALOG_STICK.rawRight;
 			default: super.getRawID(ID);
 		}
 	}

--- a/flixel/input/gamepad/mappings/OUYAMapping.hx
+++ b/flixel/input/gamepad/mappings/OUYAMapping.hx
@@ -2,8 +2,9 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.OUYAID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class OUYAMapping extends FlxGamepadMapping
+class OUYAMapping extends FlxTypedGamepadMapping<OUYAID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 19;
@@ -19,7 +20,7 @@ class OUYAMapping extends FlxGamepadMapping
 		rightStick = OUYAID.RIGHT_ANALOG_STICK;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:OUYAID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -50,7 +51,7 @@ class OUYAMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):OUYAID
 	{
 		return switch (ID)
 		{
@@ -93,9 +94,14 @@ class OUYAMapping extends FlxGamepadMapping
 			case _: super.getInputLabel(id);
 		}
 	}
-
+	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.OUYA(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:OUYAID):Int
 	{
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X; else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y; else if (axisID == rightStick.x)
 			RIGHT_ANALOG_STICK_FAKE_X;

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -96,7 +96,7 @@ class PS4Mapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -2,8 +2,9 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.PS4ID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class PS4Mapping extends FlxGamepadMapping
+class PS4Mapping extends FlxTypedGamepadMapping<PS4ID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 21;
@@ -24,7 +25,7 @@ class PS4Mapping extends FlxGamepadMapping
 		supportsPointer = true;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:PS4ID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -59,7 +60,7 @@ class PS4Mapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):PS4ID
 	{
 		return switch (ID)
 		{
@@ -119,8 +120,13 @@ class PS4Mapping extends FlxGamepadMapping
 		}
 	}
 	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.PS4(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:PS4ID):Int
 	{
 		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X; else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y; else if (axisID == rightStick.x)

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -19,8 +19,8 @@ class PS4Mapping extends FlxTypedGamepadMapping<PS4ID>
 
 	override function initValues():Void
 	{
-		leftStick = PS4ID.leftAnalogStick;
-		rightStick = PS4ID.rightAnalogStick;
+		leftStick = PS4ID.LEFT_ANALOG_STICK;
+		rightStick = PS4ID.RIGHT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = true;
 	}
@@ -85,14 +85,14 @@ class PS4Mapping extends FlxTypedGamepadMapping<PS4ID>
 			case DPAD_RIGHT: PS4ID.DPAD_RIGHT;
 			case LEFT_TRIGGER: PS4ID.L2;
 			case RIGHT_TRIGGER: PS4ID.R2;
-			case LEFT_STICK_DIGITAL_UP: PS4ID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: PS4ID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: PS4ID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: PS4ID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: PS4ID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: PS4ID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: PS4ID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: PS4ID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: PS4ID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: PS4ID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: PS4ID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: PS4ID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: PS4ID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: PS4ID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: PS4ID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: PS4ID.RIGHT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/PS4Mapping.hx
+++ b/flixel/input/gamepad/mappings/PS4Mapping.hx
@@ -19,8 +19,8 @@ class PS4Mapping extends FlxTypedGamepadMapping<PS4ID>
 
 	override function initValues():Void
 	{
-		leftStick = PS4ID.LEFT_ANALOG_STICK;
-		rightStick = PS4ID.RIGHT_ANALOG_STICK;
+		leftStick = PS4ID.leftAnalogStick;
+		rightStick = PS4ID.rightAnalogStick;
 		supportsMotion = true;
 		supportsPointer = true;
 	}
@@ -85,14 +85,14 @@ class PS4Mapping extends FlxTypedGamepadMapping<PS4ID>
 			case DPAD_RIGHT: PS4ID.DPAD_RIGHT;
 			case LEFT_TRIGGER: PS4ID.L2;
 			case RIGHT_TRIGGER: PS4ID.R2;
-			case LEFT_STICK_DIGITAL_UP: PS4ID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: PS4ID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: PS4ID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: PS4ID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: PS4ID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: PS4ID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: PS4ID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: PS4ID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: PS4ID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: PS4ID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: PS4ID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: PS4ID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: PS4ID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: PS4ID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: PS4ID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: PS4ID.rightAnalogStick.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -63,7 +63,7 @@ class PSVitaMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: PSVitaID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: PSVitaID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: PSVitaID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 	

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -87,7 +87,7 @@ class PSVitaMapping extends FlxTypedGamepadMapping<PSVitaID>
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.PSVita(getRawID(id));
+		return FlxGamepadMappedInput.PS_VITA(getRawID(id));
 	}
 	
 	override function isAxisFlipped(axisID:Int):Bool

--- a/flixel/input/gamepad/mappings/PSVitaMapping.hx
+++ b/flixel/input/gamepad/mappings/PSVitaMapping.hx
@@ -2,8 +2,9 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.PSVitaID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class PSVitaMapping extends FlxGamepadMapping
+class PSVitaMapping extends FlxTypedGamepadMapping<PSVitaID>
 {
 	override function initValues():Void
 	{
@@ -11,7 +12,7 @@ class PSVitaMapping extends FlxGamepadMapping
 		rightStick = PSVitaID.RIGHT_ANALOG_STICK;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:PSVitaID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -39,7 +40,7 @@ class PSVitaMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):PSVitaID
 	{
 		return switch (ID)
 		{
@@ -83,8 +84,13 @@ class PSVitaMapping extends FlxGamepadMapping
 			case _: super.getInputLabel(id);
 		}
 	}
-
-	override public function isAxisFlipped(axisID:Int):Bool
+	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.PSVita(getRawID(id));
+	}
+	
+	override function isAxisFlipped(axisID:Int):Bool
 	{
 		return axisID == PSVitaID.LEFT_ANALOG_STICK.y || axisID == PSVitaID.RIGHT_ANALOG_STICK.y;
 	}

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -70,7 +70,9 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			case ACCEPT: SwitchJoyconLeftID.RIGHT;
+			case CANCEL: SwitchJoyconLeftID.DOWN;
+			default: super.getRawID(id);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -22,7 +22,7 @@ class SwitchJoyconLeftMapping extends FlxTypedGamepadMapping<SwitchJoyconLeftID>
 
 	override function initValues():Void
 	{
-		leftStick = SwitchJoyconLeftID.leftAnalogStick;
+		leftStick = SwitchJoyconLeftID.LEFT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
 		bottomIsAccept = false;
@@ -64,10 +64,10 @@ class SwitchJoyconLeftMapping extends FlxTypedGamepadMapping<SwitchJoyconLeftID>
 			case RIGHT_SHOULDER: SwitchJoyconLeftID.SR;
 			case LEFT_TRIGGER: SwitchJoyconLeftID.ZL;
 			case EXTRA_0: SwitchJoyconLeftID.L;
-			case LEFT_STICK_DIGITAL_UP: SwitchJoyconLeftID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconLeftID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconLeftID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconLeftID.leftAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -95,7 +95,7 @@ class SwitchJoyconLeftMapping extends FlxTypedGamepadMapping<SwitchJoyconLeftID>
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.SwitchJoyconLeft(getRawID(id));
+		return FlxGamepadMappedInput.SWITCH_JOYCON_LEFT(getRawID(id));
 	}
 	
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -2,11 +2,12 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.SwitchJoyconLeftID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
 /**
  * @since 4.8.0
  */
-class SwitchJoyconLeftMapping extends FlxGamepadMapping
+class SwitchJoyconLeftMapping extends FlxTypedGamepadMapping<SwitchJoyconLeftID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 32;
@@ -27,7 +28,7 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 		bottomIsAccept = false;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:SwitchJoyconLeftID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -49,7 +50,7 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(id:FlxGamepadInputID):Int
+	override function getRawID(id:FlxGamepadInputID):SwitchJoyconLeftID
 	{
 		return switch (id)
 		{
@@ -92,8 +93,13 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 		}
 	}
 	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.SwitchJoyconLeft(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:SwitchJoyconLeftID):Int
 	{
 		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x)

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -22,7 +22,7 @@ class SwitchJoyconLeftMapping extends FlxTypedGamepadMapping<SwitchJoyconLeftID>
 
 	override function initValues():Void
 	{
-		leftStick = SwitchJoyconLeftID.LEFT_ANALOG_STICK;
+		leftStick = SwitchJoyconLeftID.leftAnalogStick;
 		supportsMotion = true;
 		supportsPointer = false;
 		bottomIsAccept = false;
@@ -64,10 +64,10 @@ class SwitchJoyconLeftMapping extends FlxTypedGamepadMapping<SwitchJoyconLeftID>
 			case RIGHT_SHOULDER: SwitchJoyconLeftID.SR;
 			case LEFT_TRIGGER: SwitchJoyconLeftID.ZL;
 			case EXTRA_0: SwitchJoyconLeftID.L;
-			case LEFT_STICK_DIGITAL_UP: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconLeftID.LEFT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: SwitchJoyconLeftID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconLeftID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconLeftID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconLeftID.leftAnalogStick.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconLeftMapping.hx
@@ -24,6 +24,7 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 		leftStick = SwitchJoyconLeftID.LEFT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
+		bottomIsAccept = false;
 	}
 
 	override public function getID(rawID:Int):FlxGamepadInputID
@@ -70,8 +71,6 @@ class SwitchJoyconLeftMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			case ACCEPT: SwitchJoyconLeftID.RIGHT;
-			case CANCEL: SwitchJoyconLeftID.DOWN;
 			default: super.getRawID(id);
 		}
 	}

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -72,7 +72,9 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			case ACCEPT: SwitchJoyconRightID.A;
+			case CANCEL: SwitchJoyconRightID.B;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -22,7 +22,7 @@ class SwitchJoyconRightMapping extends FlxTypedGamepadMapping<SwitchJoyconRightI
 
 	override function initValues():Void
 	{
-		leftStick = SwitchJoyconRightID.LEFT_ANALOG_STICK;
+		leftStick = SwitchJoyconRightID.leftAnalogStick;
 		supportsMotion = true;
 		supportsPointer = false;
 		bottomIsAccept = false;
@@ -66,10 +66,10 @@ class SwitchJoyconRightMapping extends FlxTypedGamepadMapping<SwitchJoyconRightI
 			case RIGHT_SHOULDER: SwitchJoyconRightID.SR;
 			case EXTRA_0: SwitchJoyconRightID.R;
 			case RIGHT_TRIGGER: SwitchJoyconRightID.ZR;
-			case LEFT_STICK_DIGITAL_UP: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: SwitchJoyconRightID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconRightID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconRightID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconRightID.leftAnalogStick.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -24,6 +24,7 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 		leftStick = SwitchJoyconRightID.LEFT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
+		bottomIsAccept = false;
 	}
 
 	override public function getID(rawID:Int):FlxGamepadInputID
@@ -72,8 +73,6 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			case ACCEPT: SwitchJoyconRightID.A;
-			case CANCEL: SwitchJoyconRightID.B;
 			default: super.getRawID(ID);
 		}
 	}

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -22,7 +22,7 @@ class SwitchJoyconRightMapping extends FlxTypedGamepadMapping<SwitchJoyconRightI
 
 	override function initValues():Void
 	{
-		leftStick = SwitchJoyconRightID.leftAnalogStick;
+		leftStick = SwitchJoyconRightID.LEFT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
 		bottomIsAccept = false;
@@ -66,10 +66,10 @@ class SwitchJoyconRightMapping extends FlxTypedGamepadMapping<SwitchJoyconRightI
 			case RIGHT_SHOULDER: SwitchJoyconRightID.SR;
 			case EXTRA_0: SwitchJoyconRightID.R;
 			case RIGHT_TRIGGER: SwitchJoyconRightID.ZR;
-			case LEFT_STICK_DIGITAL_UP: SwitchJoyconRightID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconRightID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconRightID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconRightID.leftAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchJoyconRightID.LEFT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -98,7 +98,7 @@ class SwitchJoyconRightMapping extends FlxTypedGamepadMapping<SwitchJoyconRightI
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.SwitchJoyconRight(getRawID(id));
+		return FlxGamepadMappedInput.SWITCH_JOYCON_RIGHT(getRawID(id));
 	}
 	
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchJoyconRightMapping.hx
@@ -2,11 +2,12 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.SwitchJoyconRightID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
 /**
  * @since 4.8.0
  */
-class SwitchJoyconRightMapping extends FlxGamepadMapping
+class SwitchJoyconRightMapping extends FlxTypedGamepadMapping<SwitchJoyconRightID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 32;
@@ -27,7 +28,7 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 		bottomIsAccept = false;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:SwitchJoyconRightID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -50,7 +51,7 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):SwitchJoyconRightID
 	{
 		return switch (ID)
 		{
@@ -95,8 +96,13 @@ class SwitchJoyconRightMapping extends FlxGamepadMapping
 		}
 	}
 	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.SwitchJoyconRight(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:SwitchJoyconRightID):Int
 	{
 		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x)

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -95,7 +95,9 @@ class SwitchProMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			default: -1;
+			case ACCEPT: SwitchProID.A;
+			case CANCEL: SwitchProID.B;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -2,11 +2,12 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.SwitchProID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
 /**
  * @since 4.8.0
  */
-class SwitchProMapping extends FlxGamepadMapping
+class SwitchProMapping extends FlxTypedGamepadMapping<SwitchProID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 32;
@@ -28,7 +29,7 @@ class SwitchProMapping extends FlxGamepadMapping
 		bottomIsAccept = false;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:SwitchProID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -62,7 +63,7 @@ class SwitchProMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):SwitchProID
 	{
 		return switch (ID)
 		{
@@ -120,8 +121,13 @@ class SwitchProMapping extends FlxGamepadMapping
 		}
 	}
 	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.SwitchPro(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:SwitchProID):Int
 	{
 		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x)

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -22,8 +22,8 @@ class SwitchProMapping extends FlxTypedGamepadMapping<SwitchProID>
 
 	override function initValues():Void
 	{
-		leftStick = SwitchProID.leftAnalogStick;
-		rightStick = SwitchProID.rightAnalogStick;
+		leftStick = SwitchProID.LEFT_ANALOG_STICK;
+		rightStick = SwitchProID.RIGHT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
 		bottomIsAccept = false;
@@ -85,14 +85,14 @@ class SwitchProMapping extends FlxTypedGamepadMapping<SwitchProID>
 			case DPAD_DOWN: SwitchProID.DPAD_DOWN;
 			case DPAD_LEFT: SwitchProID.DPAD_LEFT;
 			case DPAD_RIGHT: SwitchProID.DPAD_RIGHT;
-			case LEFT_STICK_DIGITAL_UP: SwitchProID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SwitchProID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SwitchProID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SwitchProID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: SwitchProID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: SwitchProID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: SwitchProID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: SwitchProID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: SwitchProID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchProID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchProID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchProID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: SwitchProID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: SwitchProID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: SwitchProID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: SwitchProID.RIGHT_ANALOG_STICK.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -25,6 +25,7 @@ class SwitchProMapping extends FlxGamepadMapping
 		rightStick = SwitchProID.RIGHT_ANALOG_STICK;
 		supportsMotion = true;
 		supportsPointer = false;
+		bottomIsAccept = false;
 	}
 
 	override public function getID(rawID:Int):FlxGamepadInputID
@@ -95,8 +96,6 @@ class SwitchProMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			case ACCEPT: SwitchProID.A;
-			case CANCEL: SwitchProID.B;
 			default: super.getRawID(ID);
 		}
 	}

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -96,11 +96,6 @@ class SwitchProMapping extends FlxGamepadMapping
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-<<<<<<< HEAD
-=======
-			case ACCEPT: SwitchProID.A;
-			case CANCEL: SwitchProID.B;
->>>>>>> dev
 			default: super.getRawID(ID);
 		}
 	}

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -123,7 +123,7 @@ class SwitchProMapping extends FlxTypedGamepadMapping<SwitchProID>
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.SwitchPro(getRawID(id));
+		return FlxGamepadMappedInput.SWITCH_PRO(getRawID(id));
 	}
 	
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/SwitchProMapping.hx
+++ b/flixel/input/gamepad/mappings/SwitchProMapping.hx
@@ -22,8 +22,8 @@ class SwitchProMapping extends FlxTypedGamepadMapping<SwitchProID>
 
 	override function initValues():Void
 	{
-		leftStick = SwitchProID.LEFT_ANALOG_STICK;
-		rightStick = SwitchProID.RIGHT_ANALOG_STICK;
+		leftStick = SwitchProID.leftAnalogStick;
+		rightStick = SwitchProID.rightAnalogStick;
 		supportsMotion = true;
 		supportsPointer = false;
 		bottomIsAccept = false;
@@ -85,14 +85,14 @@ class SwitchProMapping extends FlxTypedGamepadMapping<SwitchProID>
 			case DPAD_DOWN: SwitchProID.DPAD_DOWN;
 			case DPAD_LEFT: SwitchProID.DPAD_LEFT;
 			case DPAD_RIGHT: SwitchProID.DPAD_RIGHT;
-			case LEFT_STICK_DIGITAL_UP: SwitchProID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: SwitchProID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: SwitchProID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: SwitchProID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: SwitchProID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: SwitchProID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: SwitchProID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: SwitchProID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: SwitchProID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: SwitchProID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: SwitchProID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: SwitchProID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: SwitchProID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: SwitchProID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: SwitchProID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: SwitchProID.rightAnalogStick.rawRight;
 			#if FLX_JOYSTICK_API
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -80,12 +80,11 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case WiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case WiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case WiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			default:
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawUp) LEFT_STICK_DIGITAL_UP;
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawDown) LEFT_STICK_DIGITAL_DOWN;
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft) LEFT_STICK_DIGITAL_LEFT;
-				if (rawID == WiiRemoteID.LEFT_ANALOG_STICK.rawRight) LEFT_STICK_DIGITAL_RIGHT;
-				NONE;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			default: super.getRawID(rawID);
 		}
 	}
 
@@ -147,7 +146,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: WiiRemoteID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: WiiRemoteID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: WiiRemoteID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -174,7 +173,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.LEFT_ANALOG_STICK.rawDown;
 			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
 			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 
@@ -195,7 +194,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case START: WiiRemoteID.REMOTE_PLUS;
 			case TILT_PITCH: WiiRemoteID.REMOTE_TILT_PITCH;
 			case TILT_ROLL: WiiRemoteID.REMOTE_TILT_ROLL;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -81,10 +81,10 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 			case WiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case WiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case WiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			case id if (id == WiiRemoteID.leftAnalogStick.rawUp): LEFT_STICK_DIGITAL_UP;
-			case id if (id == WiiRemoteID.leftAnalogStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
-			case id if (id == WiiRemoteID.leftAnalogStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
-			case id if (id == WiiRemoteID.leftAnalogStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
 			default: super.getID(rawID);
 		}
 	}
@@ -139,14 +139,14 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 			case RIGHT_TRIGGER: WiiRemoteID.CLASSIC_R;
 			case EXTRA_0: WiiRemoteID.CLASSIC_ONE;
 			case EXTRA_1: WiiRemoteID.CLASSIC_TWO;
-			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: WiiRemoteID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: WiiRemoteID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: WiiRemoteID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: WiiRemoteID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: WiiRemoteID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: WiiRemoteID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: WiiRemoteID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: WiiRemoteID.RIGHT_ANALOG_STICK.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -170,10 +170,10 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 			case DPAD_RIGHT: WiiRemoteID.NUNCHUK_DPAD_RIGHT;
 			case TILT_PITCH: WiiRemoteID.NUNCHUK_TILT_PITCH;
 			case TILT_ROLL: WiiRemoteID.NUNCHUK_TILT_ROLL;
-			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.leftAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.LEFT_ANALOG_STICK.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -266,13 +266,13 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 	{
 		leftStick = switch (attachment)
 		{
-			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: WiiRemoteID.leftAnalogStick;
+			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: WiiRemoteID.LEFT_ANALOG_STICK;
 			case NONE: WiiRemoteID.remoteDPad;
 		}
 
 		rightStick = switch (attachment)
 		{
-			case WII_CLASSIC_CONTROLLER: WiiRemoteID.rightAnalogStick;
+			case WII_CLASSIC_CONTROLLER: WiiRemoteID.RIGHT_ANALOG_STICK;
 			default: null;
 		}
 

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -351,6 +351,6 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 	
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.WiiRemote(getRawID(id));
+		return FlxGamepadMappedInput.WII(getRawID(id));
 	}
 }

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -81,10 +81,10 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 			case WiiRemoteID.NUNCHUK_DPAD_DOWN: DPAD_DOWN;
 			case WiiRemoteID.NUNCHUK_DPAD_LEFT: DPAD_LEFT;
 			case WiiRemoteID.NUNCHUK_DPAD_RIGHT: DPAD_RIGHT;
-			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawUp): LEFT_STICK_DIGITAL_UP;
-			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
-			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
-			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
+			case id if (id == WiiRemoteID.leftAnalogStick.rawUp): LEFT_STICK_DIGITAL_UP;
+			case id if (id == WiiRemoteID.leftAnalogStick.rawDown): LEFT_STICK_DIGITAL_DOWN;
+			case id if (id == WiiRemoteID.leftAnalogStick.rawLeft): LEFT_STICK_DIGITAL_LEFT;
+			case id if (id == WiiRemoteID.leftAnalogStick.rawRight): LEFT_STICK_DIGITAL_RIGHT;
 			default: super.getID(rawID);
 		}
 	}
@@ -139,14 +139,14 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 			case RIGHT_TRIGGER: WiiRemoteID.CLASSIC_R;
 			case EXTRA_0: WiiRemoteID.CLASSIC_ONE;
 			case EXTRA_1: WiiRemoteID.CLASSIC_TWO;
-			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: WiiRemoteID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: WiiRemoteID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: WiiRemoteID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: WiiRemoteID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: WiiRemoteID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: WiiRemoteID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: WiiRemoteID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: WiiRemoteID.rightAnalogStick.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -170,10 +170,10 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 			case DPAD_RIGHT: WiiRemoteID.NUNCHUK_DPAD_RIGHT;
 			case TILT_PITCH: WiiRemoteID.NUNCHUK_TILT_PITCH;
 			case TILT_ROLL: WiiRemoteID.NUNCHUK_TILT_ROLL;
-			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.LEFT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: WiiRemoteID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: WiiRemoteID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: WiiRemoteID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: WiiRemoteID.leftAnalogStick.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -266,13 +266,13 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 	{
 		leftStick = switch (attachment)
 		{
-			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: WiiRemoteID.LEFT_ANALOG_STICK;
-			case NONE: WiiRemoteID.REMOTE_DPAD;
+			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: WiiRemoteID.leftAnalogStick;
+			case NONE: WiiRemoteID.remoteDPad;
 		}
 
 		rightStick = switch (attachment)
 		{
-			case WII_CLASSIC_CONTROLLER: WiiRemoteID.RIGHT_ANALOG_STICK;
+			case WII_CLASSIC_CONTROLLER: WiiRemoteID.rightAnalogStick;
 			default: null;
 		}
 

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -267,7 +267,7 @@ class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 		leftStick = switch (attachment)
 		{
 			case WII_NUNCHUCK, WII_CLASSIC_CONTROLLER: WiiRemoteID.LEFT_ANALOG_STICK;
-			case NONE: WiiRemoteID.remoteDPad;
+			case NONE: WiiRemoteID.REMOTE_DPAD;
 		}
 
 		rightStick = switch (attachment)

--- a/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
+++ b/flixel/input/gamepad/mappings/WiiRemoteMapping.hx
@@ -3,8 +3,9 @@ package flixel.input.gamepad.mappings;
 import flixel.input.gamepad.FlxGamepad.FlxGamepadAttachment;
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.WiiRemoteID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class WiiRemoteMapping extends FlxGamepadMapping
+class WiiRemoteMapping extends FlxTypedGamepadMapping<WiiRemoteID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 20;
@@ -20,7 +21,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		supportsPointer = false;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:WiiRemoteID):FlxGamepadInputID
 	{
 		return switch (attachment)
 		{
@@ -30,7 +31,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getIDClassicController(rawID:Int):FlxGamepadInputID
+	function getIDClassicController(rawID:WiiRemoteID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -63,7 +64,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getIDNunchuk(rawID:Int):FlxGamepadInputID
+	function getIDNunchuk(rawID:WiiRemoteID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -84,11 +85,11 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawDown): LEFT_STICK_DIGITAL_DOWN;
 			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawLeft): LEFT_STICK_DIGITAL_LEFT;
 			case id if (id == WiiRemoteID.LEFT_ANALOG_STICK.rawRight): LEFT_STICK_DIGITAL_RIGHT;
-			default: super.getRawID(rawID);
+			default: super.getID(rawID);
 		}
 	}
 
-	function getIDDefault(rawID:Int):FlxGamepadInputID
+	function getIDDefault(rawID:WiiRemoteID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -107,7 +108,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):WiiRemoteID
 	{
 		return switch (attachment)
 		{
@@ -117,7 +118,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getRawClassicController(ID:FlxGamepadInputID):Int
+	function getRawClassicController(ID:FlxGamepadInputID):WiiRemoteID
 	{
 		return switch (ID)
 		{
@@ -150,7 +151,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getRawNunchuk(ID:FlxGamepadInputID):Int
+	function getRawNunchuk(ID:FlxGamepadInputID):WiiRemoteID
 	{
 		return switch (ID)
 		{
@@ -177,7 +178,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	function getRawDefault(ID:FlxGamepadInputID):Int
+	function getRawDefault(ID:FlxGamepadInputID):WiiRemoteID
 	{
 		return switch (ID)
 		{
@@ -198,7 +199,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function isAxisForMotion(ID:FlxGamepadInputID):Bool
+	override function isAxisForMotion(ID:WiiRemoteID):Bool
 	{
 		if (attachment == NONE)
 		{
@@ -213,14 +214,14 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		return false;
 	}
 
-	override public function isAxisFlipped(axisID:Int):Bool
+	override function isAxisFlipped(axisID:WiiRemoteID):Bool
 	{
 		return axisID == WiiRemoteID.LEFT_TRIGGER_FAKE;
 	}
 
 	#if FLX_JOYSTICK_API
 	// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:WiiRemoteID):Int
 	{
 		// return null for this unused access so it doesn't overlap a button input
 		if (attachment == NONE && axisID == WiiRemoteID.REMOTE_NULL_AXIS)
@@ -252,7 +253,7 @@ class WiiRemoteMapping extends FlxGamepadMapping
 		return axisID;
 	}
 
-	override public function checkForFakeAxis(ID:FlxGamepadInputID):Int
+	override function checkForFakeAxis(ID:FlxGamepadInputID):WiiRemoteID
 	{
 		if (attachment == WII_NUNCHUCK && ID == FlxGamepadInputID.LEFT_TRIGGER)
 			return WiiRemoteID.NUNCHUK_Z;
@@ -346,5 +347,10 @@ class WiiRemoteMapping extends FlxGamepadMapping
 			case START: "plus";
 			default: null;
 		}
+	}
+	
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.WiiRemote(getRawID(id));
 	}
 }

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -93,7 +93,7 @@ class XInputMapping extends FlxGamepadMapping
 			case RIGHT_STICK_DIGITAL_DOWN: XInputID.RIGHT_ANALOG_STICK.rawDown;
 			case RIGHT_STICK_DIGITAL_LEFT: XInputID.RIGHT_ANALOG_STICK.rawLeft;
 			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.RIGHT_ANALOG_STICK.rawRight;
-			default: -1;
+			default: super.getRawID(ID);
 		}
 	}
 

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -2,8 +2,9 @@ package flixel.input.gamepad.mappings;
 
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.gamepad.id.XInputID;
+import flixel.input.gamepad.mappings.FlxGamepadMapping;
 
-class XInputMapping extends FlxGamepadMapping
+class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 {
 	#if FLX_JOYSTICK_API
 	static inline var LEFT_ANALOG_STICK_FAKE_X:Int = 15;
@@ -22,7 +23,7 @@ class XInputMapping extends FlxGamepadMapping
 		rightStick = XInputID.RIGHT_ANALOG_STICK;
 	}
 
-	override public function getID(rawID:Int):FlxGamepadInputID
+	override function getID(rawID:XInputID):FlxGamepadInputID
 	{
 		return switch (rawID)
 		{
@@ -60,7 +61,7 @@ class XInputMapping extends FlxGamepadMapping
 		}
 	}
 
-	override public function getRawID(ID:FlxGamepadInputID):Int
+	override function getRawID(ID:FlxGamepadInputID):XInputID
 	{
 		return switch (ID)
 		{
@@ -98,7 +99,7 @@ class XInputMapping extends FlxGamepadMapping
 	}
 
 	#if flash
-	override public function isAxisFlipped(axisID:Int):Bool
+	override function isAxisFlipped(axisID:XInputID):Bool
 	{
 		if (manufacturer == GooglePepper)
 			return false;
@@ -108,14 +109,19 @@ class XInputMapping extends FlxGamepadMapping
 	#end
 
 	#if xbox1
-	override public function isAxisFlipped(axisID:Int):Bool
+	override function isAxisFlipped(axisID:XInputID):Bool
 	{
 		return axisID == XInputID.LEFT_ANALOG_STICK.y || axisID == XInputID.RIGHT_ANALOG_STICK.y;
 	}
 	#end
 
+	override function getMappedInput(id:FlxGamepadInputID)
+	{
+		return FlxGamepadMappedInput.XInput(getRawID(id));
+	}
+	
 	#if FLX_JOYSTICK_API
-	override public function axisIndexToRawID(axisID:Int):Int
+	override function axisIndexToRawID(axisID:XInputID):Int
 	{
 		// Analog stick and trigger values overlap with regular buttons so we remap to "fake" button ID's
 		return if (axisID == leftStick.x) LEFT_ANALOG_STICK_FAKE_X; else if (axisID == leftStick.y) LEFT_ANALOG_STICK_FAKE_Y; else if (axisID == rightStick.x)

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -104,14 +104,14 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 		if (manufacturer == GooglePepper)
 			return false;
 
-		return axisID == XInputID.leftAnalogStick.y || axisID == XInputID.rightAnalogStick.y;
+		return axisID == XInputID.LEFT_ANALOG_STICK.y || axisID == XInputID.RIGHT_ANALOG_STICK.y;
 	}
 	#end
 
 	#if xbox1
 	override function isAxisFlipped(axisID:XInputID):Bool
 	{
-		return axisID == XInputID.leftAnalogStick.y || axisID == XInputID.rightAnalogStick.y;
+		return axisID == XInputID.LEFT_ANALOG_STICK.y || axisID == XInputID.RIGHT_ANALOG_STICK.y;
 	}
 	#end
 

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -19,8 +19,8 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 
 	override function initValues():Void
 	{
-		leftStick = XInputID.LEFT_ANALOG_STICK;
-		rightStick = XInputID.RIGHT_ANALOG_STICK;
+		leftStick = XInputID.leftAnalogStick;
+		rightStick = XInputID.rightAnalogStick;
 	}
 
 	override function getID(rawID:XInputID):FlxGamepadInputID
@@ -86,14 +86,14 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			case LEFT_STICK_DIGITAL_UP: XInputID.LEFT_ANALOG_STICK.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: XInputID.LEFT_ANALOG_STICK.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: XInputID.LEFT_ANALOG_STICK.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: XInputID.LEFT_ANALOG_STICK.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: XInputID.RIGHT_ANALOG_STICK.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: XInputID.RIGHT_ANALOG_STICK.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: XInputID.RIGHT_ANALOG_STICK.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.RIGHT_ANALOG_STICK.rawRight;
+			case LEFT_STICK_DIGITAL_UP: XInputID.leftAnalogStick.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: XInputID.leftAnalogStick.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: XInputID.leftAnalogStick.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: XInputID.leftAnalogStick.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: XInputID.rightAnalogStick.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: XInputID.rightAnalogStick.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: XInputID.rightAnalogStick.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.rightAnalogStick.rawRight;
 			default: super.getRawID(ID);
 		}
 	}
@@ -104,14 +104,14 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 		if (manufacturer == GooglePepper)
 			return false;
 
-		return axisID == XInputID.LEFT_ANALOG_STICK.y || axisID == XInputID.RIGHT_ANALOG_STICK.y;
+		return axisID == XInputID.leftAnalogStick.y || axisID == XInputID.rightAnalogStick.y;
 	}
 	#end
 
 	#if xbox1
 	override function isAxisFlipped(axisID:XInputID):Bool
 	{
-		return axisID == XInputID.LEFT_ANALOG_STICK.y || axisID == XInputID.RIGHT_ANALOG_STICK.y;
+		return axisID == XInputID.leftAnalogStick.y || axisID == XInputID.rightAnalogStick.y;
 	}
 	#end
 

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -117,7 +117,7 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 
 	override function getMappedInput(id:FlxGamepadInputID)
 	{
-		return FlxGamepadMappedInput.XInput(getRawID(id));
+		return FlxGamepadMappedInput.X_INPUT(getRawID(id));
 	}
 	
 	#if FLX_JOYSTICK_API

--- a/flixel/input/gamepad/mappings/XInputMapping.hx
+++ b/flixel/input/gamepad/mappings/XInputMapping.hx
@@ -19,8 +19,8 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 
 	override function initValues():Void
 	{
-		leftStick = XInputID.leftAnalogStick;
-		rightStick = XInputID.rightAnalogStick;
+		leftStick = XInputID.LEFT_ANALOG_STICK;
+		rightStick = XInputID.RIGHT_ANALOG_STICK;
 	}
 
 	override function getID(rawID:XInputID):FlxGamepadInputID
@@ -86,14 +86,14 @@ class XInputMapping extends FlxTypedGamepadMapping<XInputID>
 			case LEFT_TRIGGER_FAKE: LEFT_TRIGGER_FAKE;
 			case RIGHT_TRIGGER_FAKE: RIGHT_TRIGGER_FAKE;
 			#end
-			case LEFT_STICK_DIGITAL_UP: XInputID.leftAnalogStick.rawUp;
-			case LEFT_STICK_DIGITAL_DOWN: XInputID.leftAnalogStick.rawDown;
-			case LEFT_STICK_DIGITAL_LEFT: XInputID.leftAnalogStick.rawLeft;
-			case LEFT_STICK_DIGITAL_RIGHT: XInputID.leftAnalogStick.rawRight;
-			case RIGHT_STICK_DIGITAL_UP: XInputID.rightAnalogStick.rawUp;
-			case RIGHT_STICK_DIGITAL_DOWN: XInputID.rightAnalogStick.rawDown;
-			case RIGHT_STICK_DIGITAL_LEFT: XInputID.rightAnalogStick.rawLeft;
-			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.rightAnalogStick.rawRight;
+			case LEFT_STICK_DIGITAL_UP: XInputID.LEFT_ANALOG_STICK.rawUp;
+			case LEFT_STICK_DIGITAL_DOWN: XInputID.LEFT_ANALOG_STICK.rawDown;
+			case LEFT_STICK_DIGITAL_LEFT: XInputID.LEFT_ANALOG_STICK.rawLeft;
+			case LEFT_STICK_DIGITAL_RIGHT: XInputID.LEFT_ANALOG_STICK.rawRight;
+			case RIGHT_STICK_DIGITAL_UP: XInputID.RIGHT_ANALOG_STICK.rawUp;
+			case RIGHT_STICK_DIGITAL_DOWN: XInputID.RIGHT_ANALOG_STICK.rawDown;
+			case RIGHT_STICK_DIGITAL_LEFT: XInputID.RIGHT_ANALOG_STICK.rawLeft;
+			case RIGHT_STICK_DIGITAL_RIGHT: XInputID.RIGHT_ANALOG_STICK.rawRight;
 			default: super.getRawID(ID);
 		}
 	}


### PR DESCRIPTION
- `FlxGamepadManager`: Adds `acceptMode`, options are:
  - `BOTTOM`: The bottom face button is `ACCEPT` and the right face button is `CANCEL`. This is common on western-style consoles, like XBox or American PS4/5
  - `RIGHT`:  The right face button is `ACCEPT` and the bottom face button is `CANCEL`. This is common in Japanese PS4/5 consoles, and Nintendo consoles
  - `USE_MAPPING`: Behavies like `BOTTOM` for nearly all gamepads, but `RIGHT` for Nintendo Switch gamepads
- `FlxGamepad`: Adds getMappedInput, which returns the device and the device specific input id
  - Change all device specific input ids to enum abstracts over int (were classes)
  - Adds ids for analog stick digital directions
- `FlxGamepadMapping`: Added `FlxTypedGamepadMapping<T>` where `T` is the enum result of `getRawID`
  - All `FlxGamepadMapping` extending classes use a specific ID enum for T