### PR TITLE
add "mod" function to FlxMath

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -575,11 +575,13 @@ class FlxMath
 	}
 	
 	/**
-	 * Performs a modulo operation on two numbers.
-	 * This function differs from the built-in `%` operator in that it always
-	 * returns a positive result even with negative numbers involved.
-	 * For example, `-5 % 3` would return `-2` (truncated division),
-	 * while `mod(-5, 3)` would return `1` (Euclidean division).
+	 * Performs a modulo operation to calculate the remainder of `a` divided by `b`.
+	 * 
+	 * The definition of "remainder" varies by implementation;
+	 * this one is similar to GLSL or Python in that it uses Euclidean division, which always returns positive,
+	 * while Haxe's `%` operator uses signed truncated division.
+	 * 
+	 * For example, `-5 % 3` returns `-2` while `FlxMath.mod(-5, 3)` returns `1`.
 	 * 
 	 * @param a The dividend.
 	 * @param b The divisor.

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -573,4 +573,13 @@ class FlxMath
 	{
 		return (n > 0) ? n : -n;
 	}
+	
+	/**
+	 * Returns `a mod b`.
+	 */
+	public static inline function mod(a:Float, b:Float):Float
+	{
+		b = Math.abs(b);
+		return a - b * Math.floor(a / b);
+	}
 }

--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -575,7 +575,15 @@ class FlxMath
 	}
 	
 	/**
-	 * Returns `a mod b`.
+	 * Performs a modulo operation on two numbers.
+	 * This function differs from the built-in `%` operator in that it always
+	 * returns a positive result even with negative numbers involved.
+	 * For example, `-5 % 3` would return `-2` (truncated division),
+	 * while `mod(-5, 3)` would return `1` (Euclidean division).
+	 * 
+	 * @param a The dividend.
+	 * @param b The divisor.
+	 * @return `a mod b`.
 	 */
 	public static inline function mod(a:Float, b:Float):Float
 	{

--- a/tests/unit/src/flixel/math/FlxMathTest.hx
+++ b/tests/unit/src/flixel/math/FlxMathTest.hx
@@ -102,4 +102,16 @@ class FlxMathTest extends FlxTest
 		// #2126
 		Assert.areEqual(1521730678.942, FlxMath.roundDecimal(1521730678.942, 3));
 	}
+
+	@Test
+	function testMod()
+	{
+		Assert.areEqual(0, FlxMath.mod(8, 4));
+		Assert.areEqual(3, FlxMath.mod(8, 5));
+		Assert.areEqual(0.355, FlxMath.mod(0.941, 0.586));
+		Assert.areEqual(1, FlxMath.mod(-5, 3));
+		Assert.areEqual(1, FlxMath.mod(-5, -3));
+		Assert.areEqual(0.128, FlxMath.mod(-0.834, 0.481));
+		Assert.areEqual(2.5, FlxMath.mod(9, -6.5));
+	}
 }


### PR DESCRIPTION
this pr adds a more "mathematically accurate" alternative to the built-in modulo operator to `FlxMath` as a helper function

<br>

haxe `a % b` behavior (truncated division):

<p><a href="https://commons.wikimedia.org/wiki/File:Divmod_truncated.svg#/media/File:Divmod_truncated.svg"><img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Divmod_truncated.svg" alt="Divmod truncated.svg" height="213" width="411"></a><h6>By <a href="//commons.wikimedia.org/wiki/User:Mathnerd314159" title="User:Mathnerd314159">Mathnerd314159</a> - Own work based on: <a href="//commons.wikimedia.org/wiki/File:Divmod.svg" title="File:Divmod.svg">Divmod.svg</a>&nbsp;by <a href="//commons.wikimedia.org/wiki/User:Salix_alba" title="User:Salix alba">Salix alba</a>, <a href="https://creativecommons.org/licenses/by-sa/3.0" title="Creative Commons Attribution-Share Alike 3.0">CC BY-SA 3.0</a>, <a href="https://commons.wikimedia.org/w/index.php?curid=101128950">Link</a></h6></p>

<br>

`a mod b` behavior (euclidean division):

<p><a href="https://commons.wikimedia.org/wiki/File:Divmod_Euclidean.svg#/media/File:Divmod_Euclidean.svg"><img src="https://upload.wikimedia.org/wikipedia/commons/d/d4/Divmod_Euclidean.svg" alt="Divmod Euclidean.svg" height="213" width="411"></a><h6>By <a href="//commons.wikimedia.org/wiki/User:Mathnerd314159" title="User:Mathnerd314159">Mathnerd314159</a> - Own work based on: <a href="//commons.wikimedia.org/wiki/File:Divmod.svg" title="File:Divmod.svg">Divmod.svg</a>&nbsp;by <a href="//commons.wikimedia.org/wiki/User:Salix_alba" title="User:Salix alba">Salix alba</a>, <a href="https://creativecommons.org/licenses/by-sa/3.0" title="Creative Commons Attribution-Share Alike 3.0">CC BY-SA 3.0</a>, <a href="https://commons.wikimedia.org/w/index.php?curid=101128955">Link</a></h6></p>