### PR TITLE
Replace `FlxSound.onComplete` with `FlxSound.onFinish`

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -6,6 +6,7 @@ import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.system.FlxAssets.FlxSoundAsset;
 import flixel.tweens.FlxTween;
+import flixel.util.FlxSignal;
 import flixel.util.FlxStringUtil;
 import openfl.events.Event;
 import openfl.events.IEventDispatcher;
@@ -70,9 +71,15 @@ class FlxSound extends FlxBasic
 	public var autoDestroy:Bool;
 	
 	/**
+	 * Signal that is dispatched on sound complete.
+	 */
+	public var onFinish:FlxSignal;
+
+	/**
 	 * Tracker for sound complete callback. If assigned, will be called
 	 * each time when sound reaches its end.
 	 */
+	@:deprecated("`FlxSound.onComplete` is deprecated! Use `FlxSound.onFinish` instead.")
 	public var onComplete:Void->Void;
 	
 	/**
@@ -245,11 +252,15 @@ class FlxSound extends FlxBasic
 		amplitudeRight = 0;
 		autoDestroy = false;
 		
+		if (onFinish == null)
+			onFinish = new FlxSignal();
+
 		if (_transform == null)
 			_transform = new SoundTransform();
 		_transform.pan = 0;
 	}
 	
+	@:haxe.warning("-WDeprecated")
 	override public function destroy():Void
 	{
 		// Prevents double destroy
@@ -431,12 +442,15 @@ class FlxSound extends FlxBasic
 	}
 	#end
 	
+	@:haxe.warning("-WDeprecated")
 	function init(Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{
 		looped = Looped;
 		autoDestroy = AutoDestroy;
 		updateTransform();
 		exists = true;
+		onFinish.removeAll();
+		onFinish.add(onComplete);
 		onComplete = OnComplete;
 		#if FLX_PITCH
 		pitch = 1;
@@ -636,8 +650,11 @@ class FlxSound extends FlxBasic
 	 * An internal helper function used to help Flash
 	 * clean up finished sounds or restart looped sounds.
 	 */
+	@:haxe.warning("-WDeprecated")
 	function stopped(?_):Void
 	{
+		onFinish.dispatch();
+
 		if (onComplete != null)
 			onComplete();
 			

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -449,7 +449,6 @@ class FlxSound extends FlxBasic
 		autoDestroy = AutoDestroy;
 		updateTransform();
 		exists = true;
-		onFinish.removeAll();
 		onFinish.add(onComplete);
 		onComplete = OnComplete;
 		#if FLX_PITCH


### PR DESCRIPTION
Adjusts FlxSound to comply with the new changes in flixel revolving change a bunch of single callbacks to use FlxSignals instead.