### PR TITLE
Remove old conditional from `FlxSignal.getHandler` on Hashlink

### DIFF
--- a/flixel/util/FlxSignal.hx
+++ b/flixel/util/FlxSignal.hx
@@ -193,7 +193,7 @@ private class FlxBaseSignal<T> implements IFlxSignal<T>
 	{
 		for (handler in handlers)
 		{
-			if (#if (neko || hl) // simply comparing the functions doesn't do the trick on these targets
+			if (#if neko // simply comparing the functions doesn't do the trick on neko
 				Reflect.compareMethods(handler.listener, listener) #else handler.listener == listener #end)
 			{
 				return handler; // Listener was already registered.


### PR DESCRIPTION
The conditional removed in this PR is nearly 7 years old (https://github.com/HaxeFlixel/flixel/commit/77c9c1bef52a386a437220589b29dc7cfe867737) and it seems that the issue it was originally covering up has been fixed. 

This was causing issues when the passed listener function's parameters are nullable, I originally encountered this issue when my gameResized listener was not being removed when calling FlxSignal's `remove` function. After looking into it, FlxSignal's `remove` and `has` functions both rely on `FlxSignal.getHandler()` which uses `Reflect.compareMethods` on Hashlink and Neko. I left the neko conditional alone as it seems that Neko support is getting removed in flixel 7.0.0 so I'm unsure if messing with it is worth it.
I've created a test case where this issue is reproducible:

```haxe
class SignalState extends FlxState
{
	override function create():Void
	{
		FlxG.signals.gameResized.add(listener);
	}

	function listener(?w:Int, ?h:Int):Void
	{
		trace("Signal received!", w, h);
	}

	override function update(elapsed:Float):Void
	{
		super.update(elapsed);

		if (FlxG.keys.justPressed.SPACE)
		{
			trace('Has handler: ' + FlxG.signals.gameResized.has(listener));
			trace('Removing listener.');
			FlxG.signals.gameResized.remove(listener);
		}
	}
}
```