### PR TITLE
Add FlxGraphic.freeImageBuffer (dump)

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -633,6 +633,10 @@ class FlxGraphic implements IFlxDestroyable
 					FlxG.log.warn('Graphic dimensions (${width}x${height}) exceed the maximum allowed size (${max}x${max}), which may cause rendering issues.');
 			}
 			#end
+
+			#if FLX_FREE_IMAGE_BUFFER
+			freeImageBuffer();
+			#end
 		}
 
 		return value;

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -633,10 +633,6 @@ class FlxGraphic implements IFlxDestroyable
 					FlxG.log.warn('Graphic dimensions (${width}x${height}) exceed the maximum allowed size (${max}x${max}), which may cause rendering issues.');
 			}
 			#end
-
-			#if FLX_FREE_IMAGE_BUFFER
-			freeImageBuffer();
-			#end
 		}
 
 		return value;

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -423,15 +423,15 @@ class FlxGraphic implements IFlxDestroyable
 	}
 
 	/**
-	 * Frees the software image buffer for this graphic's `BitmapData`.
+	 * If possible, frees the software image buffer for this graphic's `BitmapData`.
 	 * This can significantly reduce RAM usage at the cost of not being able to draw on the graphic.
+	 * Call `FlxGraphic.refresh()` to refresh this graphic's `BitmapData` and restore drawing functionality.
 	 * 
-	 * Note that this operation might not complete immediately; 
-	 * it might take a bit for the garbage collector to collect the bitmap.
+	 * Note that the buffer may not be cleaned up immediately.
 	 * 
 	 * @see `openfl.display.BitmapData.disposeImage()`
 	 */
-	public function dump():Void
+	public function freeImageBuffer():Void
 	{
 		if (bitmap != null)
 			bitmap.disposeImage();

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -421,7 +421,22 @@ class FlxGraphic implements IFlxDestroyable
 		if (newBitmap != null)
 			bitmap = newBitmap;
 	}
-	
+
+	/**
+	 * Frees the software image buffer for this graphic's `BitmapData`.
+	 * This can significantly reduce RAM usage at the cost of not being able to draw on the graphic.
+	 * 
+	 * Note that this operation might not complete immediately; 
+	 * it might take a bit for the garbage collector to collect the bitmap.
+	 * 
+	 * @see `openfl.display.BitmapData.disposeImage()`
+	 */
+	public function dump():Void
+	{
+		if (bitmap != null)
+			bitmap.disposeImage();
+	}
+
 	@:deprecated("`undump` is deprecated, use `refresh`")
 	public function undump():Void
 	{

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -58,12 +58,6 @@ private enum UserDefines
 	 * If this flag is set to any string, that is used for the file extension
 	 */
 	FLX_DEFAULT_SOUND_EXT;
-	/**
-	 * If enabled, FlxGraphic instances will automatically call `FlxGraphic.freeImageBuffer()`.
-	 * This significantly decreases RAM usage but makes the bitmap uneditable.
-	 * Call `FlxGraphic.refresh()` to restore functionality for drawing on the bitmap.
-	 */
-	FLX_FREE_IMAGE_BUFFER;
 }
 
 /**

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -58,6 +58,12 @@ private enum UserDefines
 	 * If this flag is set to any string, that is used for the file extension
 	 */
 	FLX_DEFAULT_SOUND_EXT;
+	/**
+	 * If enabled, FlxGraphic instances will automatically call `FlxGraphic.freeImageBuffer()`.
+	 * This significantly decreases RAM usage but makes the bitmap uneditable.
+	 * Call `FlxGraphic.refresh()` to restore functionality for drawing on the bitmap.
+	 */
+	FLX_FREE_IMAGE_BUFFER;
 }
 
 /**


### PR DESCRIPTION
Adds the feature described in #3034. I think it might also be possible to add undumping, but I'd have to play around and confirm.

One concern I have is about the naming, imo I feel as if `dump` isn't very descriptive and there's also deprecated `canBeDumped` and `undump()` fields that aren't related to this.

Also, the original issue mentions:
> Depending on the type of graphic I think this should probably even be the default in many cases, requiring the graphic to be explicitly "undumped" to be drawn on.

Maybe there could be a compile flag (`FLX_GRAPHIC_DEFAULT_DUMP`?) or a variable that decides whether the graphics should be automatically dumped