### PR TITLE
FlxDebugger: Add scale and defaultScale

### DIFF
--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -3,25 +3,25 @@ package flixel.system.debug;
 import openfl.display.BitmapData;
 import openfl.display.Sprite;
 #if FLX_DEBUG
+import flixel.FlxG;
+import flixel.system.FlxAssets;
+import flixel.system.debug.completion.CompletionList;
+import flixel.system.debug.console.Console;
+import flixel.system.debug.interaction.Interaction;
+import flixel.system.debug.log.BitmapLog;
+import flixel.system.debug.log.Log;
+import flixel.system.debug.stats.Stats;
+import flixel.system.debug.watch.Tracker;
+import flixel.system.debug.watch.Watch;
+import flixel.system.ui.FlxSystemButton;
+import flixel.util.FlxHorizontalAlign;
+import openfl.display.DisplayObject;
 import openfl.events.MouseEvent;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
 import openfl.text.TextField;
 import openfl.text.TextFieldAutoSize;
 import openfl.text.TextFormat;
-import openfl.display.DisplayObject;
-import flixel.FlxG;
-import flixel.system.debug.console.Console;
-import flixel.system.debug.log.Log;
-import flixel.system.debug.stats.Stats;
-import flixel.system.debug.watch.Watch;
-import flixel.system.debug.watch.Tracker;
-import flixel.system.debug.completion.CompletionList;
-import flixel.system.debug.log.BitmapLog;
-import flixel.system.debug.interaction.Interaction;
-import flixel.system.FlxAssets;
-import flixel.system.ui.FlxSystemButton;
-import flixel.util.FlxHorizontalAlign;
 
 using flixel.util.FlxArrayUtil;
 #end
@@ -33,6 +33,20 @@ using flixel.util.FlxArrayUtil;
 class FlxDebugger extends openfl.display.Sprite
 {
 	#if FLX_DEBUG
+	
+	
+	/**
+	 * The scale of the debug windows must be set before the `FlxGame` is made.
+	 * Can also use the compile flag `-DFLX_DEBUGGER_SCALE=2`
+	 */
+	public static var defaultScale:Int
+	#if FLX_DEBUGGER_SCALE
+	= Std.parseInt('${haxe.macro.Compiler.getDefine("FLX_DEBUGGER_SCALE")}');
+	#else
+	= 1;
+	#end
+	
+	
 	/**
 	 * Internal, used to space out windows from the edges.
 	 */
@@ -50,6 +64,7 @@ class FlxDebugger extends openfl.display.Sprite
 	public var vcr:VCR;
 	public var console:Console;
 	public var interaction:Interaction;
+	public var scale:Int;
 
 	var completionList:CompletionList;
 
@@ -84,13 +99,18 @@ class FlxDebugger extends openfl.display.Sprite
 	/**
 	 * Instantiates the debugger overlay.
 	 *
-	 * @param   Width    The width of the screen.
-	 * @param   Height   The height of the screen.
+	 * @param   width   The width of the screen.
+	 * @param   height  The height of the screen.
+	 * @param   scale   The scale of the debugger relative to the stage size
 	 */
 	@:allow(flixel.FlxGame)
-	function new(Width:Float, Height:Float)
+	function new(width:Float, height:Float, scale = 0)
 	{
 		super();
+		if (scale == 0)
+			scale = defaultScale;
+		scaleX = scale;
+		scaleY = scale;
 
 		visible = false;
 		tabChildren = false;
@@ -99,7 +119,7 @@ class FlxDebugger extends openfl.display.Sprite
 
 		_topBar = new Sprite();
 		_topBar.graphics.beginFill(0x000000, 0xAA / 255);
-		_topBar.graphics.drawRect(0, 0, FlxG.stage.stageWidth, TOP_HEIGHT);
+		_topBar.graphics.drawRect(0, 0, FlxG.stage.stageWidth / scaleX, TOP_HEIGHT);
 		_topBar.graphics.endFill();
 		addChild(_topBar);
 
@@ -148,7 +168,7 @@ class FlxDebugger extends openfl.display.Sprite
 
 		addChild(completionList);
 
-		onResize(Width, Height);
+		onResize(width, height);
 
 		addEventListener(MouseEvent.MOUSE_OVER, onMouseOver);
 		addEventListener(MouseEvent.MOUSE_OUT, onMouseOut);
@@ -292,16 +312,19 @@ class FlxDebugger extends openfl.display.Sprite
 		}
 	}
 
-	public function onResize(Width:Float, Height:Float):Void
+	public function onResize(width:Float, height:Float, scale = 0):Void
 	{
-		_screen.x = Width;
-		_screen.y = Height;
+		if (scale == 0)
+			scale = defaultScale;
+		this.scale = scale;
+		_screen.x = width / scale;
+		_screen.y = height / scale;
 
 		updateBounds();
-		_topBar.width = FlxG.stage.stageWidth;
+		_topBar.width = FlxG.stage.stageWidth / scaleX;
 		resetButtonLayout();
 		resetLayout();
-		scaleX = scaleY = 1;
+		scaleX = scaleY = scale;
 		x = -FlxG.scaleMode.offset.x;
 		y = -FlxG.scaleMode.offset.y;
 	}
@@ -342,10 +365,10 @@ class FlxDebugger extends openfl.display.Sprite
 	{
 		hAlignButtons(_buttons[FlxHorizontalAlign.LEFT], 10, true, 10);
 
-		var offset = FlxG.stage.stageWidth * 0.5 - hAlignButtons(_buttons[FlxHorizontalAlign.CENTER], 10, false) * 0.5;
+		var offset = FlxG.stage.stageWidth / scaleX * 0.5 - hAlignButtons(_buttons[FlxHorizontalAlign.CENTER], 10, false) * 0.5;
 		hAlignButtons(_buttons[FlxHorizontalAlign.CENTER], 10, true, offset);
 
-		var offset = FlxG.stage.stageWidth - hAlignButtons(_buttons[FlxHorizontalAlign.RIGHT], 10, false);
+		var offset = FlxG.stage.stageWidth / scaleX - hAlignButtons(_buttons[FlxHorizontalAlign.RIGHT], 10, false);
 		hAlignButtons(_buttons[FlxHorizontalAlign.RIGHT], 10, true, offset);
 	}
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -4,6 +4,7 @@ import haxe.io.Path;
 import haxe.macro.Compiler;
 import haxe.macro.Context;
 import haxe.macro.Expr.Position;
+
 using StringTools;
 #if (flixel_addons >= "3.2.2")
 import flixel.addons.system.macros.FlxAddonDefines;
@@ -58,6 +59,11 @@ private enum UserDefines
 	 * If this flag is set to any string, that is used for the file extension
 	 */
 	FLX_DEFAULT_SOUND_EXT;
+	
+	/**
+	 * Used to make the debug windows bigger
+	 */
+	FLX_DEBUGGER_SCALE;
 }
 
 /**

--- a/tests/coverage/Project.xml
+++ b/tests/coverage/Project.xml
@@ -79,5 +79,6 @@
 		<haxedef name="FLX_NO_HEALTH" />
 		<haxedef name="FLX_4_LEGACY_COLLISION" />
 		<haxedef name="FLX_DEFAULT_SOUND_EXT" />
+		<haxedef name="FLX_DEBUGGER_SCALE" value="2" />
 	</section>
 </project>


### PR DESCRIPTION
- Adds `FlxDebugger.defaultScale`
- Adds scale arg to constructor and `onResize`
- Adds compiler flag `FLX_DEBUGGER_SCALE`