### PR TITLE
Rudimentary Gamepad Recording and Loading Support for FlxReplay

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -965,8 +965,8 @@ class FlxGamepad implements IFlxDestroyable
 	}
 	
 	/**
-	 * Part of the keystroke recording system.
-	 * Takes data about key presses and sets it into array.
+	 * Part of the gamepad recording system.
+	 * Takes data about analog and buttons and sets it into array.
 	 *
 	 * @param	Record	Array of data about key states.
 	 */

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -1,5 +1,7 @@
 package flixel.input.gamepad;
 
+import flixel.system.replay.GamepadRecord;
+import flixel.system.replay.CodeValuePair;
 import flixel.input.FlxInput.FlxInputState;
 import flixel.input.gamepad.FlxGamepadMappedInput;
 import flixel.input.gamepad.lists.FlxGamepadAnalogList;
@@ -907,6 +909,55 @@ class FlxGamepad implements IFlxDestroyable
 			LabelValuePair.weak("model", model),
 			LabelValuePair.weak("deadZone", deadZone)
 		]);
+	}
+	/**
+	 * If any buttons are not "released",
+	 * this function will return an array indicating
+	 * which buttons are pressed and what state they are in.
+	 *
+	 * @return	An array of button state data. Null if there is no data.
+	 */
+	@:allow(flixel.system.replay.FlxReplay)
+	function record():GamepadRecord
+	{
+		var data:Array<CodeValuePair> = null;
+		
+		for (button in buttons)
+		{
+			if (button == null || button.released)
+			{
+				continue;
+			}
+			
+			if (data == null)
+			{
+				data = new Array<CodeValuePair>();
+			}
+			
+			data.push(new CodeValuePair(button.ID, button.current));
+		}
+		
+		return new GamepadRecord(id, data);
+	}
+	
+	/**
+	 * Part of the keystroke recording system.
+	 * Takes data about key presses and sets it into array.
+	 *
+	 * @param	Record	Array of data about key states.
+	 */
+	@:allow(flixel.system.replay.FlxReplay)
+	function playback(record:Array<CodeValuePair>):Void
+	{
+		var i = 0;
+		final len = record.length;
+		
+		while (i < len)
+		{
+			final keyRecord = record[i++];
+			final id = getButton(keyRecord.code);
+			id.current = keyRecord.value;
+		}
 	}
 }
 

--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -958,7 +958,9 @@ class FlxGamepad implements IFlxDestroyable
 		for (i in 0...axis.length)
 		{
 			var axisValue = getAxisValue(i);
-			analogData.push(new IntegerFloatPair(i, axisValue));
+			if (axisValue != 0)
+				analogData.push(new IntegerFloatPair(i, axisValue));
+
 		}
 		
 		return new GamepadRecord(id, data, analogData);
@@ -984,7 +986,10 @@ class FlxGamepad implements IFlxDestroyable
 		}
 		i = 0;
 		final len = record.analog.length;
-		
+		for (i in 0...axis.length)
+		{
+			axis[i] = 0;
+		}
 		while (i < len)
 		{
 			final keyRecord = record.analog[i++];

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -371,6 +371,12 @@ class FlxGamepadManager implements IFlxInputManager
 		return -1;
 	}
 
