### PR TITLE
Warn when `FLX_HEALTH` or `FLX_NO_HEALTH` is not defined, deprecate `tilemap.rayStep`

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1,6 +1,5 @@
 package flixel;
 
-import openfl.display.Graphics;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
@@ -13,6 +12,7 @@ import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxDirectionFlags;
 import flixel.util.FlxSpriteUtil;
 import flixel.util.FlxStringUtil;
+import openfl.display.Graphics;
 
 /**
  * At their core `FlxObjects` are just boxes with positions that can move and collide with other
@@ -46,7 +46,7 @@ import flixel.util.FlxStringUtil;
  * FlxG.overlap(playerGroup, medKitGroup
  *     function onOverlap(player, medKit)
  *     {
- *         player.health = 100;
+ *         player.heal(100);
  *         medKit.kill();
  *     }
  * );
@@ -670,7 +670,9 @@ class FlxObject extends FlxBasic
 	/**
 	 * Handy for storing health percentage or armor points or whatever.
 	 */
-	@:deprecated("object.health is being removed in version 6.0.0")
+	#if FLX_HEALTH_NOT_DEFINED
+	@:deprecated("object.health is deprecated, add <haxedef name=\"FLX_HEALTH\"/> in your project.xml to continue using it")
+	#end
 	public var health:Float = 1;
 	#end
 
@@ -1160,7 +1162,10 @@ class FlxObject extends FlxBasic
 	 *
 	 * @param   Damage   How much health to take away (use a negative number to give a health bonus).
 	 */
-	@:deprecated("object.health is being removed in version 6.0.0")
+	
+	#if FLX_HEALTH_NOT_DEFINED
+	@:deprecated("object.hurt is deprecated, add <haxedef name=\"FLX_HEALTH\"/> in your project.xml to continue using it")
+	#end
 	public function hurt(damage:Float):Void
 	{
 		health = health - damage;

--- a/flixel/path/FlxPathfinder.hx
+++ b/flixel/path/FlxPathfinder.hx
@@ -128,6 +128,7 @@ class FlxTypedPathfinder<Tilemap:FlxBaseTilemap<FlxObject>, Data:FlxTypedPathfin
 	 * @param data   The pathfinder data for this current search.
 	 * @param points An array of FlxPoint nodes.
 	 */
+	@:haxe.warning("-WDeprecated")
 	function simplifyPath(data:Data, points:Array<FlxPoint>, simplify:FlxPathSimplifier):Array<FlxPoint>
 	{
 		switch(simplify)
@@ -242,6 +243,7 @@ class FlxTypedPathfinder<Tilemap:FlxBaseTilemap<FlxObject>, Data:FlxTypedPathfin
 	 * @param points     An array of FlxPoint nodes.
 	 * @param reolution  Defaults to 1, meaning check every tile or so.  Higher means more checks!
 	 */
+	@:haxe.warning("-WDeprecated")
 	function simplifyRayStep(data:Data, points:Array<FlxPoint>, resolution:Float):Void
 	{
 		// A point used to calculate rays
@@ -688,6 +690,7 @@ enum FlxPathSimplifier
 	 * Removes nodes who'with neighbors that have no walls directly blocking
 	 * Uses `tilemap.rayStep`.
 	 */
+	@:deprecated("RAY_STEP is deprecated, use RAY, instead")
 	RAY_STEP(resolution:Float);
 
 	/**

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -26,6 +26,8 @@ private enum UserDefines
 	FLX_NO_DEBUG;
 	/* Removes FlxObject.health */
 	FLX_NO_HEALTH;
+	/* Enables FlxObject.health */
+	FLX_HEALTH;
 	FLX_RECORD;
 	/* Defined in HaxeFlixel CI tests, do not use */
 	FLX_UNIT_TEST;
@@ -103,7 +105,8 @@ private enum HelperDefines
 	/* Used in HaxeFlixel CI, should have no effect on personal projects */
 	FLX_NO_CI;
 	FLX_SAVE;
-	FLX_HEALTH;
+	/** Neither FLX_HEALTH not FLX_NO_HEALTH was defined */
+	FLX_HEALTH_NOT_DEFINED;
 	FLX_NO_TRACK_POOLS;
 	FLX_NO_TRACK_GRAPHICS;
 	FLX_OPENGL_AVAILABLE;
@@ -210,10 +213,15 @@ class FlxDefines
 		defineInversion(FLX_UNIT_TEST, FLX_NO_UNIT_TEST);
 		defineInversion(FLX_COVERAGE_TEST, FLX_NO_COVERAGE_TEST);
 		defineInversion(FLX_SWF_VERSION_TEST, FLX_NO_SWF_VERSION_TEST);
-		defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
 		defineInversion(FLX_TRACK_POOLS, FLX_NO_TRACK_POOLS);
 		defineInversion(FLX_DEFAULT_SOUND_EXT, FLX_NO_DEFAULT_SOUND_EXT);
 		// defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS); // special case
+		// defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
+		if (!defined(FLX_NO_HEALTH) && !defined(FLX_HEALTH))
+		{
+			define(FLX_HEALTH_NOT_DEFINED);
+			define(FLX_HEALTH);
+		}
 	}
 
 	static function defineHelperDefines()

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -235,6 +235,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  Returns true if the ray made it from Start to End without hitting anything.
 	 *          Returns false and fills Result if a tile was hit.
 	 */
+	@:deprecated("rayStep is deprecated, ray() has an infinite resolution, without any loss in performance")
 	public function rayStep(start:FlxPoint, end:FlxPoint, ?result:FlxPoint, resolution:Float = 1):Bool
 	{
 		throw "rayStep must be implemented?";

--- a/tests/unit/src/flixel/system/frontEnds/ConsoleFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/ConsoleFrontEndTest.hx
@@ -10,7 +10,7 @@ import massive.munit.Assert;
 class ConsoleFrontEndTest
 {
 	@Test
-	#if !debug @Ignore #end
+	#if (!debug || hl) @Ignore #end // Fails on HL: https://github.com/HaxeFoundation/hashlink/issues/769
 	function testEnum()
 	{
 		FlxG.console.registerEnum(TestEnum);

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -674,6 +674,7 @@ class FlxTilemapTest extends FlxTest
 	}
 	
 	@Test
+	@:haxe.warning("-WDeprecated")
 	function testNegativeIndex()
 	{
 		final mapData = [


### PR DESCRIPTION
Fixes #3349
- `FlxObject`: Add user define FLX_HEALTH, warn people who use health, without defining it
- `FlxBaseTilemap`: Deprecate `rayStep`
- `FlxPathSimplifier`: Deprecate `RAY_STEP`