### PR TITLE
Make sure Git SHA is for the Flixel repository

### DIFF
--- a/flixel/system/macros/FlxGitSHA.hx
+++ b/flixel/system/macros/FlxGitSHA.hx
@@ -1,5 +1,6 @@
 package flixel.system.macros;
 
+import haxe.io.Path;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import sys.io.Process;
@@ -58,7 +59,7 @@ class FlxGitSHA
 			}
 		}
 
-		return result;
+		return Path.normalize(result);
 	}
 
 	public static function getGitSHA(path:String):String
@@ -66,9 +67,11 @@ class FlxGitSHA
 		var oldWd = Sys.getCwd();
 
 		Sys.setCwd(path);
-		var sha = getProcessOutput("git", ["rev-parse", "HEAD"]);
+		var output = getProcessOutput("git", ["rev-parse", "HEAD", "--show-toplevel"]).split("\n");
+		var sha = output[0];
+		var gitPath = Path.normalize(output[1]);
 		var shaRegex = ~/[a-f0-9]{40}/g;
-		if (!shaRegex.match(sha))
+		if (!shaRegex.match(sha) || path != gitPath)
 			sha = "";
 
 		Sys.setCwd(oldWd);


### PR DESCRIPTION
`git rev-parse HEAD` (which is what FlxGitSHA.hx uses to get the current commit SHA) will get the current commit of a git repostory, EVEN in subdirectories. 
So if you have a project with a git repository and a .haxelib folder with a haxelib release of Flixel, FlxGitSHA will get the project's current git commit thinking that it's Flixel's current commit

This PR adds a `--show-toplevel` argument to the command which returns the path of the git repository and compares it with the path from `getLibraryPath()`

Merry Christmas!