### PR TITLE
Checkstyle fixes

### DIFF
--- a/checkstyle.json
+++ b/checkstyle.json
@@ -19,7 +19,8 @@
 	"exclude": {
 		"all": [
 			"TestSuite",
-			"/export/"
+			"/export/",
+			"tests/unit/bin/"
 		],
 		"AvoidStarImport": [
 			"flixel.math.FlxRandomTest"

--- a/flixel/tweens/motion/Motion.hx
+++ b/flixel/tweens/motion/Motion.hx
@@ -55,7 +55,8 @@ class Motion extends FlxTween
 		}
 	}
 	
-	override function isTweenOf(object:Dynamic, ?field:String):Bool {
+	override function isTweenOf(object:Dynamic, ?field:String):Bool
+	{
 		return _object == object
 			&& (field == null || field == "x" || field == "y");
 	}

--- a/flixel/util/FlxDirectionFlags.hx
+++ b/flixel/util/FlxDirectionFlags.hx
@@ -41,7 +41,8 @@ enum abstract FlxDirectionFlags(Int) from Int from FlxDirection to Int
 	public var degrees(get, never):Float;
 	function get_degrees():Float
 	{
-		return switch (this) {
+		return switch (this)
+		{
 			case RIGHT: 0;
 			case DOWN: 90;
 			case UP: -90;

--- a/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
@@ -64,7 +64,7 @@ class BMFontTest extends FlxTest
 	}
 	
 	// This assumes the incoming font has a specific configuration we are checking for
-	private function assertFont(font:BMFont)
+	function assertFont(font:BMFont)
 	{
 		// INFO
 		Assert.areEqual("Arial Black", font.info.face);
@@ -127,7 +127,7 @@ class BMFontTest extends FlxTest
 		}
 	}
 	
-	private function assertCharMatches(expected:BMFontChar, actual:BMFontChar)
+	function assertCharMatches(expected:BMFontChar, actual:BMFontChar)
 	{
 		Assert.areEqual(expected.id, actual.id);
 		Assert.areEqual(expected.x, actual.x);
@@ -143,7 +143,7 @@ class BMFontTest extends FlxTest
 		// 	Assert.areEqual(expected.letter, actual.letter);
 	}
 	
-	private function assertKerningMatches(expected:BMFontKerning, actual:BMFontKerning)
+	function assertKerningMatches(expected:BMFontKerning, actual:BMFontKerning)
 	{
 		Assert.areEqual(expected.first, actual.first);
 		Assert.areEqual(expected.second, actual.second);

--- a/tests/unit/src/flixel/math/FlxPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxPointTest.hx
@@ -160,7 +160,8 @@ class FlxPointTest extends FlxTest
 	}
 
 	@Test
-	function testPivotDegrees() {
+	function testPivotDegrees()
+	{
 		// Pivot around point in same quadrant
 		point1.set(10, 10);
 		point2.set(5, 5);
@@ -183,10 +184,10 @@ class FlxPointTest extends FlxTest
 	}
 
 	function assertPointNearlyEquals(p:FlxPoint, x:Float, y:Float, tolerance:Float = .01, ?msg:String, ?info:PosInfos)
-		{
-			if (msg == null)
-				msg = 'Expected (x: $x | y: $y) but was $p';
+	{
+		if (msg == null)
+			msg = 'Expected (x: $x | y: $y) but was $p';
 
-			Assert.isTrue(Math.abs(x - p.x) <= tolerance && Math.abs(y -p.y) <= tolerance, msg, info);
-		}
+		Assert.isTrue(Math.abs(x - p.x) <= tolerance && Math.abs(y -p.y) <= tolerance, msg, info);
+	}
 }

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -444,8 +444,8 @@ class FlxTilemapTest extends FlxTest
 		tilemap.y += 20;
 		tilemap.scale.set(2, 2);
 		
-		final SIZE = 16;
-		final HALF = 8;
+		final size = 16;
+		final half = 8;
 		
 		Assert.areEqual(tilemap.getTileIndex(4), tilemap.getTileIndex(1, 1));
 		Assert.areEqual(1, tilemap.getTileIndex(4));
@@ -454,12 +454,12 @@ class FlxTilemapTest extends FlxTest
 		
 		Assert.areEqual(-1, tilemap.getMapIndex(1000, 1));
 		Assert.areEqual(-1, tilemap.getTileIndex(1000, 1));
-		Assert.areEqual(8, tilemap.getMapIndexAt(10 + 2 * SIZE + HALF, 20 + 2 * SIZE + HALF));
-		Assert.areEqual(0, tilemap.getTileIndexAt(10 + 2 * SIZE + HALF, 20 + 2 * SIZE + HALF));
-		Assert.areEqual(-1, tilemap.getTileIndexAt(10 + 1000 * SIZE + HALF, 20 + 2 * SIZE + HALF));
+		Assert.areEqual(8, tilemap.getMapIndexAt(10 + 2 * size + half, 20 + 2 * size + half));
+		Assert.areEqual(0, tilemap.getTileIndexAt(10 + 2 * size + half, 20 + 2 * size + half));
+		Assert.areEqual(-1, tilemap.getTileIndexAt(10 + 1000 * size + half, 20 + 2 * size + half));
 		
 		Assert.areEqual(tilemap.getTileData(4), tilemap.getTileData(1, 1));
-		Assert.areEqual(tilemap.getTileData(1, 1), tilemap.getTileDataAt(10 + 1 * SIZE + HALF, 20 + 1 * SIZE + HALF));
+		Assert.areEqual(tilemap.getTileData(1, 1), tilemap.getTileDataAt(10 + 1 * size + half, 20 + 1 * size + half));
 	}
 	
 	function testGetColumnRowAt()
@@ -494,25 +494,25 @@ class FlxTilemapTest extends FlxTest
 		tilemap.y = 20;
 		tilemap.scale.set(2, 2);
 		
-		final SIZE = 16;
-		final HALF = 8;
+		final size = 16;
+		final half = 8;
 		
 		Assert.areEqual(0, tilemap.getColumnAt(tilemap.getColumnPos(0)));
 		Assert.areEqual(1, tilemap.getColumnAt(tilemap.getColumnPos(1)));
 		Assert.areEqual(2, tilemap.getColumnAt(tilemap.getColumnPos(2)));
 		Assert.areEqual(3, tilemap.getColumnAt(tilemap.getColumnPos(3)));
 		Assert.areEqual(1000, tilemap.getColumnAt(tilemap.getColumnPos(1000)));
-		Assert.areEqual(10 + 3 * SIZE, tilemap.getColumnPos(3));
-		Assert.areEqual(10 + 3 * SIZE + HALF, tilemap.getColumnPos(3, true));
-		Assert.areEqual(10 + 1000 * SIZE, tilemap.getColumnPos(1000));
+		Assert.areEqual(10 + 3 * size, tilemap.getColumnPos(3));
+		Assert.areEqual(10 + 3 * size + half, tilemap.getColumnPos(3, true));
+		Assert.areEqual(10 + 1000 * size, tilemap.getColumnPos(1000));
 		
 		Assert.areEqual(0, tilemap.getRowAt(tilemap.getRowPos(0)));
 		Assert.areEqual(1, tilemap.getRowAt(tilemap.getRowPos(1)));
 		Assert.areEqual(2, tilemap.getRowAt(tilemap.getRowPos(2)));
 		Assert.areEqual(1000, tilemap.getRowAt(tilemap.getRowPos(1000)));
-		Assert.areEqual(20 + 2 * SIZE, tilemap.getRowPos(2));
-		Assert.areEqual(20 + 2 * SIZE + HALF, tilemap.getRowPos(2, true));
-		Assert.areEqual(20 + 1000 * SIZE, tilemap.getRowPos(1000));
+		Assert.areEqual(20 + 2 * size, tilemap.getRowPos(2));
+		Assert.areEqual(20 + 2 * size + half, tilemap.getRowPos(2, true));
+		Assert.areEqual(20 + 1000 * size, tilemap.getRowPos(1000));
 		
 		Assert.areEqual(null, tilemap.getTilePos(1000));
 		Assert.areEqual(null, tilemap.getTilePos(-1));
@@ -524,10 +524,10 @@ class FlxTilemapTest extends FlxTest
 			Assert.areEqual(expectedY, actual.y, 'Point y [${actual.y}] was not equal to expected value [$expectedY]', infos);
 		}
 		
