### PR TITLE
FlxSave: Allow custom handling of parsing errors

### DIFF
--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -189,9 +189,6 @@ class FlxSave implements IFlxDestroyable
 					status = BOUND(name, path);
 					return true;
 				case FAILURE(PARSING(rawData, exception), sharedObject) if (backupParser != null):
-					
-					data = sharedObject.data;
-					
 					// Use the provided backup parser
 					final parsedData = backupParser(rawData, exception);
 					if (parsedData == null)
@@ -200,6 +197,7 @@ class FlxSave implements IFlxDestroyable
 						return false;
 					}
 					
+					data = sharedObject.data;
 					for (field in Reflect.fields(parsedData))
 						Reflect.setField(data, field, Reflect.field(parsedData, field));
 					

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -188,6 +188,7 @@ class FlxSave implements IFlxDestroyable
 					data = _sharedObject.data;
 					status = BOUND(name, path);
 					return true;
+				#if !flash
 				case FAILURE(PARSING(rawData, exception), sharedObject) if (backupParser != null):
 					// Use the provided backup parser
 					final parsedData = backupParser(rawData, exception);
@@ -203,6 +204,7 @@ class FlxSave implements IFlxDestroyable
 					sharedObject.data = parsedData;
 					status = BOUND(name, path);
 					return true;
+				#end
 				case FAILURE(type, sharedObject):
 					_sharedObject = sharedObject;
 					status = LOAD_ERROR(type);

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -197,11 +197,10 @@ class FlxSave implements IFlxDestroyable
 						return false;
 					}
 					
-					data = sharedObject.data;
-					for (field in Reflect.fields(parsedData))
-						Reflect.setField(data, field, Reflect.field(parsedData, field));
-					
 					_sharedObject = sharedObject;
+					data = parsedData;
+					@:privateAccess
+					sharedObject.data = parsedData;
 					status = BOUND(name, path);
 					return true;
 				case FAILURE(type, sharedObject):

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -105,7 +105,7 @@ class FlxSave implements IFlxDestroyable
 	public static inline function resolveFlixelClasses(name:String)
 	{
 		#if flash
-		return Type.resolveEnum(name);
+		return Type.resolveClass(name);
 		#else
 		@:privateAccess
 		return SharedObject.__resolveClass(name);

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -104,8 +104,12 @@ class FlxSave implements IFlxDestroyable
 	 */
 	public static inline function resolveFlixelClasses(name:String)
 	{
+		#if flash
+		return Type.resolveEnum(name);
+		#else
 		@:privateAccess
 		return SharedObject.__resolveClass(name);
+		#end
 	}
 	
 	/**
@@ -425,9 +429,17 @@ private class FlxSharedObject extends SharedObject
 {
 	#if (flash || android || ios)
 	/** Use SharedObject as usual */
-	public static inline function getLocal(name:String, ?localPath:String):SharedObject
+	public static inline function getLocal(name:String, ?localPath:String):LoadResult
 	{
-		return SharedObject.getLocal(name, localPath);
+		try
+		{
+			final obj = SharedObject.getLocal(name, localPath);
+			return SUCCESS(obj);
+		}
+		catch (e)
+		{
+			return FAILURE(IO(e));
+		}
 	}
 	
 	public static inline function exists(name:String, ?path:String)

--- a/flixel/util/FlxSave.hx
+++ b/flixel/util/FlxSave.hx
@@ -166,9 +166,9 @@ class FlxSave implements IFlxDestroyable
 	 * @param   path          The full or partial path to the file that created the shared object.
 	 *                        Mainly used to differentiate from other FlxSaves. If you do not specify
 	 *                        this parameter, the company name specified in your Project.xml is used.
-	 * @param   backupParser  A function that takes a string and an error and returns parsed data.
-	 *                        If there is an error parsing the raw save data, this will be called as
+	 * @param   backupParser  If there is an error parsing the raw save data, this will be called as
 	 *                        a backup. if null is returned, the save will stay in an error state.
+	 *                        **Note:** This arg is never used when targeting flash
 	 * @return  Whether or not you successfully connected to the save data.
 	 */
 	public function bind(name:String, ?path:String, ?backupParser:(String, Exception)->Null<Any>):Bool
@@ -435,6 +435,7 @@ private class FlxSharedObject extends SharedObject
 		}
 		catch (e)
 		{
+			// We can't detect parsing or naming errors in flash, just use IO for everything
 			return FAILURE(IO(e));
 		}
 	}


