### PR TITLE
Precise volume change callbacks

### DIFF
--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -467,16 +467,16 @@ class SoundFrontEnd
 	@:haxe.warning("-WDeprecated")
 	function set_volume(Volume:Float):Float
 	{
-		Volume = FlxMath.bound(Volume, 0, 1);
+		volume = FlxMath.bound(Volume, 0, 1);
 
 		if (volumeHandler != null)
 		{
-			volumeHandler(muted ? 0 : Volume);
+			volumeHandler(muted ? 0 : volume);
 		}
 
-		onVolumeChange.dispatch(muted ? 0 : Volume);
+		onVolumeChange.dispatch(muted ? 0 : volume);
 
-		return volume = Volume;
+		return volume;
 	}
 }
 #end


### PR DESCRIPTION
I've noticed that both `onVolumeChange` and `volumeHandler` seem to return the newly set value of `FlxG.sound.volume` while `volume` itself still stays as the same previous value until the return of the setter function gets called, this PR sets `volume` to the new value first and then the callbacks get dispatched.

This lead to causing problems with my code, would like to see this get pulled.