### PR TITLE
implement overloaded methods on FlxColor

### DIFF
--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -1,8 +1,8 @@
 package flixel.util;
 
-import flixel.tweens.FlxEase;
 import flixel.math.FlxMath;
 import flixel.system.macros.FlxMacroUtil;
+import flixel.tweens.FlxEase;
 
 /**
  * Class representing a color, based on Int. Provides a variety of methods for creating and converting colors.
@@ -22,7 +22,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public static inline var WHITE:FlxColor = 0xFFFFFFFF;
 	public static inline var GRAY:FlxColor = 0xFF808080;
 	public static inline var BLACK:FlxColor = 0xFF000000;
-
+	
 	public static inline var GREEN:FlxColor = 0xFF008000;
 	public static inline var LIME:FlxColor = 0xFF00FF00;
 	public static inline var YELLOW:FlxColor = 0xFFFFFF00;
@@ -34,61 +34,61 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public static inline var PINK:FlxColor = 0xFFFFC0CB;
 	public static inline var MAGENTA:FlxColor = 0xFFFF00FF;
 	public static inline var CYAN:FlxColor = 0xFF00FFFF;
-
+	
 	/**
 	 * A `Map<String, Int>` whose values are the static colors of `FlxColor`.
 	 * You can add more colors for `FlxColor.fromString(String)` if you need.
 	 */
 	public static var colorLookup(default, null):Map<String, Int> = FlxMacroUtil.buildMap("flixel.util.FlxColor");
-
+	
 	public var red(get, set):Int;
 	public var blue(get, set):Int;
 	public var green(get, set):Int;
 	public var alpha(get, set):Int;
-
+	
 	public var redFloat(get, set):Float;
 	public var blueFloat(get, set):Float;
 	public var greenFloat(get, set):Float;
 	public var alphaFloat(get, set):Float;
-
+	
 	public var cyan(get, set):Float;
 	public var magenta(get, set):Float;
 	public var yellow(get, set):Float;
 	public var black(get, set):Float;
-
+	
 	/**
 	 * The red, green and blue channels of this color as a 24 bit integer (from 0 to 0xFFFFFF)
 	 */
 	public var rgb(get, set):FlxColor;
-
+	
 	/** 
 	 * The hue of the color in degrees (from 0 to 359)
 	 */
 	public var hue(get, set):Float;
-
+	
 	/**
 	 * The saturation of the color (from 0 to 1)
 	 */
 	public var saturation(get, set):Float;
-
+	
 	/**
 	 * The brightness (aka value) of the color (from 0 to 1)
 	 */
 	public var brightness(get, set):Float;
-
+	
 	/**
 	 * The lightness of the color (from 0 to 1)
 	 */
 	public var lightness(get, set):Float;
-
+	
 	/**
 	 * The luminance, or "percieved brightness" of a color (from 0 to 1)
 	 * RGB -> Luma calculation from https://www.w3.org/TR/AERT/#color-contrast
 	 */
 	public var luminance(get, never):Float;
