### PR TITLE
Piecewise axis separate

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -159,8 +159,16 @@ class FlxObject extends FlxBasic
 	 */
 	public static function separate(object1:FlxObject, object2:FlxObject):Bool
 	{
+		var tmp1 = object1.last.copyTo();
+		var tmp2 = object2.last.copyTo();
 		final separatedX = separateX(object1, object2);
+		object1.last.x = object1.x;
+		object2.last.x = object2.x;
 		final separatedY = separateY(object1, object2);
+		object1.last.copyFrom(tmp1);
+		object2.last.copyFrom(tmp2);
+		tmp1.put();
+		tmp2.put();
 		return separatedX || separatedY;
 		
 		/*

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -117,30 +117,19 @@ class FlxObjectTest extends FlxTest
 		Assert.isFalse(FlxG.overlap(object1, object2));
 		Assert.isTrue(object1.y > object2.y);
 	}
-	@Test
-	function testComputeOverlapOnBothAxisNewlyOverlapping():Void
-	{
-		final object1 = new FlxObject(10.01, -.01, 10, 10);
-		final object2 = new FlxObject(0, 10, 10, 10);
-		
-		object1.setPosition(9.95, .05);
-		
-		FlxAssert.areNear(-.05, FlxObject.computeOverlapX(object1, object2));
-		FlxAssert.areNear(-.05, FlxObject.computeOverlapY(object1, object2));
-	}
 	
 	@Test
 	function testSeparateOnBothAxisNewlyOverlapping():Void
 	{
-		final object1 = new FlxObject(10.01, -.01, 10, 10);
+		final object1 = new FlxObject(11, -1, 10, 10);
 		final object2 = new FlxObject(0, 10, 10, 10);
 		object2.immovable = true;
 		
-		object1.setPosition(9.95, .05);
+		object1.setPosition(9, 2);
 		
 		Assert.isTrue(FlxObject.separate(object1, object2));
 		// X-axis resolves first and no collision
-		Assert.areEqual(9.95, object1.x);
+		Assert.areEqual(9, object1.x);
 		// Y-axis resolves second and is stopped by collision
 		Assert.areEqual(0, object1.y);
 	}

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -80,7 +80,7 @@ class FlxObjectTest extends FlxTest
 	}
 	
 	@Test
-	function testSeprateX():Void
+	function testSeparateX():Void
 	{
 		final object1 = new FlxObject(5, 0, 10, 10);
 		object1.last.x = 10;
@@ -100,7 +100,7 @@ class FlxObjectTest extends FlxTest
 	}
 	
 	@Test
-	function testSeprateY():Void
+	function testSeparateY():Void
 	{
 		final object1 = new FlxObject(0, 5, 10, 10);
 		object1.last.y = 10;
@@ -117,9 +117,36 @@ class FlxObjectTest extends FlxTest
 		Assert.isFalse(FlxG.overlap(object1, object2));
 		Assert.isTrue(object1.y > object2.y);
 	}
+	@Test
+	function testComputeOverlapOnBothAxisNewlyOverlapping():Void
+	{
+		final object1 = new FlxObject(10.01, -.01, 10, 10);
+		final object2 = new FlxObject(0, 10, 10, 10);
+		
+		object1.setPosition(9.95, .05);
+		
+		FlxAssert.areNear(-.05, FlxObject.computeOverlapX(object1, object2));
+		FlxAssert.areNear(-.05, FlxObject.computeOverlapY(object1, object2));
+	}
 	
 	@Test
-	function testSeprateXFromOpposite():Void
+	function testSeparateOnBothAxisNewlyOverlapping():Void
+	{
+		final object1 = new FlxObject(10.01, -.01, 10, 10);
+		final object2 = new FlxObject(0, 10, 10, 10);
+		object2.immovable = true;
+		
+		object1.setPosition(9.95, .05);
+		
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// X-axis resolves first and no collision
+		Assert.areEqual(9.95, object1.x);
+		// Y-axis resolves second and is stopped by collision
+		Assert.areEqual(0, object1.y);
+	}
+	
+	@Test
+	function testSeparateXFromOpposite():Void
 	{
 		/*
 		 * NOTE: An odd y value on either may result in a rounding error where the second
@@ -142,7 +169,7 @@ class FlxObjectTest extends FlxTest
 	}
 	
 	@Test
-	function testSeprateYFromOpposite():Void
+	function testSeparateYFromOpposite():Void
 	{
 		/*
 		 * NOTE: An odd y value on either may result in a rounding error where the second
@@ -371,7 +398,7 @@ class FlxObjectTest extends FlxTest
 	}
 
 	@Test
-	function testgetRotatedBounds()
+	function testGetRotatedBounds()
 	{
 		var expected = FlxRect.get();
 		var rect = FlxRect.get();

--- a/tests/unit/src/flixel/math/FlxRectTest.hx
+++ b/tests/unit/src/flixel/math/FlxRectTest.hx
@@ -34,7 +34,7 @@ class FlxRectTest extends FlxTest
 	}
 
 	@Test
-	function testgetRotatedBounds()
+	function testGetRotatedBounds()
 	{
 		var pivot = FlxPoint.get();
 		var expected = FlxRect.get();
@@ -64,7 +64,7 @@ class FlxRectTest extends FlxTest
 	}
 
 	@Test
-	function testgetRotatedBoundsSelf()
+	function testGetRotatedBoundsSelf()
 	{
 		var pivot = FlxPoint.get();
 		var expected = FlxRect.get();


### PR DESCRIPTION
The existing separation logic does not correctly detect/resolve the following scenario:

1. Object A's starting position (red dotted box) does not overlap with Object B (black box) on either the X or Y axis
2. Object A moves to now be overlapping on _BOTH_ axes of Object B (shown by red solid box)
![image](https://github.com/user-attachments/assets/19607366-03e8-46c1-b40c-d18d3d8a0f29)

This is caused because the "swept hull's" look at each axis individually before updating Object A's X and Y components.

### Current implementation
![image](https://github.com/user-attachments/assets/0373b766-d205-4a01-baca-337945bcc041)

1. Shows Object A's last (dotted red) and current (solid red) positions
2. Shows Object A's intermediate position in Yellow
3. Blue box shows swept hull along X-axis based on Object A's `last` coordinates
4. No collision found, so Object A's intermediate x-position is updated
5. Blue box shows swept hull along Y-axis based on Object A's `last` coordinates
6. No collision found, so Object A's intermediate y-position is updated

### New implementation
![image](https://github.com/user-attachments/assets/b8be9a01-5d54-4bdf-81cb-2e998e23d918)
1. Shows Object A's last (dotted red) and current (solid red) positions
2. Shows Object A's intermediate position in Yellow
3. Blue box shows swept hull along X-axis based on Object A's `last` coordinates
4. No collision found, so Object A's intermediate x-position is updated
  * Not pictured: After this step, we temporarily update Object A's last x-position so that new swept hull captures the correct space
5. Blue box shows swept hull along Y-axis based on Object A's newly updated `last` coordinates
6. No collision found, so Object A's intermediate y-position is updated

Issue discussed in discord [here](https://discord.com/channels/162395145352904705/165234904815239168/1361086759315968012)

Reference material that I remembered existed when I started running into this from [Leilani's island devlog](https://forums.tigsource.com/index.php?topic=46289.msg1386874#msg1386874)