### PR TITLE
AssetFrontEnd misinformation!?!?!?!?

### DIFF
--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -35,7 +35,7 @@ using StringTools;
  * 
  * ### Quick Setup for "Hot-Reloading"
  * To simplify the process mentioned above, the `FLX_CUSTOM_ASSETS_DIRECTORY` flag was created.
- * By adding `-DFLX_CUSTOM_ASSETS_DIRECTORY="../../../assets"` to your lime build command
+ * By adding `-DFLX_CUSTOM_ASSETS_DIRECTORY="assets"` to your lime build command
  * it will automatically grab assets from your project root's assets folder rather than, the
  * default "export/hl/bin/assets". This will only work with a single asset root folder with one
  * asset library and will use the openfl asset system if the asset id starts with "flixel/" or


### PR DESCRIPTION
I was setting up FlxG.assets for a HaxeFlixel project and I'm pretty sure this multi-line comment is wrong for the usage of `FLX_CUSTOM_ASSETS_DIRECTORY` define as it's supposed to be just `assets` and not `../../../assets`. When I used `../../../assets`, it just straight up gave me an error.

In the [pull request](https://github.com/HaxeFlixel/flixel/pull/2982) for FlxG.assets, it also says to use just `assets` for the `FLX_CUSTOM_ASSETS_DIRECTORY` define.