+	public function addPlaybackGamepad(gamepad:FlxGamepad)
+	{
+		_gamepads[gamepad.id] = gamepad;
+		_activeGamepads.push(gamepad);
+	}
+
 	function addGamepad(Device:GameInputDevice):Void
 	{
 		if (Device == null)

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -166,7 +166,7 @@ class FlxReplay
 			continueFrame = false;
 		#end
 
-		#if FLX_GAMEINPUT_API
+		#if FLX_GAMEPAD
 		var gamepadRecords:Array<GamepadRecord> = new Array();
 		for (gamepad in FlxG.gamepads.getActiveGamepads())
 		{
@@ -192,7 +192,7 @@ class FlxReplay
 		#if FLX_KEYBOARD
 		frameRecorded.keys = keysRecord;
 		#end
-		#if FLX_GAMEINPUT_API
+		#if FLX_GAMEPAD
 		frameRecorded.gamepad = gamepadRecords;
 		#end
 
@@ -239,7 +239,7 @@ class FlxReplay
 			FlxG.mouse.playback(fr.mouse);
 		}
 		#end
-		#if FLX_GAMEINPUT_API
+		#if FLX_GAMEPAD
 		if (fr.gamepad != null)
 		{
 			for (record in fr.gamepad)

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -1,5 +1,6 @@
 package flixel.system.replay;
 
+import flixel.input.gamepad.FlxGamepad;
 import flixel.FlxG;
 import flixel.util.FlxArrayUtil;
 
@@ -171,6 +172,7 @@ class FlxReplay
 			var gamepadRecord:GamepadRecord = gamepad.record();
 			if (gamepadRecord != null)
 			{
+				gamepadRecords.push(gamepadRecord);
 				continueFrame = false;
 			}
 		}
@@ -198,6 +200,8 @@ class FlxReplay
 			_frames.resize(_capacity);
 		}
 	}
+
+	var fakeGamepads:Map<Int, FlxGamepad> = [];
 
 	/**
 	 * Get the current frame record data and load it into the input managers.
@@ -231,6 +235,26 @@ class FlxReplay
 			FlxG.mouse.playback(fr.mouse);
 		}
 		#end
+		if (fr.gamepad != null)
+		{
+			for (record in fr.gamepad)
+			{
+				var gamepad = null;
+				if (fakeGamepads.exists(record.gamepadID))
+				{
+					gamepad = fakeGamepads.get(record.gamepadID);
+				}
+				else
+				{
+					gamepad = new FlxGamepad(-record.gamepadID, FlxG.gamepads, FlxGamepadModel.UNKNOWN, null);
+					FlxG.gamepads.addPlaybackGamepad(gamepad);
+					gamepad.recording = true;
+					fakeGamepads.set(record.gamepadID, gamepad);
+				}
+				
+				gamepad.playback(record);
+			}
+		}
 	}
 
 	/**

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -165,6 +165,18 @@ class FlxReplay
 			continueFrame = false;
 		#end
 
+		#if FLX_GAMEINPUT_API
+		var gamepadRecords:Array<GamepadRecord> = new Array();
+		for (gamepad in FlxG.gamepads.getActiveGamepads())
+		{
+			var gamepadRecord:GamepadRecord = gamepad.record();
+			if (gamepadRecord != null)
+			{
+				continueFrame = false;
+			}
+		}
+		#end
+
 		if (continueFrame)
 		{
 			frame++;

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -166,6 +166,7 @@ class FlxReplay
 			continueFrame = false;
 		#end
 
+		#if FLX_GAMEINPUT_API
 		var gamepadRecords:Array<GamepadRecord> = new Array();
 		for (gamepad in FlxG.gamepads.getActiveGamepads())
 		{
@@ -176,6 +177,7 @@ class FlxReplay
 				continueFrame = false;
 			}
 		}
+		#end
 
 		if (continueFrame)
 		{
@@ -190,7 +192,9 @@ class FlxReplay
 		#if FLX_KEYBOARD
 		frameRecorded.keys = keysRecord;
 		#end
+		#if FLX_GAMEINPUT_API
 		frameRecorded.gamepad = gamepadRecords;
+		#end
 
 		_frames[frameCount++] = frameRecorded;
 
@@ -235,6 +239,7 @@ class FlxReplay
 			FlxG.mouse.playback(fr.mouse);
 		}
 		#end
+		#if FLX_GAMEINPUT_API
 		if (fr.gamepad != null)
 		{
 			for (record in fr.gamepad)
@@ -255,6 +260,7 @@ class FlxReplay
 				gamepad.playback(record);
 			}
 		}
+		#end
 	}
 
 	/**

--- a/flixel/system/replay/FlxReplay.hx
+++ b/flixel/system/replay/FlxReplay.hx
@@ -165,7 +165,6 @@ class FlxReplay
 			continueFrame = false;
 		#end
 
-		#if FLX_GAMEINPUT_API
 		var gamepadRecords:Array<GamepadRecord> = new Array();
 		for (gamepad in FlxG.gamepads.getActiveGamepads())
 		{
@@ -175,7 +174,6 @@ class FlxReplay
 				continueFrame = false;
 			}
 		}
-		#end
 
 		if (continueFrame)
 		{
@@ -190,6 +188,7 @@ class FlxReplay
 		#if FLX_KEYBOARD
 		frameRecorded.keys = keysRecord;
 		#end
+		frameRecorded.gamepad = gamepadRecords;
 
 		_frames[frameCount++] = frameRecorded;
 

--- a/flixel/system/replay/FrameRecord.hx
+++ b/flixel/system/replay/FrameRecord.hx
@@ -21,6 +21,11 @@ class FrameRecord
 	public var mouse:MouseRecord;
 
 	/**
+	 * An array containing all the gamepad inputs.
+	 */
+	public var gamepad:Array<GamepadRecord>;
+
+	/**
 	 * Instantiate array new frame record.
 	 */
 	public function new()
