### PR TITLE
Fixing issue with `preUpdate` signal being called before `updateInput`

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -681,9 +681,10 @@ class FlxGame extends Sprite
 
 		updateElapsed();
 
-		FlxG.signals.preUpdate.dispatch();
-
 		updateInput();
+		
+		// not sure if this will cause issues, but it did cause `key` and `mouse` input checks to run twice if this was above `updateInput()`.
+		FlxG.signals.preUpdate.dispatch();
 
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.update(FlxG.elapsed);

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -683,7 +683,6 @@ class FlxGame extends Sprite
 
 		updateInput();
 		
-		// not sure if this will cause issues, but it did cause `key` and `mouse` input checks to run twice if this was above `updateInput()`.
 		FlxG.signals.preUpdate.dispatch();
 
 		#if FLX_SOUND_SYSTEM


### PR DESCRIPTION
It made no sense why it was being dispached after `updateElapsed` but not `updateInput`.

All that im aware this does is solve an issue with the signal checking input's on 2 seperate update cycles, because the `justPressed` would be still toggled on before it could update.

This also means any key / mouse checks were about 1 update cycle behind, so this should fix this.


Also omg its my first time making a pr to haxe at all, an engine ive been working in for almost 5 years holy. I've never once thought about fixing an issue here lol