### PR TITLE
Add PS5 / DualSense controller model support

### DIFF
--- a/flixel/input/gamepad/FlxGamepad.hx
+++ b/flixel/input/gamepad/FlxGamepad.hx
@@ -832,7 +832,7 @@ class FlxGamepad implements IFlxDestroyable
 		{
 			case LOGITECH: new LogitechMapping(attachment);
 			case OUYA: new OUYAMapping(attachment);
-			case PS4: new PS4Mapping(attachment);
+			case PS4 | PS5: new PS4Mapping(attachment);
 			case PSVITA: new PSVitaMapping(attachment);
 			case XINPUT: new XInputMapping(attachment);
 			case MAYFLASH_WII_REMOTE: new MayflashWiiRemoteMapping(attachment);
@@ -930,6 +930,7 @@ enum FlxGamepadModel
 	LOGITECH;
 	OUYA;
 	PS4;
+	PS5;
 	PSVITA;
 	XINPUT;
 	MAYFLASH_WII_REMOTE;

--- a/flixel/input/gamepad/FlxGamepadManager.hx
+++ b/flixel/input/gamepad/FlxGamepadManager.hx
@@ -409,8 +409,10 @@ class FlxGamepadManager implements IFlxInputManager
 		name = name.toLowerCase().remove("-").remove("_");
 		return if (name.contains("ouya"))
 				OUYA; // "OUYA Game Controller"
-			else if (name.contains("wireless controller") || name.contains("ps4"))
+			else if (name.contains("wireless controller") || name.contains("ps4") || name.contains("dualshock 4"))
 				PS4; // "Wireless Controller" or "PS4 controller"
+			else if (name.contains("ps5") || name.contains('dualsense'))
+				PS5;
 			else if (name.contains("logitech"))
 				LOGITECH;
 			else if ((name.contains("xbox") && name.contains("360")) || name.contains("xinput"))


### PR DESCRIPTION
Currently PS5/PS4 controllers seem to work, but the `model` shows up as UNKNOWN.
This adds `'dualshock 4'` to the model check for ps4 controllers, and adds ps5 controllers to the list as well to fix the model name issue.