### PR TITLE
[FlxSound] Remove Flash conditional in loadByteArray()

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -13,9 +13,7 @@ import openfl.media.Sound;
 import openfl.media.SoundChannel;
 import openfl.media.SoundTransform;
 import openfl.net.URLRequest;
-#if flash11
 import openfl.utils.ByteArray;
-#end
 
 /**
  * This is the universal flixel sound object, used for streaming, music, and sound effects.
@@ -409,7 +407,6 @@ class FlxSound extends FlxBasic
 		return init(Looped, AutoDestroy, OnComplete);
 	}
 	
-	#if flash11
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a ByteArray.
 	 *
@@ -429,7 +426,6 @@ class FlxSound extends FlxBasic
 		
 		return init(Looped, AutoDestroy, OnComplete);
 	}
-	#end
 	
 	function init(Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
 	{


### PR DESCRIPTION
When trying to find a way to load a sound from bytes, I came across `loadByteArray()` in `FlxSound`. The function is currently inside a `flash11` conditional. However, I tested it on both Windows and HashLink targets and it worked just fine.

I'd say that this conditional should be removed (unless it causes other problems ofc) since it sounds pretty useful and the only way for me to find it was to scroll through `FlxSound`.