### PR TITLE
add lime and openfl to haxelib.json dependencies

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -7,5 +7,8 @@
 	"version": "5.9.0",
 	"releasenote": "TBD",
 	"contributors": ["haxeflixel", "Gama11", "GeoKureli"],
-	"dependencies": {}
+	"dependencies": {
+		"lime": "",
+		"openfl": ""
+	}
 }


### PR DESCRIPTION
I believe if we add this here, running `haxelib install flixel` installs flixel, lime, and openfl all in one, which would simplify the installation process imo !

right now we don't version them, so they'd just install whatever latest is available via haxelib. I'm unsure how in depth haxe / haxelib actually supports versioning semantics and properly resolving it all, but for lime and openfl, in most cases we keep flixel up to date with latest lime/openfl changes