### PR TITLE
allow destroying flxsignals during dispatch

### DIFF
--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -302,12 +302,15 @@ private class Macro
 
 			processingListeners = false;
 
-			for (handler in pendingRemove)
+			if (pendingRemove != null)
 			{
-				removeHandler(handler);
+				for (handler in pendingRemove)
+				{
+					removeHandler(handler);
+				}
+				if (pendingRemove.length > 0)
+					pendingRemove = [];
 			}
-			if (pendingRemove.length > 0)
-				pendingRemove = [];
 		}
 	}
 }


### PR DESCRIPTION
At first glance this does seem like a bit of a strange request, don't have high hopes for getting this merged

This issue has come up a lot when trying to `destroy` sprites when an animation completes. I would much prefer to be able just destroy during dispatch rather than `kill` the sprite, or use a longer if check under `update`