### PR TITLE
Don't clear the asset key when destroying an FlxGraphic

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -449,8 +449,6 @@ class FlxGraphic implements IFlxDestroyable
 
 		shader = null;
 
-		key = null;
-		assetsKey = null;
 		assetsClass = null;
 		imageFrame = FlxDestroyUtil.destroy(imageFrame);
 


### PR DESCRIPTION
I've found that I sometimes have to debug issues with accidentally disposing of FlxGraphics I don't mean to. In these cases, I generally try to diagnose the issue by setting a breakpoint and inspecting the problematic graphic, but since the key gets set to null, I can't see which graphic is causing problems.