### PR TITLE
GC-Free group iterator

### DIFF
--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -938,7 +938,9 @@ class FlxTypedGroupIterator<T>
 	var _cursor:Int;
 	var _length:Int;
 
-	public function new(groupMembers:Array<T>, ?filter:T->Bool)
+	// NOTE: these methods are inlined to ensure there are no allocation when iterating through a group
+	
+	public inline function new(groupMembers:Array<T>, ?filter:T->Bool)
 	{
 		_groupMembers = groupMembers;
 		_filter = filter;
@@ -946,12 +948,12 @@ class FlxTypedGroupIterator<T>
 		_length = _groupMembers.length;
 	}
 
-	public function next()
+	public inline function next()
 	{
 		return hasNext() ? _groupMembers[_cursor++] : null;
 	}
 
-	public function hasNext():Bool
+	public inline function hasNext():Bool
 	{
 		while (_cursor < _length && (_groupMembers[_cursor] == null || _filter != null && !_filter(_groupMembers[_cursor])))
 		{


### PR DESCRIPTION
This pull request inlines all of the methods from `FlxTypedGroupIterator` to ensure there are no object allocation when looping through a group.
This is a common practice taken by Haxe developers, and it's quite good hygiene to reduce GC pressure notably if you are looping through a group each frames.

I tried this change with the following code:
```haxe
var group = new FlxGroup();
var memberId = 0;

for (member in group)
{
	member.ID = memberId++;
}
```

Here are the following JS and C++ output without this change:
```js
var group = new flixel_group_FlxTypedGroup();
var memberId = 0;
var member = new flixel_group_FlxTypedGroupIterator(group.members,null);
while(member.hasNext()) {
	var member1 = member.next();
	member1.ID = memberId++;
}
```
cpp:
```cpp
::flixel::group::FlxTypedGroup group =  ::flixel::group::FlxTypedGroup_obj::__alloc( HX_CTX ,null());
int memberId = 0;
{
	::Dynamic filter = null();
	::flixel::group::FlxTypedGroupIterator member =  ::flixel::group::FlxTypedGroupIterator_obj::__alloc( HX_CTX ,group->members,filter);
	while(member->hasNext()){
		::flixel::FlxBasic member1 = member->next().StaticCast<  ::flixel::FlxBasic >();
		memberId = (memberId + 1);
		member1->ID = (memberId - 1);
    }
}
```
(NOTE: for the C++ output I removed the `HXLINE` calls as it took a lot of place.)

Here is the JS output with this change (the C++ output is a bit long, but I can send it if required):
```js
var group = new flixel_group_FlxTypedGroup();
var memberId = 0;
var _g__groupMembers = group.members;
var _g__filter = null;
var _g__cursor = 0;
var _g__length = _g__groupMembers.length;
while(true) {
	while(_g__cursor < _g__length && (_g__groupMembers[_g__cursor] == null || _g__filter != null && !_g__filter(_g__groupMembers[_g__cursor]))) ++_g__cursor;
	if(!(_g__cursor < _g__length)) {
		break;
	}
	while(_g__cursor < _g__length && (_g__groupMembers[_g__cursor] == null || _g__filter != null && !_g__filter(_g__groupMembers[_g__cursor]))) ++_g__cursor;
	var member = _g__cursor < _g__length ? _g__groupMembers[_g__cursor++] : null;
	member.ID = memberId++;
}
```
As you can see, the iterator has been fully inlined and no longer causes it to be allocated.