### PR TITLE
Fix camera.color

### DIFF
--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -130,7 +130,6 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 			shader.colorOffset.value = colorOffsets;
 		}
 
-		setParameterValue(shader.hasTransform, true);
 		setParameterValue(shader.hasColorTransform, colored || hasColorOffsets);
 
 		#if (openfl > "8.7.0")

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -76,7 +76,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			shader.colorOffset.value = null;
 		}
 
-		setParameterValue(shader.hasTransform, true);
 		setParameterValue(shader.hasColorTransform, colored || hasColorOffsets);
 
 		#if (openfl > "8.7.0")

--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -15,8 +15,16 @@ class FlxGraphicsShader extends GraphicsShader
 		
 		if (hasColorTransform)
 		{
-			openfl_ColorOffsetv = (openfl_ColorOffsetv * colorMultiplier) + (colorOffset / 255.0);
-			openfl_ColorMultiplierv *= colorMultiplier;
+			if (openfl_HasColorTransform)
+			{
+				openfl_ColorOffsetv = (openfl_ColorOffsetv * colorMultiplier) + (colorOffset / 255.0);
+				openfl_ColorMultiplierv *= colorMultiplier;
+			}
+			else
+			{
+				openfl_ColorOffsetv = colorOffset / 255.0;
+				openfl_ColorMultiplierv = colorMultiplier;
+			}
 		}
 	")
 	@:glFragmentHeader("
@@ -25,7 +33,7 @@ class FlxGraphicsShader extends GraphicsShader
 		vec4 flixel_texture2D(sampler2D bitmap, vec2 coord)
 		{
 			vec4 color = texture2D(bitmap, coord);
-			if (!hasTransform)
+			if (!(hasTransform || openfl_HasColorTransform))
 				return color;
 			
 			if (color.a == 0.0)

--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -4,66 +4,51 @@ import openfl.display.GraphicsShader;
 
 class FlxGraphicsShader extends GraphicsShader
 {
-	@:glVertexSource("
-		#pragma header
-
+	@:glVertexHeader("
 		attribute float alpha;
 		attribute vec4 colorMultiplier;
 		attribute vec4 colorOffset;
 		uniform bool hasColorTransform;
-
-		void main(void)
+	")
+	@:glVertexBody("
+		openfl_Alphav = openfl_Alpha * alpha;
+		
+		if (hasColorTransform)
 		{
-			#pragma body
-
-			openfl_Alphav = openfl_Alpha * alpha;
-
-			if (hasColorTransform)
-			{
-				openfl_ColorOffsetv = colorOffset / 255.0;
-				openfl_ColorMultiplierv = colorMultiplier;
-			}
-		}")
+			openfl_ColorOffsetv = (openfl_ColorOffsetv * colorMultiplier) + (colorOffset / 255.0);
+			openfl_ColorMultiplierv *= colorMultiplier;
+		}
+	")
 	@:glFragmentHeader("
-		uniform bool hasTransform;
+		uniform bool hasTransform;  // TODO: Is this still needed?
 		uniform bool hasColorTransform;
-
 		vec4 flixel_texture2D(sampler2D bitmap, vec2 coord)
 		{
 			vec4 color = texture2D(bitmap, coord);
 			if (!hasTransform)
-			{
 				return color;
-			}
-
+			
 			if (color.a == 0.0)
-			{
 				return vec4(0.0, 0.0, 0.0, 0.0);
-			}
-
-			if (!hasColorTransform)
+			
+			if (openfl_HasColorTransform || hasColorTransform)
 			{
-				return color * openfl_Alphav;
+				color = vec4 (color.rgb / color.a, color.a);
+				vec4 mult = vec4 (openfl_ColorMultiplierv.rgb, 1.0);
+				color = clamp (openfl_ColorOffsetv + (color * mult), 0.0, 1.0);
+				
+				if (color.a == 0.0)
+					return vec4 (0.0, 0.0, 0.0, 0.0);
+				
+				return vec4 (color.rgb * color.a * openfl_Alphav, color.a * openfl_Alphav);
 			}
-
-			color = vec4(color.rgb / color.a, color.a);
-
-			color = clamp(openfl_ColorOffsetv + (color * openfl_ColorMultiplierv), 0.0, 1.0);
-
-			if (color.a > 0.0)
-			{
-				return vec4(color.rgb * color.a * openfl_Alphav, color.a * openfl_Alphav);
-			}
-			return vec4(0.0, 0.0, 0.0, 0.0);
+			
+			return color * openfl_Alphav;
 		}
 	")
-	@:glFragmentSource("
-		#pragma header
-
-		void main(void)
-		{
-			gl_FragColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
-		}")
+	@:glFragmentBody("
+		gl_FragColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
+	")
 	public function new()
 	{
 		super();


### PR DESCRIPTION
Sprite shaders using flixel_texture2D now honor the color transform of the display object they are being drawn to.

Fixes https://github.com/haxeFlixel/flixel/issues/3207

Note to self: ~~This shader is super over-complicated and I don't really think most of these properties are needed. But simplifying will cause slightly different (IMO better) behavior, though that is a breaking change~~ Did it, no apparent difference in behavior