### PR TITLE
Deprecate FlxGraphicSource in favor of FlxGraphicAsset

### DIFF
--- a/flixel/graphics/atlas/FlxAtlas.hx
+++ b/flixel/graphics/atlas/FlxAtlas.hx
@@ -173,7 +173,7 @@ class FlxAtlas implements IFlxDestroyable
 	 *                    You can omit it if you pass `String` or `Class<Dynamic>` as a `Graphic` source.
 	 * @return  Newly created and added node, or `null` if there is no space for it.
 	 */
-	public function addNode(Graphic:FlxGraphicSource, ?Key:String):FlxNode
+	public function addNode(Graphic:FlxGraphicAsset, ?Key:String):FlxNode
 	{
 		var key:String = FlxAssets.resolveKey(Graphic, Key);
 
@@ -602,7 +602,7 @@ class FlxAtlas implements IFlxDestroyable
 	 * @param   region        Region of source image to use as a source graphic
 	 * @return  Generated `FlxTileFrames` for the added node
 	 */
-	public function addNodeWithSpacesAndBorders(Graphic:FlxGraphicSource, ?Key:String, tileSize:FlxPoint, tileSpacing:FlxPoint, ?tileBorder:FlxPoint,
+	public function addNodeWithSpacesAndBorders(Graphic:FlxGraphicAsset, ?Key:String, tileSize:FlxPoint, tileSpacing:FlxPoint, ?tileBorder:FlxPoint,
 			?region:FlxRect):FlxTileFrames
 	{
 		var key:String = FlxAssets.resolveKey(Graphic, Key);

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -36,16 +36,19 @@ class VirtualInputData extends #if nme ByteArray #else ByteArrayData #end {}
 typedef FlxTexturePackerJsonAsset = FlxJsonAsset<TexturePackerAtlas>;
 typedef FlxAsepriteJsonAsset = FlxJsonAsset<AseAtlas>;
 typedef FlxSoundAsset = OneOfThree<String, Sound, Class<Sound>>;
-typedef FlxGraphicAsset = OneOfThree<FlxGraphic, BitmapData, String>;
 typedef FlxTilemapGraphicAsset = OneOfFour<FlxFramesCollection, FlxGraphic, BitmapData, String>;
 typedef FlxBitmapFontGraphicAsset = OneOfFour<FlxFrame, FlxGraphic, BitmapData, String>;
-abstract FlxGraphicSource(OneOfThree<BitmapData, Class<Dynamic>, String>) from BitmapData from Class<Dynamic> from String
+
+abstract FlxGraphicAsset(OneOfFour<FlxGraphic, BitmapData, String, Class<Dynamic>>) from FlxGraphic to FlxGraphic from BitmapData to BitmapData from String to String from Class<Dynamic> to Class<Dynamic>
 {
-	public function resolveBitmapData()
+	public inline function resolveBitmapData():BitmapData
 	{
 		return FlxAssets.resolveBitmapData(cast this);
 	}
 }
+
+@:deprecated("`FlxGraphicSource` is deprecated, use `FlxGraphicAsset` instead")
+typedef FlxGraphicSource = FlxGraphicAsset;
 
 abstract FlxAngelCodeAsset(OneOfThree<Xml, String, Bytes>) from Xml from String from Bytes
 {
@@ -54,7 +57,6 @@ abstract FlxAngelCodeAsset(OneOfThree<Xml, String, Bytes>) from Xml from String 
 		return BMFont.parse(cast this);
 	}
 }
-
 
 @:deprecated("`FlxAngelCodeXmlAsset` is deprecated, use `FlxAngelCodeAsset` instead")// 5.6.0
 typedef FlxAngelCodeXmlAsset = FlxAngelCodeAsset;
@@ -304,9 +306,13 @@ class FlxAssets
 	 * @param   graphic  input data to get BitmapData object for.
 	 * @return  BitmapData for specified Dynamic object.
 	 */
-	public static function resolveBitmapData(graphic:FlxGraphicSource):BitmapData
+	public static function resolveBitmapData(graphic:FlxGraphicAsset):BitmapData
 	{
-		if ((graphic is BitmapData))
+		if ((graphic is FlxGraphic))
+		{
+			return cast(graphic, FlxGraphic).bitmap;
+		}
+		else if ((graphic is BitmapData))
 		{
 			return cast graphic;
 		}
@@ -333,12 +339,16 @@ class FlxAssets
 	 * @param   key      optional key string.
 	 * @return  Key String for specified Graphic object.
 	 */
-	public static function resolveKey(graphic:FlxGraphicSource, ?key:String):String
+	public static function resolveKey(graphic:FlxGraphicAsset, ?key:String):String
 	{
 		if (key != null)
 			return key;
 		
-		if ((graphic is BitmapData))
+		if ((graphic is FlxGraphic))
+		{
+			return cast(graphic, FlxGraphic).key;
+		}
+		else if ((graphic is BitmapData))
 		{
 			return key;
 		}

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -415,7 +415,7 @@ class FlxDebugger extends openfl.display.Sprite
 			resetButtonLayout();
 	}
 
-	public function addWindowToggleButton(window:Window, icon:FlxGraphicSource):Void
+	public function addWindowToggleButton(window:Window, icon:FlxGraphicAsset):Void
 	{
 		var button = addButton(RIGHT, icon.resolveBitmapData(), window.toggleVisible, true, true);
 		window.toggleButton = button;

--- a/flixel/system/debug/interaction/tools/Tool.hx
+++ b/flixel/system/debug/interaction/tools/Tool.hx
@@ -43,7 +43,7 @@ class Tool extends Sprite implements IFlxDestroyable
 		return _brain.activeTool == this && _brain.visible;
 	}
 
-	function setButton(icon:FlxGraphicSource):Void
+	function setButton(icon:FlxGraphicAsset):Void
 	{
 		button = new FlxSystemButton(icon.resolveBitmapData(), onButtonClicked, true);
 		button.toggled = true;

--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -527,7 +527,7 @@ class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
 	 * @since   4.1.0
 	 */
-	public function loadMapFromGraphic(mapGraphic:FlxGraphicSource, invert = false, scale = 1, ?colorMap:Array<FlxColor>,
+	public function loadMapFromGraphic(mapGraphic:FlxGraphicAsset, invert = false, scale = 1, ?colorMap:Array<FlxColor>,
 			tileGraphic:FlxTilemapGraphicAsset, tileWidth = 0, tileHeight = 0, ?autoTile:FlxTilemapAutoTiling,
 			startingIndex = 0, drawIndex = 1, collideIndex = 1)
 	{

--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -54,7 +54,7 @@ class FlxSpriteUtil
 	 * @param	mask		The mask to apply. Remember the non-alpha zero areas are the parts that will display.
 	 * @return 	The FlxSprite for chaining
 	 */
-	public static function alphaMask(output:FlxSprite, source:FlxGraphicSource, mask:FlxGraphicSource):FlxSprite
+	public static function alphaMask(output:FlxSprite, source:FlxGraphicAsset, mask:FlxGraphicAsset):FlxSprite
 	{
 		var data:BitmapData = FlxAssets.resolveBitmapData(source);
 		var maskData:BitmapData = FlxAssets.resolveBitmapData(mask);

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -562,7 +562,7 @@ class FlxStringUtil
 	 * @param   colorMap   An array of color values (alpha values are ignored) in the order they're intended to be assigned as indices
 	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format.
 	 */
-	public static function imageToCSV(graphic:FlxGraphicSource, invert = false, scale = 1, ?colorMap:Array<FlxColor>):String
+	public static function imageToCSV(graphic:FlxGraphicAsset, invert = false, scale = 1, ?colorMap:Array<FlxColor>):String
 	{
 		return bitmapToCSV(graphic.resolveBitmapData(), invert, scale, colorMap);
 	}


### PR DESCRIPTION
FlxGraphicSource from my understanding serves the same purpose as FlxGraphicAsset, so I merged FlxGraphicSource's resolveBitmapData function and BitmapData class support into FlxGraphicAsset, deprecated it, and updated any usage of it inside flixel. 

My main issue with FlxGraphicSource is the lack of support for FlxGraphic. When using FlxAtlas, one of the very few classes that support it, having to write `FlxAtlas.addNode(graphic.bitmap);` instead of `FlxAtlas.addNode(graphic);` feels like an unnecessary workaround.