### PR TITLE
Add more functions and variables to FlxSoundGroup

### DIFF
--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -61,7 +61,7 @@ class FlxSoundGroup extends FlxBasic
 	{
 		super.kill();
 		for (sound in sounds)
-			@:privateAccess sound.cleanup(false);
+			sound.kill();
 	}
 	
 	override public function update(elapsed:Float):Void
@@ -192,19 +192,17 @@ class FlxSoundGroup extends FlxBasic
 	
 	function get_length():Float
 	{
-		var _length:Float = 0.0;
+		var maxLength:Float = 0.0;
 		for (sound in sounds)
 		{
-			if (sound.length > _length)
+			if (sound.length > maxLength)
 			{
-				_length = sound.length;
+				maxLength = sound.length;
 			}
 		}
-		return _length;
+		return maxLength;
 	}
-	
-	var _alreadyPaused:Bool = false;
-	var _paused:Bool;
+
 	
 	function onFocus():Void
 	{

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -1,29 +1,76 @@
 package flixel.sound;
 
+import flixel.util.FlxStringUtil;
+
 /**
  * A way of grouping sounds for things such as collective volume control
  */
-class FlxSoundGroup
+class FlxSoundGroup extends FlxBasic
 {
 	/**
 	 * The sounds in this group
 	 */
 	public var sounds:Array<FlxSound> = [];
-
+	
 	/**
 	 * The volume of this group
 	 */
 	public var volume(default, set):Float;
-
+	
+	/**
+	 * The pitch of this group
+	 */
+	public var pitch(default, set):Float;
+	
+	/**
+	 * The position of this group in milliseconds.
+	 * If set while paused, changes only come into effect after a `resume()` call.
+	 */
+	public var time(default, set):Float;
+	
+	/**
+	 * The length of the *longest* sound in the group
+	 */
+	public var length(get, never):Float;
+	
+	/**
+	 * Whether or not the sound group is currently playing.
+	 */
+	public var playing(default, null):Bool;
+	
 	/**
 	 * Create a new sound group
 	 * @param	volume  The initial volume of this group
 	 */
 	public function new(volume:Float = 1)
 	{
+		super();
 		this.volume = volume;
+		FlxG.signals.focusLost.add(onFocusLost);
+		FlxG.signals.focusGained.add(onFocus);
 	}
-
+	
+	override public function destroy()
+	{
+		for (sound in sounds)
+			sound.destroy();
+		super.destroy();
+	}
+	
+	override public function kill():Void
+	{
+		super.kill();
+		for (sound in sounds)
+			@:privateAccess sound.cleanup(false);
+	}
+	
+	override public function update(elapsed:Float):Void
+	{
+		super.update(elapsed);
+		for (sound in sounds)
+			sound.update(elapsed);
+	}
+	
 	/**
 	 * Add a sound to this group, will remove the sound from any group it is currently in
 	 * @param	sound The sound to add to this group
@@ -36,7 +83,7 @@ class FlxSoundGroup
 			// remove from prev group
 			if (sound.group != null)
 				sound.group.sounds.remove(sound);
-			
+				
 			sounds.push(sound);
 			@:bypassAccessor
 			sound.group = this;
@@ -45,7 +92,7 @@ class FlxSoundGroup
 		}
 		return false;
 	}
-
+	
 	/**
 	 * Remove a sound from this group
 	 * @param	sound The sound to remove
@@ -63,7 +110,7 @@ class FlxSoundGroup
 		}
 		return false;
 	}
-
+	
 	/**
 	 * Call this function to pause all sounds in this group.
 	 * @since 4.3.0
@@ -72,8 +119,31 @@ class FlxSoundGroup
 	{
 		for (sound in sounds)
 			sound.pause();
+		playing = false;
 	}
-
+	
+	/**
+	 * Call this function to pause all sounds in this group.
+	 * @since 5.9.0
+	 */
+	public function play():Void
+	{
+		for (sound in sounds)
+			sound.play();
+		playing = true;
+	}
+	
+	/**
+	 * Call this function to pause all sounds in this group.
+	 * @since 5.9.0
+	 */
+	public function stop():Void
+	{
+		for (sound in sounds)
+			sound.stop();
+		playing = false;
+	}
+	
 	/**
 	 * Unpauses all sounds in this group. Only works on sounds that have been paused.
 	 * @since 4.3.0
@@ -82,15 +152,79 @@ class FlxSoundGroup
 	{
 		for (sound in sounds)
 			sound.resume();
+		playing = true;
 	}
-
+	
 	function set_volume(volume:Float):Float
 	{
 		this.volume = volume;
 		for (sound in sounds)
 		{
-			sound.updateTransform();
+			sound.volume = volume;
 		}
 		return volume;
+	}
+	
+	function set_time(time:Float):Float
+	{
+		this.time = time;
+		for (sound in sounds)
+		{
+			sound.time = time;
+		}
+		return time;
+	}
+	
+	function set_pitch(pitch:Float):Float
+	{
+		this.pitch = pitch;
+		for (sound in sounds)
+		{
+			sound.pitch = pitch;
+		}
+		return pitch;
+	}
+	
+	function get_time():Float
+	{
+		return time;
+	}
+	
+	function get_length():Float
+	{
+		var _length:Float = 0.0;
+		for (sound in sounds)
+		{
+			if (sound.length > _length)
+			{
+				_length = sound.length;
+			}
+		}
+		return _length;
+	}
+	
+	var _alreadyPaused:Bool = false;
+	var _paused:Bool;
+	
+	function onFocus():Void
+	{
+		for(sound in sounds)
+			@:privateAccess sound.onFocus();
+	}
+	
+	function onFocusLost():Void
+	{
+		for(sound in sounds)
+			@:privateAccess sound.onFocusLost();
+	}
+	
+	override public function toString():String
+	{
+		return FlxStringUtil.getDebugString([
+			LabelValuePair.weak("playing", playing),
+			LabelValuePair.weak("time", time),
+			LabelValuePair.weak("length", length),
+			LabelValuePair.weak("volume", volume)
+		]);
 	}
 }

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -17,10 +17,12 @@ class FlxSoundGroup extends FlxBasic
 	 */
 	public var volume(default, set):Float;
 	
+	#if FLX_PITCH
 	/**
 	 * The pitch of this group
 	 */
 	public var pitch(default, set):Float;
+	#end
 	
 	/**
 	 * The position of this group in milliseconds.
@@ -46,8 +48,10 @@ class FlxSoundGroup extends FlxBasic
 	{
 		super();
 		this.volume = volume;
+		#if FLX_SOUND_SYSTEM
 		FlxG.signals.focusLost.add(onFocusLost);
 		FlxG.signals.focusGained.add(onFocus);
+		#end
 	}
 	
 	override public function destroy()
@@ -175,6 +179,7 @@ class FlxSoundGroup extends FlxBasic
 		return time;
 	}
 	
+	#if FLX_PITCH
 	function set_pitch(pitch:Float):Float
 	{
 		this.pitch = pitch;
@@ -184,6 +189,7 @@ class FlxSoundGroup extends FlxBasic
 		}
 		return pitch;
 	}
+	#end
 	
 	function get_time():Float
 	{
@@ -203,7 +209,7 @@ class FlxSoundGroup extends FlxBasic
 		return maxLength;
 	}
 
-	
+	#if FLX_SOUND_SYSTEM
 	function onFocus():Void
 	{
 		for(sound in sounds)
@@ -215,6 +221,7 @@ class FlxSoundGroup extends FlxBasic
 		for(sound in sounds)
 			@:privateAccess sound.onFocusLost();
 	}
+	#end
 	
 	override public function toString():String
 	{


### PR DESCRIPTION
Adds `pitch` `time` `length` `playing` variables and `stop` and `play` functions.
Also changes to extend `FlxBasic` too for `update` `destory` `kill` etc functions

My use case for this is that I am currently working on adding split vocal files to a funkin modding tool (who would have guessed) and I would like to use a `FlxSoundGroup` for easily pausing/playing/stopping (etc) all vocal tracks at once rather than just using an array or a bunch of different `FlxSound` variables