### PR TITLE
Fix function description in FlxMath

### DIFF
--- a/flixel/math/FlxMath.hx
+++ b/flixel/math/FlxMath.hx
@@ -270,7 +270,7 @@ class FlxMath
 	}
 
 	/**
-	 * Makes sure that value always stays between 0 and max,
+	 * Makes sure that value always stays between min and max,
 	 * by wrapping the value around.
 	 *
 	 * @param 	value 	The value to wrap around


### PR DESCRIPTION
The comment describing FlxMath.wrap says it wraps the value between 0 and max, when it doesn't do that.