### PR TITLE
FlxBitmapText: Replace mention to renamed property in documentation

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -74,7 +74,7 @@ class FlxBitmapText extends FlxSprite
 
 	/**
 	 * The type of automatic wrapping to use, when the text doesn't fit the width. Ignored when
-	 * `autoSize` is true. Use options like: `NONE`, `CHAR`, `WORD(NEVER)` and `WORD(FIELD_WIDTH)`
+	 * `autoSize` is true. Use options like: `NONE`, `CHAR`, `WORD(NEVER)` and `WORD(LINE_WIDTH)`
 	 */
 	public var wrap(default, set):Wrap = WORD(NEVER);
 


### PR DESCRIPTION
The `FIELD_WIDTH` property doesn't exist. I assume it was renamed to `LINE_WIDTH` at some later point in time