### PR TITLE
FlxBitmapText: add autoBounds

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1,6 +1,5 @@
 package flixel.text;
 
-import openfl.display.BitmapData;
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxSprite;
@@ -12,6 +11,7 @@ import flixel.text.FlxText.FlxTextAlign;
 import flixel.text.FlxText.FlxTextBorderStyle;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import openfl.display.BitmapData;
 import openfl.geom.ColorTransform;
 
 using flixel.util.FlxColorTransformUtil;
@@ -94,6 +94,12 @@ class FlxBitmapText extends FlxSprite
 	 * Default value if true.
 	 */
 	public var autoSize(default, set):Bool = true;
+	
+	/**
+	 * Whether to autmatically adjust the `width`, `height`, `offset` and
+	 * `origin` whenever the size of the text is changed.
+	 */
+	public var autoBounds(default, set):Bool = true;
 
 	/**
 	 * Number of pixels between text and text field border
@@ -1278,11 +1284,8 @@ class FlxBitmapText extends FlxSprite
 				borderDrawData.splice(0, borderDrawData.length);
 			}
 
-			// use local var to avoid get_width and recursion
-			final newWidth = width = Math.abs(scale.x) * frameWidth;
-			final newHeight = height = Math.abs(scale.y) * frameHeight;
-			offset.set(-0.5 * (newWidth - frameWidth), -0.5 * (newHeight - frameHeight));
-			centerOrigin();
+			if (autoBounds)
+				autoAdjustBounds();
 		}
 
 		if (!useTiles)
@@ -1396,6 +1399,15 @@ class FlxBitmapText extends FlxSprite
 
 		if (pendingPixelsChange)
 			throw "pendingPixelsChange was changed to true while processing changed pixels";
+	}
+	
+	function autoAdjustBounds()
+	{
+		// use local var to avoid get_width and recursion
+		final newWidth = width = Math.abs(scale.x) * frameWidth;
+		final newHeight = height = Math.abs(scale.y) * frameHeight;
+		offset.set(-0.5 * (newWidth - frameWidth), -0.5 * (newHeight - frameHeight));
+		centerOrigin();
 	}
 
 	function drawText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData, useTiles:Bool = false):Void
@@ -1609,6 +1621,14 @@ class FlxBitmapText extends FlxSprite
 			pendingTextChange = true;
 
 		return autoSize = value;
+	}
+	
+	function set_autoBounds(value:Bool):Bool
+	{
+		if (autoBounds != value)
+			pendingTextChange = true;
+		
+		return this.autoBounds = value;
 	}
 
 	function set_padding(value:Int):Int

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -98,6 +98,7 @@ class FlxBitmapText extends FlxSprite
 	/**
 	 * Whether to autmatically adjust the `width`, `height`, `offset` and
 	 * `origin` whenever the size of the text is changed.
+	 * @since 6.1.0
 	 */
 	public var autoBounds(default, set):Bool = true;
 

--- a/tests/unit/src/flixel/text/FlxBitmapTextTest.hx
+++ b/tests/unit/src/flixel/text/FlxBitmapTextTest.hx
@@ -32,6 +32,18 @@ class FlxBitmapTextTest extends FlxTest
 		Assert.areEqual(text1.font, text2.font);
 	}
 	
+	@Test // #1526 and #2750
+	function testAutoBounds()
+	{
+		final text = new FlxBitmapText("test");
+		text.autoBounds = false;
+		text.offset.x = 100;
+		text.text = "text.text.text";
+		@:privateAccess
+		text.checkPendingChanges(true);
+		Assert.areEqual(100, text.offset.x);
+	}
+	
 	@Test
 	function testWrapMono()
 	{


### PR DESCRIPTION
Add FlxBitmapText.autoBounds, allowing you to disable it and set width/height/offset/origin as you please

Related to https://github.com/HaxeFlixel/flixel/issues/2716 as an example where graphic size and collision size are coupled in a confusing way

Honestly, I wonder if autoBounds should be FlxSprite field