### PR TITLE
Add muted property to FlxSoundGroup

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -605,7 +605,7 @@ class FlxSound extends FlxBasic
 		final volume = (group != null ? group.volume : 1.0) * _volume * _volumeAdjust;
 		
 		#if FLX_SOUND_SYSTEM
-		if (FlxG.sound.muted)
+		if (FlxG.sound.muted || (group != null && group.muted))
 			return 0.0;
 		
 		return FlxG.sound.applySoundCurve(FlxG.sound.volume * volume);

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -602,10 +602,10 @@ class FlxSound extends FlxBasic
 	
 	function calcTransformVolume():Float
 	{
-		final volume = (group != null ? group.volume : 1.0) * _volume * _volumeAdjust;
+		final volume = (group != null ? group.getVolume() : 1.0) * _volume * _volumeAdjust;
 		
 		#if FLX_SOUND_SYSTEM
-		if (FlxG.sound.muted || (group != null && group.muted))
+		if (FlxG.sound.muted)
 			return 0.0;
 		
 		return FlxG.sound.applySoundCurve(FlxG.sound.volume * volume);

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -18,7 +18,7 @@ class FlxSoundGroup
 	/**
 	 * Whether or not this group is muted
 	 */
-	public var muted:Bool;
+	public var muted(default, set):Bool;
 
 	/**
 	 * Create a new sound group
@@ -106,5 +106,15 @@ class FlxSoundGroup
 			sound.updateTransform();
 		}
 		return volume;
+	}
+
+	function set_muted(value:Bool):Bool
+	{
+		muted = value;
+		for (sound in sounds)
+		{
+			sound.updateTransform();
+		}
+		return muted;
 	}
 }

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -16,6 +16,11 @@ class FlxSoundGroup
 	public var volume(default, set):Float;
 
 	/**
+	 * Whether or not this group is muted
+	 */
+	public var muted:Bool;
+
+	/**
 	 * Create a new sound group
 	 * @param	volume  The initial volume of this group
 	 */

--- a/flixel/sound/FlxSoundGroup.hx
+++ b/flixel/sound/FlxSoundGroup.hx
@@ -89,6 +89,15 @@ class FlxSoundGroup
 			sound.resume();
 	}
 
+	/**
+	 * Returns the volume of this group, taking `muted` in account.
+	 * @return The volume of the group or 0 if the group is muted.
+	 */
+	public function getVolume():Float
+	{
+		return muted ? 0.0 : volume;
+	}
+
 	function set_volume(volume:Float):Float
 	{
 		this.volume = volume;


### PR DESCRIPTION
A convenience property like `FlxG.sound.muted` that allows us to mute sounds on a group basis.

In my use case I wanted to allow muting sound effects and music seperately and this seems like the simplest option to do so as it will retain the volume of the group