### PR TITLE
replace callback with onLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `FlxAnimationController`: Add `onLoop`, `onFrameChange` and `onFinish`, to replace `callback` and `finishCallback` ([#3205](https://github.com/HaxeFlixel/flixel/pull/3205)) ([#3216](https://github.com/HaxeFlixel/flixel/pull/3216))
 - `FlxStrip`: Add support for blendmodes ([#3213](https://github.com/HaxeFlixel/flixel/pull/3213))
 - `FlxTextBorderStyle`: Add SHADOW_XY, prevent border clipping ([#3236](https://github.com/HaxeFlixel/flixel/pull/3236))
-- `LogStyle`: Add `callback` to replace `callbackFunction` ([#3239](https://github.com/HaxeFlixel/flixel/pull/3239))
+- `LogStyle`: Add `onLog` signal to replace `callbackFunction` ([#3239](https://github.com/HaxeFlixel/flixel/pull/3239))([#3307](https://github.com/HaxeFlixel/flixel/pull/3307))
 - `FlxBar`: Add custom border sizes ([#3234](https://github.com/HaxeFlixel/flixel/pull/3234))
 - Gamepads: Add `acceptMode` and "mapped inputs" ([#3276](https://github.com/HaxeFlixel/flixel/pull/3276)) ([#3280](https://github.com/HaxeFlixel/flixel/pull/3280))
   - Add `ACCEPT` and `CANCEL` input IDs that conditionally map to either `A` or `B` depending on `FlxG.gamepads.acceptMode`

--- a/flixel/system/debug/log/LogStyle.hx
+++ b/flixel/system/debug/log/LogStyle.hx
@@ -1,5 +1,7 @@
 package flixel.system.debug.log;
 
+import flixel.util.FlxSignal;
+
 using flixel.util.FlxStringUtil;
 
 /**
@@ -43,8 +45,10 @@ class LogStyle
 	
 	/**
 	 * A callback function that is called when this LogStyle is used
+	 * **Note:** Unlike the deprecated `callbackFunction`, this is called every time,
+	 * even when logged with `once = true` and even in release mode.
 	 */
-	public var callback:(data:Any)->Void;
+	public final onLog = new FlxTypedSignal<(data:Any)->Void>();
 
 	/**
 	 * Whether an exception is thrown when this LogStyle is used.
@@ -81,7 +85,8 @@ class LogStyle
 		this.errorSound = errorSound;
 		this.openConsole = openConsole;
 		this.callbackFunction = callbackFunction;
-		this.callback = callback;
+		if (callback != null)
+			onLog.add(callback);
 		this.throwException = throwException;
 	}
 	

--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -50,16 +50,15 @@ class LogFrontEnd
 		if (style == null)
 			style = LogStyle.NORMAL;
 		
-		if (!(data is Array))
-			data = [data];
+		final arrayData = (!(data is Array) ? [data] : cast data);
 		
 		#if FLX_DEBUG
 		// Check null game since `FlxG.save.bind` may be called before `new FlxGame`
 		if (FlxG.game == null || FlxG.game.debugger == null)
 		{
-			_standardTraceFunction(data);
+			_standardTraceFunction(arrayData);
 		}
-		else if (FlxG.game.debugger.log.add(data, style, fireOnce))
+		else if (FlxG.game.debugger.log.add(arrayData, style, fireOnce))
 		{
 			#if (FLX_SOUND_SYSTEM && !FLX_UNIT_TEST)
 			if (style.errorSound != null)
@@ -75,14 +74,13 @@ class LogFrontEnd
 			
 			if (style.callbackFunction != null)
 				style.callbackFunction();
-			
-			if (style.callback != null)
-				style.callback(data);
 		}
 		#end
 		
+		style.onLog.dispatch(data);
+		
 		if (style.throwException)
-			throw style.toLogString(data);
+			throw style.toLogString(arrayData);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3273
Removes the new `callback` field and adds a `onLog` signal. onLog fires even in release mode, and ignores fireOnce