### PR DESCRIPTION
Adds a `backupParser` arg to `bind`, which is called to handle parsing errors, also adds `FlxSaveStatus.LOAD_ERROR` which is an error that happened during the bind (load) process, where ERROR happened during the flush (save) process that was not resolved.

Alternative to https://github.com/HaxeFlixel/flixel/pull/3270, any thoughts @EliteMasterEric ?

When the load error is a parsing error, the raw save data and parsing exception are available in the save's state. To repair the save, manually edit and/or unserialize it, wipe the old save and replace it with the new, repaired data

Example
```hx
package states;

import flixel.FlxG;
import flixel.util.FlxSave;
import haxe.Exception;
import haxe.Json;
import haxe.Serializer;
import haxe.Unserializer;
import openfl.net.SharedObject;

#if generateData
enum Values { A; B; }
#end

class SaveCrashTestState3270 extends flixel.FlxState
{
    inline static var INVALID_DATA = "oy8:someDatafy5:valuewy13:states.Valuesy1:B:0y9:otherDatay6:stringg";
    
    
    var save:FlxSave;
    
    override function create()
    {
        super.create();
        
        #if generateData
        // Used to get `INVALID_DATA`
        final data = { someData:false, value: Values.B, otherData:"string" };
        trace('serializing data${Json.stringify(data)}');
        final serialized = Serializer.run(data);
        trace('serialized data: ${serialized}');
        trace(Serializer.run({ someData:false, otherData:"string" }));
        #else
        runTest();
        #end
    }
    
    function runTest()
    {
        trace('Saving invalid data: "$INVALID_DATA"');
        saveRawData("test-save", INVALID_DATA);
        trace('loading "test-save"');
        save = new FlxSave();
        save.bind("test-save", resolveParsingError);
        switch save.status
        {
            case BOUND(_,_):
                trace('Bind successful: ${Json.stringify(save.data)}');
                trace('Erasing save');
                save.erase();
            case found:
                trace('Bind failed: $found');
        }
    }
    
    function resolveParsingError(rawData:String, e:Exception)
    {
        trace('Parsing failed, data:"$rawData", error:"$e"');
        
        trace("patching data");
        final reg = ~/y5:valuewy13:states.Valuesy.:.+:0/;
        final patchedData = reg.split(rawData).join("");
        
        trace('Resolving patched data: "$patchedData"');
        final unserializer = new Unserializer(patchedData);
        final resolver = { resolveEnum: Type.resolveEnum, resolveClass: FlxSave.resolveFlixelClasses };
        unserializer.setResolver(cast resolver);
        final parsedData = unserializer.unserialize();
        trace('resolving data: ${Json.stringify(parsedData)}');
        return parsedData;
    }
    
    @:access(openfl.net.SharedObject)
    @:access(flixel.util.FlxSave)
    function saveRawData(name:String, encodedData:String)
    {
        final meta = openfl.Lib.current.stage.application.meta;
        var path = meta["company"];
        if (path == null || path == "")
            path = "HaxeFlixel";
        else
            path = FlxSave.validate(path);
        
        final obj = SharedObject.getLocal(name, path);
        
        // put outdated data in save
        // copied from SharedObject.hx flush
        #if (js && html5)
            var storage = js.Browser.getLocalStorage();
            
            if (storage != null)
            {
                storage.removeItem(obj.__localPath + ":" + obj.__name);
                storage.setItem(obj.__localPath + ":" + obj.__name, encodedData);
            }
        #else
            var path = SharedObject.__getPath(obj.__localPath, obj.__name);
            var directory = haxe.io.Path.directory(path);
            
            if (!sys.FileSystem.exists(directory))
            {
                SharedObject.__mkdir(directory);
            }
            
            var output = sys.io.File.write(path, false);
            output.writeString(encodedData);
            output.close();
        #end
    }
}
```