### PR TITLE
Fix alpha channel

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1707,7 +1707,7 @@ class FlxCamera extends FlxBasic
 			}
 			else
 			{
-				final alpha = color.alphaFloat * _fxFlashAlpha;
+				final alpha = _fxFlashColor.alphaFloat * _fxFlashAlpha;
 				fill(_fxFlashColor.rgb, true, alpha, canvas.graphics);
 			}
 		}


### PR DESCRIPTION
In HaxeFlixel 5.9.0, the drawFX function was overhauled, but alpha handling was unaccounted for. This overhaul broke how alpha was displayed when using `FlxCamera.flash()`- when assigning a color with opacity, it would ignore the alpha value and display the color at full opacity. This pull request fixes that issue.