### PR TITLE
fix custom asset path, add _abs

### DIFF
--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -59,13 +59,12 @@ class AssetFrontEnd
 	public function new ()
 	{
 		final rawPath = '${haxe.macro.Compiler.getDefine("FLX_CUSTOM_ASSETS_DIRECTORY")}';
-		// Remove final slash and accepts backslashes and removes redundancies
-		directory = Path.normalize(rawPath);
+		directory = '${haxe.macro.Compiler.getDefine("FLX_CUSTOM_ASSETS_DIRECTORY_ABS")}';
 		// Verify valid directory
 		if (sys.FileSystem.exists(directory) == false)
-			throw 'Invalid value:"$directory" of FLX_CUSTOM_ASSETS_DIRECTORY, expecting relative or absolute path';
+			throw 'Error finding custom asset directory:"$directory" from given path: $rawPath';
 		// remove final "/assets" since the id typically contains it
-		final split = sys.FileSystem.absolutePath(directory).split("/");
+		final split = directory.split("/");
 		split.pop();
 		parentDirectory = split.join("/");
 	}

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -1,9 +1,9 @@
 package flixel.system.macros;
 
+import haxe.io.Path;
 import haxe.macro.Compiler;
 import haxe.macro.Context;
 import haxe.macro.Expr.Position;
-import haxe.io.Path;
 #if (flixel_addons >= "3.2.2")
 import flixel.addons.system.macros.FlxAddonDefines;
 #end
@@ -98,6 +98,8 @@ private enum HelperDefines
 	FLX_OPENGL_AVAILABLE;
 	/** Defined to `1`(or `true`) if `FLX_CUSTOM_ASSETS_DIRECTORY` is not defined */
 	FLX_STANDARD_ASSETS_DIRECTORY;
+	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
+	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
 }
 
 class FlxDefines
@@ -283,12 +285,13 @@ class FlxDefines
 				// Todo: check sys targets
 				final rawDirectory = Path.normalize(definedValue(FLX_CUSTOM_ASSETS_DIRECTORY));
 				final directory = Path.normalize(rawDirectory);
+				final absPath = sys.FileSystem.absolutePath(directory);
 				if (!sys.FileSystem.isDirectory(directory) || directory == "1")
 				{
-					final absPath = sys.FileSystem.absolutePath(directory);
 					abort('FLX_CUSTOM_ASSETS_DIRECTORY must be a path to a directory, got "$rawDirectory"'
 						+ '\nabsolute path: $absPath', (macro null).pos);
 				}
+				define(FLX_CUSTOM_ASSETS_DIRECTORY_ABS, absPath);
 			}
 		}
 		else // define boolean inversion
@@ -330,9 +333,9 @@ class FlxDefines
 		return Context.defined(Std.string(define));
 	}
 
-	static inline function define(define:Dynamic)
+	static inline function define(define:Dynamic, ?value:String)
 	{
-		Compiler.define(Std.string(define));
+		Compiler.define(Std.string(define), value);
 	}
 
 	static function abort(message:String, pos:Position)


### PR DESCRIPTION
fix issue with FLX_CUSTOM_ASSETS_DIRECTORY, where it checked different paths at runtime vs compile-time

Now, the correct path is always relative to the project.xml, so in the default flixel template you would do: "assets"

Fix for https://github.com/HaxeFlixel/flixel/pull/2982