-
+	
 	static var COLOR_REGEX = ~/^(0x|#)(([A-F0-9]{2}){3,4})$/i;
-
+	
 	/**
 	 * Create a color from the least significant four bytes of an Int
 	 *
@@ -99,7 +99,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return new FlxColor(Value);
 	}
-
+	
 	/**
 	 * Generate a color from integer RGB values (0 to 255)
 	 *
@@ -109,12 +109,35 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param Alpha	How opaque the color should be, from 0 to 255
 	 * @return The color as a FlxColor
 	 */
-	public static inline function fromRGB(Red:Int, Green:Int, Blue:Int, Alpha:Int = 255):FlxColor
+	public static overload extern inline function fromRGB(Red:Int, Green:Int, Blue:Int, Alpha:Int = 255):FlxColor
 	{
 		var color = new FlxColor();
 		return color.setRGB(Red, Green, Blue, Alpha);
 	}
-
+	
+	/**
+	 * Generate a color from an array of integer RGB values (0 to 255)
+	 * @param Array The array of RGB values, each value should be from 0 to 255
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromRGB(Array:Array<Int>):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setRGB(Array[0], Array[1], Array[2], 255);
+	}
+	
+	/**
+	 * Generate a color from an array of integer RGB values (0 to 255)
+	 * @param Array The array of RGB values, each value should be from 0 to 255
+	 * @param Alpha How opaque the color should be, from 0 to 255
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromRGB(Array:Array<Int>, Alpha:Int = 255):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setRGB(Array[0], Array[1], Array[2], Alpha);
+	}
+	
 	/**
 	 * Generate a color from float RGB values (0 to 1)
 	 *
@@ -124,12 +147,35 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param Alpha	How opaque the color should be, from 0 to 1
 	 * @return The color as a FlxColor
 	 */
-	public static inline function fromRGBFloat(Red:Float, Green:Float, Blue:Float, Alpha:Float = 1):FlxColor
+	public static overload extern inline function fromRGBFloat(Red:Float, Green:Float, Blue:Float, Alpha:Float = 1):FlxColor
 	{
 		var color = new FlxColor();
 		return color.setRGBFloat(Red, Green, Blue, Alpha);
 	}
-
+	
+	/**
+	 * Generate a color from an array of float RGB values (0 to 1)
+	 * @param Array The array of RGB values, each value should be from 0 to 1
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromRGBFloat(Array:Array<Float>):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setRGBFloat(Array[0], Array[1], Array[2], Array[3]);
+	}
+	
+	/**
+	 * Generate a color from an array of float RGB values (0 to 1)
+	 * @param Array The array of RGB values, each value should be from 0 to 1
+	 * @param Alpha How opaque the color should be, from 0 to 1
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromRGBFloat(Array:Array<Float>, Alpha:Float = 1):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setRGBFloat(Array[0], Array[1], Array[2], Alpha);
+	}
+	
 	/**
 	 * Generate a color from CMYK values (0 to 1)
 	 *
@@ -140,12 +186,35 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param Alpha		How opaque the color should be, from 0 to 1
 	 * @return The color as a FlxColor
 	 */
-	public static inline function fromCMYK(Cyan:Float, Magenta:Float, Yellow:Float, Black:Float, Alpha:Float = 1):FlxColor
+	public static overload extern inline function fromCMYK(Cyan:Float, Magenta:Float, Yellow:Float, Black:Float, Alpha:Float = 1):FlxColor
 	{
 		var color = new FlxColor();
 		return color.setCMYK(Cyan, Magenta, Yellow, Black, Alpha);
 	}
+	
+	/**
+	 * Generate a color from an array of CMYK values (0 to 1)
+	 * @param Array The array of CMYK, each value should be from 0 to 1
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromCMYK(Array:Array<Float>):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setCMYK(Array[0], Array[1], Array[2], Array[3], Array[4]);
+	}
 
+	/**
+	 * Generate a color from an array of CMYK values (0 to 1)
+	 * @param Array The array of CMYK, each value should be from 0 to 1
+	 * @param Alpha How opaque the color should be, from 0 to 1
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromCMYK(Array:Array<Float>, Alpha:Float):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setCMYK(Array[0], Array[1], Array[2], Array[3], Alpha);
+	}
+	
 	/**
 	 * Generate a color from HSB (aka HSV) components.
 	 *
@@ -155,12 +224,33 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param	Alpha		How opaque the color should be, either between 0 and 1 or 0 and 255.
 	 * @return	The color as a FlxColor
 	 */
-	public static function fromHSB(Hue:Float, Saturation:Float, Brightness:Float, Alpha:Float = 1):FlxColor
+	public static overload extern inline function fromHSB(Hue:Float, Saturation:Float, Brightness:Float, Alpha:Float = 1):FlxColor
 	{
 		var color = new FlxColor();
 		return color.setHSB(Hue, Saturation, Brightness, Alpha);
 	}
 
+	/**
+	 * Generate a color from an array of HSB (aka HSV) components.
+	 * @param Array The array of HSB values
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromHSB(Array:Array<Float>):FlxColor {
+		var color = new FlxColor();
+		return color.setHSB(Array[0], Array[1], Array[2], Array[3]);
+	}
+
+	/**
+	 * Generate a color from an array of HSB (aka HSV) components.
+	 * @param Array The array of HSB values
+	 * @param Alpha How opaque the color should be, either between 0 and 1 or 0 and 255.
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromHSB(Array:Array<Float>, Alpha:Float = 1):FlxColor {
+		var color = new FlxColor();
+		return color.setHSB(Array[0], Array[1], Array[2], Alpha);
+	}
+	
 	/**
 	 * Generate a color from HSL components.
 	 *
@@ -170,12 +260,35 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 * @param	Alpha		How opaque the color should be, either between 0 and 1 or 0 and 255.
 	 * @return	The color as a FlxColor
 	 */
-	public static inline function fromHSL(Hue:Float, Saturation:Float, Lightness:Float, Alpha:Float = 1):FlxColor
+	public static overload extern inline function fromHSL(Hue:Float, Saturation:Float, Lightness:Float, Alpha:Float = 1):FlxColor
 	{
 		var color = new FlxColor();
 		return color.setHSL(Hue, Saturation, Lightness, Alpha);
 	}
 
+	/**
+	 * Generate a color from HSL components.
+	 * @param Array The array of HSL values.
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromHSL(Array:Array<Float>):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setHSL(Array[0], Array[1], Array[2], Array[3]);
+	}
+
+	/**
+	 * Generate a color from HSL components.
+	 * @param Array The array of HSL values.
+	 * @param Alpha How opaque the color should be, either between 0 and 1 or 0 and 255.
+	 * @return The color as a FlxColor
+	 */
+	public static overload extern inline function fromHSL(Array:Array<Float>, Alpha:Float = 1):FlxColor
+	{
+		var color = new FlxColor();
+		return color.setHSL(Array[0], Array[1], Array[2], Alpha);
+	}
+	
 	/**
 	 * Parses a `String` and returns a `FlxColor` or `null` if the `String` couldn't be parsed.
 	 *
@@ -195,7 +308,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var result:Null<FlxColor> = null;
 		str = StringTools.trim(str);
-
+		
 		if (COLOR_REGEX.match(str))
 		{
 			var hexColor:String = "0x" + COLOR_REGEX.matched(2);
@@ -217,10 +330,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 				}
 			}
 		}
-
+		
 		return result;
 	}
-
+	
 	/**
 	 * Get HSB color wheel values in an array which will be 360 elements in size
 	 *
@@ -231,7 +344,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return [for (c in 0...360) fromHSB(c, 1.0, 1.0, Alpha)];
 	}
-
+	
 	/**
 	 * Get an interpolated color based on two different colors.
 	 *
@@ -246,10 +359,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var g:Int = Std.int((Color2.green - Color1.green) * Factor + Color1.green);
 		var b:Int = Std.int((Color2.blue - Color1.blue) * Factor + Color1.blue);
 		var a:Int = Std.int((Color2.alpha - Color1.alpha) * Factor + Color1.alpha);
-
+		
 		return fromRGB(r, g, b, a);
 	}
-
+	
 	/**
 	 * Create a gradient from one color to another
 	 *
@@ -262,20 +375,20 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	public static function gradient(Color1:FlxColor, Color2:FlxColor, Steps:Int, ?Ease:EaseFunction):Array<FlxColor>
 	{
 		var output = new Array<FlxColor>();
-
+		
 		if (Ease == null)
 		{
 			Ease = FlxEase.linear;
 		}
-
+		
 		for (step in 0...Steps)
 		{
 			output[step] = interpolate(Color1, Color2, Ease(step / (Steps - 1)));
 		}
-
+		
 		return output;
 	}
-
+	
 	/**
 	 * Multiply the RGB channels of two FlxColors
 	 */
@@ -284,7 +397,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGBFloat(lhs.redFloat * rhs.redFloat, lhs.greenFloat * rhs.greenFloat, lhs.blueFloat * rhs.blueFloat);
 	}
