### PR TITLE
DisplayFrontEnd

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -214,7 +214,7 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Whether the positions of the objects rendered on this camera are rounded.
 	 * If set on individual objects, they ignore the global camera setting.
-	 * Defaults to `false` with `FlxG.renderTile` and to `true` with `FlxG.renderBlit`.
+	 * Defaults to `false` with `FlxG.renderTile` and to `true` with `FlxG.render.blit`.
 	 * WARNING: setting this to `false` on blitting targets is very expensive.
 	 */
 	public var pixelPerfectRender:Bool;
@@ -780,7 +780,7 @@ class FlxCamera extends FlxBasic
 	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix, ?transform:ColorTransform, ?blend:BlendMode, ?smoothing:Bool = false,
 			?shader:FlxShader):Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			_helperMatrix.copyFrom(matrix);
 
@@ -812,7 +812,7 @@ class FlxCamera extends FlxBasic
 	public function copyPixels(?frame:FlxFrame, ?pixels:BitmapData, ?sourceRect:Rectangle, destPoint:Point, ?transform:ColorTransform, ?blend:BlendMode,
 			?smoothing:Bool = false, ?shader:FlxShader):Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (pixels != null)
 			{
@@ -856,7 +856,7 @@ class FlxCamera extends FlxBasic
 	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>,
 			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false, ?transform:ColorTransform, ?shader:FlxShader):Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (position == null)
 				position = renderPoint.set();
@@ -953,7 +953,7 @@ class FlxCamera extends FlxBasic
 	 */
 	function transformRect(rect:FlxRect):FlxRect
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			rect.offset(-viewMarginLeft, -viewMarginTop);
 
@@ -976,7 +976,7 @@ class FlxCamera extends FlxBasic
 	 */
 	function transformPoint(point:FlxPoint):FlxPoint
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			point.subtract(viewMarginLeft, viewMarginTop);
 
