### PR TITLE
Update outdated documentation for BitmapFrontEnd.

### DIFF
--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -163,7 +163,7 @@ class BitmapFrontEnd
 	 * Caches the specified graphic.
 	 *
 	 * @param   graphic  The graphic to cache.
-	 * @return	The cached graphic.
+	 * @return  The cached graphic.
 	 */
 	public inline function addGraphic(graphic:FlxGraphic):FlxGraphic
 	{
@@ -174,7 +174,7 @@ class BitmapFrontEnd
 	/**
 	 * Gets an FlxGraphic object from this storage from its key.
 	 * 
-	 * @param	key	The FlxGraphics key (or name).
+	 * @param	key	 The FlxGraphics key (or name).
 	 * @return	The FlxGraphic with the specified key, or null if the object doesn't exist.
 	 */
 	public inline function get(key:String):FlxGraphic
@@ -185,8 +185,8 @@ class BitmapFrontEnd
 	/**
 	 * Gets a key from a cached BitmapData.
 	 *
-	 * @param  bmd BitmapData to find in the cache.
-	 * @return The BitmapData's key or null if there isn't such BitmapData in cache.
+	 * @param   bmd  BitmapData to find in the cache.
+	 * @return   The BitmapData's key or null if there isn't such BitmapData in cache.
 	 */
 	public function findKeyForBitmap(bmd:BitmapData):String
 	{
@@ -202,8 +202,8 @@ class BitmapFrontEnd
 	/**
 	 * Helper method for getting cache key for FlxGraphic objects created from the class.
 	 *
-	 * @param	source BitmapData source class.
-	 * @return	Full name for provided class.
+	 * @param   source  BitmapData source class.
+	 * @return  Full name for provided class.
 	 */
 	public inline function getKeyForClass(source:Class<Dynamic>):String
 	{
@@ -233,8 +233,8 @@ class BitmapFrontEnd
 	/**
 	 * Gets unique key for bitmap cache.
 	 *
-	 * @param	baseKey	key's prefix.
-	 * @return	unique key.
+	 * @param   baseKey  key's prefix.
+	 * @return  unique key.
 	 */
 	public function getUniqueKey(?baseKey:String):String
 	{
@@ -261,11 +261,11 @@ class BitmapFrontEnd
 	 * Generates key from provided base key and information about tile size and offsets in spritesheet
 	 * and the region of image to use as spritesheet graphics source.
 	 *
-	 * @param	baseKey			Beginning of the key. Usually it is the key for original spritesheet graphics (like "assets/tile.png").
-	 * @param	frameSize		The size of tile in spritesheet.
-	 * @param	frameSpacing	Offsets between tiles in offsets.
-	 * @param	region			Region of image to use as spritesheet graphics source.
-	 * @return	Generated key for spritesheet with inserted spaces between tiles.
+	 * @param   baseKey       Beginning of the key. Usually it is the key for original spritesheet graphics (like "assets/tile.png").
+	 * @param   frameSize     The size of tile in spritesheet.
+	 * @param   frameSpacing  Offsets between tiles in offsets.
+	 * @param   region        Region of image to use as spritesheet graphics source.
+	 * @return  Generated key for spritesheet with inserted spaces between tiles.
 	 */
 	public function getKeyWithSpacesAndBorders(baseKey:String, ?frameSize:FlxPoint, ?frameSpacing:FlxPoint, ?frameBorder:FlxPoint, ?region:FlxRect):String
 	{
@@ -288,7 +288,7 @@ class BitmapFrontEnd
 
 	/**
 	 * Totally removes specified FlxGraphic object.
-	 * @param graphic The object you want to remove and destroy.
+	 * @param   graphic  The object you want to remove and destroy.
 	 */
 	public function remove(graphic:FlxGraphic):Void
 	{
@@ -303,7 +303,7 @@ class BitmapFrontEnd
 
 	/**
 	 * Totally removes FlxGraphic object with specified key.
-	 * @param key Key of the cached FlxGraphic object.
+	 * @param   key  Key of the cached graphic.
 	 */
 	public function removeByKey(key:String):Void
 	{

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -132,7 +132,7 @@ class BitmapFrontEnd
 	 * @param   key     Force the cache to use a specific Key to index the bitmap.
 	 * @return  The created graphic.
 	 */
-	public function create(width:Int, height:Int, color:FlxColor, unique:Bool = false, ?key:String):FlxGraphic
+	public function create(width:Int, height:Int, color:FlxColor, unique = false, ?key:String):FlxGraphic
 	{
 		return FlxGraphic.fromRectangle(width, height, color, unique, key);
 	}

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -162,7 +162,7 @@ class BitmapFrontEnd
 	/**
 	 * Caches a specified FlxGraphic object.
 	 *
-	 * @param	graphic	FlxGraphic to store in the cache.
+	 * @param   graphic  The graphic to cache.
 	 * @return	Cached FlxGraphic object.
 	 */
 	public inline function addGraphic(graphic:FlxGraphic):FlxGraphic

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -160,7 +160,7 @@ class BitmapFrontEnd
 	}
 
 	/**
-	 * Caches a specified FlxGraphic object.
+	 * Caches the specified graphic.
 	 *
 	 * @param   graphic  The graphic to cache.
 	 * @return	Cached FlxGraphic object.

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -125,12 +125,12 @@ class BitmapFrontEnd
 	/**
 	 * Creates a new FlxGraphic object (a colored rectangle) and caches it.
 	 *
-	 * @param	width	How wide the rectangle should be.
-	 * @param	height	How high the rectangle should be.
-	 * @param	color	What color the rectangle should be (0xAARRGGBB).
-	 * @param	unique	Ensures that the bitmap data uses a new slot in the cache.
-	 * @param	key		Force the cache to use a specific Key to index the bitmap.
-	 * @return	The FlxGraphic we just created.
+	 * @param   width   How wide the rectangle should be.
+	 * @param   height  How high the rectangle should be.
+	 * @param   color   What color the rectangle should be (0xAARRGGBB).
+	 * @param   unique  Ensures that the bitmap data uses a new slot in the cache.
+	 * @param   key     Force the cache to use a specific Key to index the bitmap.
+	 * @return  The created graphic.
 	 */
 	public function create(width:Int, height:Int, color:FlxColor, unique:Bool = false, ?key:String):FlxGraphic
 	{

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -186,7 +186,7 @@ class BitmapFrontEnd
 	 * Gets a key from a cached BitmapData.
 	 *
 	 * @param   bmd  BitmapData to find in the cache.
-	 * @return   The BitmapData's key or null if there isn't such BitmapData in cache.
+	 * @return  The BitmapData's key or null if there isn't such BitmapData in cache.
 	 */
 	public function findKeyForBitmap(bmd:BitmapData):String
 	{

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -114,12 +114,12 @@ class BitmapFrontEnd
 	/**
 	 * Check the local bitmap cache to see if a bitmap with this key has been loaded already.
 	 *
-	 * @param	Key	The key identifying the bitmap.
-	 * @return	Whether or not this file can be found in the cache.
+	 * @param   key  The key identifying the bitmap.
+	 * @return  Whether or not this file can be found in the cache.
 	 */
-	public inline function checkCache(Key:String):Bool
+	public inline function checkCache(key:String):Bool
 	{
-		return get(Key) != null;
+		return get(key) != null;
 	}
 
 	/**
@@ -174,8 +174,8 @@ class BitmapFrontEnd
 	/**
 	 * Gets an FlxGraphic object from this storage from its key.
 	 * 
-	 * @param	key	 The FlxGraphics key (or name).
-	 * @return	The FlxGraphic with the specified key, or null if the object doesn't exist.
+	 * @param   key  The FlxGraphics key (or name).
+	 * @return  The FlxGraphic with the specified key, or null if the object doesn't exist.
 	 */
 	public inline function get(key:String):FlxGraphic
 	{
@@ -213,12 +213,12 @@ class BitmapFrontEnd
 	/**
 	 * Creates string key for further caching.
 	 *
-	 * @param	systemKey	The first string key to use as a base for a new key. It's usually an asset key ("assets/image.png").
-	 * @param	userKey		The second string key to use as a base for a new key. It's usually a key provided by the user
-	 * @param	unique		Whether generated key should be unique or not.
-	 * @return	Created key.
+	 * @param   systemKey  The first string key to use as a base for a new key. It's usually an asset key ("assets/image.png").
+	 * @param   userKey    The second string key to use as a base for a new key. It's usually a key provided by the user
+	 * @param   unique     Whether generated key should be unique or not.
+	 * @return  Created key.
 	 */
-	public function generateKey(systemKey:String, userKey:String, unique:Bool = false):String
+	public function generateKey(systemKey:String, userKey:String, unique = false):String
 	{
 		var key:String = userKey;
 		if (key == null)

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -1,6 +1,5 @@
 package flixel.system.frontEnds;
 
-import openfl.display.BitmapData;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.frames.FlxFrame;
 import flixel.math.FlxPoint;
@@ -8,6 +7,7 @@ import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import openfl.Assets;
+import openfl.display.BitmapData;
 #if FLX_OPENGL_AVAILABLE
 import lime.graphics.opengl.GL;
 #end
@@ -114,7 +114,7 @@ class BitmapFrontEnd
 	/**
 	 * Check the local bitmap cache to see if a bitmap with this key has been loaded already.
 	 *
-	 * @param	Key		The string key identifying the bitmap.
+	 * @param	Key	The key identifying the bitmap.
 	 * @return	Whether or not this file can be found in the cache.
 	 */
 	public inline function checkCache(Key:String):Bool
@@ -123,51 +123,48 @@ class BitmapFrontEnd
 	}
 
 	/**
-	 * Generates a new BitmapData object (a colored rectangle) and caches it.
+	 * Creates a new FlxGraphic object (a colored rectangle) and caches it.
 	 *
-	 * @param	Width	How wide the rectangle should be.
-	 * @param	Height	How high the rectangle should be.
-	 * @param	Color	What color the rectangle should be (0xAARRGGBB)
-	 * @param	Unique	Ensures that the bitmap data uses a new slot in the cache.
-	 * @param	Key		Force the cache to use a specific Key to index the bitmap.
-	 * @return	The BitmapData we just created.
+	 * @param	width	How wide the rectangle should be.
+	 * @param	height	How high the rectangle should be.
+	 * @param	color	What color the rectangle should be (0xAARRGGBB).
+	 * @param	unique	Ensures that the bitmap data uses a new slot in the cache.
+	 * @param	key		Force the cache to use a specific Key to index the bitmap.
+	 * @return	The FlxGraphic we just created.
 	 */
-	public function create(Width:Int, Height:Int, Color:FlxColor, Unique:Bool = false, ?Key:String):FlxGraphic
+	public function create(width:Int, height:Int, color:FlxColor, unique:Bool = false, ?key:String):FlxGraphic
 	{
-		return FlxGraphic.fromRectangle(Width, Height, Color, Unique, Key);
+		return FlxGraphic.fromRectangle(width, height, color, unique, key);
 	}
 
 	/**
 	 * Loads a bitmap from a file, clones it if necessary and caches it.
-	 * @param	Graphic		Optional FlxGraphics object to create FlxGraphic from.
-	 * @param	Frames			Optional FlxFramesCollection object to create FlxGraphic from.
-	 * @param	Bitmap			Optional BitmapData object to create FlxGraphic from.
-	 * @param	BitmapClass	Optional Class for BitmapData to create FlxGraphic from.
-	 * @param	Str			Optional String key to use for FlxGraphic instantiation.
-	 * @param	Unique			Ensures that the bitmap data uses a new slot in the cache.
-	 * @param	Key				Force the cache to use a specific Key to index the bitmap.
+	 * 
+	 * @param	graphic FlxGraphic object, BitmapData or String from which to create the new FlxGraphic.
+	 * @param	unique Ensures that the bitmap data uses a new slot in the cache.
+	 * @param	key Sets a custom key (or name) to the newly created FlxGraphic. 
 	 * @return	The FlxGraphic we just created.
 	 */
-	public function add(Graphic:FlxGraphicAsset, Unique:Bool = false, ?Key:String):FlxGraphic
+	public function add(graphic:FlxGraphicAsset, unique:Bool = false, ?key:String):FlxGraphic
 	{
-		if ((Graphic is FlxGraphic))
+		if (graphic is FlxGraphic)
 		{
-			return FlxGraphic.fromGraphic(cast Graphic, Unique, Key);
+			return FlxGraphic.fromGraphic(cast graphic, unique, key);
 		}
-		else if ((Graphic is BitmapData))
+		else if (graphic is BitmapData)
 		{
-			return FlxGraphic.fromBitmapData(cast Graphic, Unique, Key);
+			return FlxGraphic.fromBitmapData(cast graphic, unique, key);
 		}
 
 		// String case
-		return FlxGraphic.fromAssetKey(Std.string(Graphic), Unique, Key);
+		return FlxGraphic.fromAssetKey(Std.string(graphic), unique, key);
 	}
 
 	/**
-	 * Caches specified FlxGraphic object.
+	 * Caches a specified FlxGraphic object.
 	 *
 	 * @param	graphic	FlxGraphic to store in the cache.
-	 * @return	cached FlxGraphic object.
+	 * @return	Cached FlxGraphic object.
 	 */
 	public inline function addGraphic(graphic:FlxGraphic):FlxGraphic
 	{
@@ -176,9 +173,10 @@ class BitmapFrontEnd
 	}
 
 	/**
-	 * Gets FlxGraphic object from this storage by specified key.
-	 * @param	key	Key for FlxGraphic object (its name)
-	 * @return	FlxGraphic with the key name, or null if there is no such object
+	 * Gets an FlxGraphic object from this storage from its key.
+	 * 
+	 * @param	key	The FlxGraphics key (or name).
+	 * @return	The FlxGraphic with the specified key, or null if the object doesn't exist.
 	 */
 	public inline function get(key:String):FlxGraphic
 	{
@@ -186,10 +184,10 @@ class BitmapFrontEnd
 	}
 
 	/**
-	 * Gets key from bitmap cache for specified BitmapData
+	 * Gets a key from a cached BitmapData.
 	 *
-	 * @param	bmd	BitmapData to find in cache
-	 * @return	BitmapData's key or null if there isn't such BitmapData in cache
+	 * @param  bmd BitmapData to find in the cache.
+	 * @return The BitmapData's key or null if there isn't such BitmapData in cache.
 	 */
 	public function findKeyForBitmap(bmd:BitmapData):String
 	{
@@ -205,7 +203,7 @@ class BitmapFrontEnd
 	/**
 	 * Helper method for getting cache key for FlxGraphic objects created from the class.
 	 *
-	 * @param	source	BitmapData source class.
+	 * @param	source BitmapData source class.
 	 * @return	Full name for provided class.
 	 */
 	public inline function getKeyForClass(source:Class<Dynamic>):String
@@ -234,10 +232,10 @@ class BitmapFrontEnd
 	}
 
 	/**
-	 * Gets unique key for bitmap cache
+	 * Gets unique key for bitmap cache.
 	 *
-	 * @param	baseKey	key's prefix
-	 * @return	unique key
+	 * @param	baseKey	key's prefix.
+	 * @return	unique key.
 	 */
 	public function getUniqueKey(?baseKey:String):String
 	{
@@ -264,11 +262,11 @@ class BitmapFrontEnd
 	 * Generates key from provided base key and information about tile size and offsets in spritesheet
 	 * and the region of image to use as spritesheet graphics source.
 	 *
-	 * @param	baseKey			Beginning of the key. Usually it is the key for original spritesheet graphics (like "assets/tile.png")
-	 * @param	frameSize		the size of tile in spritesheet
-	 * @param	frameSpacing	offsets between tiles in offsets
-	 * @param	region			region of image to use as spritesheet graphics source
-	 * @return	Generated key for spritesheet with inserted spaces between tiles
+	 * @param	baseKey			Beginning of the key. Usually it is the key for original spritesheet graphics (like "assets/tile.png").
+	 * @param	frameSize		The size of tile in spritesheet.
+	 * @param	frameSpacing	Offsets between tiles in offsets.
+	 * @param	region			Region of image to use as spritesheet graphics source.
+	 * @return	Generated key for spritesheet with inserted spaces between tiles.
 	 */
 	public function getKeyWithSpacesAndBorders(baseKey:String, ?frameSize:FlxPoint, ?frameSpacing:FlxPoint, ?frameBorder:FlxPoint, ?region:FlxRect):String
 	{
@@ -291,7 +289,7 @@ class BitmapFrontEnd
 
 	/**
 	 * Totally removes specified FlxGraphic object.
-	 * @param   graphic  object you want to remove and destroy.
+	 * @param graphic The object you want to remove and destroy.
 	 */
 	public function remove(graphic:FlxGraphic):Void
 	{
@@ -306,7 +304,7 @@ class BitmapFrontEnd
 
 	/**
 	 * Totally removes FlxGraphic object with specified key.
-	 * @param	key	the key for cached FlxGraphic object.
+	 * @param key Key of the cached FlxGraphic object.
 	 */
 	public function removeByKey(key:String):Void
 	{

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -123,7 +123,7 @@ class BitmapFrontEnd
 	}
 
 	/**
-	 * Creates a new FlxGraphic object (a colored rectangle) and caches it.
+	 * Creates a new graphic of a colored rectangle and caches it.
 	 *
 	 * @param   width   How wide the rectangle should be.
 	 * @param   height  How high the rectangle should be.

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -163,7 +163,7 @@ class BitmapFrontEnd
 	 * Caches the specified graphic.
 	 *
 	 * @param   graphic  The graphic to cache.
-	 * @return	Cached FlxGraphic object.
+	 * @return	The cached graphic.
 	 */
 	public inline function addGraphic(graphic:FlxGraphic):FlxGraphic
 	{


### PR DESCRIPTION
- Changed arguments to start with a lowercase letter.
- Fixed documentation ported over from flash(?), where the documented @:params would not align to function arguments.