-
+	
 	/**
 	 * Add the RGB channels of two FlxColors
 	 */
@@ -293,7 +406,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGB(lhs.red + rhs.red, lhs.green + rhs.green, lhs.blue + rhs.blue);
 	}
-
+	
 	/**
 	 * Subtract the RGB channels of one FlxColor from another
 	 */
@@ -302,7 +415,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGB(lhs.red - rhs.red, lhs.green - rhs.green, lhs.blue - rhs.blue);
 	}
-
+	
 	/**
 	 * Returns a Complementary Color Harmony of this color.
 	 * A complementary hue is one directly opposite the color given on the color wheel
@@ -313,7 +426,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return fromHSB(FlxMath.wrap(Std.int(hue) + 180, 0, 350), brightness, saturation, alphaFloat);
 	}
-
+	
 	/**
 	 * Returns an Analogous Color Harmony for the given color.
 	 * An Analogous harmony are hues adjacent to each other on the color wheel
@@ -325,10 +438,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var warmer:Int = fromHSB(FlxMath.wrap(Std.int(hue) - Threshold, 0, 350), saturation, brightness, alphaFloat);
 		var colder:Int = fromHSB(FlxMath.wrap(Std.int(hue) + Threshold, 0, 350), saturation, brightness, alphaFloat);
-
+		
 		return {original: this, warmer: warmer, colder: colder};
 	}
-
+	
 	/**
 	 * Returns an Split Complement Color Harmony for this color.
 	 * A Split Complement harmony are the two hues on either side of the color's Complement
@@ -341,10 +454,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var oppositeHue:Int = FlxMath.wrap(Std.int(hue) + 180, 0, 350);
 		var warmer:FlxColor = fromHSB(FlxMath.wrap(oppositeHue - Threshold, 0, 350), saturation, brightness, alphaFloat);
 		var colder:FlxColor = fromHSB(FlxMath.wrap(oppositeHue + Threshold, 0, 350), saturation, brightness, alphaFloat);
-
+		
 		return {original: this, warmer: warmer, colder: colder};
 	}
-
+	
 	/**
 	 * Returns a Triadic Color Harmony for this color. A Triadic harmony are 3 hues equidistant
 	 * from each other on the color wheel.
@@ -355,10 +468,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		var triadic1:FlxColor = fromHSB(FlxMath.wrap(Std.int(hue) + 120, 0, 359), saturation, brightness, alphaFloat);
 		var triadic2:FlxColor = fromHSB(FlxMath.wrap(Std.int(triadic1.hue) + 120, 0, 359), saturation, brightness, alphaFloat);
-
+		
 		return {color1: this, color2: triadic1, color3: triadic2};
 	}
-
+	
 	/**
 	 * Return a 24 bit version of this color (i.e. without an alpha value)
 	 *
@@ -369,7 +482,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return this & 0xffffff;
 	}
-
+	
 	/**
 	 * Return a String representation of the color in the format
 	 *
@@ -379,10 +492,9 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	 */
 	public inline function toHexString(Alpha:Bool = true, Prefix:Bool = true):String
 	{
-		return (Prefix ? "0x" : "") + (Alpha ? StringTools.hex(alpha,
-			2) : "") + StringTools.hex(red, 2) + StringTools.hex(green, 2) + StringTools.hex(blue, 2);
+		return (Prefix ? "0x" : "") + (Alpha ? StringTools.hex(alpha, 2) : "") + StringTools.hex(red, 2) + StringTools.hex(green, 2) + StringTools.hex(blue, 2);
 	}