@@ -994,7 +994,7 @@ class FlxCamera extends FlxBasic
 	 */
 	inline function transformVector(vector:FlxPoint):FlxPoint
 	{
-		if (FlxG.renderBlit && _useBlitMatrix)
+		if (FlxG.render.blit && _useBlitMatrix)
 			vector.scale(zoom);
 
 		return vector;
@@ -1046,9 +1046,9 @@ class FlxCamera extends FlxBasic
 		flashSprite.addChild(_scrollRect);
 		_scrollRect.scrollRect = new Rectangle();
 
-		pixelPerfectRender = FlxG.renderBlit;
+		pixelPerfectRender = FlxG.render.blit;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			screen = new FlxSprite();
 			buffer = new BitmapData(width, height, true, 0);
@@ -1089,7 +1089,7 @@ class FlxCamera extends FlxBasic
 	{
 		FlxDestroyUtil.removeChild(flashSprite, _scrollRect);
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			FlxDestroyUtil.removeChild(_scrollRect, _flashBitmap);
 			screen = FlxDestroyUtil.destroy(screen);
@@ -1424,7 +1424,7 @@ class FlxCamera extends FlxBasic
 	 */
 	function updateInternalSpritePositions():Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (_flashBitmap != null)
 			{
@@ -1688,7 +1688,7 @@ class FlxCamera extends FlxBasic
 	 */
 	public function fill(Color:FlxColor, BlendAlpha:Bool = true, FxAlpha:Float = 1.0, ?graphics:Graphics):Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (BlendAlpha)
 			{
@@ -1727,7 +1727,7 @@ class FlxCamera extends FlxBasic
 		// Draw the "flash" special effect onto the buffer
 		if (_fxFlashAlpha > 0.0)
 		{
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				var color = _fxFlashColor;
 				color.alphaFloat *= _fxFlashAlpha;
@@ -1743,7 +1743,7 @@ class FlxCamera extends FlxBasic
 		// Draw the "fade" special effect onto the buffer
 		if (_fxFadeAlpha > 0.0)
 		{
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				var color = _fxFadeColor;
 				color.alphaFloat *= _fxFadeAlpha;
@@ -1760,7 +1760,7 @@ class FlxCamera extends FlxBasic
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	function checkResize():Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (width != buffer.width || height != buffer.height)
 			{
@@ -1866,7 +1866,7 @@ class FlxCamera extends FlxBasic
 		totalScaleX = scaleX * FlxG.scaleMode.scale.x;
 		totalScaleY = scaleY * FlxG.scaleMode.scale.y;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			updateBlitMatrix();
 
@@ -2002,7 +2002,7 @@ class FlxCamera extends FlxBasic
 	function set_alpha(Alpha:Float):Float
 	{
 		alpha = FlxMath.bound(Alpha, 0, 1);
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			_flashBitmap.alpha = Alpha;
 		}
@@ -2025,7 +2025,7 @@ class FlxCamera extends FlxBasic
 		color = Color;
 		var colorTransform:ColorTransform;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (_flashBitmap == null)
 			{
@@ -2042,7 +2042,7 @@ class FlxCamera extends FlxBasic
 		colorTransform.greenMultiplier = color.greenFloat;
 		colorTransform.blueMultiplier = color.blueFloat;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			_flashBitmap.transform.colorTransform = colorTransform;
 		}
@@ -2057,7 +2057,7 @@ class FlxCamera extends FlxBasic
 	function set_antialiasing(Antialiasing:Bool):Bool
 	{
 		antialiasing = Antialiasing;
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			_flashBitmap.smoothing = Antialiasing;
 		}

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -12,6 +12,7 @@ import flixel.system.frontEnds.BitmapLogFrontEnd;
 import flixel.system.frontEnds.CameraFrontEnd;
 import flixel.system.frontEnds.ConsoleFrontEnd;
 import flixel.system.frontEnds.DebuggerFrontEnd;
+import flixel.system.frontEnds.DisplayFrontEnd;
 import flixel.system.frontEnds.InputFrontEnd;
 import flixel.system.frontEnds.LogFrontEnd;
 import flixel.system.frontEnds.PluginFrontEnd;
@@ -152,7 +153,9 @@ class FlxG
 
 	public static var renderBlit(default, null):Bool;
 	public static var renderTile(default, null):Bool;
-
+	
+	public static var display(default, null) = new DisplayFrontEnd();
+	
 	/**
 	 * Represents the amount of time in seconds that passed since last frame.
 	 */

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -12,10 +12,10 @@ import flixel.system.frontEnds.BitmapLogFrontEnd;
 import flixel.system.frontEnds.CameraFrontEnd;
 import flixel.system.frontEnds.ConsoleFrontEnd;
 import flixel.system.frontEnds.DebuggerFrontEnd;
-import flixel.system.frontEnds.DisplayFrontEnd;
 import flixel.system.frontEnds.InputFrontEnd;
 import flixel.system.frontEnds.LogFrontEnd;
 import flixel.system.frontEnds.PluginFrontEnd;
+import flixel.system.frontEnds.RenderFrontEnd;
 import flixel.system.frontEnds.SignalFrontEnd;
 import flixel.system.frontEnds.SoundFrontEnd;
 import flixel.system.frontEnds.VCRFrontEnd;
@@ -151,10 +151,15 @@ class FlxG
 
 	public static var renderMethod(default, null):FlxRenderMethod;
 
+	@:deprecated("FlxG.renderBlit is deprecated, use FlxG.render.blit, instead")
 	public static var renderBlit(default, null):Bool;
+	@:deprecated("FlxG.renderTile is deprecated, use FlxG.render.tile, instead")
 	public static var renderTile(default, null):Bool;
 	
-	public static var display(default, null) = new DisplayFrontEnd();
+	/**
+	 * 
+	 */
+	public static var render(default, null) = new RenderFrontEnd();
 	
 	/**
 	 * Represents the amount of time in seconds that passed since last frame.
@@ -620,6 +625,7 @@ class FlxG
 	 * Called by `FlxGame` to set up `FlxG` during `FlxGame`'s constructor.
 	 */
 	@:allow(flixel.FlxGame.new)
+	@:haxe.warning("-WDeprecated")
 	static function init(game:FlxGame, width:Int, height:Int):Void
 	{
 		if (width < 0)
@@ -631,12 +637,15 @@ class FlxG
 		FlxG.width = width;
 		FlxG.height = height;
 
-		initRenderMethod();
+		render.init();
+		renderMethod = render.method;
+		renderBlit = renderMethod == BLITTING;
+		renderTile = renderMethod == DRAW_TILES;
 
 		FlxG.initialWidth = width;
 		FlxG.initialHeight = height;
 
-		resizeGame(Lib.current.stage.stageWidth, Lib.current.stage.stageHeight);
+		resizeGame(stage.stageWidth, stage.stageHeight);
 
 		// Instantiate inputs
 		#if FLX_KEYBOARD
@@ -673,50 +682,6 @@ class FlxG
 		#if FLX_SOUND_SYSTEM
 		sound = new SoundFrontEnd();
 		#end
-	}
-
-	static function initRenderMethod():Void
-	{
-		renderMethod = BLITTING;
-
-		#if (!lime_legacy && !flash)
-		#if (lime >= "7.0.0")
-		renderMethod = switch (stage.window.context.type)
-		{
-			case OPENGL, OPENGLES, WEBGL: DRAW_TILES;
-			default: BLITTING;
-		}
-		#else
-		if (!Lib.application.config.windows[0].hardware)
-		{
-			renderMethod = BLITTING;
-		}
-		else
-		{
-			renderMethod = switch (stage.window.renderer.type)
-			{
-				case OPENGL, CONSOLE: DRAW_TILES;
-				case CANVAS, FLASH, CAIRO: BLITTING;
-				default: BLITTING;
-			}
-		}
-		#end
-		#else
-		#if web
-		renderMethod = BLITTING;
-		#else
-		renderMethod = DRAW_TILES;
-		#end
-		#end
-
-		#if air
-		renderMethod = BLITTING;
-		#end
-
-		renderBlit = renderMethod == BLITTING;
-		renderTile = renderMethod == DRAW_TILES;
-
-		FlxObject.defaultPixelPerfectPosition = renderBlit;
 	}
 
 	#if FLX_SAVE

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -472,7 +472,7 @@ class FlxGame extends Sprite
 		var height:Int = FlxG.stage.stageHeight;
 
 		#if !flash
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			FlxG.bitmap.onContext();
 		#end
 
@@ -863,7 +863,7 @@ class FlxGame extends Sprite
 
 		FlxG.signals.preDraw.dispatch();
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			FlxDrawBaseItem.drawCalls = 0;
 
 		#if FLX_POST_PROCESS
@@ -884,7 +884,7 @@ class FlxGame extends Sprite
 			_state.draw();
 		}
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			FlxG.cameras.render();
 

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1366,7 +1366,7 @@ class FlxObject extends FlxBasic
 
 	inline function beginDrawDebug(camera:FlxCamera):Graphics
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			FlxSpriteUtil.flashGfx.clear();
 			return FlxSpriteUtil.flashGfx;
@@ -1379,7 +1379,7 @@ class FlxObject extends FlxBasic
 
 	inline function endDrawDebug(camera:FlxCamera)
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
 	}
 	#end

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -150,7 +150,7 @@ class FlxSprite extends FlxObject
 	public var framePixels:BitmapData;
 
 	/**
-	 * Always `true` on `FlxG.renderBlit`. On `FlxG.renderTile` it determines whether
+	 * Always `true` on `FlxG.render.blit`. On `FlxG.render.tile` it determines whether
 	 * `framePixels` is used and defaults to `false` for performance reasons.
 	 */
 	public var useFramePixels(default, set):Bool = true;
@@ -246,7 +246,7 @@ class FlxSprite extends FlxObject
 	/**
 	 * Change the size of your sprite's graphic.
 	 * NOTE: The hitbox is not automatically adjusted, use `updateHitbox()` for that.
-	 * WARNING: With `FlxG.renderBlit`, scaling sprites decreases rendering performance by a factor of about x10!
+	 * WARNING: With `FlxG.render.blit`, scaling sprites decreases rendering performance by a factor of about x10!
 	 * @see https://snippets.haxeflixel.com/sprites/scale/
 	 */
 	public var scale(default, null):FlxPoint;
@@ -374,7 +374,7 @@ class FlxSprite extends FlxObject
 	{
 		super(X, Y);
 
-		useFramePixels = FlxG.renderBlit;
+		useFramePixels = FlxG.render.blit;
 		if (SimpleGraphic != null)
 			loadGraphic(SimpleGraphic);
 	}
@@ -758,7 +758,7 @@ class FlxSprite extends FlxObject
 
 		centerOrigin();
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			dirty = true;
 			updateFramePixels();
@@ -910,7 +910,7 @@ class FlxSprite extends FlxObject
 			graphic.bitmap.draw(bitmapData, _matrix, null, brushBlend, null, Brush.antialiasing);
 		}
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			dirty = true;
 			calcFrame();
@@ -925,7 +925,7 @@ class FlxSprite extends FlxObject
 	 */
 	public function drawFrame(Force:Bool = false):Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (Force || dirty)
 			{
@@ -984,7 +984,7 @@ class FlxSprite extends FlxObject
 
 	/**
 	 * Sets the sprite's color transformation with control over color offsets.
-	 * With `FlxG.renderTile`, offsets are only supported on OpenFL Next version 3.6.0 or higher.
+	 * With `FlxG.render.tile`, offsets are only supported on OpenFL Next version 3.6.0 or higher.
 	 *
 	 * @param   redMultiplier     The value for the red multiplier, in the range from `0` to `1`.
 	 * @param   greenMultiplier   The value for the green multiplier, in the range from `0` to `1`.
@@ -1169,7 +1169,7 @@ class FlxSprite extends FlxObject
 	{
 		checkEmptyFrame();
 
-		if (FlxG.renderTile && !force)
+		if (FlxG.render.tile && !force)
 			return;
 
 		updateFramePixels();
@@ -1185,7 +1185,7 @@ class FlxSprite extends FlxObject
 
 		// don't try to regenerate frame pixels if _frame already uses it as source of graphics
 		// if you'll try then it will clear framePixels and you won't see anything
-		if (FlxG.renderTile && _frameGraphic != null)
+		if (FlxG.render.tile && _frameGraphic != null)
 		{
 			dirty = false;
 			return framePixels;
@@ -1208,7 +1208,7 @@ class FlxSprite extends FlxObject
 			framePixels.colorTransform(_flashRect, colorTransform);
 		}
 
-		if (FlxG.renderTile && useFramePixels)
+		if (FlxG.render.tile && useFramePixels)
 		{
 			// recreate _frame for native target, so it will use modified framePixels
 			_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
@@ -1277,12 +1277,12 @@ class FlxSprite extends FlxObject
 	}
 
 	/**
-	 * Returns the result of `isSimpleRenderBlit()` if `FlxG.renderBlit` is
-	 * `true`, or `false` if `FlxG.renderTile` is `true`.
+	 * Returns the result of `isSimpleRenderBlit()` if `FlxG.render.blit` is
+	 * `true`, or `false` if `FlxG.render.tile` is `true`.
 	 */
 	public function isSimpleRender(?camera:FlxCamera):Bool
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			return false;
 
 		return isSimpleRenderBlit(camera);
@@ -1451,7 +1451,7 @@ class FlxSprite extends FlxObject
 			return null;
 		}
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
 		}
@@ -1618,7 +1618,7 @@ class FlxSprite extends FlxObject
 	@:noCompletion
 	function set_flipX(Value:Bool):Bool
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			_facingHorizontalMult = Value ? -1 : 1;
 		}
@@ -1629,7 +1629,7 @@ class FlxSprite extends FlxObject
 	@:noCompletion
 	function set_flipY(Value:Bool):Bool
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			_facingVerticalMult = Value ? -1 : 1;
 		}
@@ -1646,7 +1646,7 @@ class FlxSprite extends FlxObject
 	@:noCompletion
 	function set_useFramePixels(value:Bool):Bool
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			if (value != useFramePixels)
 			{

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -53,7 +53,7 @@ class FlxSubState extends FlxState
 		closeCallback = null;
 		openCallback = null;
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			_bgSprite = new FlxBGSprite();
 		}
@@ -63,14 +63,14 @@ class FlxSubState extends FlxState
 	override public function draw():Void
 	{
 		// Draw background
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			for (camera in getCamerasLegacy())
 			{
 				camera.fill(bgColor);
 			}
 		}
-		else // FlxG.renderTile
+		else // FlxG.render.tile
 		{
 			if (_bgSprite != null && _bgSprite.visible)
 				_bgSprite.draw();
@@ -107,7 +107,7 @@ class FlxSubState extends FlxState
 	@:noCompletion
 	override function set_bgColor(value:FlxColor):FlxColor
 	{
-		if (FlxG.renderTile && _bgSprite != null)
+		if (FlxG.render.tile && _bgSprite != null)
 		{
 			_bgSprite.alpha = value.alphaFloat;
 			_bgSprite.visible = _bgSprite.alpha > 0;

--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -264,7 +264,7 @@ class FlxTypedEmitter<T:FlxSprite & IFlxParticle> extends FlxTypedGroup<T>
 		var particle:T = Type.createInstance(particleClass, []);
 		var frame = Multiple ? FlxG.random.int(0, totalFrames - 1) : -1;
 
-		if (FlxG.renderBlit && bakedRotationAngles > 0)
+		if (FlxG.render.blit && bakedRotationAngles > 0)
 			particle.loadRotatedGraphic(Graphics, bakedRotationAngles, frame, false, AutoBuffer);
 		else
 			particle.loadGraphic(Graphics, Multiple);

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -161,7 +161,7 @@ class FlxFrame implements IFlxDestroyable
 		offset = FlxPoint.get();
 
 		blitMatrix = new Vector<Float>(6);
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			tileMatrix = new Vector<Float>(6);
 	}
 
@@ -177,7 +177,7 @@ class FlxFrame implements IFlxDestroyable
 		blitMatrix[4] = _matrix.tx;
 		blitMatrix[5] = _matrix.ty;
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			prepareBlitMatrix(_matrix, false);
 			tileMatrix[0] = _matrix.a;
@@ -295,7 +295,7 @@ class FlxFrame implements IFlxDestroyable
 	 */
 	public function prepareMatrix(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false, flipY:Bool = false):FlxMatrix
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			mat.identity();
 			return mat;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -52,7 +52,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 	override public function render(camera:FlxCamera):Void
 	{
-		if (!FlxG.renderTile)
+		if (!FlxG.render.tile)
 			return;
 
 		if (numTriangles <= 0)

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -320,7 +320,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	{
 		// Set up our global flash graphics object to draw out the path
 		var gfx:Graphics = null;
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			gfx = FlxSpriteUtil.flashGfx;
 			gfx.clear();
@@ -368,7 +368,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 			prevNodeScreen.put();
 		}
 		
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			// then stamp the path down onto the game buffer
 			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
@@ -386,7 +386,7 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 			result.y -= camera.scroll.y * object.scrollFactor.y;
 		}
 		
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			result.x -= camera.viewMarginX;
 			result.y -= camera.viewMarginY;

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -376,7 +376,7 @@ class Interaction extends Window
 
 	public function getDebugGraphics():Graphics
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			FlxSpriteUtil.flashGfx.clear();
 			return FlxSpriteUtil.flashGfx;
@@ -408,7 +408,7 @@ class Interaction extends Window
 		}
 
 		// Draw the debug info to the main camera buffer.
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
 	}
 

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -206,7 +206,7 @@ class Pointer extends Tool
 		}
 
 		// Render everything into the camera buffer
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
 	}
 }

