### PR TITLE
Fix distanceTo regression in FlxPoint

### DIFF
--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -752,7 +752,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function distanceSquaredTo(x:Float, y:Float):Float
 	{
-		return (this.x - x) * (this.x - x) + (this.y - y) + (this.y - y);
+		return (this.x - x) * (this.x - x) + (this.y - y) * (this.y - y);
 	}
 
 	/**

--- a/tests/unit/src/flixel/math/FlxPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxPointTest.hx
@@ -45,6 +45,45 @@ class FlxPointTest extends FlxTest
 	}
 
 	@Test
+	function testDistanceTo():Void
+	{
+		assertDistanceTo(0, 0, 0, 0, 0);
+		assertDistanceTo(0, 0, 1, 0, 1);
+		assertDistanceTo(0, 0, 0, 1, 1);
+		assertDistanceTo(0, 0, -1, 0, 1);
+		assertDistanceTo(0, 0, 0, -1, 1);
+
+		assertDistanceTo(0, 0, 1, 1, Math.sqrt(2));
+		assertDistanceTo(0, 0, -1, 1, Math.sqrt(2));
+		assertDistanceTo(0, 0, 1, -1, Math.sqrt(2));
+		assertDistanceTo(0, 0, -1, -1, Math.sqrt(2));
+
+		assertDistanceTo(3, 4, 0, 0, 5);
+		assertDistanceTo(-3, -4, 0, 0, 5);
+		assertDistanceTo(3, 4, -3, -4, 10);
+
+		assertDistanceTo(5, 5, 10, 10, Math.sqrt(50));
+		assertDistanceTo(-5, -5, -10, -10, Math.sqrt(50));
+
+		assertDistanceTo(7, -3, -2, 6, Math.sqrt(162));
+		assertDistanceTo(-7, 3, 2, -6, Math.sqrt(162));
+	}
+
+	function assertDistanceTo(x0, y0, x1, y1, expected:Float):Void
+	{
+		point1.set(x0, y0);
+		point2.set(x1, y1);
+		FlxAssert.areNear(point1.distanceTo(point2), expected);
+		FlxAssert.areNear(point2.distanceTo(point1), expected);
+		FlxAssert.areNear(point1.dist(point2), expected);
+		FlxAssert.areNear(point2.dist(point1), expected);
+		FlxAssert.areNear(point1.distanceSquaredTo(point2), expected * expected);
+		FlxAssert.areNear(point2.distanceSquaredTo(point1), expected * expected);
+		FlxAssert.areNear(point1.distSquared(point2), expected * expected);
+		FlxAssert.areNear(point2.distSquared(point1), expected * expected);
+	}
+
+	@Test
 	function testDegreesBetween():Void
 	{
 		point1.set(0, 1);


### PR DESCRIPTION
Fix regression introduced in 6.0.0 where a multiply in `distanceSquaredTo` was changed to an add, meaning all `distanceTo`/`dist`-functions got broken.

Added tests for all the affected functions as well.

In case a minimal setup to test the issue is needed:
```haxe
package;

import flixel.math.FlxPoint;
import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;
import flixel.text.FlxText;
import flixel.util.FlxColor;

class PlayState extends FlxState
{
    var player = new FlxSprite(0, 128);
    var enemy = new FlxSprite (0, 0);
    var text = new FlxText(0, 0, 0, "", 16);

    override public function create()
    {
        super.create();
        player.makeGraphic(32, 32, FlxColor.WHITE);
        enemy.makeGraphic(32, 32, FlxColor.RED);

        player.screenCenter(X);
        enemy.screenCenter(XY);

        add(text);
        add(player);
        add(enemy);
    }

    override public function update(elapsed:Float)
    {
        var up:Bool = FlxG.keys.pressed.UP;
        var down:Bool = FlxG.keys.pressed.DOWN;
        var left:Bool = FlxG.keys.pressed.LEFT;
        var right:Bool = FlxG.keys.pressed.RIGHT;

        if (up && down) {
            up = down = false;
        }
        if (left && right) {
            left = right = false;
        }

        var dx = 0, dy = 0;
        dx = left ? -1 : dx;
        dx = right ? 1 : dx;
        dy = up ? -1 : dy;
        dy = down ? 1 : dy;

        var velocity = 250 * new FlxPoint(dx, dy).normalize();
        player.velocity.set(velocity.x, velocity.y);

        text.text = 'distanceTo: ${player.getPosition().distanceTo(enemy.getPosition())}
        distanceSquaredTo: ${player.getPosition().distanceSquaredTo(enemy.getPosition())}
        dist: ${player.getPosition().dist(enemy.getPosition())}
        distSquared: ${player.getPosition().distSquared(enemy.getPosition())}
        ';

        super.update(elapsed);
    }
}
```
Note how `distanceTo`/`dist` reports `NaN` or weird values depending on if the player is above or below the enemy and that `distanceSquaredTo`/`distSquared` can get negative values without the fix.