-
+	
 	/**
 	 * Return a String representation of the color in the format #RRGGBB
 	 *
@@ -392,7 +504,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return "#" + toHexString(false, false);
 	}
-
+	
 	/**
 	 * Get a string of color information about this color
 	 *
@@ -407,10 +519,10 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		// HSB/HSL info
 		result += "Hue: " + FlxMath.roundDecimal(hue, 2) + " Saturation: " + FlxMath.roundDecimal(saturation, 2) + " Brightness: "
 			+ FlxMath.roundDecimal(brightness, 2) + " Lightness: " + FlxMath.roundDecimal(lightness, 2);
-
+			
 		return result;
 	}
-
+	
 	/**
 	 * Get a darkened version of this color
 	 *
@@ -424,7 +536,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		output.lightness = output.lightness * (1 - Factor);
 		return output;
 	}
-
+	
 	/**
 	 * Get a lightened version of this color
 	 *
@@ -438,7 +550,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		output.lightness = output.lightness + (1 - lightness) * Factor;
 		return output;
 	}
-
+	
 	/**
 	 * Get the inversion of this color
 	 *
@@ -451,7 +563,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		output.alpha = oldAlpha;
 		return output;
 	}
-
+	
 	/**
 	 * Set RGB values as integers (0 to 255)
 	 *
@@ -469,7 +581,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		alpha = Alpha;
 		return this;
 	}
-
+	
 	/**
 	 * Set RGB values as floats (0 to 1)
 	 *
@@ -487,7 +599,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		alphaFloat = Alpha;
 		return this;
 	}
-
+	
 	/**
 	 * Set CMYK values as floats (0 to 1)
 	 *
@@ -506,7 +618,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		alphaFloat = Alpha;
 		return this;
 	}
-
+	
 	/**
 	 * Set HSB (aka HSV) components
 	 *
@@ -522,7 +634,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var match = Brightness - chroma;
 		return setHueChromaMatch(Hue, chroma, match, Alpha);
 	}
-
+	
 	/**
 	 * Set HSL components.
 	 *
@@ -538,7 +650,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var match = Lightness - chroma / 2;
 		return setHueChromaMatch(Hue, chroma, match, Alpha);
 	}
-
+	
 	/**
 	 * Private utility function to perform common operations between setHSB and setHSL
 	 */
