### PR TITLE
Fix outdated references to FLX_SOUND_ADD_EXT

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -337,7 +337,7 @@ class FlxSound extends FlxBasic
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from an embedded MP3.
 	 *
-	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 *
 	 * @param	EmbeddedSound	An embedded Class object representing an MP3 file.
 	 * @param	Looped			Whether or not this sound should loop endlessly.

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -103,7 +103,7 @@ class SoundFrontEnd
 	/**
 	 * Set up and play a looping background soundtrack.
 	 *
-	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 *
 	 * @param   embeddedMusic  The sound file you want to loop in the background.
 	 * @param   volume         How loud the sound should be, from 0 to 1.
@@ -134,7 +134,7 @@ class SoundFrontEnd
 	/**
 	 * Creates a new FlxSound object.
 	 *
-	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 *
 	 * @param   embeddedSound   The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
 	 * @param   volume          How loud to play it (0 to 1).
@@ -234,7 +234,7 @@ class SoundFrontEnd
 	/**
 	 * Plays a sound from an embedded sound. Tries to recycle a cached sound first.
 	 *
-	 * **Note:** If the `FLX_SOUND_ADD_EXT` flag is enabled, you may omit the file extension
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 *
 	 * @param   embeddedSound  The embedded sound resource you want to play.
 	 * @param   volume         How loud to play it (0 to 1).

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -54,7 +54,7 @@
 		<haxedef name="FLX_NO_SAVE" />
 		<haxedef name="FLX_NO_HEALTH" />
 		<haxedef name="FLX_4_LEGACY_COLLISION" />
-		<haxedef name="FLX_SOUND_ADD_EXT" />
+		<haxedef name="FLX_DEFAULT_SOUND_EXT" />
 	</section>
 	<section if="coverage2">
 		<haxedef name="debug" />
@@ -78,6 +78,6 @@
 		<haxedef name="FLX_NO_SAVE" />
 		<haxedef name="FLX_NO_HEALTH" />
 		<haxedef name="FLX_4_LEGACY_COLLISION" />
-		<haxedef name="FLX_SOUND_ADD_EXT" />
+		<haxedef name="FLX_DEFAULT_SOUND_EXT" />
 	</section>
 </project>


### PR DESCRIPTION
`FLX_SOUND_ADD_EXT` was renamed to `FLX_DEFAULT_SOUND_EXT` in https://github.com/HaxeFlixel/flixel/pull/3314/commits/457c83eb3801d6f438a14f55c098d14f0ecfe735 but there were still a couple of references to the old name