### PR TITLE
Implement `FlxSignal.cancel`/`canceled`

### DIFF
--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -129,9 +129,9 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 
 	public function new()
 	{
+		canceled = false;
 		handlers = [];
 		pendingRemove = [];
-		canceled = false;
 	}
 
 	public function add(listener:T)
@@ -322,10 +322,7 @@ private class Macro
 			for (handler in handlers)
 			{
 				if (canceled)
-				{
-					canceled = false;
 					break;
-				}
 
 				handler.listener($a{exprs});
 
@@ -333,6 +330,7 @@ private class Macro
 					removeHandler(handler);
 			}
 
+			canceled = false;
 			processingListeners = false;
 
 			for (handler in pendingRemove)


### PR DESCRIPTION
FlxSignals have lacked the ability to cancel propagation for a long time now, even though it is found in related OpenFl and Lime classes. I have recently had the need to cancel FlxSignal dispatch during propagation, hence this pull request

Also reorganized the order of some class fields to fit with the interface

May need more advanced testing (not sure how unit tests etc will work out) but this simple test cases compiles and functions as expected ("Progress Three" is never traced):

```haxe
package;

import flixel.FlxState;

import flixel.util.FlxSignal;

class PlayState extends FlxState
{
	public var processes:FlxSignal;

	override public function create()
	{
		super.create();

		processes = new FlxSignal();

		processes.add(processOne);

		processes.add(processTwo);

		processes.add(processThree);

		processes.dispatch();
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);
	}

	public function processOne():Void
	{
		trace("Process One");
	}

	public function processTwo():Void
	{
		trace("Process Two");

		processes.cancel();
	}

	public function processThree():Void
	{
		trace("Progress Three");
	}
}
```

This is my first time interacting with abstracts, so I might be missing something basic