--- a/flixel/system/debug/interaction/tools/Transform.hx
+++ b/flixel/system/debug/interaction/tools/Transform.hx
@@ -324,7 +324,7 @@ class Transform extends Tool
 		drawMarkers(gfx);
 
 		// Draw the debug info to the main camera buffer.
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
 	}
 

--- a/flixel/system/debug/stats/Stats.hx
+++ b/flixel/system/debug/stats/Stats.hx
@@ -94,7 +94,7 @@ class Stats extends Window
 	{
 		super("Stats", new GraphicStats(0, 0), 0, 0, false);
 
-		var minHeight = if (FlxG.renderTile) 200 else 185;
+		var minHeight = if (FlxG.render.tile) 200 else 185;
 		minSize.y = minHeight;
 		resize(INITIAL_WIDTH, minHeight);
 
@@ -136,7 +136,7 @@ class Stats extends Window
 		_leftTextField.multiline = _rightTextField.multiline = true;
 
 		var drawMethod = "";
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			drawMethod =
 				#if FLX_RENDER_TRIANGLE
@@ -273,7 +273,7 @@ class Stats extends Window
 			}
 			visibleCount = Std.int(divide(visibleCount, _visibleObjectMarker));
 
-			if (FlxG.renderTile)
+			if (FlxG.render.tile)
 			{
 				for (i in 0..._drawCallsMarker)
 				{
@@ -286,7 +286,7 @@ class Stats extends Window
 			_drawMarker = 0;
 			_activeObjectMarker = 0;
 			_visibleObjectMarker = 0;
-			if (FlxG.renderTile)
+			if (FlxG.render.tile)
 			{
 				_drawCallsMarker = 0;
 			}
@@ -304,7 +304,7 @@ class Stats extends Window
 		updateTimeGraph.update(updTime);
 
 		_rightTextField.text = activeCount + " (" + updTime + "ms)\n" + visibleCount + " (" + drwTime + "ms)\n"
-			+ (FlxG.renderTile ? (drawCallsCount + "\n") : "") + FlxQuadTree._NUM_CACHED_QUAD_TREES + "\n" + FlxLinkedList._NUM_CACHED_FLX_LIST;
+			+ (FlxG.render.tile ? (drawCallsCount + "\n") : "") + FlxQuadTree._NUM_CACHED_QUAD_TREES + "\n" + FlxLinkedList._NUM_CACHED_FLX_LIST;
 	}
 
 	function divide(f1:Float, f2:Float):Float

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -132,7 +132,7 @@ class CameraFrontEnd
 			return;
 		}
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			for (i in 0...list.length)
 			{
@@ -260,7 +260,7 @@ class CameraFrontEnd
 				continue;
 			}
 
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				camera.checkResize();
 
