### PR TITLE
FlxSprite: Update old clipRect documentation

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -272,8 +272,6 @@ class FlxSprite extends FlxObject
 
 	/**
 	 * Clipping rectangle for this sprite.
-	 * Changing the rect's properties directly doesn't have any effect,
-	 * reassign the property to update it (`sprite.clipRect = sprite.clipRect;`).
 	 * Set to `null` to discard graphic frame clipping.
 	 */
 	public var clipRect(default, set):FlxRect;


### PR DESCRIPTION
My understanding is that since #3381 clipRect doesn't require to be constantly set via the setter, in which case the documentation should be updated