### PR TITLE
Automatically append file extension to sound asset ids

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -337,6 +337,8 @@ class FlxSound extends FlxBasic
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from an embedded MP3.
 	 *
+	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 *
 	 * @param	EmbeddedSound	An embedded Class object representing an MP3 file.
 	 * @param	Looped			Whether or not this sound should loop endlessly.
 	 * @param	AutoDestroy		Whether or not this FlxSound instance should be destroyed when the sound finishes playing.

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -241,9 +241,11 @@ class AssetFrontEnd
 	 */
 	public dynamic function exists(id:String, ?type:FlxAssetType)
 	{
+		#if FLX_SOUND_ADD_EXT
 		// add file extension
 		if (type == SOUND)
-			id = addSoundExtIf(id);
+			id = addSoundExt(id);
+		#end
 		
 		#if FLX_STANDARD_ASSETS_DIRECTORY
 		return Assets.exists(id, type.toOpenFlType());
@@ -267,9 +269,11 @@ class AssetFrontEnd
 	 */
 	public dynamic function isLocal(id:String, ?type:FlxAssetType, useCache = true)
 	{
+		#if FLX_SOUND_ADD_EXT
 		// add file extension
 		if (type == SOUND)
-			id = addSoundExtIf(id);
+			id = addSoundExt(id);
+		#end
 		
 		#if FLX_STANDARD_ASSETS_DIRECTORY
 		return Assets.isLocal(id, type.toOpenFlType(), useCache);

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -85,10 +85,10 @@ class AssetFrontEnd
 	public function new () {}
 	#end
 	
-	#if (FLX_SOUND_ADD_EXT == "1" || FLX_SOUND_NO_ADD_EXT)
+	#if (FLX_DEFAULT_SOUND_EXT == "1" || FLX_NO_DEFAULT_SOUND_EXT)
 	public final defaultSoundExtension:String = #if flash ".mp3" #else ".ogg" #end;
 	#else
-	public final defaultSoundExtension:String = '.${haxe.macro.Compiler.getDefine("FLX_SOUND_ADD_EXT")}';
+	public final defaultSoundExtension:String = '.${haxe.macro.Compiler.getDefine("FLX_DEFAULT_SOUND_EXT")}';
 	#end
 	
 	/**
@@ -237,7 +237,7 @@ class AssetFrontEnd
 	 */
 	public dynamic function exists(id:String, ?type:FlxAssetType)
 	{
-		#if FLX_SOUND_ADD_EXT
+		#if FLX_DEFAULT_SOUND_EXT
 		// add file extension
 		if (type == SOUND)
 			id = addSoundExt(id);
@@ -265,7 +265,7 @@ class AssetFrontEnd
 	 */
 	public dynamic function isLocal(id:String, ?type:FlxAssetType, useCache = true)
 	{
-		#if FLX_SOUND_ADD_EXT
+		#if FLX_DEFAULT_SOUND_EXT
 		// add file extension
 		if (type == SOUND)
 			id = addSoundExt(id);
@@ -351,7 +351,7 @@ class AssetFrontEnd
 	/**
 	 * Gets an instance of a sound, logs when the asset is not found.
 	 * 
-	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
 	 * @param   id        The ID or asset path for the sound
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
@@ -378,7 +378,7 @@ class AssetFrontEnd
 	
 	inline function addSoundExtIf(id:String)
 	{
-		#if FLX_SOUND_ADD_EXT
+		#if FLX_DEFAULT_SOUND_EXT
 		return addSoundExt(id);
 		#else
 		return id;

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -85,14 +85,10 @@ class AssetFrontEnd
 	public function new () {}
 	#end
 	
-	#if (FLX_SOUND_ADD_EXT == "wav")
-	public static final defaultSoundExtension:String = '.wav';
-	#elseif (FLX_SOUND_ADD_EXT == "mp3")
-	public static final defaultSoundExtension:String = '.mp3';
-	#elseif (FLX_SOUND_ADD_EXT == "ogg")
-	public static final defaultSoundExtension:String = '.ogg';
+	#if (FLX_SOUND_ADD_EXT == "1" || FLX_SOUND_NO_ADD_EXT)
+	public final defaultSoundExtension:String = #if flash ".mp3" #else ".ogg" #end;
 	#else
-	public static final defaultSoundExtension:String = #if flash ".mp3" #else ".ogg" #end;
+	public final defaultSoundExtension:String = '.${haxe.macro.Compiler.getDefine("FLX_SOUND_ADD_EXT")}';
 	#end
 	
 	/**

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -85,6 +85,16 @@ class AssetFrontEnd
 	public function new () {}
 	#end
 	
+	#if (FLX_SOUND_ADD_EXT == "wav")
+	public static final defaultSoundExtension:String = '.wav';
+	#elseif (FLX_SOUND_ADD_EXT == "mp3")
+	public static final defaultSoundExtension:String = '.mp3';
+	#elseif (FLX_SOUND_ADD_EXT == "ogg")
+	public static final defaultSoundExtension:String = '.ogg';
+	#else
+	public static final defaultSoundExtension:String = #if flash ".mp3" #else ".ogg" #end;
+	#end
+	
 	/**
 	 * Used by methods like `getAsset`, `getBitmapData`, `getText`, their "unsafe" counterparts and
 	 * the like to get assets synchronously. Can be set to a custom function to avoid the existing
@@ -378,7 +388,7 @@ class AssetFrontEnd
 	inline function addSoundExt(id:String)
 	{
 		if (!id.endsWith(".mp3") && !id.endsWith(".ogg") && !id.endsWith(".wav"))
-			return id + "." + #if flash "mp3" #else "ogg" #end;
+			return id + defaultSoundExtension;
 			
 		return id;
 	}

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -231,6 +231,10 @@ class AssetFrontEnd
 	 */
 	public dynamic function exists(id:String, ?type:FlxAssetType)
 	{
+		// add file extension
+		if (type == SOUND)
+			id = addSoundExtIf(id);
+		
 		#if FLX_STANDARD_ASSETS_DIRECTORY
 		return Assets.exists(id, type.toOpenFlType());
 		#else
@@ -253,6 +257,10 @@ class AssetFrontEnd
 	 */
 	public dynamic function isLocal(id:String, ?type:FlxAssetType, useCache = true)
 	{
+		// add file extension
+		if (type == SOUND)
+			id = addSoundExtIf(id);
+		
 		#if FLX_STANDARD_ASSETS_DIRECTORY
 		return Assets.isLocal(id, type.toOpenFlType(), useCache);
 		#else
@@ -327,11 +335,13 @@ class AssetFrontEnd
 	 */
 	public inline function getSoundUnsafe(id:String, useCache = true):Sound
 	{
-		return cast getAssetUnsafe(id, SOUND, useCache);
+		return cast getAssetUnsafe(addSoundExtIf(id), SOUND, useCache);
 	}
 	
 	/**
-	 * Gets an instance of a sound, logs when the asset is not found
+	 * Gets an instance of a sound, logs when the asset is not found.
+	 * 
+	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
 	 * 
 	 * @param   id        The ID or asset path for the sound
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
@@ -340,7 +350,7 @@ class AssetFrontEnd
 	 */
 	public inline function getSound(id:String, useCache = true, ?logStyle:LogStyle):Sound
 	{
-		return cast getAsset(id, SOUND, useCache, logStyle);
+		return cast getAsset(addSoundExtIf(id), SOUND, useCache, logStyle);
 	}
 	
 	/**
@@ -353,10 +363,24 @@ class AssetFrontEnd
 	 */
 	public inline function getSoundAddExt(id:String, useCache = true, ?logStyle:LogStyle):Sound
 	{
+		return getSound(addSoundExt(id), useCache, logStyle);
+	}
+	
+	inline function addSoundExtIf(id:String)
+	{
+		#if FLX_SOUND_ADD_EXT
+		return addSoundExt(id);
+		#else
+		return id;
+		#end
+	}
+	
+	inline function addSoundExt(id:String)
+	{
 		if (!id.endsWith(".mp3") && !id.endsWith(".ogg") && !id.endsWith(".wav"))
-			id += "." + #if flash "mp3" #else "ogg" #end;
+			return id + "." + #if flash "mp3" #else "ogg" #end;
 			
-		return getSound(id, useCache, logStyle);
+		return id;
 	}
 	
 	/**

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -103,6 +103,8 @@ class SoundFrontEnd
 	/**
 	 * Set up and play a looping background soundtrack.
 	 *
+	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 *
 	 * @param   embeddedMusic  The sound file you want to loop in the background.
 	 * @param   volume         How loud the sound should be, from 0 to 1.
 	 * @param   looped         Whether to loop this music.
@@ -131,6 +133,8 @@ class SoundFrontEnd
 
 	/**
 	 * Creates a new FlxSound object.
+	 *
+	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
 	 *
 	 * @param   embeddedSound   The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
 	 * @param   volume          How loud to play it (0 to 1).
@@ -229,6 +233,8 @@ class SoundFrontEnd
 
 	/**
 	 * Plays a sound from an embedded sound. Tries to recycle a cached sound first.
+	 *
+	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
 	 *
 	 * @param   embeddedSound  The embedded sound resource you want to play.
 	 * @param   volume         How loud to play it (0 to 1).

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -55,7 +55,7 @@ private enum UserDefines
 	/**
 	 * Allows you to use sound paths with no extension, and the default sound type for that
 	 * target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
-	 * If this flag is set to "wav", "mp3" or "ogg" if will use that type
+	 * If this flag is set to any string, that is used for the file extension
 	 */
 	FLX_SOUND_ADD_EXT;
 }

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -57,7 +57,7 @@ private enum UserDefines
 	 * target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
 	 * If this flag is set to any string, that is used for the file extension
 	 */
-	FLX_SOUND_ADD_EXT;
+	FLX_DEFAULT_SOUND_EXT;
 }
 
 /**
@@ -106,7 +106,7 @@ private enum HelperDefines
 	FLX_STANDARD_ASSETS_DIRECTORY;
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
-	FLX_SOUND_NO_ADD_EXT;
+	FLX_NO_DEFAULT_SOUND_EXT;
 }
 
 class FlxDefines
@@ -207,7 +207,7 @@ class FlxDefines
 		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
 		defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
 		defineInversion(FLX_TRACK_POOLS, FLX_NO_TRACK_POOLS);
-		defineInversion(FLX_SOUND_ADD_EXT, FLX_SOUND_NO_ADD_EXT);
+		defineInversion(FLX_DEFAULT_SOUND_EXT, FLX_NO_DEFAULT_SOUND_EXT);
 		// defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS); // special case
 	}
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -53,7 +53,9 @@ private enum UserDefines
 	 */
 	FLX_CUSTOM_ASSETS_DIRECTORY;
 	/**
-	 * allows you to use sound paths with no extension, and the default sound type for that target will be used
+	 * Allows you to use sound paths with no extension, and the default sound type for that
+	 * target will be used. If enabled it will use ogg on all targets except flash, which uses mp3.
+	 * If this flag is set to "wav", "mp3" or "ogg" if will use that type
 	 */
 	FLX_SOUND_ADD_EXT;
 }

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -106,7 +106,7 @@ private enum HelperDefines
 	FLX_STANDARD_ASSETS_DIRECTORY;
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
-	FLX_SOUND_NO_ADD_EXT
+	FLX_SOUND_NO_ADD_EXT;
 }
 
 class FlxDefines

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -52,6 +52,10 @@ private enum UserDefines
 	 * any `</asset>` tags in your project.xml, to reduce your total memory
 	 */
 	FLX_CUSTOM_ASSETS_DIRECTORY;
+	/**
+	 * allows you to use sound paths with no extension, and the default sound type for that target will be used
+	 */
+	FLX_SOUND_ADD_EXT;
 }
 
 /**
@@ -100,6 +104,7 @@ private enum HelperDefines
 	FLX_STANDARD_ASSETS_DIRECTORY;
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
+	FLX_SOUND_NO_ADD_EXT
 }
 
 class FlxDefines
@@ -200,6 +205,7 @@ class FlxDefines
 		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
 		defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
 		defineInversion(FLX_TRACK_POOLS, FLX_NO_TRACK_POOLS);
+		defineInversion(FLX_SOUND_ADD_EXT, FLX_SOUND_NO_ADD_EXT);
 		// defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS); // special case
 	}
 

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -54,6 +54,7 @@
 		<haxedef name="FLX_NO_SAVE" />
 		<haxedef name="FLX_NO_HEALTH" />
 		<haxedef name="FLX_4_LEGACY_COLLISION" />
+		<haxedef name="FLX_SOUND_ADD_EXT" />
 	</section>
 	<section if="coverage2">
 		<haxedef name="debug" />
@@ -77,5 +78,6 @@
 		<haxedef name="FLX_NO_SAVE" />
 		<haxedef name="FLX_NO_HEALTH" />
 		<haxedef name="FLX_4_LEGACY_COLLISION" />
+		<haxedef name="FLX_SOUND_ADD_EXT" />
 	</section>
 </project>


### PR DESCRIPTION
Define flag FLX_DEFAULT_SOUND_EXT to allow sound asset ids to omit the extension. Useful when targeting multiple platforms that use different sound files. Can also use the flag to determine the desired sound extension, setting the flags value to "mp3" "wav" or "ogg" will use that extension. The default extension can be read via `FlxG.assets.defaultSoundExtension`