### PR TITLE
Remove OpenFl `KeyboardEvent`s in `FlxKeyManager` on destroy to avoid crashes

### DIFF
--- a/flixel/input/FlxKeyManager.hx
+++ b/flixel/input/FlxKeyManager.hx
@@ -228,6 +228,9 @@ class FlxKeyManager<Key:Int, KeyList:FlxBaseKeyList> implements IFlxInputManager
 	 */
 	public function destroy():Void
 	{
+		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
+		FlxG.stage.removeEventListener(KeyboardEvent.KEY_UP, onKeyUp);
+		
 		_keyListArray = null;
 		_keyListMap = null;
 	}


### PR DESCRIPTION
Can be easily replicated by destroying an `FlxKeyboard` / `FlxKeyManager`.