@@ -28,6 +33,7 @@ class FrameRecord
 		frame = 0;
 		keys = null;
 		mouse = null;
+		gamepad = null;
 	}
 
 	/**
@@ -37,11 +43,12 @@ class FrameRecord
 	 * @param Mouse		Mouse data from the mouse manager.
 	 * @return A reference to this FrameRecord object.
 	 */
-	public function create(Frame:Float, ?Keys:Array<CodeValuePair>, ?Mouse:MouseRecord):FrameRecord
+	public function create(Frame:Float, ?Keys:Array<CodeValuePair>, ?Mouse:MouseRecord, ?Gamepad:Array<GamepadRecord>):FrameRecord
 	{
 		frame = Math.floor(Frame);
 		keys = Keys;
 		mouse = Mouse;
+		gamepad = Gamepad;
 
 		return this;
 	}
@@ -53,6 +60,7 @@ class FrameRecord
 	{
 		keys = null;
 		mouse = null;
+		gamepad = null;
 	}
 
 	/**
@@ -85,6 +93,29 @@ class FrameRecord
 			output += mouse.x + "," + mouse.y + "," + mouse.button + "," + mouse.wheel;
 		}
 
+		for (record in gamepad)
+		{
+			output += "g";
+			if (record != null)
+			{
+				output += record.gamepadID + ",";
+				var object:CodeValuePair;
+				var i:Int = 0;
+				var l:Int = keys.length;
+				while (i < l)
+				{
+					if (i > 0)
+					{
+						output += ",";
+					}
+					object = record.buttons[i++];
+					output += object.code + ":" + object.value;
+				}
+			}
+		}
+		
+		trace(output);
+
 		return output;
 	}
 
@@ -103,8 +134,10 @@ class FrameRecord
 
 		// split up keyboard and mouse data
 		array = array[1].split("m");
+		var gamepadArray:Array<String> = array[1].split("g");
+
 		var keyData:String = array[0];
-		var mouseData:String = array[1];
+		var mouseData:String = gamepadArray.splice(0, 1)[0];
 
 		// parse keyboard data
 		if (keyData.length > 0)

--- a/flixel/system/replay/FrameRecord.hx
+++ b/flixel/system/replay/FrameRecord.hx
@@ -93,28 +93,43 @@ class FrameRecord
 			output += mouse.x + "," + mouse.y + "," + mouse.button + "," + mouse.wheel;
 		}
 
-		for (record in gamepad)
+		if (gamepad != null)
 		{
-			output += "g";
-			if (record != null)
+			for (record in gamepad)
 			{
-				output += record.gamepadID + ",";
-				var object:CodeValuePair;
-				var i:Int = 0;
-				var l:Int = keys.length;
-				while (i < l)
+				output += "g";
+				if (record != null)
 				{
-					if (i > 0)
+					output += record.gamepadID + ",";
+					var object:CodeValuePair;
+					var i:Int = 0;
+					var l:Int = record.buttons.length;
+					while (i < l)
 					{
-						output += ",";
+						if (i > 0)
+						{
+							output += ",";
+						}
+						object = record.buttons[i++];
+						output += object.code + ":" + object.value;
 					}
-					object = record.buttons[i++];
-					output += object.code + ":" + object.value;
+					output += "/";
+					var object:IntegerFloatPair;
+					var i:Int = 0;
+					var l:Int = record.analog.length;
+					while (i < l)
+					{
+						if (i > 0)
+						{
+							output += ",";
+						}
+						object = record.analog[i++];
+						output += object.code + ":" + object.value;
+					}
 				}
 			}
 		}
-		
-		trace(output);
+
 
 		return output;
 	}
@@ -170,6 +185,66 @@ class FrameRecord
 			if (array.length >= 4)
 			{
 				mouse = new MouseRecord(Std.parseInt(array[0]), Std.parseInt(array[1]), Std.parseInt(array[2]), Std.parseInt(array[3]));
+			}
+		}
+
+		if (gamepadArray.length > 0)
+		{
+			for (gamepadString in gamepadArray)
+			{
+				array = gamepadString.split(",");
+				var currentGamepad:GamepadRecord = new GamepadRecord(Std.parseInt(array[0]), [], []);
+				
+				var inputsArray:Array<String> = gamepadString.substring(array[0].length + 1).split("/");
+				var buttonsArray:Array<String> = inputsArray[0].split(",");
+				var analogArray:Array<String> = inputsArray[1].split(",");
+				
+				// go through each data pair and enter it into this frame's button state
+				var buttonPair:Array<String>;
+				i = 0;
+				l = inputsArray[0].length;
+				while (i < l)
+				{
+					var pairString = buttonsArray[i++];
+					if (pairString != null)
+					{
+						buttonPair = pairString.split(":");
+						if (buttonPair.length == 2)
+						{
+							if (gamepad == null)
+							{
+								gamepad = new Array<GamepadRecord>();
+							}
+							currentGamepad.buttons.push(new CodeValuePair(Std.parseInt(buttonPair[0]), Std.parseInt(buttonPair[1])));
+						}
+					}
+				}
+				
+				// go through each data pair and enter it into this frame's analog state
+				if (analogArray.length > 0)
+				{
+					var analogPair:Array<String>;
+					i = 0;
+					l = inputsArray[0].length;
+					while (i < l)
+					{
+						var pairString = analogArray[i++];
+						if (pairString != null)
+						{
+							analogPair = pairString.split(":");
+							if (analogPair.length == 2)
+							{
+								if (gamepad == null)
+								{
+									gamepad = new Array<GamepadRecord>();
+								}
+								currentGamepad.analog.push(new IntegerFloatPair(Std.parseInt(analogPair[0]), Std.parseFloat(analogPair[1])));
+							}
+						}
+					}
+				}
+				
+				this.gamepad.push(currentGamepad);
 			}
 		}
 

--- a/flixel/system/replay/FrameRecord.hx
+++ b/flixel/system/replay/FrameRecord.hx
@@ -221,25 +221,22 @@ class FrameRecord
 				}
 				
 				// go through each data pair and enter it into this frame's analog state
-				if (analogArray.length > 0)
+				var analogPair:Array<String>;
+				i = 0;
+				l = inputsArray[0].length;
+				while (i < l)
 				{
-					var analogPair:Array<String>;
-					i = 0;
-					l = inputsArray[0].length;
-					while (i < l)
+					var pairString = analogArray[i++];
+					if (pairString != null)
 					{
-						var pairString = analogArray[i++];
-						if (pairString != null)
+						analogPair = pairString.split(":");
+						if (analogPair.length == 2)
 						{
-							analogPair = pairString.split(":");
-							if (analogPair.length == 2)
+							if (gamepad == null)
 							{
-								if (gamepad == null)
-								{
-									gamepad = new Array<GamepadRecord>();
-								}
-								currentGamepad.analog.push(new IntegerFloatPair(Std.parseInt(analogPair[0]), Std.parseFloat(analogPair[1])));
+								gamepad = new Array<GamepadRecord>();
 							}
+							currentGamepad.analog.push(new IntegerFloatPair(Std.parseInt(analogPair[0]), Std.parseFloat(analogPair[1])));
 						}
 					}
 				}

--- a/flixel/system/replay/GamepadRecord.hx
+++ b/flixel/system/replay/GamepadRecord.hx
@@ -16,6 +16,10 @@ class GamepadRecord
 	 * An array referring to digital gamepad buttons and it's state.
 	 */
 	public var buttons(default, null):Array<CodeValuePair>;
