### PR TITLE
Sprite `clipRect` improvements

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -436,6 +436,8 @@ class FlxSprite extends FlxObject
 		_frame = FlxDestroyUtil.destroy(_frame);
 		_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
 
+		clipRect = FlxDestroyUtil.put(clipRect);
+
 		shader = null;
 	}
 
@@ -1562,10 +1564,7 @@ class FlxSprite extends FlxObject
 	@:noCompletion
 	function set_clipRect(rect:FlxRect):FlxRect
 	{
-		if (rect != null)
-			clipRect = rect.round();
-		else
-			clipRect = null;
+		clipRect = rect;
 
 		if (frames != null)
 			frame = frames.frames[animation.frameIndex];


### PR DESCRIPTION
- Don't round `clipRect` to ensure smooth clipping no matter the scale
- Put `clipRect` back into the pool when the sprite is destroyed

Here is a sample demonstrating the visual changes of this pull request:
```haxe
package;

import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;

class PlayState extends FlxState
{
	var sprite:FlxSprite;
	var speed:Float = 1 / 4;
	var total:Float = 0;

	override function create():Void
	{
		super.create();

		sprite = new FlxSprite();
		sprite.loadGraphic("flixel/images/logo/default.png");
		sprite.scale.set(12, 12);
		sprite.updateHitbox();
		sprite.screenCenter();
		add(sprite);

		sprite.clipRect = flixel.math.FlxRect.get(0, 0, sprite.frameWidth, sprite.frameHeight);
	}

	function updateClipRect(increment:Float):Void
	{
		total += increment;
		sprite.clipRect.y = total;
		sprite.clipRect = sprite.clipRect;
	}

	override function update(elapsed:Float):Void
	{
		super.update(elapsed);

		if (FlxG.keys.pressed.DOWN)
			updateClipRect(sprite.frameHeight * speed * elapsed);

		if (FlxG.keys.pressed.UP)
			updateClipRect(sprite.frameHeight * -speed * elapsed);
	}
}
```

Without this change, the sprite from the sample clips in "chuncks"
https://github.com/user-attachments/assets/36343c09-b20e-4c6a-80f0-d219225f2620

With this change, the sprite now clips much smoother
https://github.com/user-attachments/assets/304f8b45-75c4-4cfe-bd1b-3f0a01b07c20
