### PR TITLE
Improve thrown error message when attempting to draw a destroyed FlxGraphic

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -608,7 +608,7 @@ class FlxCamera extends FlxBasic
 		
 		// TODO: catch this error when the dev actually messes up, not in the draw phase
 		if (graphic.isDestroyed)
-			throw 'Attempted to queue an invalid FlxDrawItem, did you destroy a cached sprite?';
+			throw 'Cannot queue ${graphic.key}. This sprite was destroyed.';
 
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smooth;


### PR DESCRIPTION
The error message that is thrown when attempting to draw a destroyed graphic currently is vague. It doesn't say what it tried to access, but was destroyed:

![Screenshot 2025-04-13 075124](https://github.com/user-attachments/assets/a90b9558-f8af-4a99-b6b5-cb267818c7f1)

It is harder to troubleshoot the issue if you don't know which graphic is getting destroyed when its not supposed to. Thanks to [this PR](https://github.com/HaxeFlixel/flixel/pull/3402), the key of a FlxGraphic isn't set to null when the graphic is destroyed. This means that it can be used in the thrown error message:

![Screenshot 2025-04-12 230131](https://github.com/user-attachments/assets/33e1a3e7-66e1-4018-9b61-70cd7c9674a2)

This aids in the process of figuring out which graphic was destroyed so you can start working on finding where it got destroyed.