-		assertPosEqual(10 + -SIZE, 20 + -SIZE, tilemap.getTilePos(-1, -1));
-		assertPosEqual(10 + SIZE, 20 + SIZE, tilemap.getTilePos(1, 1));
-		assertPosEqual(10 + 1000 * SIZE, 20 + 1000 * SIZE, tilemap.getTilePos(1000, 1000));
-		assertPosEqual(10 + 1000 * SIZE, 20 + 1000 * SIZE, tilemap.getTilePosAt(10 + 1000 * SIZE, 20 + 1000 * SIZE));
+		assertPosEqual(10 + -size, 20 + -size, tilemap.getTilePos(-1, -1));
+		assertPosEqual(10 + size, 20 + size, tilemap.getTilePos(1, 1));
+		assertPosEqual(10 + 1000 * size, 20 + 1000 * size, tilemap.getTilePos(1000, 1000));
+		assertPosEqual(10 + 1000 * size, 20 + 1000 * size, tilemap.getTilePosAt(10 + 1000 * size, 20 + 1000 * size));
 	}
 	
 	@Test
@@ -543,7 +543,7 @@ class FlxTilemapTest extends FlxTest
 		tilemap.y = 20;
 		tilemap.scale.set(2, 2);
 		
-		final SIZE = 16;
+		final size = 16;
 		
 		Assert.isTrue(tilemap.tileExists(4));
 		Assert.isTrue(tilemap.tileExists(1, 1));
