### PR TITLE
Check if maxTextureSize >0 rather than !=-1

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -637,7 +637,7 @@ class FlxGraphic implements IFlxDestroyable
 
 			#if FLX_OPENGL_AVAILABLE
 			var max:Int = FlxG.bitmap.maxTextureSize;
-			if (max != -1)
+			if (max > 0)
 			{
 				if (width > max || height > max)
 					FlxG.log.warn('Graphic dimensions (${width}x${height}) exceed the maximum allowed size (${max}x${max}), which may cause rendering issues.');


### PR DESCRIPTION
In some strange circumstances `FlxG.bitmap.maxTextureSize` can return 0 or a number lower than 0. This is a bit safer way to try to make sure that the returned value is valid