### PR TITLE
Small FlxBGSprite size fix

### DIFF
--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -29,7 +29,7 @@ class FlxBGSprite extends FlxSprite
 			}
 
 			_matrix.identity();
-			_matrix.scale(camera.viewWidth, camera.viewHeight);
+			_matrix.scale(camera.viewWidth + 1, camera.viewHeight + 1);
 			_matrix.translate(camera.viewMarginLeft, camera.viewMarginTop);
 			camera.drawPixels(frame, _matrix, colorTransform);
 


### PR DESCRIPTION
Due to some issue with openfl size render rounding using ``FlxBGSprite`` can create a small one pixel gap when fullscreened.
| Before| After|
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/2f131644-fbae-4d3b-b981-99ee1bd737cb) | ![image](https://github.com/user-attachments/assets/86bf7d65-b553-456d-a947-1c14f7bd1903)|

Heres my test code:
```haxe
class PlayState extends FlxState
{
	override public function create()
	{
		super.create();
		FlxG.camera.bgColor = FlxColor.GREEN;
		var bgSprite = new FlxBGSprite();
		bgSprite.color = FlxColor.RED;
		add(bgSprite);
	}
}

```