@@ -552,10 +552,10 @@ class FlxTilemapTest extends FlxTest
 		Assert.isFalse(tilemap.tileExists(1, 3));
 		Assert.isFalse(tilemap.tileExists(5, 5));
 		
-		Assert.isTrue(tilemap.tileExistsAt(10 + 1 * SIZE, 20 + 1 * SIZE));
-		Assert.isFalse(tilemap.tileExistsAt(10 + 3 * SIZE, 20 + 1 * SIZE));
-		Assert.isFalse(tilemap.tileExistsAt(10 + 1 * SIZE, 20 + 3 * SIZE));
-		Assert.isFalse(tilemap.tileExistsAt(10 + 5 * SIZE, 20 + 5 * SIZE));
+		Assert.isTrue(tilemap.tileExistsAt(10 + 1 * size, 20 + 1 * size));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 3 * size, 20 + 1 * size));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 1 * size, 20 + 3 * size));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 5 * size, 20 + 5 * size));
 	}
 	
 	@Test
@@ -571,41 +571,41 @@ class FlxTilemapTest extends FlxTest
 		tilemap.y = 20;
 		tilemap.scale.set(2, 2);
 		
-		final SIZE = 16;
+		final size = 16;
 		
 		Assert.isFalse(tilemap.columnExists(5));
 		Assert.isFalse(tilemap.rowExists(5));
 		Assert.isFalse(tilemap.tileExists(5, 5));
-		Assert.isFalse(tilemap.columnExistsAt(10 + 5 * SIZE));
-		Assert.isFalse(tilemap.rowExistsAt(20 + 5 * SIZE));
-		Assert.isFalse(tilemap.tileExistsAt(10 + 5 * SIZE, 20 + 5 * SIZE));
+		Assert.isFalse(tilemap.columnExistsAt(10 + 5 * size));
+		Assert.isFalse(tilemap.rowExistsAt(20 + 5 * size));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 5 * size, 20 + 5 * size));
 		
 		Assert.isFalse(tilemap.columnExists(4));
 		Assert.isFalse(tilemap.rowExists(4));
 		Assert.isFalse(tilemap.tileExists(4, 4));