@@ -270,7 +270,7 @@ class CameraFrontEnd
 				}
 			}
 
-			if (FlxG.renderTile)
+			if (FlxG.render.tile)
 			{
 				camera.clearDrawStack();
 				camera.canvas.graphics.clear();
@@ -280,7 +280,7 @@ class CameraFrontEnd
 				#end
 			}
 
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				camera.fill(camera.bgColor, camera.useBgAlphaBlending);
 				camera.screen.dirty = true;
@@ -295,7 +295,7 @@ class CameraFrontEnd
 	@:allow(flixel.FlxGame)
 	inline function render():Void
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			for (camera in list)
 			{
@@ -322,7 +322,7 @@ class CameraFrontEnd
 
 			camera.drawFX();
 
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				if (useBufferLocking)
 				{

--- a/flixel/system/frontEnds/DisplayFrontEnd.hx
+++ b/flixel/system/frontEnds/DisplayFrontEnd.hx
@@ -1,0 +1,73 @@
+package flixel.system.frontEnds;
+
+import flixel.FlxG.FlxRenderMethod as RenderMethod;
+
+class DisplayFrontEnd
+{
+	public function new () {}
+	
+	public var render(get, never):FlxRenderMethod;
+	inline function get_render():FlxRenderMethod
+	{
+		return FlxG.renderMethod;
+	}
+	
+	public var pixelMode(default, set):FlxPixelMode;
+	inline function set_pixelMode(value:FlxPixelMode)
+	{
+		switch value
+		{
+			case CUSTOM:// do nothing
+			case PIXELATED:
+				FlxSprite.defaultAntialiasing = false;
+				
+				if (FlxG.state != null)
+					FlxG.stage.quality = LOW;
+				
+				#if html5
+				lime.app.Application.current.window.element.style.setProperty("image-rendering", "pixelated");
+				#end
+			case SMOOTH:
+				FlxSprite.defaultAntialiasing = true;
+				
+				if (FlxG.state != null)
+					FlxG.stage.quality = HIGH;
+				
+				#if html5
+				lime.app.Application.current.window.element.style.removeProperty("image-rendering");
+				#end
+		}
+		return pixelMode = value;
+	}
+}
+
+abstract FlxRenderMethod(RenderMethod) from RenderMethod
+{
+	public var blit(get, never):Bool;
+	inline function get_blit() return this == BLITTING;
+	
+	public var tile(get, never):Bool;
+	inline function get_tile() return this == DRAW_TILES;
+}
+
+enum FlxPixelMode
+{
+	/**
+	 * Enables various features that result in crisp pixels, namely:
+	 * - Changes `FlxSprite.defaultAntialiasing` to `false`
+	 * - On web, changes the `image-rendering` to `"pixelated"`
+	 */
+	PIXELATED;
+	
+	/**
+	 * Makes no changes to any default redering properties
+	 */
+	CUSTOM;
+	
+	/**
+	 * Enables various features that result in crisp pixels, namely:
+	 * - Changes `FlxSprite.defaultAntialiasing` to `true`
+	 * - On web, changes the `image-rendering` to `"pixelated"`
+	 */
+	SMOOTH;
+}

--- a/flixel/system/frontEnds/RenderFrontEnd.hx
+++ b/flixel/system/frontEnds/RenderFrontEnd.hx
@@ -1,19 +1,47 @@
 package flixel.system.frontEnds;
 
-import flixel.FlxG.FlxRenderMethod as RenderMethod;
+import flixel.FlxG;
+import openfl.display.Stage;
 
-class DisplayFrontEnd
+class RenderFrontEnd
 {
+	public var method:FlxRenderMethod;
+	public var blit(default, null):Bool;
+	public var tile(default, null):Bool;
+	
+	public var pixelMode(default, null):FlxPixelMode = CUSTOM;
+	
 	public function new () {}
 	
-	public var render(get, never):FlxRenderMethod;
-	inline function get_render():FlxRenderMethod
+	@:allow(flixel.FlxG)
+	function init()
 	{
-		return FlxG.renderMethod;
+		method = BLITTING;
+		
+		#if (!lime_legacy && !flash)
+		method = switch (FlxG.stage.window.context.type)
+		{
+			case OPENGL, OPENGLES, WEBGL: DRAW_TILES;
+			default: BLITTING;
+		}
+		#else
+		#if web
+		method = BLITTING;
+		#else
+		method = DRAW_TILES;
+		#end
+		#end
+		
+		#if air
+		method = BLITTING;
+		#end
+		
+		blit = method == BLITTING;
+		tile = method == DRAW_TILES;
+		FlxObject.defaultPixelPerfectPosition = blit;
 	}
 	
-	public var pixelMode(default, set):FlxPixelMode;
-	inline function set_pixelMode(value:FlxPixelMode)
+	public function setPixelMode(value:FlxPixelMode)
 	{
 		switch value
 		{
@@ -37,17 +65,7 @@ class DisplayFrontEnd
 				lime.app.Application.current.window.element.style.removeProperty("image-rendering");
 				#end
 		}
-		return pixelMode = value;
 	}
-}
-
-abstract FlxRenderMethod(RenderMethod) from RenderMethod
-{
-	public var blit(get, never):Bool;
-	inline function get_blit() return this == BLITTING;
-	
-	public var tile(get, never):Bool;
-	inline function get_tile() return this == DRAW_TILES;
 }
 
 enum FlxPixelMode

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1078,7 +1078,7 @@ class FlxText extends FlxSprite
 		if (textField == null)
 			return;
 
-		if (FlxG.renderTile && !RunOnCpp)
+		if (FlxG.render.tile && !RunOnCpp)
 			return;
 
 		regenGraphic();

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -295,7 +295,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	{
 		super();
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			_helperPoint = new Point();
 			_matrix = new FlxMatrix();
@@ -314,7 +314,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		debugBoundingBoxColorPartial = FlxColor.PINK;
 		debugBoundingBoxColorNotSolid = FlxColor.TRANSPARENT;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			FlxG.debugger.drawDebugChanged.add(onDrawDebugChanged);
 		#end
 	}
@@ -330,7 +330,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
 		_buffers = FlxDestroyUtil.destroyArray(_buffers);
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			#if FLX_DEBUG
 			_debugRect = null;
@@ -360,7 +360,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		FlxG.cameras.cameraResized.remove(onCameraChanged);
 
 		#if FLX_DEBUG
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			FlxG.debugger.drawDebugChanged.remove(onDrawDebugChanged);
 		#end
 
@@ -508,7 +508,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 	function updateDebugTile(tileBitmap:BitmapData, color:FlxColor):BitmapData
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			return null;
 
 		if (tileWidth <= 0 || tileHeight <= 0)
@@ -542,7 +542,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	override function updateMap():Void
 	{
 		#if FLX_DEBUG
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 			_debugRect = new Rectangle(0, 0, tileWidth, tileHeight);
 		#end
 
@@ -554,7 +554,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	#if FLX_DEBUG
 	override public function drawDebugOnCamera(camera:FlxCamera):Void
 	{
-		if (!FlxG.renderTile)
+		if (!FlxG.render.tile)
 			return;
 
 		var buffer:FlxTilemapBuffer = null;
@@ -677,7 +677,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 			buffer = _buffers[i];
 
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				if (buffer.isDirty(this, camera))
 					drawTilemap(buffer, camera);
@@ -725,7 +725,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 */
 	override public function setDirty(dirty:Bool = true):Void
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			return;
 
 		for (buffer in _buffers)
@@ -1233,7 +1233,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		var scaledHeight:Float = 0;
 		var drawItem = null;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			buffer.fill();
 		}
@@ -1287,7 +1287,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 				{
 					frame = tile.frame;
 
-					if (FlxG.renderBlit)
+					if (FlxG.render.blit)
 					{
 						frame.paint(buffer.pixels, _flashPoint, true);
 
@@ -1335,13 +1335,13 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 					}
 				}
 
-				if (FlxG.renderBlit)
+				if (FlxG.render.blit)
 					_flashPoint.x += tileWidth;
 
 				columnIndex++;
 			}
 
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 				_flashPoint.y += tileHeight;
 			rowIndex += widthInTiles;
 		}
@@ -1349,7 +1349,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		buffer.x = screenXInTiles * scaledTileWidth;
 		buffer.y = screenYInTiles * scaledTileHeight;
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			if (isColored)
 				buffer.colorTransform(colorTransform);
@@ -1366,7 +1366,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	#if FLX_DEBUG
 	function makeDebugTile(color:FlxColor):BitmapData
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 			return null;
 
 		var debugTile = new BitmapData(tileWidth, tileHeight, true, 0);

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -61,7 +61,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	public var pixelPerfectRender:Null<Bool>;
 
 	/**
-	 * The actual buffer BitmapData. (Only used if FlxG.renderBlit == true)
+	 * The actual buffer BitmapData. (Only used if FlxG.render.blit == true)
 	 */
 	public var pixels(default, null):BitmapData;
 
@@ -117,7 +117,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 		updateColumns(tileWidth, widthInTiles, scaleX, camera);
 		updateRows(tileHeight, heightInTiles, scaleY, camera);
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			final newWidth = Std.int(columns * tileWidth);
 			final newHeight = Std.int(rows * tileHeight);
@@ -144,7 +144,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public function destroy():Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			pixels = FlxDestroyUtil.dispose(pixels);
 			blend = null;
@@ -161,7 +161,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public function fill(color = FlxColor.TRANSPARENT):Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			pixels.fillRect(_flashRect, color);
 		}

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -172,7 +172,7 @@ class FlxBar extends FlxSprite
 
 		_filledBarPoint = new Point();
 		_filledBarRect = new Rectangle();
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			_zeroOffset = new Point();
 			_emptyBarRect = new Rectangle();
