### PR TITLE
fix cliprect on scaled members in FlxSpriteGroup

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -1086,7 +1086,8 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		if (ClipRect == null)
 			Sprite.clipRect = null;
 		else
-			Sprite.clipRect = FlxRect.get(ClipRect.x - Sprite.x + x, ClipRect.y - Sprite.y + y, ClipRect.width, ClipRect.height);
+			Sprite.clipRect = FlxRect.get((ClipRect.x - Sprite.x + x) * (1 / Sprite.scale.x), (ClipRect.y - Sprite.y + y) * (1 / Sprite.scale.y),
+				ClipRect.width * (1 / Sprite.scale.x), ClipRect.height * (1 / Sprite.scale.y));
 	}
 
 	// Functions for the FlxCallbackPoint

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -1081,13 +1081,12 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 	inline function scrollFactorTransform(Sprite:FlxSprite, ScrollFactor:FlxPoint)
 		Sprite.scrollFactor.copyFrom(ScrollFactor);
 
-	inline function clipRectTransform(Sprite:FlxSprite, ClipRect:FlxRect)
+	function clipRectTransform(Sprite:FlxSprite, ClipRect:FlxRect)
 	{
 		if (ClipRect == null)
 			Sprite.clipRect = null;
 		else
-			Sprite.clipRect = FlxRect.get((ClipRect.x - Sprite.x + x) * (1 / Sprite.scale.x), (ClipRect.y - Sprite.y + y) * (1 / Sprite.scale.y),
-				ClipRect.width * (1 / Sprite.scale.x), ClipRect.height * (1 / Sprite.scale.y));
+			Sprite.clipRect = FlxRect.get(ClipRect.x - Sprite.x + x, ClipRect.y - Sprite.y + y, ClipRect.width, ClipRect.height);
 	}
 
 	// Functions for the FlxCallbackPoint


### PR DESCRIPTION
setting cliprect to a flxsprite group that has scaled members results in weird clipping

this video shows the clipping prior to the change, notice the profile picture becomes visible further to the left than other members of the group, as well as being clipped due to the height of the clipRect being 102 and the original size of the profile picture before being scaled was 184 - after scaling down the picture is 72 pixels. 

https://github.com/user-attachments/assets/841808ec-57e2-4302-a729-95370a747220

with the change, FlxSpriteGroup changes the height of the members' clipRect based on their scale.
after the change:

https://github.com/user-attachments/assets/474aeb47-c16b-4330-8f67-6f6e4baf4898


note that in the videos, the crown is not a part of the sprite group, so it being visible before the rest of the group is not relevant
