### PR TITLE
FlxCamera: Fix filter memory leak

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1660,7 +1660,7 @@ class FlxCamera extends FlxBasic
 	 * @param   Color        The color to fill with in `0xAARRGGBB` hex format.
 	 * @param   BlendAlpha   Whether to blend the alpha value or just wipe the previous contents. Default is `true`.
 	 */
-	public function fill(Color:FlxColor, BlendAlpha:Bool = true, FxAlpha:Float = 1.0, ?graphics:Graphics):Void
+	public function fill(Color:FlxColor, BlendAlpha:Bool = true, FxAlpha:Float = 1.0, ?graphics:Graphics, force:Bool = false):Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -1676,7 +1676,7 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			if (FxAlpha == 0)
+			if (FxAlpha == 0 && !force)
 				return;
 
 			final targetGraphics = (graphics == null) ? canvas.graphics : graphics;

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1676,9 +1676,6 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			if (FxAlpha == 0 && (!filtersEnabled || filters == null || filters.length == 0))
-				return;
-
 			final targetGraphics = (graphics == null) ? canvas.graphics : graphics;
 
 			targetGraphics.overrideBlendMode(null);

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1660,7 +1660,7 @@ class FlxCamera extends FlxBasic
 	 * @param   Color        The color to fill with in `0xAARRGGBB` hex format.
 	 * @param   BlendAlpha   Whether to blend the alpha value or just wipe the previous contents. Default is `true`.
 	 */
-	public function fill(Color:FlxColor, BlendAlpha:Bool = true, FxAlpha:Float = 1.0, ?graphics:Graphics, force:Bool = false):Void
+	public function fill(Color:FlxColor, BlendAlpha:Bool = true, FxAlpha:Float = 1.0, ?graphics:Graphics):Void
 	{
 		if (FlxG.renderBlit)
 		{
@@ -1676,7 +1676,7 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			if (FxAlpha == 0 && !force)
+			if (FxAlpha == 0 && (!filtersEnabled || filters == null || filters.length == 0))
 				return;
 
 			final targetGraphics = (graphics == null) ? canvas.graphics : graphics;

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -289,7 +289,7 @@ class CameraFrontEnd
 			}
 			else
 			{
-				camera.fill(camera.bgColor.rgb, camera.useBgAlphaBlending, camera.bgColor.alphaFloat, null, camera.filtersEnabled && camera.filters != null && camera.filters.length > 0);
+				camera.fill(camera.bgColor.rgb, camera.useBgAlphaBlending, camera.bgColor.alphaFloat);
 			}
 		}
 	}

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -289,7 +289,7 @@ class CameraFrontEnd
 			}
 			else
 			{
-				camera.fill(camera.bgColor.rgb, camera.useBgAlphaBlending, camera.bgColor.alphaFloat);
+				camera.fill(camera.bgColor.rgb, camera.useBgAlphaBlending, camera.bgColor.alphaFloat, null, camera.filtersEnabled && camera.filters != null && camera.filters.length > 0);
 			}
 		}
 	}


### PR DESCRIPTION
currently the game rapidly leaks memory if 5 conditions are met:
- using `renderTile`
- some camera `bgColor` alpha is `0`
- no sprites or anything being rendered to this camera (nothing in draw stack)
- at least one `BitmapFilter` applied to this camera
- no flash fx or color fade fx active on this camera

unsure of exactly what the lower-level issue is causing this bug, but my guess is that after the `canvas.graphics` is cleared in `CameraFrontEnd.lock`, due to the above conditions its never drawn to again before the next frame, and so the filters are put in a weird state and somehow memory is leaked

this pr fixes the issue by adding a `force` option to `FlxCamera.fill` to bypass the alpha early-return for `renderTile`, and forcing a `bgColor` fill for it if any filters are currently active on the camera regardless of the alpha value

---

to reproduce the issue:
```haxe
package;

import openfl.filters.BitmapFilter;

import flixel.FlxCamera;
import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;

class TestState extends FlxState {
	override function create():Void {
		super.create();
		
		add(new FlxSprite().makeGraphic(1, 1, 0x0));
		// ^ remove this line and the game will leak memory like crazy
		
		var cam:FlxCamera = new FlxCamera();
		cam.bgColor = 0x0;
		FlxG.cameras.add(cam, true);
		cam.filters = [new BitmapFilter()];
	}
}
```

before and after fix:

<img width="251" height="309" alt="Screenshot 2025-08-06 153823" src="https://github.com/user-attachments/assets/59ec06f6-c69f-42c2-a8e0-f430d931f875" />

<img width="252" height="301" alt="image" src="https://github.com/user-attachments/assets/c8490a98-d7d7-41ab-a3d5-178b6da1504f" />
