### PR TITLE
Remove Neko Target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         haxe-version: ["4.2.5", "4.3.6"]
-        target: [html5, hl, neko, flash, cpp]
+        target: [html5, hl, flash, cpp]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/checkstyle.json
+++ b/checkstyle.json
@@ -12,7 +12,7 @@
 		["FLX_GAMEINPUT_API"],
 		["flash", "web"],
 		["html5", "js", "web"],
-		["neko", "desktop", "sys"],
+		["desktop", "sys"],
 		["android", "cpp", "mobile"]
 	],
 	"exclude": {

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -180,7 +180,7 @@ class FlxG
 	public static var scaleMode(default, set):BaseScaleMode = new RatioScaleMode();
 
 	/**
-	 * Use this to toggle between fullscreen and normal mode. Works on CPP, Neko and Flash.
+	 * Use this to toggle between fullscreen and normal mode. Works on CPP and Flash.
 	 * You can easily toggle fullscreen with e.g.: `FlxG.fullscreen = !FlxG.fullscreen;`
 	 */
 	public static var fullscreen(get, set):Bool;
@@ -344,7 +344,7 @@ class FlxG
 	}
 
 	/**
-	 * Resizes the window. Only works on desktop targets (Neko, Windows, Linux, Mac).
+	 * Resizes the window. Only works on desktop targets (Windows, Linux, Mac).
 	 */
 	public static function resizeWindow(width:Int, height:Int):Void
 	{

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -356,10 +356,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 				red = transform.redMultiplier;
 				green = transform.greenMultiplier;
 				blue = transform.blueMultiplier;
-
-				#if !neko
 				alpha = transform.alphaMultiplier;
-				#end
 			}
 
 			var color = FlxColor.fromRGBFloat(red, green, blue, alpha);

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -121,7 +121,7 @@ class Interaction extends Window
 	
 	function updateMouse(event:MouseEvent):Void
 	{
-		#if (neko || js) // openfl/openfl#1305
+		#if js // openfl/openfl#1305
 		if (event.stageX == null || event.stageY == null)
 			return;
 		#end

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -251,7 +251,7 @@ class FlxDefines
 		
 		if (!defined("flash") || defined("flash11_8"))
 			define(FLX_GAMEINPUT_API);
-		else if (!defined("openfl_next") && (defined("cpp") || defined("neko")))
+		else if (!defined("openfl_next") && (defined("cpp")))
 			define(FLX_JOYSTICK_API);
 
 		#if nme

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -963,13 +963,6 @@ class FlxBar extends FlxSprite
 
 	function get_value():Float
 	{
-		#if neko
-		if (value == null)
-		{
-			value = min;
-		}
-		#end
-
 		return value;
 	}
 

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -379,8 +379,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 */
 	public inline function toHexString(Alpha:Bool = true, Prefix:Bool = true):String
 	{
-		return (Prefix ? "0x" : "") + (Alpha ? StringTools.hex(alpha,
-			2) : "") + StringTools.hex(red, 2) + StringTools.hex(green, 2) + StringTools.hex(blue, 2);
+		return (Prefix ? "0x" : "") + (Alpha ? StringTools.hex(alpha, 2) : "") + StringTools.hex(red, 2) + StringTools.hex(green, 2) + StringTools.hex(blue, 2);
 	}
 
 	/**
@@ -575,18 +574,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 
 	inline function getThis():Int
 	{
-		#if neko
-		return Std.int(this);
-		#else
 		return this;
-		#end
-	}
-
-	inline function validate():Void
-	{
-		#if neko
-		this = Std.int(this);
-		#end
 	}
 
 	inline function get_red():Int
@@ -631,7 +619,6 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 
 	inline function set_red(Value:Int):Int
 	{
-		validate();
 		this &= 0xff00ffff;
 		this |= boundChannel(Value) << 16;
 		return Value;
@@ -639,7 +626,6 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 
 	inline function set_green(Value:Int):Int
 	{
-		validate();
 		this &= 0xffff00ff;
 		this |= boundChannel(Value) << 8;
 		return Value;
@@ -647,7 +633,6 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 
 	inline function set_blue(Value:Int):Int
 	{
-		validate();
 		this &= 0xffffff00;
 		this |= boundChannel(Value);
 		return Value;
@@ -655,7 +640,6 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 
 	inline function set_alpha(Value:Int):Int
 	{
-		validate();
 		this &= 0x00ffffff;
 		this |= boundChannel(Value) << 24;
 		return Value;
@@ -787,7 +771,6 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 
 	inline function set_rgb(value:FlxColor):FlxColor
 	{
-		validate();
 		this = (this & 0xff000000) | (value & 0x00ffffff);
 		return value;
 	}

--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -193,7 +193,7 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 	{
 		for (handler in handlers)
 		{
-			if (#if (neko || hl) // simply comparing the functions doesn't do the trick on these targets
+			if (#if hl // simply comparing the functions doesn't do the trick on this target
 				Reflect.compareMethods(handler.listener, listener) #else handler.listener == listener #end)
 			{
 				return handler; // Listener was already registered.

--- a/haxelib.json
+++ b/haxelib.json
@@ -2,7 +2,7 @@
 	"name": "flixel",
 	"url" : "https://github.com/HaxeFlixel/flixel",
 	"license": "MIT",
-	"tags": ["game", "openfl", "flash", "html5", "neko", "cpp", "android", "ios", "cross"],
+	"tags": ["game", "openfl", "flash", "html5", "cpp", "android", "ios", "cross"],
 	"description": "HaxeFlixel is a 2D game engine based on OpenFL that delivers cross-platform games.",
 	"version": "6.1.0",
 	"releasenote": "Various improvements to debug tools",

--- a/tests/coverage/test.bat
+++ b/tests/coverage/test.bat
@@ -5,7 +5,3 @@ haxelib run lime build flash -Dcoverage3
 haxelib run lime build html5 -Dcoverage1
 haxelib run lime build html5 -Dcoverage2
 haxelib run lime build html5 -Dcoverage3
-
-haxelib run lime build neko -Dcoverage1
-haxelib run lime build neko -Dcoverage2
-haxelib run lime build neko -Dcoverage3

--- a/tests/unit/.vscode/tasks.json
+++ b/tests/unit/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"type": "hxml",
-			"file": "test-neko.hxml",
+			"file": "test-cpp.hxml",
 			"group": {
 				"kind": "build",
 				"isDefault": true

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -8,11 +8,10 @@ There's a 1:1 mapping between `.hx` files in Flixel and the unit test project - 
 
 ### Building
 
-Run one of the `test-*.hxml` files in this directory to run the tests on that specific target, e.g. `haxe test-neko.hxml`. Currently supported are:
+Run one of the `test-*.hxml` files in this directory to run the tests on that specific target, e.g. `haxe test-cpp.hxml`. Currently supported are:
 
 - `web` (Flash + HTML5)
 - `cpp`
-- `neko`
 
 Alternatively, this can be done from within Visual Studio Code - (`F1` -> `Tasks: Run Task` -> Choose the target to test).
 

--- a/tests/unit/test-neko.hxml
+++ b/tests/unit/test-neko.hxml
@@ -1,2 +1,0 @@
--cmd haxelib run munit gen
--cmd haxelib run lime test neko


### PR DESCRIPTION
Addresses #3361 

As stated in the original issue that brought this to my attention, Neko is no longer officially supported, and has been deprecated since 2021. Very, very few people use it (or seemingly have in a long time), and it has been all but entirely superseded by Hashlink.

This PR removes the Neko target and all mentions of it.