### PR TITLE
Fix invalid max texture size values by caching it on create

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -334,6 +334,12 @@ class FlxGame extends Sprite
 			addChild(postProcessLayer);
 		#end
 
+		// We have to call this after a stage is created
+		// otherwise it will fail and cause a crash
+		#if FLX_OPENGL_AVAILABLE
+		FlxG.bitmap.setMaxTextureSize();
+		#end
+
 		// Creating the debugger overlay
 		#if FLX_DEBUG
 		debugger = new FlxDebugger(FlxG.stage.stageWidth, FlxG.stage.stageHeight);

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -27,7 +27,7 @@ class BitmapFrontEnd
 	 * 
 	 * @see https://opengl.gpuinfo.org/displaycapability.php?name=GL_MAX_TEXTURE_SIZE
 	 */
-	public var maxTextureSize(get, never):Int;
+	public var maxTextureSize(default, null):Int;
 	#end
 
 	/**
@@ -393,12 +393,10 @@ class BitmapFrontEnd
 	}
 
 	#if FLX_OPENGL_AVAILABLE
-	function get_maxTextureSize():Int
+	@:allow(flixel.FlxGame)
+	function setMaxTextureSize():Void
 	{
-		if (FlxG.stage.window.context.attributes.hardware)
-			return cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
-		
-		return -1;
+		maxTextureSize = FlxG.stage.window.context.attributes.hardware ? cast GL.getParameter(GL.MAX_TEXTURE_SIZE) : -1; 
 	}
 	#end
 


### PR DESCRIPTION
As OpenGL is not thread safe, if a user were to asynchronously create a `FlxGraphic` it would query OpenGL for the max texture size on a different thread and possibly return invalid values. 
This can be fixed by querying OpenGL once at game creation and caching that value.