### PR TITLE
Improve `FlxSprite` color transform handling, deprecate `FlxColor.to24Bit()`

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -255,14 +255,14 @@ class FlxSprite extends FlxObject
 	 * Blending modes, just like Photoshop or whatever, e.g. "multiply", "screen", etc.
 	 */
 	public var blend(default, set):BlendMode;
-
+	
 	/**
 	 * Tints the whole sprite to a color (`0xRRGGBB` format) - similar to OpenGL vertex colors. You can use
 	 * `0xAARRGGBB` colors, but the alpha value will simply be ignored. To change the opacity use `alpha`.
 	 * @see https://snippets.haxeflixel.com/sprites/color/
 	 */
-	public var color(default, set):FlxColor = 0xffffff;
-
+	public var color(default, set):FlxColor = FlxColor.WHITE;
+	
 	public var colorTransform(default, null):ColorTransform;
 
 	/**
@@ -1008,7 +1008,7 @@ class FlxSprite extends FlxObject
 			dirty = true;
 		return positions;
 	}
-
+	
 	/**
 	 * Sets the sprite's color transformation with control over color offsets.
 	 * With `FlxG.renderTile`, offsets are only supported on OpenFL Next version 3.6.0 or higher.
@@ -1025,13 +1025,13 @@ class FlxSprite extends FlxObject
 	public function setColorTransform(redMultiplier = 1.0, greenMultiplier = 1.0, blueMultiplier = 1.0, alphaMultiplier = 1.0,
 			redOffset = 0.0, greenOffset = 0.0, blueOffset = 0.0, alphaOffset = 0.0):Void
 	{
-		color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier).rgb;
-		alpha = alphaMultiplier;
+		@:bypassAccessor color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier, 0);
+		@:bypassAccessor alpha = alphaMultiplier;
 
 		colorTransform.setMultipliers(redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier);
 		colorTransform.setOffsets(redOffset, greenOffset, blueOffset, alphaOffset);
 
-		useColorTransform = alpha != 1 || color != 0xffffff || colorTransform.hasRGBOffsets();
+		useColorTransform = alpha != 1 || color != 0xffffff || colorTransform.hasRGBAOffsets();
 		dirty = true;
 	}
 	
@@ -1040,15 +1040,16 @@ class FlxSprite extends FlxObject
 		if (colorTransform == null)
 			return;
 
-		useColorTransform = alpha != 1 || color != 0xffffff;
+		useColorTransform = alpha != 1 || color.rgb != 0xffffff;
 		if (useColorTransform)
 			colorTransform.setMultipliers(color.redFloat, color.greenFloat, color.blueFloat, alpha);
 		else
 			colorTransform.setMultipliers(1, 1, 1, 1);
 
+		useColorTransform = useColorTransform || colorTransform.hasRGBAOffsets();
 		dirty = true;
 	}
-
+	
 	/**
 	 * Checks to see if a point in 2D world space overlaps this `FlxSprite` object's
 	 * current displayed pixels. This check is ALWAYS made in screen space, and

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -263,7 +263,10 @@ class FlxSprite extends FlxObject
 	 */
 	public var color(default, set):FlxColor = FlxColor.WHITE;
 	
-	public var colorTransform(default, null):ColorTransform;
+	/**
+	 * The color effects of this sprite, changes to `color` or `alplha` will be reflected here
+	 */
+	public final colorTransform = new ColorTransform();
 
 	/**
 	 * Whether or not to use a `ColorTransform` set via `setColorTransform()`.
@@ -394,7 +397,6 @@ class FlxSprite extends FlxObject
 		scale = FlxPoint.get(1, 1);
 		_halfSize = FlxPoint.get();
 		_matrix = new FlxMatrix();
-		colorTransform = new ColorTransform();
 		_scaledOrigin = new FlxPoint();
 	}
 
@@ -428,7 +430,6 @@ class FlxSprite extends FlxObject
 		_flashRect2 = null;
 		_flashPointZero = null;
 		_matrix = null;
-		colorTransform = null;
 		blend = null;
 
 		frames = null;
@@ -1037,9 +1038,6 @@ class FlxSprite extends FlxObject
 	
 	function updateColorTransform():Void
 	{
-		if (colorTransform == null)
-			return;
-
 		useColorTransform = alpha != 1 || color.rgb != 0xffffff;
 		if (useColorTransform)
 			colorTransform.setMultipliers(color.redFloat, color.greenFloat, color.blueFloat, alpha);

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1025,7 +1025,7 @@ class FlxSprite extends FlxObject
 	public function setColorTransform(redMultiplier = 1.0, greenMultiplier = 1.0, blueMultiplier = 1.0, alphaMultiplier = 1.0,
 			redOffset = 0.0, greenOffset = 0.0, blueOffset = 0.0, alphaOffset = 0.0):Void
 	{
-		color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier).to24Bit();
+		color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier).rgb;
 		alpha = alphaMultiplier;
 
 		colorTransform.setMultipliers(redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier);

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1507,11 +1507,12 @@ class FlxSprite extends FlxObject
 	@:noCompletion
 	function set_alpha(Alpha:Float):Float
 	{
+		Alpha = FlxMath.bound(Alpha, 0, 1);
 		if (alpha == Alpha)
 		{
 			return Alpha;
 		}
-		alpha = FlxMath.bound(Alpha, 0, 1);
+		alpha = Alpha;
 		updateColorTransform();
 		return alpha;
 	}

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -208,7 +208,10 @@ class FlxSprite extends FlxObject
 	public var bakedRotationAngle(default, null):Float = 0;
 
 	/**
-	 * Set alpha to a number between `0` and `1` to change the opacity of the sprite.
+	 * Set alpha to a number between `0` and `1` to change the opacity of the sprite. Calling
+	 * `setColorTransform` will also change this value
+	 * 
+	 * **NOTE:** This value is automatically clamped to 0 <= a <= 1
 	 @see https://snippets.haxeflixel.com/sprites/alpha/
 	 */
 	public var alpha(default, set):Float = 1.0;
