### PR TITLE
add null-safety to FlxTouchManager

### DIFF
--- a/flixel/input/touch/FlxTouchManager.hx
+++ b/flixel/input/touch/FlxTouchManager.hx
@@ -1,6 +1,7 @@
 package flixel.input.touch;
 
 #if FLX_TOUCH
+import flixel.util.FlxDestroyUtil;
 import openfl.Lib;
 import openfl.events.TouchEvent;
 import openfl.ui.Multitouch;
@@ -9,32 +10,33 @@ import openfl.ui.MultitouchInputMode;
 /**
  * @author Zaphod
  */
+@:nullSafety(Strict)
 class FlxTouchManager implements IFlxInputManager
 {
 	/**
 	 * The maximum number of concurrent touch points supported by the current device.
 	 */
-	public static var maxTouchPoints:Int = 0;
+	public static var maxTouchPoints(default, null):Int = 0;
 
 	/**
 	 * All active touches including just created, moving and just released.
 	 */
-	public var list:Array<FlxTouch>;
+	public final list:Array<FlxTouch> = [];
 
 	/**
 	 * Storage for inactive touches (some sort of cache for them).
 	 */
-	var _inactiveTouches:Array<FlxTouch>;
+	final _inactiveTouches:Array<FlxTouch> = [];
 
 	/**
 	 * Helper storage for active touches (for faster access)
 	 */
-	var _touchesCache:Map<Int, FlxTouch>;
+	final _touchesCache:Map<Int, FlxTouch> = [];
 
 	/**
 	 * WARNING: can be null if no active touch with the provided ID could be found
 	 */
-	public inline function getByID(TouchPointID:Int):FlxTouch
+	public inline function getByID(TouchPointID:Int):Null<FlxTouch>
 	{
 		return _touchesCache.get(TouchPointID);
 	}
@@ -42,16 +44,9 @@ class FlxTouchManager implements IFlxInputManager
 	/**
 	 * Return the first touch if there is one, beware of null
 	 */
-	public function getFirst():FlxTouch
+	public function getFirst():Null<FlxTouch>
 	{
-		if (list[0] != null)
-		{
-			return list[0];
-		}
-		else
-		{
-			return null;
-		}
+		return list[0];
 	}
 
 	/**
@@ -60,19 +55,9 @@ class FlxTouchManager implements IFlxInputManager
 	@:noCompletion
 	public function destroy():Void
 	{
-		for (touch in list)
-		{
-			touch.destroy();
-		}
-		list = null;
-
-		for (touch in _inactiveTouches)
-		{
-			touch.destroy();
-		}
-		_inactiveTouches = null;
-
-		_touchesCache = null;
+		_touchesCache.clear();
+		FlxDestroyUtil.destroyArray(list);
+		FlxDestroyUtil.destroyArray(_inactiveTouches);
 	}
 
 	/**
@@ -88,11 +73,10 @@ class FlxTouchManager implements IFlxInputManager
 			TouchArray = new Array<FlxTouch>();
 		}
 
-		var touchLen:Int = TouchArray.length;
-
+		final touchLen:Int = TouchArray.length;
 		if (touchLen > 0)
 		{
-			TouchArray.splice(0, touchLen);
+			TouchArray.resize(0);
 		}
 
 		for (touch in list)
@@ -119,10 +103,10 @@ class FlxTouchManager implements IFlxInputManager
 			TouchArray = new Array<FlxTouch>();
 		}
 
-		var touchLen:Int = TouchArray.length;
+		final touchLen:Int = TouchArray.length;
 		if (touchLen > 0)
 		{
-			TouchArray.splice(0, touchLen);
+			TouchArray.resize(0);
 		}
 
 		for (touch in list)
@@ -141,10 +125,7 @@ class FlxTouchManager implements IFlxInputManager
 	 */
 	public function reset():Void
 	{
-		for (key in _touchesCache.keys())
-		{
-			_touchesCache.remove(key);
-		}
+		_touchesCache.clear();
 
 		for (touch in list)
 		{
@@ -152,15 +133,12 @@ class FlxTouchManager implements IFlxInputManager
 			_inactiveTouches.push(touch);
 		}
 
-		list.splice(0, list.length);
+		list.resize(0);
 	}
 
 	@:allow(flixel.FlxG)
 	function new()
 	{
-		list = new Array<FlxTouch>();
-		_inactiveTouches = new Array<FlxTouch>();
-		_touchesCache = new Map<Int, FlxTouch>();
 		maxTouchPoints = Multitouch.maxTouchPoints;
 		Multitouch.inputMode = MultitouchInputMode.TOUCH_POINT;
 
@@ -174,7 +152,7 @@ class FlxTouchManager implements IFlxInputManager
 	 */
 	function handleTouchBegin(FlashEvent:TouchEvent):Void
 	{
-		var touch:FlxTouch = _touchesCache.get(FlashEvent.touchPointID);
+		var touch:Null<FlxTouch> = _touchesCache.get(FlashEvent.touchPointID);
 		if (touch != null)
 		{
 			touch.setXY(Std.int(FlashEvent.stageX), Std.int(FlashEvent.stageY));
@@ -192,7 +170,7 @@ class FlxTouchManager implements IFlxInputManager
 	 */
 	function handleTouchEnd(FlashEvent:TouchEvent):Void
 	{
-		var touch:FlxTouch = _touchesCache.get(FlashEvent.touchPointID);
+		final touch:Null<FlxTouch> = _touchesCache.get(FlashEvent.touchPointID);
 
 		if (touch != null)
 		{
@@ -205,7 +183,7 @@ class FlxTouchManager implements IFlxInputManager
 	 */
 	function handleTouchMove(FlashEvent:TouchEvent):Void
 	{
-		var touch:FlxTouch = _touchesCache.get(FlashEvent.touchPointID);
+		final touch:Null<FlxTouch> = _touchesCache.get(FlashEvent.touchPointID);
 
 		if (touch != null)
 		{
@@ -239,7 +217,8 @@ class FlxTouchManager implements IFlxInputManager
 	{
 		if (_inactiveTouches.length > 0)
 		{
-			var touch:FlxTouch = _inactiveTouches.pop();
+			@:nullSafety(Off)
+			final touch:FlxTouch = _inactiveTouches.pop();
 			touch.recycle(X, Y, PointID, pressure);
 			return add(touch);
 		}


### PR DESCRIPTION
A contribution towards #3267, which I decided to do after getting a null reference error in a null-safe class because `getFirst` wasn't annotated as nullable (although to be fair I should've read the documentation first...). I tried to do it based on how https://github.com/HaxeFlixel/flixel/pull/3420/ did it.

Also I've noticed that PR also changes the parameter names from pascal case to camel case, should the same be done in this PR?