### PR TITLE
Query max texture size only once instead of every time it's needed.

### DIFF
--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -342,10 +342,14 @@ class BitmapFrontEnd
 	}
 
 	#if FLX_OPENGL_AVAILABLE
+	static var _maxTextureSize:Int = -1;
 	function get_maxTextureSize():Int
 	{
-		if (FlxG.stage.window.context.attributes.hardware)
-			return cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		if (_maxTextureSize > 0) return _maxTextureSize;
+		
+		if (FlxG.stage.window.context.attributes.hardware) {
+			return (_maxTextureSize = cast GL.getParameter(GL.MAX_TEXTURE_SIZE));
+		}
 		
 		return -1;
 	}

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -342,13 +342,13 @@ class BitmapFrontEnd
 	}
 
 	#if FLX_OPENGL_AVAILABLE
+	static var _maxTextureSize = -1;
 	function get_maxTextureSize():Int
 	{
-		static var size = -1;
-		if (size < 0 && FlxG.stage.window.context.attributes.hardware)
-			size = cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		if (_maxTextureSize < 0 && FlxG.stage.window.context.attributes.hardware)
+			_maxTextureSize = cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
 		
-		return size;
+		return _maxTextureSize;
 	}
 	#end
 

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -342,16 +342,13 @@ class BitmapFrontEnd
 	}
 
 	#if FLX_OPENGL_AVAILABLE
-	static var _maxTextureSize:Int = -1;
 	function get_maxTextureSize():Int
 	{
-		if (_maxTextureSize > 0) return _maxTextureSize;
+		static var size = -1;
+		if (size < 0 && FlxG.stage.window.context.attributes.hardware)
+			size = cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
 		
-		if (FlxG.stage.window.context.attributes.hardware) {
-			return (_maxTextureSize = cast GL.getParameter(GL.MAX_TEXTURE_SIZE));
-		}
-		
-		return -1;
+		return size;
 	}
 	#end
 


### PR DESCRIPTION
Redo of #3368 to allow edits by maintainers.