### PR TITLE
fix: enable proper Int/Floats parsing in the debugger watch windows on HTML5

### DIFF
--- a/flixel/system/debug/watch/EditableTextField.hx
+++ b/flixel/system/debug/watch/EditableTextField.hx
@@ -142,10 +142,8 @@ class EditableTextField extends TextField implements IFlxDestroyable
 	{
 		var value:Dynamic = switch (expectedType)
 		{
-			#if neko
 			case TInt: Std.parseInt(text);
 			case TFloat: Std.parseFloat(text);
-			#end
 			case TBool if (text == "true"): true;
 			case TBool if (text == "false"): false;
 			case TEnum(e):


### PR DESCRIPTION
tldr: js was parsing ints/floats as strings, this PR makes it parse em as their proper types

Since Javascript is Javascript, on HTML5, the debug watch/tracker stuff would parse in a funny manner

lets say you had 

```haxe

var x:Int = 0;
var y:Int = 30;
var z:Int = 0;

// pseudocode setter
function z_setter(value:Int)
{
  x = y + z;
  return z = value;
}
```
and if you were to have `z` in a flixel debug tracker, and modify the value, it would return the new value as a string (more or less), rather than an int

so then, because javascript is javascript, if you changed the value of `z` in the watch window to say, 13, `x` would then be `3013` (`x = y + z` / `x = 30 + 13 ==== 3013!! javascript is awesome!` rather than `43` (`x = 30 + 13 ===== 43!!`), concatenating the number and treating it as a string, rather than forcing Int.

Seems like maybe neko ran into that issue before, since we have that in a dedicated compiler conditional around some code that ran `Std.parseInt()` and `Std.parseFloat()`. So just removing the conditional and using that functionality on all platforms seems to fix the *javascript treating everything as any time at all times* quirk.

I've tested on HTML5 and Mac, if Windows/Linux/Hashlink have issues, we can probably just wrap it in a `#if web` conditional rather than `#if neko` (unless we still target neko... lol)