### PR TITLE
Make `FlxG.cameras.bgColor` a real variable so new FlxCameras default properly

### DIFF
--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -30,7 +30,7 @@ class CameraFrontEnd
 	/**
 	 * The current (global, applies to all cameras) bgColor.
 	 */
-	public var bgColor(get, set):FlxColor;
+	public var bgColor(default, set):FlxColor;
 
 	/** @since 4.2.0 */
 	public var cameraAdded(default, null):FlxTypedSignal<FlxCamera->Void> = new FlxTypedSignal<FlxCamera->Void>();
@@ -362,12 +362,7 @@ class CameraFrontEnd
 			camera.onResize();
 		}
 	}
-
-	function get_bgColor():FlxColor
-	{
-		return (FlxG.camera == null) ? FlxColor.BLACK : FlxG.camera.bgColor;
-	}
-
+	
 	function set_bgColor(Color:FlxColor):FlxColor
 	{
 		for (camera in list)


### PR DESCRIPTION
I should've made my explanation clearer.
<br>

In haxeflixel, new FlxCameras' bgColors default to `FlxG.cameras.bgColor`.
https://github.com/HaxeFlixel/flixel/blob/145186da9df788ef1b5ad38c73c431d81cd667c4/flixel/FlxCamera.hx#L166-L170 As seen in `FlxCamera.new()`:
https://github.com/HaxeFlixel/flixel/blob/145186da9df788ef1b5ad38c73c431d81cd667c4/flixel/FlxCamera.hx#L1064
<br>
The problem is that `FlxG.cameras.bgColor` has a getter rather than being a real variable.
https://github.com/HaxeFlixel/flixel/blob/145186da9df788ef1b5ad38c73c431d81cd667c4/flixel/system/frontEnds/CameraFrontEnd.hx#L366-L369
Let's say a user sets `FlxG.cameras.bgColor` to `0xffffffff`. Going off the docs, that should set all of the cameras' `bgColors` *and* be the new default `bgColor`.
https://github.com/HaxeFlixel/flixel/blob/145186da9df788ef1b5ad38c73c431d81cd667c4/flixel/system/frontEnds/CameraFrontEnd.hx#L174-L194

The real kicker is that `FlxG.camera` gets nullified during state switches. New cameras' `bgColors` default to (null), which is 0x000000 in the case of `FlxG.cameras.bgColors`. That completely undermined both the implementation *and* the user!


## A reproduceable bug this fixes:
```haxe
class PlayState extends FlxState
{
	override function create()
	{
		super.create();

		FlxG.cameras.bgColor = FlxColor.GREEN; // this sets the cameras' bgColors and the default to GREEN

		var text = new FlxText();
		text.text = "PlayState bgColor should be GREEN.";
		text.color = FlxColor.CYAN;
		text.size = 16;
		text.setBorderStyle(FlxTextBorderStyle.SHADOW, FlxColor.BLUE, 4);
		text.screenCenter();
		add(text);
		
		var button = new FlxButton(0, 0, "Switch States", switchState);
		button.screenCenter();
		button.y = text.y + text.height + 16;
		add(button);
	}
	
	private function switchState():Void
	{
		FlxG.switchState(OtherState.new);
	}
}

class OtherState extends FlxState
{
	override function create()
	{
		super.create();
		
		var text = new FlxText();
		text.text = "OtherState bgColor should be GREEN.";
		text.color = FlxColor.PINK;
		text.size = 16;
		text.setBorderStyle(FlxTextBorderStyle.SHADOW, FlxColor.RED, 4);
		text.screenCenter();
		add(text);
		
		var button = new FlxButton(0, 0, "Switch States", switchState);
		button.screenCenter();
		button.y = text.y + text.height + 16;
		add(button);
	}
	
	private function switchState():Void
	{
		FlxG.switchState(PlayState.new);
	}
}
```

## In short, making `FlxG.cameras.bgColor` a real variable:

* allows you to actually set the default bgColor

* prevents the default from being "reset by getters" to 0x000000 by state switches.
* fixes the behavior observed yet ignored in #3252

> I'm not sure why this getter exists, in my opinion it makes more sense for `FlxG.cameras.bgColor` to just be a setter that isn't automatically determined by the `bgColor` of `FlxG.camera`. If there is a reason for this or if it is actually a bug, I would like to know. In my opinion it seems like strange behavior.