@@ -198,7 +198,7 @@ class FlxBar extends FlxSprite
 	{
 		positionOffset = FlxDestroyUtil.put(positionOffset);
 
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			frontFrames = null;
 			_filledFlxRect = FlxDestroyUtil.put(_filledFlxRect);
@@ -352,7 +352,7 @@ class FlxBar extends FlxSprite
 	 */
 	public function createColoredEmptyBar(empty:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			var emptyKey:String = "empty: " + barWidth + "x" + barHeight + ":" + empty.toHexString();
 			if (showBorder)
@@ -406,7 +406,7 @@ class FlxBar extends FlxSprite
 	 */
 	public function createColoredFilledBar(fill:FlxColor, showBorder:Bool = false, border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			var filledKey:String = "filled: " + barWidth + "x" + barHeight + ":" + fill.toHexString();
 			if (showBorder)
@@ -484,7 +484,7 @@ class FlxBar extends FlxSprite
 	public function createGradientEmptyBar(empty:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
 			border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			var emptyKey:String = "Gradient:" + barWidth + "x" + barHeight + ",colors:[";
 			for (col in empty)
@@ -552,7 +552,7 @@ class FlxBar extends FlxSprite
 	public function createGradientFilledBar(fill:Array<FlxColor>, chunkSize:Int = 1, rotation:Int = 180, showBorder:Bool = false,
 			border:FlxColor = FlxColor.WHITE, borderSize:Int = 1):FlxBar
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			var filledKey:String = "Gradient:" + barWidth + "x" + barHeight + ",colors:[";
 			for (col in fill)
@@ -639,7 +639,7 @@ class FlxBar extends FlxSprite
 		{
 			var emptyGraphic:FlxGraphic = FlxG.bitmap.add(empty);
 
-			if (FlxG.renderTile)
+			if (FlxG.render.tile)
 			{
 				frames = emptyGraphic.imageFrame;
 			}
@@ -681,7 +681,7 @@ class FlxBar extends FlxSprite
 		{
 			var filledGraphic:FlxGraphic = FlxG.bitmap.add(fill);
 
-			if (FlxG.renderTile)
+			if (FlxG.render.tile)
 			{
 				frontFrames = filledGraphic.imageFrame;
 			}
@@ -744,7 +744,7 @@ class FlxBar extends FlxSprite
 	 */
 	public function updateEmptyBar():Void
 	{
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			pixels.copyPixels(_emptyBar, _emptyBarRect, _zeroOffset);
 			dirty = true;
@@ -806,7 +806,7 @@ class FlxBar extends FlxSprite
 					_filledBarPoint.y = Std.int((barHeight - _filledBarRect.height) / 2);
 			}
 
-			if (FlxG.renderBlit)
+			if (FlxG.render.blit)
 			{
 				pixels.copyPixels(_filledBar, _filledBarRect, _filledBarPoint, null, null, true);
 			}
@@ -823,7 +823,7 @@ class FlxBar extends FlxSprite
 			}
 		}
 
-		if (FlxG.renderBlit)
+		if (FlxG.render.blit)
 		{
 			dirty = true;
 		}
@@ -852,7 +852,7 @@ class FlxBar extends FlxSprite
 	{
 		super.draw();
 		
-		if (!FlxG.renderTile)
+		if (!FlxG.render.tile)
 			return;
 		
 		if (alpha == 0)
@@ -897,7 +897,7 @@ class FlxBar extends FlxSprite
 
 	override function set_pixels(pixels:BitmapData):BitmapData
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			return pixels; // hack
 		}
@@ -982,7 +982,7 @@ class FlxBar extends FlxSprite
 
 	function get_frontFrames():FlxImageFrame
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			return frontFrames;
 		}
@@ -991,7 +991,7 @@ class FlxBar extends FlxSprite
 
 	function set_frontFrames(value:FlxImageFrame):FlxImageFrame
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			if (value != null)
 				value.parent.incrementUseCount();
@@ -1011,7 +1011,7 @@ class FlxBar extends FlxSprite
 
 	function get_backFrames():FlxImageFrame
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			return cast frames;
 		}
@@ -1020,7 +1020,7 @@ class FlxBar extends FlxSprite
 
 	function set_backFrames(value:FlxImageFrame):FlxImageFrame
 	{
-		if (FlxG.renderTile)
+		if (FlxG.render.tile)
 		{
 			frames = value;
 		}


### PR DESCRIPTION
- Adds `FlxG.render.pixelMode`. Possible values:
  - `PIXELATED`: Sets all rendering options to be pixel-perfect
  - `SMOOTH`: Enabled anti-Aliasing, disables pixel-perfect
- Adds `FlxG.render.tile` and `blit` to replace `FlxG.renderTile` and `renderBlit`

To Do: Rethink these names