-		Assert.isFalse(tilemap.columnExistsAt(10 + 4 * SIZE));
-		Assert.isFalse(tilemap.rowExistsAt(20 + 4 * SIZE));
+		Assert.isFalse(tilemap.columnExistsAt(10 + 4 * size));
+		Assert.isFalse(tilemap.rowExistsAt(20 + 4 * size));
 		
 		Assert.isTrue(tilemap.columnExists(3));
 		Assert.isFalse(tilemap.rowExists(3));
 		Assert.isFalse(tilemap.tileExists(3, 3));
-		Assert.isTrue(tilemap.columnExistsAt(10 + 3 * SIZE));
-		Assert.isFalse(tilemap.rowExistsAt(20 + 3 * SIZE));
-		Assert.isFalse(tilemap.tileExistsAt(10 + 3 * SIZE, 20 + 3 * SIZE));
+		Assert.isTrue(tilemap.columnExistsAt(10 + 3 * size));
+		Assert.isFalse(tilemap.rowExistsAt(20 + 3 * size));
+		Assert.isFalse(tilemap.tileExistsAt(10 + 3 * size, 20 + 3 * size));
 		
 		Assert.isTrue(tilemap.columnExists(2));
 		Assert.isTrue(tilemap.rowExists(2));
 		Assert.isTrue(tilemap.tileExists(2, 2));
-		Assert.isTrue(tilemap.columnExistsAt(10 + 2 * SIZE));
-		Assert.isTrue(tilemap.rowExistsAt(20 + 2 * SIZE));
-		Assert.isTrue(tilemap.tileExistsAt(10 + 2 * SIZE, 20 + 2 * SIZE));
+		Assert.isTrue(tilemap.columnExistsAt(10 + 2 * size));
+		Assert.isTrue(tilemap.rowExistsAt(20 + 2 * size));
+		Assert.isTrue(tilemap.tileExistsAt(10 + 2 * size, 20 + 2 * size));
 		
 		Assert.isTrue(tilemap.columnExists(1));
 		Assert.isTrue(tilemap.rowExists(1));
 		Assert.isTrue(tilemap.tileExists(1, 1));
-		Assert.isTrue(tilemap.columnExistsAt(10 + 1 * SIZE));
-		Assert.isTrue(tilemap.rowExistsAt(20 + 1 * SIZE));
-		Assert.isTrue(tilemap.tileExistsAt(10 + 1 * SIZE, 20 + 1 * SIZE));
+		Assert.isTrue(tilemap.columnExistsAt(10 + 1 * size));
+		Assert.isTrue(tilemap.rowExistsAt(20 + 1 * size));
+		Assert.isTrue(tilemap.tileExistsAt(10 + 1 * size, 20 + 1 * size));
 		
 		Assert.isTrue(tilemap.columnExists(0));
 		Assert.isTrue(tilemap.rowExists(0));

--- a/tests/unit/src/flixel/util/FlxSignalTest.hx
+++ b/tests/unit/src/flixel/util/FlxSignalTest.hx
@@ -29,7 +29,7 @@ class FlxSignalTest extends FlxTest
 	function callbackIncrementCounter()
 		counter++;
 
-	function callbackIncrementCounter_Int(v:Int):Void
+	function callbackIncrementCounterInt(v:Int):Void
 		counter++;
 
 	function addAllEmptyCallbacks():Void
@@ -162,11 +162,11 @@ class FlxSignalTest extends FlxTest
 	}
 
 	@Test
-	function testDispatchOnce_signal1():Void
+	function testDispatchOnceSignal1():Void
 	{
 		// see https://github.com/HaxeFoundation/hashlink/issues/578
 		
-		signal1.addOnce(callbackIncrementCounter_Int);
+		signal1.addOnce(callbackIncrementCounterInt);
 		
 		signal1.dispatch(42);
 		signal1.dispatch(42);


### PR DESCRIPTION
Fixes all checkstyle violations

Note: there is no style check for cuddled curly braces because we can't disallow cuddled braces while allowing single line blocks. [I've added a suggestion to checkstyle](https://github.com/HaxeCheckstyle/haxe-checkstyle/issues/528)