### PR TITLE
FlxDrawQuadsItem: call endFill() after drawing

### DIFF
--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -136,6 +136,7 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 		camera.canvas.graphics.overrideBlendMode(blend);
 		camera.canvas.graphics.beginShaderFill(shader);
 		camera.canvas.graphics.drawQuads(rects, null, transforms);
+		camera.canvas.graphics.endFill();
 		super.render(camera);
 	}
 


### PR DESCRIPTION
I think this is always supposed to be called after a fill is started, and it's also called when drawing triangles so I assume it's an oversight here. Doesn't seem to have any impact on performance