@@ -548,7 +660,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		var hueD = Hue / 60;
 		var mid = Chroma * (1 - Math.abs(hueD % 2 - 1)) + Match;
 		Chroma += Match;
-
+		
 		switch (Std.int(hueD))
 		{
 			case 0:
@@ -564,15 +676,15 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 			case 5:
 				setRGBFloat(Chroma, Match, mid, Alpha);
 		}
-
+		
 		return this;
 	}
-
+	
 	public function new(Value:Int = 0)
 	{
 		this = Value;
 	}
-
+	
 	inline function getThis():Int
 	{
 		#if neko
@@ -581,54 +693,54 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		return this;
 		#end
 	}
-
+	
 	inline function validate():Void
 	{
 		#if neko
 		this = Std.int(this);
 		#end
 	}
-
+	
 	inline function get_red():Int
 	{
 		return (getThis() >> 16) & 0xff;
 	}
-
+	
 	inline function get_green():Int
 	{
 		return (getThis() >> 8) & 0xff;
 	}
-
+	
 	inline function get_blue():Int
 	{
 		return getThis() & 0xff;
 	}
-
+	
 	inline function get_alpha():Int
 	{
 		return (getThis() >> 24) & 0xff;
 	}
-
+	
 	inline function get_redFloat():Float
 	{
 		return red / 255;
 	}
-
+	
 	inline function get_greenFloat():Float
 	{
 		return green / 255;
 	}
-
+	
 	inline function get_blueFloat():Float
 	{
 		return blue / 255;
 	}
-
+	
 	inline function get_alphaFloat():Float
 	{
 		return alpha / 255;
 	}
-
+	
 	inline function set_red(Value:Int):Int
 	{
 		validate();
@@ -636,7 +748,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		this |= boundChannel(Value) << 16;
 		return Value;
 	}
-
+	
 	inline function set_green(Value:Int):Int
 	{
 		validate();
@@ -644,7 +756,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		this |= boundChannel(Value) << 8;
 		return Value;
 	}