@@ -246,7 +249,7 @@ class FlxSprite extends FlxObject
 	/**
 	 * Change the size of your sprite's graphic.
 	 * NOTE: The hitbox is not automatically adjusted, use `updateHitbox()` for that.
-	 * WARNING: With `FlxG.renderBlit`, scaling sprites decreases rendering performance by a factor of about x10!
+	 * **WARNING:** With `FlxG.renderBlit`, scaling sprites decreases rendering performance by a factor of about x10!
 	 * @see https://snippets.haxeflixel.com/sprites/scale/
 	 */
 	public var scale(default, null):FlxPoint;
@@ -257,8 +260,8 @@ class FlxSprite extends FlxObject
 	public var blend(default, set):BlendMode;
 	
 	/**
-	 * Tints the whole sprite to a color (`0xRRGGBB` format) - similar to OpenGL vertex colors. You can use
-	 * `0xAARRGGBB` colors, but the alpha value will simply be ignored. To change the opacity use `alpha`.
+	 * Multiplies this sprite's image by the given red, green and blue components, alpha is ignored.
+	 * To change the opacity use `alpha`. Calling `setColorTransform` will also change this value.
 	 * @see https://snippets.haxeflixel.com/sprites/color/
 	 */
 	public var color(default, set):FlxColor = FlxColor.WHITE;
@@ -1028,6 +1031,7 @@ class FlxSprite extends FlxObject
 	public function setColorTransform(redMultiplier = 1.0, greenMultiplier = 1.0, blueMultiplier = 1.0, alphaMultiplier = 1.0,
 			redOffset = 0.0, greenOffset = 0.0, blueOffset = 0.0, alphaOffset = 0.0):Void
 	{
+		alphaMultiplier = FlxMath.bound(alphaMultiplier, 0, 1);
 		@:bypassAccessor color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier, 1.0);
 		@:bypassAccessor alpha = alphaMultiplier;
 		
@@ -1520,26 +1524,24 @@ class FlxSprite extends FlxObject
 	}
 
 	@:noCompletion
-	function set_alpha(Alpha:Float):Float
+	function set_alpha(value:Float):Float
 	{
-		Alpha = FlxMath.bound(Alpha, 0, 1);
-		if (alpha == Alpha)
-		{
-			return Alpha;
-		}
-		alpha = Alpha;
+		value = FlxMath.bound(value, 0, 1);
+		if (alpha == value)
+			return value;
+		
+		alpha = value;
 		updateColorTransform();
 		return alpha;
 	}
 
 	@:noCompletion
-	function set_color(Color:FlxColor):Int
+	function set_color(value:FlxColor):Int
 	{
-		if (color == Color)
-		{
-			return Color;
-		}
-		color = Color;
+		if (color == value)
+			return value;
+		
+		color = value;
 		updateColorTransform();
 		return color;
 	}

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -266,7 +266,7 @@ class FlxSprite extends FlxObject
 	/**
 	 * The color effects of this sprite, changes to `color` or `alplha` will be reflected here
 	 */
