### PR TITLE
Fix `FlxAtlas` not persisting between states with persist flag set to true

### DIFF
--- a/flixel/graphics/atlas/FlxAtlas.hx
+++ b/flixel/graphics/atlas/FlxAtlas.hx
@@ -810,7 +810,7 @@ class FlxAtlas implements IFlxDestroyable
 
 	function onClear(_):Void
 	{
-		if (!persist || (_graphic != null && _graphic.useCount <= 0))
+		if (!persist && _graphic != null && _graphic.useCount <= 0)
 			destroy();
 	}
 


### PR DESCRIPTION
I think an oversight was made in the check so the atlas would get cleared from memory even if you had `persist` set to true.