### PR TITLE
Add shader variable to FlxSpriteGroup

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -288,7 +288,7 @@ class FlxSprite extends FlxObject
 	 * GLSL shader for this sprite. Avoid changing it frequently as this is a costly operation.
 	 * @since 4.1.0
 	 */
-	public var shader:FlxShader;
+	public var shader(default, set):FlxShader;
 
 	/**
 	 * The actual frame used for sprite rendering
@@ -1575,6 +1575,12 @@ class FlxSprite extends FlxObject
 	function set_blend(Value:BlendMode):BlendMode
 	{
 		return blend = Value;
+	}
+
+	@:noCompletion
+	function set_shader(Value:FlxShader):FlxShader
+	{
+		return shader = Value;
 	}
 
 	/**

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -810,6 +810,13 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		return blend = Value;
 	}
 
+	override function set_shader(Value:FlxShader):FlxShader
+	{
+		if (exists && shader != Value)
+			transformChildren(shaderTransform, Value);
+		return shader = Value;
+	}
+
 	override function set_clipRect(rect:FlxRect):FlxRect
 	{
 		if (exists)
@@ -1044,6 +1051,9 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 
 	inline function blendTransform(Sprite:FlxSprite, Blend:BlendMode)
 		Sprite.blend = Blend;
+
+	inline function shaderTransform(Sprite:FlxSprite, Shader:FlxShader)
+		Sprite.shader = Shader;
 
 	inline function immovableTransform(Sprite:FlxSprite, Immovable:Bool)
 		Sprite.immovable = Immovable;


### PR DESCRIPTION
Makes FlxSprite's shader variable a setter so it can be used in FlxSpriteGroup and its extensions to set the shader value of its members.