### PR TITLE
FlxBitmapText: Fix Incorrect alpha behavior

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -338,7 +338,7 @@ class FlxBitmapText extends FlxSprite
 		{
 			checkPendingChanges(true);
 			
-			final colorHelper = Std.int(alpha * 0xFF) << 24 | (this.color.rgb);
+			final colorHelper = Std.int(alpha * 0xFF) << 24 | this.color.rgb;
 			
 			final textColorTransform = textColorTransformDrawHelper.reset();
 			textColorTransform.setMultipliers(colorHelper);

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -338,7 +338,7 @@ class FlxBitmapText extends FlxSprite
 		{
 			checkPendingChanges(true);
 			
-			final colorHelper = Std.int(alpha * 0xFF) << 24 | (this.color & 0x00FFFFFF);
+			final colorHelper = Std.int(alpha * 0xFF) << 24 | (this.color.rgb);
 			
 			final textColorTransform = textColorTransformDrawHelper.reset();
 			textColorTransform.setMultipliers(colorHelper);

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -338,7 +338,7 @@ class FlxBitmapText extends FlxSprite
 		{
 			checkPendingChanges(true);
 			
-			final colorHelper = Std.int(alpha * 0xFF) << 24 | this.color;
+			final colorHelper = Std.int(alpha * 0xFF) << 24 | (this.color & 0x00FFFFFF);
 			
 			final textColorTransform = textColorTransformDrawHelper.reset();
 			textColorTransform.setMultipliers(colorHelper);


### PR DESCRIPTION
Fixed incorrect alpha behavior if you play with the alpha value.