+	/**
+	 * An array referring to analog gamepad inputs and their state.
+	 */
+	public var analog(default, null):Array<IntegerFloatPair>;
 
 	/**
 	 * Instantiate a new mouse input record.
@@ -23,9 +27,10 @@ class GamepadRecord
 	 * @param   GamepadID	The ID of the gamepad being recorded
 	 * @param	Buttons		An array referring to digital gamepad buttons and it's state.
 	 */
-	public function new(gamepadID:Int, buttons:Array<CodeValuePair>)
+	public function new(gamepadID:Int, buttons:Array<CodeValuePair>, analog:Array<IntegerFloatPair>)
 	{
-		this.gamepadID =gamepadID;
+		this.gamepadID = gamepadID;
 		this.buttons = buttons;	
+		this.analog = analog;
 	}
 }

--- a/flixel/system/replay/GamepadRecord.hx
+++ b/flixel/system/replay/GamepadRecord.hx
@@ -22,7 +22,7 @@ class GamepadRecord
 	public var analog(default, null):Array<IntegerFloatPair>;
 
 	/**
-	 * Instantiate a new mouse input record.
+	 * Instantiate a new gamepad input record.
 	 *
 	 * @param   GamepadID	The ID of the gamepad being recorded
 	 * @param	Buttons		An array referring to digital gamepad buttons and it's state.

--- a/flixel/system/replay/GamepadRecord.hx
+++ b/flixel/system/replay/GamepadRecord.hx
@@ -1,0 +1,31 @@
+package flixel.system.replay;
+
+import flixel.input.FlxInput.FlxInputState;
+
+/**
+ * A helper class for the frame records, part of the replay/demo/recording system.
+ */
+class GamepadRecord
+{
+	/**
+	 * The ID of the gamepad being recorded.
+	 */
+	public var gamepadID(default, null):Int;
+
+	/**
+	 * An array referring to digital gamepad buttons and it's state.
+	 */
+	public var buttons(default, null):Array<CodeValuePair>;
+
+	/**
+	 * Instantiate a new mouse input record.
+	 *
+	 * @param   GamepadID	The ID of the gamepad being recorded
+	 * @param	Buttons		An array referring to digital gamepad buttons and it's state.
+	 */
+	public function new(gamepadID:Int, buttons:Array<CodeValuePair>)
+	{
+		this.gamepadID =gamepadID;
+		this.buttons = buttons;	
+	}
+}

--- a/flixel/system/replay/IntegerFloatPair.hx
+++ b/flixel/system/replay/IntegerFloatPair.hx
@@ -1,0 +1,13 @@
+package flixel.system.replay;
+
+class IntegerFloatPair
+{
+	public var code:Int;
+	public var value:Float;
+
+	public function new(code:Int, value:Float)
+	{
+		this.code = code;
+		this.value = value;
+	}
+}


### PR DESCRIPTION
Adds support for recording and loading gamepad inputs inside FlxReplay-s, so far only support button and analog inputs. 
Analog Inputs are always recorded even when 0 which may cause a small jump in replay file size when having multiple gamepad inputs connected. There are a few areas where I touch FlxGamepad and FlxGamepadManager that could seem a bit sketchy, but i'm not aware of any other ways to get this to work. Tested on CPP and HTML5