-	public final colorTransform = new ColorTransform();
+	public var colorTransform(default, null) = new ColorTransform();
 
 	/**
 	 * Whether or not to use a `ColorTransform` set via `setColorTransform()`.

--- a/flixel/system/debug/DebuggerUtil.hx
+++ b/flixel/system/debug/DebuggerUtil.hx
@@ -30,7 +30,7 @@ class DebuggerUtil
 		tf.antiAliasType = AntiAliasType.NORMAL;
 		tf.gridFitType = GridFitType.PIXEL;
 		#end
-		tf.defaultTextFormat = new TextFormat(FlxAssets.FONT_DEBUGGER, Size, Color.to24Bit());
+		tf.defaultTextFormat = new TextFormat(FlxAssets.FONT_DEBUGGER, Size, Color.rgb);
 		tf.alpha = Color.alphaFloat;
 		tf.autoSize = TextFieldAutoSize.LEFT;
 		return tf;

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -289,7 +289,7 @@ class CameraFrontEnd
 			}
 			else
 			{
-				camera.fill(camera.bgColor.to24Bit(), camera.useBgAlphaBlending, camera.bgColor.alphaFloat);
+				camera.fill(camera.bgColor.rgb, camera.useBgAlphaBlending, camera.bgColor.alphaFloat);
 			}
 		}
 	}

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -862,16 +862,7 @@ class FlxText extends FlxSprite
 
 	override function updateColorTransform():Void
 	{
-		if (alpha != 1)
-		{
-			colorTransform.alphaMultiplier = alpha;
-			useColorTransform = true;
-		}
-		else
-		{
-			colorTransform.alphaMultiplier = 1;
-			useColorTransform = false;
-		}
+		colorTransform.alphaMultiplier = alpha;
 
 		dirty = true;
 	}

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -862,9 +862,6 @@ class FlxText extends FlxSprite
 
 	override function updateColorTransform():Void
 	{
-		if (colorTransform == null)
-			colorTransform = new ColorTransform();
-
 		if (alpha != 1)
 		{
 			colorTransform.alphaMultiplier = alpha;

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -664,17 +664,24 @@ class FlxText extends FlxSprite
 		updateDefaultFormat();
 		return LetterSpacing;
 	}
-
-	override function set_color(Color:FlxColor):Int
+	
+	override function setColorTransform(redMultiplier = 1.0, greenMultiplier = 1.0, blueMultiplier = 1.0, alphaMultiplier = 1.0, redOffset = 0.0, greenOffset = 0.0, blueOffset = 0.0, alphaOffset = 0.0)
 	{
-		if (_defaultFormat.color == Color.rgb)
-		{
-			return Color;
-		}
-		_defaultFormat.color = Color.rgb;
-		color = Color;
+		super.setColorTransform(1, 1, 1, 1, redOffset, greenOffset, blueOffset, alphaOffset);
+		_defaultFormat.color = FlxColor.fromRGBFloat(redMultiplier, greenMultiplier, blueMultiplier, 0);
 		updateDefaultFormat();
-		return Color;
+	}
+
+	override function set_color(value:FlxColor):Int
+	{
+		if (_defaultFormat.color == value.rgb)
+		{
+			return value;
+		}
+		_defaultFormat.color = value.rgb;
+		color = value;
+		updateDefaultFormat();
+		return value;
 	}
 
 	inline function get_font():String

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -667,11 +667,11 @@ class FlxText extends FlxSprite
 
 	override function set_color(Color:FlxColor):Int
 	{
-		if (_defaultFormat.color == Color.to24Bit())
+		if (_defaultFormat.color == Color.rgb)
 		{
 			return Color;
 		}
-		_defaultFormat.color = Color.to24Bit();
+		_defaultFormat.color = Color.rgb;
 		color = Color;
 		updateDefaultFormat();
 		return Color;
@@ -1232,7 +1232,7 @@ class FlxText extends FlxSprite
 	{
 		// Apply the default format
 		copyTextFormat(_defaultFormat, FormatAdjusted, false);
-		FormatAdjusted.color = UseBorderColor ? borderColor.to24Bit() : _defaultFormat.color;
+		FormatAdjusted.color = UseBorderColor ? borderColor.rgb : _defaultFormat.color;
 		textField.setTextFormat(FormatAdjusted);
 
 		// Apply other formats
@@ -1247,7 +1247,7 @@ class FlxText extends FlxSprite
 			{
 				var textFormat:TextFormat = formatRange.format.format;
 				copyTextFormat(textFormat, FormatAdjusted, false);
-				FormatAdjusted.color = UseBorderColor ? formatRange.format.borderColor.to24Bit() : textFormat.color;
+				FormatAdjusted.color = UseBorderColor ? formatRange.format.borderColor.rgb : textFormat.color;
 			}
 
 			textField.setTextFormat(FormatAdjusted, formatRange.range.start, Std.int(Math.min(formatRange.range.end, textField.text.length)));

--- a/flixel/util/FlxBitmapDataUtil.hx
+++ b/flixel/util/FlxBitmapDataUtil.hx
@@ -200,7 +200,7 @@ class FlxBitmapDataUtil
 					{
 						identical = false;
 
-						if (pixel1.to24Bit() != pixel2.to24Bit())
+						if (pixel1.rgb != pixel2.rgb)
 						{
 							result.setPixel32(i, j,
 								FlxColor.fromRGB(getDiff(pixel1.red, pixel2.red), getDiff(pixel1.green, pixel2.green), getDiff(pixel1.blue, pixel2.blue)));

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -364,7 +364,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 *
 	 * @return A 24 bit version of this color
 	 */