-
+	
 	inline function set_blue(Value:Int):Int
 	{
 		validate();
@@ -652,7 +764,7 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		this |= boundChannel(Value);
 		return Value;
 	}
-
+	
 	inline function set_alpha(Value:Int):Int
 	{
 		validate();
@@ -660,75 +772,75 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		this |= boundChannel(Value) << 24;
 		return Value;
 	}
-
+	
 	inline function set_redFloat(Value:Float):Float
 	{
 		red = Math.round(Value * 255);
 		return Value;
 	}
-
+	
 	inline function set_greenFloat(Value:Float):Float
 	{
 		green = Math.round(Value * 255);
 		return Value;
 	}
-
+	
 	inline function set_blueFloat(Value:Float):Float
 	{
 		blue = Math.round(Value * 255);
 		return Value;
 	}
-
+	
 	inline function set_alphaFloat(Value:Float):Float
 	{
 		alpha = Math.round(Value * 255);
 		return Value;
 	}
-
+	
 	inline function get_cyan():Float
 	{
 		return (1 - redFloat - black) / brightness;
 	}
-
+	
 	inline function get_magenta():Float
 	{
 		return (1 - greenFloat - black) / brightness;
 	}
-
+	
 	inline function get_yellow():Float
 	{
 		return (1 - blueFloat - black) / brightness;
 	}
-
+	
 	inline function get_black():Float
 	{
 		return 1 - brightness;
 	}
-
+	
 	inline function set_cyan(Value:Float):Float
 	{
 		setCMYK(Value, magenta, yellow, black, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_magenta(Value:Float):Float
 	{
 		setCMYK(cyan, Value, yellow, black, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_yellow(Value:Float):Float
 	{
 		setCMYK(cyan, magenta, Value, black, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_black(Value:Float):Float
 	{
 		setCMYK(cyan, magenta, yellow, Value, alphaFloat);
 		return Value;
 	}
-
+	
 	function get_hue():Float
 	{
 		var hueRad = Math.atan2(Math.sqrt(3) * (greenFloat - blueFloat), 2 * redFloat - greenFloat - blueFloat);
@@ -737,76 +849,76 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 		{
 			hue = 180 / Math.PI * hueRad;
 		}
-
+		
 		return hue < 0 ? hue + 360 : hue;
 	}
-
+	
 	inline function get_brightness():Float
 	{
 		return maxColor();
 	}
-
+	
 	inline function get_luminance():Float
 	{
 		return (redFloat * 299 + greenFloat * 587 + blueFloat * 114) / 1000;
 	}
-
+	
 	inline function get_saturation():Float
 	{
 		return (maxColor() - minColor()) / brightness;
 	}
-
+	
 	inline function get_lightness():Float
 	{
 		return (maxColor() + minColor()) / 2;
 	}
-
+	
 	inline function set_hue(Value:Float):Float
 	{
 		setHSB(Value, saturation, brightness, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_saturation(Value:Float):Float
 	{
 		setHSB(hue, Value, brightness, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_brightness(Value:Float):Float
 	{
 		setHSB(hue, saturation, Value, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_lightness(Value:Float):Float
 	{
 		setHSL(hue, saturation, Value, alphaFloat);
 		return Value;
 	}
-
+	
 	inline function set_rgb(value:FlxColor):FlxColor
 	{
 		validate();
 		this = (this & 0xff000000) | (value & 0x00ffffff);
 		return value;
 	}
-
+	
 	inline function get_rgb():FlxColor
 	{
 		return this & 0x00ffffff;
 	}
-
+	
 	inline function maxColor():Float
 	{
 		return Math.max(redFloat, Math.max(greenFloat, blueFloat));
 	}
-
+	
 	inline function minColor():Float
 	{
 		return Math.min(redFloat, Math.min(greenFloat, blueFloat));
 	}
-
+	
 	inline function boundChannel(Value:Int):Int
 	{
 		return Value > 0xff ? 0xff : Value < 0 ? 0 : Value;


### PR DESCRIPTION
Allows for `Array` values to be used on `from` functions (eg: `fromRGB`)
Closes #3444