### PR TITLE
Improve FlxBitmapText rendering when using renderTile with clipRect

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -803,15 +803,15 @@ class FlxSprite extends FlxObject
 	 */
 	override public function draw():Void
 	{
+		checkClipRect();
+		
 		checkEmptyFrame();
-
+		
 		if (alpha == 0 || _frame.type == FlxFrameType.EMPTY)
 			return;
-
+		
 		if (dirty) // rarely
 			calcFrame(useFramePixels);
-		
-		checkClipRect();
 		
 		for (camera in getCamerasLegacy())
 		{
@@ -839,7 +839,8 @@ class FlxSprite extends FlxObject
 	 */
 	function checkClipRect()
 	{
-		if ((clipRect == null && Math.isNaN(_lastClipRect.x))
+		if (frames == null
+		|| (clipRect == null && Math.isNaN(_lastClipRect.x))
 		|| (clipRect != null && clipRect.equals(_lastClipRect)))
 			return;
 		

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -817,12 +817,12 @@ class FlxSprite extends FlxObject
 		{
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;
-
+			
 			if (isSimpleRender(camera))
 				drawSimple(camera);
 			else
 				drawComplex(camera);
-
+			
 			#if FLX_DEBUG
 			FlxBasic.visibleCount++;
 			#end

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -597,6 +597,37 @@ class FlxFrame implements IFlxDestroyable
 		return result;
 	}
 	
+	
+	/**
+	 * Whether this frame fully contains the given rect. If clipping this frame to
+	 * the given rect would result in a smaller frame, the result is `false`
+	 * @since 6.1.0
+	 */
+	public function contains(rect:FlxRect)
+	{
+		rect.x += frame.x - offset.x;
+		rect.y += frame.y - offset.y;
+		final result = frame.contains(rect);
+		rect.x -= frame.x - offset.x;
+		rect.y -= frame.y - offset.y;
+		return result;
+	}
+	
+	/**
+	 * Whether this frame is fully contained by the given rect. If clipping this frame to
+	 * the given rect would result in a smaller frame, the result is `false`
+	 * @since 6.1.0
+	 */
+	public function isContained(rect:FlxRect)
+	{
+		rect.x += frame.x - offset.x;
+		rect.y += frame.y - offset.y;
+		final result = rect.contains(frame);
+		rect.x -= frame.x - offset.x;
+		rect.y -= frame.y - offset.y;
+		return result;
+	}
+	
 	/**
 	 * Clips this frame to the desired rect
 	 *

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -584,7 +584,21 @@ class FlxFrame implements IFlxDestroyable
 		copyTo(clippedFrame);
 		return clippedFrame.clip(rect);
 	}
-
+	
+	/**
+	 * Whether there is any overlap between this frame and the given rect. If clipping this frame to
+	 * the given rect would result in an empty frame, the result is `false`
+	 */
+	public function overlaps(rect:FlxRect)
+	{
+		rect.x += frame.x - offset.x;
+		rect.y += frame.y - offset.y;
+		final result = rect.overlaps(frame);
+		rect.x -= frame.x - offset.x;
+		rect.y -= frame.y - offset.y;
+		return result;
+	}
+	
 	/**
 	 * Clips this frame to the desired rect
 	 *

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -143,9 +143,7 @@ class FlxFrame implements IFlxDestroyable
 
 	var blitMatrix:Vector<Float>;
 
-	@:allow(flixel.graphics.FlxGraphic)
-	@:allow(flixel.graphics.frames.FlxFramesCollection)
-	function new(parent:FlxGraphic, angle = FlxFrameAngle.ANGLE_0, flipX = false, flipY = false, duration = 0.0)
+	public function new(parent:FlxGraphic, angle = FlxFrameAngle.ANGLE_0, flipX = false, flipY = false, duration = 0.0)
 	{
 		this.parent = parent;
 		this.angle = angle;

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -286,6 +286,23 @@ class FlxRect implements IFlxPooled
 	}
 
 	/**
+	 * Checks to see if this rectangle fully contains another
+	 *
+	 * @param   rect  The other rectangle
+	 * @return  Whether this rectangle contains the given rectangle
+	 * @since 6.1.0
+	 */
+	public inline function contains(rect:FlxRect):Bool
+	{
+		final result = rect.left >= left
+			&& rect.right <= right
+			&& rect.top >= top
+			&& rect.bottom <= bottom;
+		rect.putWeak();
+		return result;
+	}
+
+	/**
 	 * Returns true if this FlxRect contains the FlxPoint
 	 *
 	 * @param   point  The FlxPoint to check

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1,17 +1,19 @@
 package flixel.text;
 
-import openfl.display.BitmapData;
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxBitmapFont;
 import flixel.graphics.frames.FlxFrame;
+import flixel.graphics.tile.FlxDrawBaseItem;
+import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.text.FlxText.FlxTextAlign;
 import flixel.text.FlxText.FlxTextBorderStyle;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import openfl.display.BitmapData;
 import openfl.geom.ColorTransform;
 
 using flixel.util.FlxColorTransformUtil;
@@ -198,9 +200,9 @@ class FlxBitmapText extends FlxSprite
 	var pendingTextBitmapChange:Bool = true;
 	var pendingPixelsChange:Bool = true;
 
-	var textData:Array<Float>;
-	var textDrawData:Array<Float>;
-	var borderDrawData:Array<Float>;
+	var textData:CharList;
+	var textDrawData:CharList;
+	var borderDrawData:CharList;
 
 	/**
 	 * Helper bitmap buffer for text pixels but without any color transformations
@@ -233,7 +235,6 @@ class FlxBitmapText extends FlxSprite
 		else
 		{
 			textData = [];
-
 			textDrawData = [];
 			borderDrawData = [];
 		}
@@ -313,7 +314,11 @@ class FlxBitmapText extends FlxSprite
 		}
 	}
 
-	override public function draw():Void
+	static final bgColorTransformDrawHelper = new ColorTransform();
+	static final borderColorTransformDrawHelper = new ColorTransform();
+	static final textColorTransformDrawHelper = new ColorTransform();
+	static final matrixDrawHelper = new FlxMatrix();
+	override function draw()
 	{
 		if (FlxG.renderBlit)
 		{
@@ -323,80 +328,35 @@ class FlxBitmapText extends FlxSprite
 		else
 		{
 			checkPendingChanges(true);
-
-			var textLength:Int = Std.int(textDrawData.length / 3);
-			var borderLength:Int = Std.int(borderDrawData.length / 3);
-
-			var dataPos:Int;
-
-			var cr:Float = color.redFloat;
-			var cg:Float = color.greenFloat;
-			var cb:Float = color.blueFloat;
-
-			var borderRed:Float = borderColor.redFloat * cr;
-			var borderGreen:Float = borderColor.greenFloat * cg;
-			var borderBlue:Float = borderColor.blueFloat * cb;
-			var bAlpha:Float = borderColor.alphaFloat * alpha;
-
-			var textRed:Float = cr;
-			var textGreen:Float = cg;
-			var textBlue:Float = cb;
-			var tAlpha:Float = alpha;
-
+			
+			final colorHelper = Std.int(alpha * 0xFF) << 24 | this.color;
+			
+			final textColorTransform = textColorTransformDrawHelper.reset();
+			textColorTransform.setMultipliers(colorHelper);
 			if (useTextColor)
-			{
-				textRed *= textColor.redFloat;
-				textGreen *= textColor.greenFloat;
-				textBlue *= textColor.blueFloat;
-				tAlpha *= textColor.alphaFloat;
-			}
-
-			var bgRed:Float = cr;
-			var bgGreen:Float = cg;
-			var bgBlue:Float = cb;
-			var bgAlpha:Float = alpha;
-
-			if (background)
-			{
-				bgRed *= backgroundColor.redFloat;
-				bgGreen *= backgroundColor.greenFloat;
-				bgBlue *= backgroundColor.blueFloat;
-				bgAlpha *= backgroundColor.alphaFloat;
-			}
-
-			var drawItem;
-			var currFrame:FlxFrame = null;
-			var currTileX:Float = 0;
-			var currTileY:Float = 0;
-			var sx:Float = scale.x * _facingHorizontalMult;
-			var sy:Float = scale.y * _facingVerticalMult;
-
-			var ox:Float = origin.x;
-			var oy:Float = origin.y;
-
-			if (_facingHorizontalMult != 1)
-			{
-				ox = frameWidth - ox;
-			}
-			if (_facingVerticalMult != 1)
-			{
-				oy = frameHeight - oy;
-			}
-
-			var clippedFrameRect;
+				textColorTransform.scaleMultipliers(textColor);
+			
+			final borderColorTransform = borderColorTransformDrawHelper.reset();
+			borderColorTransform.setMultipliers(borderColor).scaleMultipliers(colorHelper);
+			
+			final scaleX:Float = scale.x * _facingHorizontalMult;
+			final scaleY:Float = scale.y * _facingVerticalMult;
+			
+			final originX:Float = _facingHorizontalMult != 1 ? frameWidth - origin.x : origin.x;
+			final originY:Float = _facingVerticalMult != 1 ? frameHeight - origin.y : origin.y;
+			
+			final clippedFrameRect = FlxRect.get(0, 0, frameWidth, frameHeight);
 
 			if (clipRect != null)
-			{
-				clippedFrameRect = clipRect.intersection(FlxRect.weak(0, 0, frameWidth, frameHeight));
+				clippedFrameRect.clipTo(clipRect);
 
-				if (clippedFrameRect.isEmpty)
-					return;
-			}
-			else
-			{
-				clippedFrameRect = FlxRect.get(0, 0, frameWidth, frameHeight);
-			}
-
+			if (clippedFrameRect.isEmpty)
+				return;
+			
+			final charClipHelper = FlxRect.get();
+			final charClippedFrame = new FlxFrame(null);
+			final screenPos = FlxPoint.get();
+			
 			final cameras = getCamerasLegacy();
 			for (camera in cameras)
 			{
@@ -405,11 +365,11 @@ class FlxBitmapText extends FlxSprite
 					continue;
 				}
 
-				getScreenPosition(_point, camera).subtractPoint(offset);
+				getScreenPosition(screenPos, camera).subtractPoint(offset);
 
 				if (isPixelPerfectRender(camera))
 				{
-					_point.floor();
+					screenPos.floor();
 				}
 
 				updateTrig();
@@ -417,90 +377,63 @@ class FlxBitmapText extends FlxSprite
 				if (background)
 				{
 					// backround tile transformations
-					currFrame = FlxG.bitmap.whitePixel;
-					_matrix.identity();
-					_matrix.scale(0.1 * clippedFrameRect.width, 0.1 * clippedFrameRect.height);
-					_matrix.translate(clippedFrameRect.x - ox, clippedFrameRect.y - oy);
-					_matrix.scale(sx, sy);
+					final matrix = matrixDrawHelper;
+					matrix.identity();
+					matrix.scale(0.1 * clippedFrameRect.width, 0.1 * clippedFrameRect.height);
+					matrix.translate(clippedFrameRect.x - originX, clippedFrameRect.y - originY);
+					matrix.scale(scaleX, scaleY);
 
 					if (angle != 0)
 					{
-						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+						matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
 
-					_matrix.translate(_point.x + ox, _point.y + oy);
-					_colorParams.setMultipliers(bgRed, bgGreen, bgBlue, bgAlpha);
-					camera.drawPixels(currFrame, null, _matrix, _colorParams, blend, antialiasing);
+					matrix.translate(screenPos.x + originX, screenPos.y + originY);
+					final colorTransform = bgColorTransformDrawHelper.reset();
+					colorTransform.setMultipliers(colorHelper).scaleMultipliers(backgroundColor);
+					camera.drawPixels(FlxG.bitmap.whitePixel, null, matrix, colorTransform, blend, antialiasing);
 				}
-
-				var hasColorOffsets:Bool = (colorTransform != null && colorTransform.hasRGBAOffsets());
-
-				drawItem = camera.startQuadBatch(font.parent, true, hasColorOffsets, blend, antialiasing, shader);
-
-				for (j in 0...borderLength)
+				
+				final hasColorOffsets = (colorTransform != null && colorTransform.hasRGBAOffsets());
+				final drawItem = camera.startQuadBatch(font.parent, true, hasColorOffsets, blend, antialiasing, shader);
+				function addQuad(charCode:Int, x:Float, y:Float, color:ColorTransform)
 				{
-					dataPos = j * 3;
-
-					currFrame = font.getCharFrame(Std.int(borderDrawData[dataPos]));
-
-					currTileX = borderDrawData[dataPos + 1];
-					currTileY = borderDrawData[dataPos + 2];
-
+					final frame = font.getCharFrame(charCode);
 					if (clipRect != null)
 					{
-						clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY);
-						currFrame = currFrame.clipTo(clippedFrameRect);
+						charClipHelper.copyFrom(clippedFrameRect).offset(-x, -y);
+						frame.clipTo(charClipHelper, charClippedFrame);
 					}
-
-					currFrame.prepareMatrix(_matrix);
-					_matrix.translate(currTileX - ox, currTileY - oy);
-					_matrix.scale(sx, sy);
+					else
+					{
+						frame.copyTo(charClippedFrame);
+					}
+					
+					final matrix = matrixDrawHelper;
+					charClippedFrame.prepareMatrix(matrix);
+					matrix.translate(x - originX, y - originY);
+					matrix.scale(scaleX, scaleY);
 					if (angle != 0)
 					{
-						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
+						matrix.rotateWithTrig(_cosAngle, _sinAngle);
 					}
-
-					_matrix.translate(_point.x + ox, _point.y + oy);
-					_colorParams.setMultipliers(borderRed, borderGreen, borderBlue, bAlpha);
-					drawItem.addQuad(currFrame, _matrix, _colorParams);
+					
+					matrix.translate(screenPos.x + originX, screenPos.y + originY);
+					drawItem.addQuad(charClippedFrame, matrix, color);
 				}
-
-				for (j in 0...textLength)
-				{
-					dataPos = j * 3;
-
-					currFrame = font.getCharFrame(Std.int(textDrawData[dataPos]));
-
-					currTileX = textDrawData[dataPos + 1];
-					currTileY = textDrawData[dataPos + 2];
-
-					if (clipRect != null)
-					{
-						clippedFrameRect.copyFrom(clipRect).offset(-currTileX, -currTileY);
-						currFrame = currFrame.clipTo(clippedFrameRect);
-					}
-
-					currFrame.prepareMatrix(_matrix);
-					_matrix.translate(currTileX - ox, currTileY - oy);
-					_matrix.scale(sx, sy);
-					if (angle != 0)
-					{
-						_matrix.rotateWithTrig(_cosAngle, _sinAngle);
-					}
-
-					_matrix.translate(_point.x + ox, _point.y + oy);
-					_colorParams.setMultipliers(textRed, textGreen, textBlue, tAlpha);
-					drawItem.addQuad(currFrame, _matrix, _colorParams);
-				}
-
+				
+				borderDrawData.forEach(addQuad.bind(_, _, _, borderColorTransform));
+				textDrawData.forEach(addQuad.bind(_, _, _, textColorTransform));
+				
 				#if FLX_DEBUG
 				FlxBasic.visibleCount++;
 				#end
 			}
-
-			// dispose clipRect helpers
+			
+			// dispose helpers
 			clippedFrameRect.put();
-
+			screenPos.put();
+			
 			#if FLX_DEBUG
 			if (FlxG.debugger.drawDebug)
 			{
@@ -509,7 +442,7 @@ class FlxBitmapText extends FlxSprite
 			#end
 		}
 	}
-
+	
 	override function set_clipRect(Rect:FlxRect):FlxRect
 	{
 		super.set_clipRect(Rect);
@@ -1084,7 +1017,7 @@ class FlxBitmapText extends FlxSprite
 		}
 		else if (FlxG.renderTile)
 		{
-			textData.splice(0, textData.length);
+			textData.clear();
 		}
 
 		_fieldWidth = frameWidth;
@@ -1147,19 +1080,15 @@ class FlxBitmapText extends FlxSprite
 
 	function blitLine(line:UnicodeString, startX:Int, startY:Int):Void
 	{
-		var data:Array<Float> = [];
+		final data:CharList = [];
 		addLineData(line, startX, startY, data);
 		
-		while (data.length > 0)
+		data.forEach(function (charCode, x, y)
 		{
-			final charCode = Std.int(data.shift());
-			final x = data.shift();
-			final y = data.shift();
-			
 			final charFrame = font.getCharFrame(charCode);
 			_flashPoint.setTo(x, y);
 			charFrame.paint(textBitmap, _flashPoint, true);
-		}
+		});
 	}
 
 	function tileLine(line:UnicodeString, startX:Int, startY:Int)
@@ -1170,10 +1099,8 @@ class FlxBitmapText extends FlxSprite
 		addLineData(line, startX, startY, textData);
 	}
 	
-	function addLineData(line:UnicodeString, startX:Int, startY:Int, data:Array<Float>)
+	function addLineData(line:UnicodeString, startX:Int, startY:Int, data:CharList)
 	{
-		var pos:Int = data.length;
-		
 		var curX:Float = startX;
 		var curY:Int = startY;
 
@@ -1197,11 +1124,7 @@ class FlxBitmapText extends FlxSprite
 			final isSpace = isSpaceChar(charCode);
 			final hasFrame = font.charExists(charCode);
 			if (hasFrame && !isSpace)
-			{
-				data[pos++] = charCode;
-				data[pos++] = curX;
-				data[pos++] = curY;
-			}
+				data.push(charCode, curX, curY);
 			
 			if (hasFrame || isSpace)
 			{
@@ -1274,8 +1197,8 @@ class FlxBitmapText extends FlxSprite
 			}
 			else
 			{
-				textDrawData.splice(0, textDrawData.length);
-				borderDrawData.splice(0, borderDrawData.length);
+				textDrawData.clear();
+				borderDrawData.clear();
 			}
 
 			// use local var to avoid get_width and recursion
@@ -1443,39 +1366,29 @@ class FlxBitmapText extends FlxSprite
 			bitmap.draw(textBitmap, _matrix, _colorParams);
 		}
 	}
-
+	
 	function tileText(posX:Int, posY:Int, isFront:Bool = true):Void
 	{
 		if (!FlxG.renderTile)
 			return;
-
-		var data:Array<Float> = isFront ? textDrawData : borderDrawData;
-
-		var pos:Int = data.length;
-		var textPos:Int;
-		var textLen:Int = Std.int(textData.length / 3);
-		var rect = FlxRect.get();
-		var frameVisible;
-
-		for (i in 0...textLen)
+		
+		final data:CharList = isFront ? textDrawData : borderDrawData;
+		final rect = FlxRect.get();
+		
+		textData.forEach(function (charCode:Int, charX:Float, charY:Float)
 		{
-			textPos = 3 * i;
-
-			frameVisible = true;
-
+			final charFrame = font.getCharFrame(charCode);
+			
 			if (clipRect != null)
 			{
-				rect.copyFrom(clipRect).offset(-textData[textPos + 1] - posX, -textData[textPos + 2] - posY);
-				frameVisible = font.getCharFrame(Std.int(textData[textPos])).clipTo(rect).type != FlxFrameType.EMPTY;
+				rect.copyFrom(clipRect);
+				rect.offset(-charX - posX, -charY - posY);
+				if (!charFrame.overlaps(rect))
+					return;
 			}
-
-			if (frameVisible)
-			{
-				data[pos++] = textData[textPos];
-				data[pos++] = textData[textPos + 1] + posX;
-				data[pos++] = textData[textPos + 2] + posY;
-			}
-		}
+			
+			data.push(charCode, charX + posX, charY + posY);
+		});
 
 		rect.put();
 	}
@@ -1818,6 +1731,53 @@ enum WordSplitConditions
 	 * line, if possible, and is added character by character until the line is filled.
 	 */
 	WIDTH(minPixels:Int);
+}
+
+@:forward(length)
+abstract CharList(Array<Float>) from Array<Float>
+{
+	public inline function new ()
+	{
+		this = [];
+	}
+	
+	// TODO: deprecate
+	overload public inline extern function push(item:Float)
+	{
+		this.push(item);
+	}
+	
+	overload public inline extern function push(charCode:Int, x:Float, y:Float)
+	{
+		this.push(charCode);
+		this.push(x);
+		this.push(y);
+	}
+	
+	public function forEach(func:(charCode:Int, x:Float, y:Float)->Void)
+	{
+		for (i in 0...Std.int(this.length / 3))
+		{
+			final pos = i * 3;
+			func(Std.int(this[pos]), this[pos + 1], this[pos + 2]);
+		}
+	}
+	
+	public inline function clear()
+	{
+		this.resize(0);
+	}
+	
+	@:arrayAccess // TODO: deprecate
+	public inline function get(index:Int):Float
+	{
+		return this[index];
+	}
+	@:arrayAccess // TODO: deprecate
+	public inline function set(index:Int, value:Float):Float
+	{
+		return this[index] = value;
+	}
 }
 
 /*

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -459,11 +459,11 @@ class FlxBitmapText extends FlxSprite
 			forEachBorder(function (xOffset, yOffset)
 			{
 				lineDrawData.forEach(function (char, x, line)
-					drawFunc(font.getCharFrame(char), x + xOffset, line * spacing + yOffset, borderColorTransform)
+					drawFunc(font.getCharFrame(char), x + xOffset + padding, line * spacing + yOffset + padding, borderColorTransform)
 				);
 			});
 			
-			lineDrawData.forEach((char, x, line)->drawFunc(font.getCharFrame(char), x, line * spacing, textColorTransform));
+			lineDrawData.forEach((char, x, line)->drawFunc(font.getCharFrame(char), x + padding, line * spacing + padding, textColorTransform));
 		}
 	}
 	

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -517,7 +517,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param	Alpha		How opaque the color should be, either between 0 and 1 or 0 and 255.
 	 * @return	This color
 	 */
-	public inline function setHSB(Hue:Float, Saturation:Float, Brightness:Float, Alpha:Float):FlxColor
+	public inline function setHSB(Hue:Float, Saturation:Float, Brightness:Float, Alpha = 1.0):FlxColor
 	{
 		var chroma = Brightness * Saturation;
 		var match = Brightness - chroma;
@@ -533,7 +533,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param	Alpha		How opaque the color should be, either between 0 and 1 or 0 and 255
 	 * @return	This color
 	 */
-	public inline function setHSL(Hue:Float, Saturation:Float, Lightness:Float, Alpha:Float):FlxColor
+	public inline function setHSL(Hue:Float, Saturation:Float, Lightness:Float, Alpha = 1.0):FlxColor
 	{
 		var chroma = (1 - Math.abs(2 * Lightness - 1)) * Saturation;
 		var match = Lightness - chroma / 2;

--- a/flixel/util/FlxColorTransformUtil.hx
+++ b/flixel/util/FlxColorTransformUtil.hx
@@ -4,7 +4,96 @@ import openfl.geom.ColorTransform;
 
 class FlxColorTransformUtil
 {
-	public static function setMultipliers(transform:ColorTransform, red:Float, green:Float, blue:Float, alpha:Float):ColorTransform
+	/**
+	 * Resets the transform to default values, multipliers become `1.0` and offsets become `0.0`
+	 */
+	public static inline function reset(transform:ColorTransform):ColorTransform
+	{
+		return set(transform, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0);
+	}
+	
+	/**
+	 * Quick way to set all of a transform's values
+	 * 
+	 * @param   rMult    The value for the red multiplier, ranges from 0 to 1
+	 * @param   gMult    The value for the green multiplier, ranges from 0 to 1
+	 * @param   bMult    The value for the blue multiplier, ranges from 0 to 1
+	 * @param   aMult    The value for the alpha transparency multiplier, ranges from 0 to 1
+	 * @param   rOffset  The offset value for the red color channel, ranges from -255 to 255
+	 * @param   gOffset  The offset value for the green color channel, ranges from -255 to 255
+	 * @param   bOffset  The offset for the blue color channel value, ranges from -255 to 255
+	 * @param   aOffset  The offset for alpha transparency channel value, ranges from -255 to 255
+	 */
+	overload public static inline extern function set(transform:ColorTransform, 
+			rMult, gMult, bMult, aMult = 1.0,
+			rOffset, gOffset, bOffset, aOffset = 0.0):ColorTransform
+	{
+		setMultipliers(transform, rMult, gMult, bMult, aMult);
+		setOffsets(transform, rOffset, gOffset, bOffset, aOffset);
+		
+		return transform;
+	}
+	
+	/**
+	 * Quick way to set all of a transform's values
+	 * 
+	 * @param   colorMult  A `FlxColor` whos `redFloat`, `greenFloat`, `blueFloat` and
+	 *                    `alphaFloat` values determine the multipliers of this transform
+	 * @param   color      A `FlxColor` whos `red`, `green`, `blue` and `alpha` values
+	 *                     determine the offsets of this transform
+	 */
+	overload public static inline extern function set(transform:ColorTransform, colorMult = FlxColor.WHITE, colorOffset:FlxColor = 0x0):ColorTransform
+	{
+		return set(transform,
+			colorMult.redFloat, colorMult.greenFloat, colorMult.blueFloat, colorMult.alphaFloat,
+			colorOffset.red, colorOffset.green, colorOffset.blue, colorOffset.alpha
+		);
+	}
+	
+	/**
+	 * Scales each color's multiplier by the specifified amount
+	 * 
+	 * @param   rMult  The amount to scale the red multiplier
+	 * @param   gMult  The amount to scale the green multiplier
+	 * @param   bMult  The amount to scale the blue multiplier
+	 * @param   aMult  The amount to scale the alpha transparency multiplier
+	 * @return ColorTransform
+	 */
+	overload public static inline extern function scaleMultipliers(transform:ColorTransform, rMult = 1.0, gMult = 1.0, bMult = 1.0, aMult = 1.0):ColorTransform
+	{
+		transform.redMultiplier *= rMult;
+		transform.greenMultiplier *= gMult;
+		transform.blueMultiplier *= bMult;
+		transform.alphaMultiplier *= aMult;
+		
+		return transform;
+	}
+	
+	/**
+	 * Scales each color's multiplier by the color's specifified normal values
+	 * 
+	 * @param   color   A `FlxColor` whos `redFloat`, `greenFloat`, `blueFloat` and
+	 *                  `alphaFloat` values scale the multipliers of this transform
+	 */
+	overload public static inline extern function scaleMultipliers(transform:ColorTransform, color:FlxColor):ColorTransform
+	{
+		transform.redMultiplier *= color.redFloat;
+		transform.greenMultiplier *= color.greenFloat;
+		transform.blueMultiplier *= color.blueFloat;
+		transform.alphaMultiplier *= color.alphaFloat;
+		
+		return transform;
+	}
+	
+	/**
+	 * Quick way to set all of a transform's multipliers
+	 * 
+	 * @param   rMult  The value for the red multiplier, ranges from 0 to 1
+	 * @param   gMult  The value for the green multiplier, ranges from 0 to 1
+	 * @param   bMult  The value for the blue multiplier, ranges from 0 to 1
+	 * @param   aMult  The value for the alpha transparency multiplier, ranges from 0 to 1
+	 */
+	overload public static inline extern function setMultipliers(transform:ColorTransform, red:Float, green:Float, blue:Float, alpha:Float):ColorTransform
 	{
 		transform.redMultiplier = red;
 		transform.greenMultiplier = green;
@@ -13,7 +102,31 @@ class FlxColorTransformUtil
 
 		return transform;
 	}
+	
+	/**
+	 * Quick way to set all of a transform's multipliers with a single color
+	 * 
+	 * @param   color   A `FlxColor` whos `redFloat`, `greenFloat`, `blueFloat` and
+	 *                  `alphaFloat` values determine the multipliers of this transform
+	 */
+	overload public static inline extern function setMultipliers(transform:ColorTransform, color:FlxColor):ColorTransform
+	{
+		transform.redMultiplier = color.redFloat;
+		transform.greenMultiplier = color.greenFloat;
+		transform.blueMultiplier = color.blueFloat;
+		transform.alphaMultiplier = color.alphaFloat;
 
+		return transform;
+	}
+
+	/**
+	 * Quick way to set all of a transform's offsets
+	 * 
+	 * @param   red    The value for the red offset, ranges from 0 to 255
+	 * @param   green  The value for the green offset, ranges from 0 to 255
+	 * @param   blue   The value for the blue offset, ranges from 0 to 255
+	 * @param   alpha  The value for the alpha transparency offset, ranges from 0 to 255
+	 */
 	public static function setOffsets(transform:ColorTransform, red:Float, green:Float, blue:Float, alpha:Float):ColorTransform
 	{
 		transform.redOffset = red;


### PR DESCRIPTION
Previously, FlxBitmapText, on text/size/font changes, would cache the position of every character it draws, this includes caching each border character individually, but this did very to actually reduce rendering time, the real bottle-neck came from clipping each frame to the clipRect.

To stress test I added this to my test state
```hx
override function draw()
{
	for (i in 0...100)
		super.draw();
	}
}
```

I noticed a huge perf difference with the following cod:
```hx
final stringLong = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

final text = new FlxBitmapText(10, 10, stringLong);
text.fieldWidth = 200;
text.setBorderStyle(OUTLINE, FlxColor.BLACK, 1);
text.autoSize = false;
text.multiLine = false;
text.clipRect = FlxRect.get(0, 0, fieldWidth, lineHeight);
add(text);
```


| old | new |
| --- | ---- |
| <img width="166" alt="Screenshot 2025-03-11 at 10 20 17 AM" src="https://github.com/user-attachments/assets/9f578048-b289-4ad5-b61f-f91298189adb" /> | <img width="163" alt="Screenshot 2025-03-11 at 10 22 10 AM" src="https://github.com/user-attachments/assets/42fa6ebe-cc3a-40d1-9141-5c673b64714a" /> |

A 98% reduction in render time

I also tried multiline with a cliprect 
Old: 
<img width="856" alt="Screenshot 2025-03-11 at 10 24 27 AM" src="https://github.com/user-attachments/assets/313b216e-7868-4dd3-9450-25a75f589e0a" />
New:
<img width="599" alt="Screenshot 2025-03-11 at 10 27 13 AM" src="https://github.com/user-attachments/assets/c312e7d6-9be2-4705-a946-884badc683b8" />

A 99.6% reduction in rendering time