-	@:deprecated("to24Bit() is deprecated, use rgb field instead.")
+	@:deprecated("to24Bit() is deprecated, use rgb field, instead.")
 	public inline function to24Bit():FlxColor
 	{
 		return this & 0xffffff;

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -1,5 +1,6 @@
 package flixel.util;
 
+import flixel.tweens.FlxEase;
 import flixel.math.FlxMath;
 import flixel.system.macros.FlxMacroUtil;
 
@@ -258,16 +259,13 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param Ease An optional easing function, such as those provided in FlxEase
 	 * @return An array of colors of length Steps, shifting from Color1 to Color2
 	 */
-	public static function gradient(Color1:FlxColor, Color2:FlxColor, Steps:Int, ?Ease:Float->Float):Array<FlxColor>
+	public static function gradient(Color1:FlxColor, Color2:FlxColor, Steps:Int, ?Ease:EaseFunction):Array<FlxColor>
 	{
 		var output = new Array<FlxColor>();
 
 		if (Ease == null)
 		{
-			Ease = function(t:Float):Float
-			{
-				return t;
-			}
+			Ease = FlxEase.linear;
 		}
 
 		for (step in 0...Steps)
@@ -366,6 +364,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 *
 	 * @return A 24 bit version of this color
 	 */
+	@:deprecated("to24Bit() is deprecated, use rgb field instead.")
 	public inline function to24Bit():FlxColor
 	{
 		return this & 0xffffff;

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -572,7 +572,7 @@ class FlxSpriteUtil
 
 		if (FillColor != FlxColor.TRANSPARENT)
 		{
-			flashGfx.beginFill(FillColor.to24Bit(), FillColor.alphaFloat);
+			flashGfx.beginFill(FillColor.rgb, FillColor.alphaFloat);
 		}
 	}
 
@@ -634,7 +634,7 @@ class FlxSpriteUtil
 			if (lineStyle.miterLimit == null)
 				lineStyle.miterLimit = 3;
 
-			flashGfx.lineStyle(lineStyle.thickness, color.to24Bit(), color.alphaFloat, lineStyle.pixelHinting, lineStyle.scaleMode, lineStyle.capsStyle,
+			flashGfx.lineStyle(lineStyle.thickness, color.rgb, color.alphaFloat, lineStyle.pixelHinting, lineStyle.scaleMode, lineStyle.capsStyle,
 				lineStyle.jointStyle, lineStyle.miterLimit);
 		}
 	}

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -492,7 +492,7 @@ class FlxStringUtil
 		{
 			for (i in 0...ColorMap.length)
 			{
-				ColorMap[i] = ColorMap[i].to24Bit();
+				ColorMap[i] = ColorMap[i].rgb;
 			}
 		}
 

--- a/tests/unit/src/flixel/FlxSpriteTest.hx
+++ b/tests/unit/src/flixel/FlxSpriteTest.hx
@@ -57,13 +57,13 @@ class FlxSpriteTest extends FlxTest
 		var color = FlxColor.RED;
 		var colorSprite = new FlxSprite();
 		colorSprite.makeGraphic(100, 100, color);
-		Assert.areEqual(color.to24Bit(), colorSprite.pixels.getPixel(0, 0));
-		Assert.areEqual(color.to24Bit(), colorSprite.pixels.getPixel(90, 90));
+		Assert.areEqual(color.rgb, colorSprite.pixels.getPixel(0, 0));
+		Assert.areEqual(color.rgb, colorSprite.pixels.getPixel(90, 90));
 
 		color = FlxColor.GREEN;
 		colorSprite = new FlxSprite();
 		colorSprite.makeGraphic(120, 120, color);
-		Assert.areEqual(color.to24Bit(), colorSprite.pixels.getPixel(119, 119));
+		Assert.areEqual(color.rgb, colorSprite.pixels.getPixel(119, 119));
 	}
 
 	@Test


### PR DESCRIPTION
Changes:
- `FlxSprite.setColorTransform()` now bypasses `color` and `alpha` setters.
- `FlxSprite.useColorTransform` now accounts for alpha offset.
- `FlxColor.to24Bit()` is now deprecated in favor of `FlxColor.rgb` field.