### PR TITLE
FlxKeyboard: Add enabled check when preparing to toggle debugger

### DIFF
--- a/flixel/input/keyboard/FlxKeyboard.hx
+++ b/flixel/input/keyboard/FlxKeyboard.hx
@@ -102,7 +102,7 @@ class FlxKeyboard extends FlxKeyManager<FlxKey, FlxKeyList>
 
 		// Debugger toggle
 		#if FLX_DEBUG
-		if (FlxG.game.debugger != null && inKeyArray(FlxG.debugger.toggleKeys, event) && !FlxInputText.globalManager.isTyping)
+		if (FlxG.game.debugger != null && inKeyArray(FlxG.debugger.toggleKeys, event) && enabled && !FlxInputText.globalManager.isTyping)
 		{
 			FlxG.debugger.visible = !FlxG.debugger.visible;
 		}


### PR DESCRIPTION
adds a check to FlxKeyboard that prevents it from opening / closing the debugger overlay if it is not enabled

as to why: i have an additional keyboard in my state (which i use alongside FlxG.keys) for a keybinding menu. this additional keyboard is usually disabled but when rebinding a key i enable my additional keyboard and disable FlxG.keys.
however, due to the debugger toggling by an FlxKeyboard always being enabled (even if said FlxKeyboard is disabled), pressing a debugger key with multiple keyboards will result in the debugger opening and closing immediately due to the visibility getting flipped twice