### PR TITLE
Triangle rendering fixes

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -890,7 +890,7 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			final isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
+			final isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end) || (colors != null && colors.length != 0);
 			final hasColorOffsets = (transform != null && transform.hasRGBAOffsets());
 			
 			final drawItem = startTrianglesBatch(graphic, smoothing, isColored, blend, hasColorOffsets, shader);

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -571,8 +571,7 @@ class FlxCamera extends FlxBasic
 	static var renderPoint:FlxPoint = FlxPoint.get();
 
 	static var renderRect:FlxRect = FlxRect.get();
-
-	@:noCompletion
+	
 	public function startQuadBatch(graphic:FlxGraphic, colored:Bool, hasColorOffsets:Bool = false, ?blend:BlendMode, smooth:Bool = false, ?shader:FlxShader)
 	{
 		#if FLX_RENDER_TRIANGLE
@@ -580,7 +579,7 @@ class FlxCamera extends FlxBasic
 		#else
 		var itemToReturn = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
-
+		
 		if (_currentDrawItem != null
 			&& _currentDrawItem.type == FlxDrawItemType.TILES
 			&& _headTiles.graphics == graphic
@@ -593,7 +592,7 @@ class FlxCamera extends FlxBasic
 		{
 			return _headTiles;
 		}
-
+		
 		if (_storageTilesHead != null)
 		{
 			itemToReturn = _storageTilesHead;
@@ -609,7 +608,7 @@ class FlxCamera extends FlxBasic
 		// TODO: catch this error when the dev actually messes up, not in the draw phase
 		if (graphic.isDestroyed)
 			throw 'Cannot queue ${graphic.key}. This sprite was destroyed.';
-
+		
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smooth;
 		itemToReturn.colored = colored;
@@ -617,27 +616,26 @@ class FlxCamera extends FlxBasic
 		itemToReturn.blending = blendInt;
 		itemToReturn.blend = blend;
 		itemToReturn.shader = shader;
-
+		
 		itemToReturn.nextTyped = _headTiles;
 		_headTiles = itemToReturn;
-
+		
 		if (_headOfDrawStack == null)
 		{
 			_headOfDrawStack = itemToReturn;
 		}
-
+		
 		if (_currentDrawItem != null)
 		{
 			_currentDrawItem.next = itemToReturn;
 		}
-
+		
 		_currentDrawItem = itemToReturn;
-
+		
 		return itemToReturn;
 		#end
 	}
-
-	@:noCompletion
+	
 	public function startTrianglesBatch(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
 	{
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
@@ -649,10 +647,8 @@ class FlxCamera extends FlxBasic
 			&& _headTriangles.colored == isColored
 			&& _headTriangles.blending == blendInt
 			&& _headTriangles.blend == blend
-			#if !flash
 			&& _headTriangles.hasColorOffsets == hasColorOffsets
 			&& _headTriangles.shader == shader
-			#end
 			)
 		{
 			return _headTriangles;
@@ -660,13 +656,12 @@ class FlxCamera extends FlxBasic
 
 		return getNewDrawTrianglesItem(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
 	}
-
-	@:noCompletion
+	
 	public function getNewDrawTrianglesItem(graphic:FlxGraphic, smoothing:Bool = false, isColored:Bool = false, ?blend:BlendMode, ?hasColorOffsets:Bool, ?shader:FlxShader):FlxDrawTrianglesItem
 	{
 		var itemToReturn:FlxDrawTrianglesItem = null;
 		var blendInt:Int = FlxDrawBaseItem.blendToInt(blend);
-
+		
 		if (_storageTrianglesHead != null)
 		{
 			itemToReturn = _storageTrianglesHead;
@@ -678,41 +673,43 @@ class FlxCamera extends FlxBasic
 		{
 			itemToReturn = new FlxDrawTrianglesItem();
 		}
-
+		
+		// TODO: catch this error when the dev actually messes up, not in the draw phase
+		if (graphic.isDestroyed)
+			throw 'Cannot queue ${graphic.key}. This sprite was destroyed.'; 
+		
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smoothing;
 		itemToReturn.colored = isColored;
 		itemToReturn.blending = blendInt;
 		itemToReturn.blend = blend;
-		#if !flash
 		itemToReturn.hasColorOffsets = hasColorOffsets;
 		itemToReturn.shader = shader;
-		#end
-
+		
 		itemToReturn.nextTyped = _headTriangles;
 		_headTriangles = itemToReturn;
-
+		
 		if (_headOfDrawStack == null)
 		{
 			_headOfDrawStack = itemToReturn;
 		}
-
+		
 		if (_currentDrawItem != null)
 		{
 			_currentDrawItem.next = itemToReturn;
 		}
-
+		
 		_currentDrawItem = itemToReturn;
-
+		
 		return itemToReturn;
 	}
-
+	
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	function clearDrawStack():Void
 	{
 		var currTiles = _headTiles;
 		var newTilesHead;
-
+		
 		while (currTiles != null)
 		{
 			newTilesHead = currTiles.nextTyped;
@@ -721,10 +718,10 @@ class FlxCamera extends FlxBasic
 			_storageTilesHead = currTiles;
 			currTiles = newTilesHead;
 		}
-
+		
 		var currTriangles:FlxDrawTrianglesItem = _headTriangles;
 		var newTrianglesHead:FlxDrawTrianglesItem;
-
+		
 		while (currTriangles != null)
 		{
 			newTrianglesHead = currTriangles.nextTyped;
@@ -733,13 +730,13 @@ class FlxCamera extends FlxBasic
 			_storageTrianglesHead = currTriangles;
 			currTriangles = newTrianglesHead;
 		}
-
+		
 		_currentDrawItem = null;
 		_headOfDrawStack = null;
 		_headTiles = null;
 		_headTriangles = null;
 	}
-
+	
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	function render():Void
 	{
@@ -750,7 +747,7 @@ class FlxCamera extends FlxBasic
 			currItem = currItem.next;
 		}
 	}
-
+	
 	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix, ?transform:ColorTransform, ?blend:BlendMode, ?smoothing:Bool = false,
 			?shader:FlxShader):Void
 	{
@@ -771,18 +768,18 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			var isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
-			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
-
+			final isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
+			final hasColorOffsets = (transform != null && transform.hasRGBAOffsets());
+			
 			#if FLX_RENDER_TRIANGLE
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend);
+			final drawItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
 			#else
-			var drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
+			final drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#end
 			drawItem.addQuad(frame, matrix, transform);
 		}
 	}
-
+	
 	public function copyPixels(?frame:FlxFrame, ?pixels:BitmapData, ?sourceRect:Rectangle, destPoint:Point, ?transform:ColorTransform, ?blend:BlendMode,
 			?smoothing:Bool = false, ?shader:FlxShader):Void
 	{
@@ -814,70 +811,64 @@ class FlxCamera extends FlxBasic
 		{
 			_helperMatrix.identity();
 			_helperMatrix.translate(destPoint.x + frame.offset.x, destPoint.y + frame.offset.y);
-
-			var isColored = (transform != null && transform.hasRGBMultipliers());
-			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
-
-			#if !FLX_RENDER_TRIANGLE
-			var drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
+			
+			final isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
+			final hasColorOffsets = (transform != null && transform.hasRGBAOffsets());
+			
+			#if FLX_RENDER_TRIANGLE
+			final drawItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
 			#else
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend);
+			final drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#end
 			drawItem.addQuad(frame, _helperMatrix, transform);
 		}
 	}
-
+	
 	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>,
 			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false, ?transform:ColorTransform, ?shader:FlxShader):Void
 	{
+		final cameraBounds = _bounds.set(viewMarginLeft, viewMarginTop, viewWidth, viewHeight);
+
 		if (FlxG.renderBlit)
 		{
 			if (position == null)
 				position = renderPoint.set();
-
-			_bounds.set(0, 0, width, height);
-
-			var verticesLength:Int = vertices.length;
-			var currentVertexPosition:Int = 0;
-
-			var tempX:Float, tempY:Float;
-			var i:Int = 0;
-			var bounds = renderRect.set();
-			drawVertices.splice(0, drawVertices.length);
-
+			
+			#if FLX_DEBUG
+			if (colors != null && colors.length != 0)
+				FlxG.log.warn('FlxCamera.drawTriangles: "colors" is deprecated and will be ignored');
+			#end
+			
+			drawVertices.length = 0;
+			final verticesLength = vertices.length;
+			final bounds = renderRect.set();
+			var i = 0;
+			
 			while (i < verticesLength)
 			{
-				tempX = position.x + vertices[i];
-				tempY = position.y + vertices[i + 1];
-
-				drawVertices[currentVertexPosition++] = tempX;
-				drawVertices[currentVertexPosition++] = tempY;
-
+				final tempX = position.x + vertices[i];
+				final tempY = position.y + vertices[i + 1];
+				
+				drawVertices.push(tempX);
+				drawVertices.push(tempY);
+				
 				if (i == 0)
-				{
 					bounds.set(tempX, tempY, 0, 0);
-				}
 				else
-				{
 					FlxDrawTrianglesItem.inflateBounds(bounds, tempX, tempY);
-				}
-
+				
 				i += 2;
 			}
-
+			
 			position.putWeak();
-
-			if (!_bounds.overlaps(bounds))
-			{
-				drawVertices.splice(drawVertices.length - verticesLength, verticesLength);
-			}
-			else
+			
+			if (cameraBounds.overlaps(bounds))
 			{
 				trianglesSprite.graphics.clear();
 				trianglesSprite.graphics.beginBitmapFill(graphic.bitmap, null, repeat, smoothing);
 				trianglesSprite.graphics.drawTriangles(drawVertices, indices, uvtData);
 				trianglesSprite.graphics.endFill();
-
+				
 				// TODO: check this block of code for cases, when zoom < 1 (or initial zoom?)...
 				if (_useBlitMatrix)
 					_helperMatrix.copyFrom(_blitMatrix);
@@ -886,12 +877,13 @@ class FlxCamera extends FlxBasic
 					_helperMatrix.identity();
 					_helperMatrix.translate(-viewMarginLeft, -viewMarginTop);
 				}
-
-				buffer.draw(trianglesSprite, _helperMatrix);
+				
+				buffer.draw(trianglesSprite, _helperMatrix, transform);
+				
 				#if FLX_DEBUG
 				if (FlxG.debugger.drawDebug)
 				{
-					var gfx:Graphics = FlxSpriteUtil.flashGfx;
+					final gfx = FlxSpriteUtil.flashGfx;
 					gfx.clear();
 					gfx.lineStyle(1, FlxColor.BLUE, 0.5);
 					gfx.drawTriangles(drawVertices, indices);
@@ -900,26 +892,17 @@ class FlxCamera extends FlxBasic
 				#end
 				// End of TODO...
 			}
-
-			bounds.put();
 		}
 		else
 		{
-			_bounds.set(0, 0, width, height);
-			var isColored:Bool = (colors != null && colors.length != 0);
-
-			#if !flash
-			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
-			isColored = isColored || (transform != null && transform.hasRGBMultipliers());
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
-			drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds, transform);
-			#else
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(graphic, smoothing, isColored, blend);
-			drawItem.addTriangles(vertices, indices, uvtData, colors, position, _bounds);
-			#end
+			final isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
+			final hasColorOffsets = (transform != null && transform.hasRGBAOffsets());
+			
+			final drawItem = startTrianglesBatch(graphic, smoothing, isColored, blend, hasColorOffsets, shader);
+			drawItem.addTriangles(vertices, indices, uvtData, colors, position, cameraBounds, transform);
 		}
 	}
-
+	
 	/**
 	 * Helper method preparing debug rectangle for rendering in blit render mode
 	 * @param	rect	rectangle to prepare for rendering

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -676,7 +676,7 @@ class FlxCamera extends FlxBasic
 		
 		// TODO: catch this error when the dev actually messes up, not in the draw phase
 		if (graphic.isDestroyed)
-			throw 'Cannot queue ${graphic.key}. This sprite was destroyed.'; 
+			throw 'Cannot queue ${graphic.key}. This sprite was destroyed.';
 		
 		itemToReturn.graphics = graphic;
 		itemToReturn.antialiasing = smoothing;
@@ -824,7 +824,7 @@ class FlxCamera extends FlxBasic
 		}
 	}
 	
-	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>,
+	public function drawTriangles(graphic:FlxGraphic, vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<FlxColor>,
 			?position:FlxPoint, ?blend:BlendMode, repeat:Bool = false, smoothing:Bool = false, ?transform:ColorTransform, ?shader:FlxShader):Void
 	{
 		final cameraBounds = _bounds.set(viewMarginLeft, viewMarginTop, viewWidth, viewHeight);
@@ -833,11 +833,6 @@ class FlxCamera extends FlxBasic
 		{
 			if (position == null)
 				position = renderPoint.set();
-			
-			#if FLX_DEBUG
-			if (colors != null && colors.length != 0)
-				FlxG.log.warn('FlxCamera.drawTriangles: "colors" is deprecated and will be ignored');
-			#end
 			
 			drawVertices.length = 0;
 			final verticesLength = vertices.length;

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -835,7 +835,7 @@ class FlxCamera extends FlxBasic
 				position = renderPoint.set();
 			
 			drawVertices.length = 0;
-			final verticesLength = vertices.length;
+			final verticesLength = Std.int(vertices.length / 2) * 2;
 			final bounds = renderRect.set();
 			var i = 0;
 			
@@ -857,7 +857,7 @@ class FlxCamera extends FlxBasic
 			
 			position.putWeak();
 			
-			if (cameraBounds.overlaps(bounds))
+			if (bounds.overlaps(cameraBounds) && Std.int(indices.length / 3) != 0)
 			{
 				trianglesSprite.graphics.clear();
 				trianglesSprite.graphics.beginBitmapFill(graphic.bitmap, null, repeat, smoothing);

--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -19,49 +19,48 @@ class FlxStrip extends FlxSprite
 	 * A `Vector` of floats where each pair of numbers is treated as a coordinate location (an x, y pair).
 	 */
 	public var vertices:DrawData<Float> = new DrawData<Float>();
-
+	
 	/**
 	 * A `Vector` of integers or indexes, where every three indexes define a triangle.
 	 */
 	public var indices:DrawData<Int> = new DrawData<Int>();
-
+	
 	/**
 	 * A `Vector` of normalized coordinates used to apply texture mapping.
 	 */
 	public var uvtData:DrawData<Float> = new DrawData<Float>();
-
+	
+	@:deprecated("colors is deprecated")
 	public var colors:DrawData<Int> = new DrawData<Int>();
-
+	
 	public var repeat:Bool = false;
-
+	
+	@:haxe.warning("-WDeprecated")
 	override public function destroy():Void
 	{
 		vertices = null;
 		indices = null;
 		uvtData = null;
 		colors = null;
-
+		
 		super.destroy();
 	}
-
+	
 	// TODO: check this for cases when zoom is less than initial zoom...
+	@:haxe.warning("-WDeprecated")
 	override public function draw():Void
 	{
 		if (alpha == 0 || graphic == null || vertices == null)
 			return;
-
+		
 		final cameras = getCamerasLegacy();
 		for (camera in cameras)
 		{
 			if (!camera.visible || !camera.exists)
 				continue;
-
+			
 			getScreenPosition(_point, camera).subtractPoint(offset);
-			#if !flash
 			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing, colorTransform, shader);
-			#else
-			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing);
-			#end
 		}
 	}
 }

--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -1,6 +1,7 @@
 package flixel;
 
 import flixel.graphics.tile.FlxDrawTrianglesItem.DrawData;
+import flixel.util.FlxColor;
 
 /**
  * A very basic rendering component which uses `drawTriangles()`.
@@ -30,12 +31,13 @@ class FlxStrip extends FlxSprite
 	 */
 	public var uvtData:DrawData<Float> = new DrawData<Float>();
 	
-	@:deprecated("colors is deprecated")
-	public var colors:DrawData<Int> = new DrawData<Int>();
+	/**
+	 * A `Vector` of colors for vertices. Works similar to `color`. Isn't supported on `FlxG.renderBlit`.
+	 */
+	public var colors:DrawData<FlxColor> = new DrawData<FlxColor>();
 	
 	public var repeat:Bool = false;
 	
-	@:haxe.warning("-WDeprecated")
 	override public function destroy():Void
 	{
 		vertices = null;
@@ -47,7 +49,6 @@ class FlxStrip extends FlxSprite
 	}
 	
 	// TODO: check this for cases when zoom is less than initial zoom...
-	@:haxe.warning("-WDeprecated")
 	override public function draw():Void
 	{
 		if (alpha == 0 || graphic == null || vertices == null)

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -663,6 +663,9 @@ class FlxFrame implements IFlxDestroyable
 			cacheFrameMatrix();
 		}
 		
+		// update uv
+		frame = frame;
+		
 		frameRect.put();
 		return this;
 	}
@@ -760,14 +763,14 @@ abstract FlxUVRect(FlxRect) from FlxRect to flixel.util.FlxPool.IFlxPooled
 	inline function set_left(value):Float { return this.x = value; }
 	
 	/** Top */
-	public var right(get, set):Float;
-	inline function get_right():Float { return this.y; }
-	inline function set_right(value):Float { return this.y = value; }
+	public var top(get, set):Float;
+	inline function get_top():Float { return this.y; }
+	inline function set_top(value):Float { return this.y = value; }
 	
 	/** Right */
-	public var top(get, set):Float;
-	inline function get_top():Float { return this.width; }
-	inline function set_top(value):Float { return this.width = value; }
+	public var right(get, set):Float;
+	inline function get_right():Float { return this.width; }
+	inline function set_right(value):Float { return this.width = value; }
 	
 	/** Bottom */
 	public var bottom(get, set):Float;
@@ -792,6 +795,16 @@ abstract FlxUVRect(FlxRect) from FlxRect to flixel.util.FlxPool.IFlxPooled
 	public static function get(l = 0.0, t = 0.0, r = 0.0, b = 0.0)
 	{
 		return FlxRect.get(l, t, r, b);
+	}
+	
+	public inline function toString()
+	{
+		return return FlxStringUtil.getDebugString([
+			LabelValuePair.weak("l", left),
+			LabelValuePair.weak("t", top),
+			LabelValuePair.weak("r", right),
+			LabelValuePair.weak("b", bottom)
+		]);
 	}
 }
 

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -129,7 +129,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		colorOffsets = null;
 	}
 	
-	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>, ?position:FlxPoint,
+	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<FlxColor>, ?position:FlxPoint,
 			?cameraBounds:FlxRect, ?transform:ColorTransform):Void
 	{
 		if (position == null)
@@ -137,11 +137,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		
 		if (cameraBounds == null)
 			cameraBounds = rect.set(0, 0, FlxG.width, FlxG.height);
-		
-		#if FLX_DEBUG
-		if (colors != null && colors.length != 0)
-			FlxG.log.warn('FlxDrawTrianglesItem.addTriangles: "colors" is deprecated and will be ignored');
-		#end
 		
 		// reset bounds outside camera view
 		bounds.set(Math.NaN, Math.NaN, Math.NaN, Math.NaN);
@@ -184,9 +179,21 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			this.indices.push(prevNumberOfVertices + index);
 		
 		final indicesLength = indices.length;
+		final colorsLength = colors != null ? colors.length : -1;
+		
 		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
-		for (_ in 0...indicesLength)
-			alphas.push(alphaMultiplier);
+		for (i in 0...indicesLength)
+		{
+			var alpha = alphaMultiplier;
+			
+			if (i < colorsLength)
+			{
+				final color = colors[indices[i]];
+				alpha *= color.alphaFloat;
+			}
+			
+			alphas.push(alpha);
+		}
 		
 		if (colored || hasColorOffsets)
 		{
@@ -211,11 +218,23 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 				alphaOffset = transform.alphaOffset;
 			}
 			
-			for (_ in 0...indicesLength)
+			for (i in 0...indicesLength)
 			{
-				colorMultipliers.push(redMultiplier);
-				colorMultipliers.push(greenMultiplier);
-				colorMultipliers.push(blueMultiplier);
+				var red = redMultiplier;
+				var green = greenMultiplier;
+				var blue = blueMultiplier;
+				
+				if (i < colorsLength)
+				{
+					final color = colors[indices[i]];
+					red *= color.redFloat;
+					green *= color.greenFloat;
+					blue *= color.blueFloat;
+				}
+				
+				colorMultipliers.push(red);
+				colorMultipliers.push(green);
+				colorMultipliers.push(blue);
 				colorMultipliers.push(1);
 				
 				colorOffsets.push(redOffset);

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -8,7 +8,6 @@ import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxShader;
 import flixel.util.FlxColor;
-import openfl.display.Graphics;
 import openfl.display.ShaderParameter;
 import openfl.display.TriangleCulling;
 import openfl.geom.ColorTransform;
@@ -20,51 +19,51 @@ typedef DrawData<T> = openfl.Vector<T>;
  */
 class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 {
-	static var point:FlxPoint = FlxPoint.get();
-	static var rect:FlxRect = FlxRect.get();
-
-	#if !flash
+	static inline final INDICES_PER_QUAD = 6;
+	static final point = FlxPoint.get();
+	static final rect = FlxRect.get();
+	static final bounds = FlxRect.get();
+	
 	public var shader:FlxShader;
-	var alphas:Array<Float>;
-	var colorMultipliers:Array<Float>;
-	var colorOffsets:Array<Float>;
-	#end
-
+	var alphas:Array<Float> = [];
+	var colorMultipliers:Array<Float> = [];
+	var colorOffsets:Array<Float> = [];
+	
 	public var vertices:DrawData<Float> = new DrawData<Float>();
 	public var indices:DrawData<Int> = new DrawData<Int>();
 	public var uvtData:DrawData<Float> = new DrawData<Float>();
+	@:deprecated("colors is deprecated")
 	public var colors:DrawData<Int> = new DrawData<Int>();
-
-	public var verticesPosition:Int = 0;
-	public var indicesPosition:Int = 0;
-	public var colorsPosition:Int = 0;
-
-	var bounds:FlxRect = FlxRect.get();
-
+	
+	@:deprecated("verticesPosition is deprecated, use vertices.length, instead")
+	public var verticesPosition(get, never):Int;
+	@:deprecated("indicesPosition is deprecated, use indices.length, instead")
+	public var indicesPosition(get, never):Int;
+	@:deprecated("colorsPosition is deprecated")
+	public var colorsPosition(get, never):Int;
+	
 	public function new()
 	{
 		super();
 		type = FlxDrawItemType.TRIANGLES;
-		#if !flash
-		alphas = [];
-		#end
 	}
-
+	
+	#if !flash
 	override public function render(camera:FlxCamera):Void
 	{
-		if (!FlxG.renderTile)
+		if (numTriangles == 0)
 			return;
-
-		if (numTriangles <= 0)
-			return;
-
-		#if !flash
-		var shader = shader != null ? shader : graphics.shader;
+		
+		// TODO: catch this error when the dev actually messes up, not in the draw phase
+		if (shader == null && graphics.isDestroyed)
+			throw 'Attempted to render an invalid FlxDrawItem, did you destroy a cached sprite?';
+		
+		final shader = shader != null ? shader : graphics.shader;
 		shader.bitmap.input = graphics.bitmap;
 		shader.bitmap.filter = (camera.antialiasing || antialiasing) ? LINEAR : NEAREST;
 		shader.bitmap.wrap = REPEAT; // in order to prevent breaking tiling behaviour in classes that use drawTriangles
 		shader.alpha.value = alphas;
-
+		
 		if (colored || hasColorOffsets)
 		{
 			shader.colorMultiplier.value = colorMultipliers;
@@ -75,32 +74,36 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			shader.colorMultiplier.value = null;
 			shader.colorOffset.value = null;
 		}
-
+		
 		setParameterValue(shader.hasTransform, true);
 		setParameterValue(shader.hasColorTransform, colored || hasColorOffsets);
-
+		
 		camera.canvas.graphics.overrideBlendMode(blend);
-
 		camera.canvas.graphics.beginShaderFill(shader);
-		#else
-		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
-		#end
-
 		camera.canvas.graphics.drawTriangles(vertices, indices, uvtData, TriangleCulling.NONE);
 		camera.canvas.graphics.endFill();
-
+		
 		#if FLX_DEBUG
 		if (FlxG.debugger.drawDebug)
 		{
-			var gfx:Graphics = camera.debugLayer.graphics;
+			final gfx = camera.debugLayer.graphics;
 			gfx.lineStyle(1, FlxColor.BLUE, 0.5);
 			gfx.drawTriangles(vertices, indices, uvtData);
 		}
 		#end
-
+		
 		super.render(camera);
 	}
-
+	
+	inline function setParameterValue(parameter:ShaderParameter<Bool>, value:Bool):Void
+	{
+		if (parameter.value == null)
+			parameter.value = [];
+		parameter.value[0] = value;
+	}
+	#end
+	
+	@:haxe.warning("-WDeprecated")
 	override public function reset():Void
 	{
 		super.reset();
@@ -108,163 +111,121 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		indices.length = 0;
 		uvtData.length = 0;
 		colors.length = 0;
-
-		verticesPosition = 0;
-		indicesPosition = 0;
-		colorsPosition = 0;
-		#if !flash
-		alphas.splice(0, alphas.length);
-		if (colorMultipliers != null)
-			colorMultipliers.splice(0, colorMultipliers.length);
-		if (colorOffsets != null)
-			colorOffsets.splice(0, colorOffsets.length);
-		#end
+		alphas.resize(0);
+		colorMultipliers.resize(0);
+		colorOffsets.resize(0);
 	}
-
+	
+	@:haxe.warning("-WDeprecated")
 	override public function dispose():Void
 	{
 		super.dispose();
-
 		vertices = null;
 		indices = null;
 		uvtData = null;
 		colors = null;
-		bounds = null;
-		#if !flash
 		alphas = null;
 		colorMultipliers = null;
 		colorOffsets = null;
-		#end
 	}
-
+	
 	public function addTriangles(vertices:DrawData<Float>, indices:DrawData<Int>, uvtData:DrawData<Float>, ?colors:DrawData<Int>, ?position:FlxPoint,
-			?cameraBounds:FlxRect #if !flash , ?transform:ColorTransform #end):Void
+			?cameraBounds:FlxRect, ?transform:ColorTransform):Void
 	{
 		if (position == null)
 			position = point.set();
-
+		
 		if (cameraBounds == null)
 			cameraBounds = rect.set(0, 0, FlxG.width, FlxG.height);
-
-		var verticesLength:Int = vertices.length;
-		var prevVerticesLength:Int = this.vertices.length;
-		var numberOfVertices:Int = Std.int(verticesLength / 2);
-		var prevIndicesLength:Int = this.indices.length;
-		var prevUVTDataLength:Int = this.uvtData.length;
-		var prevColorsLength:Int = this.colors.length;
-		var prevNumberOfVertices:Int = this.numVertices;
-
-		var tempX:Float, tempY:Float;
-		var i:Int = 0;
-		var currentVertexPosition:Int = prevVerticesLength;
-
+		
+		#if FLX_DEBUG
+		if (colors != null && colors.length != 0)
+			FlxG.log.warn('FlxDrawTrianglesItem.addTriangles: "colors" is deprecated and will be ignored');
+		#end
+		
+		// reset bounds outside camera view
+		bounds.set(Math.NaN, Math.NaN, Math.NaN, Math.NaN);
+		
+		final prevNumberOfVertices = numVertices;
+		final verticesLength = vertices.length;
+		var i = 0;
+		
 		while (i < verticesLength)
 		{
-			tempX = position.x + vertices[i];
-			tempY = position.y + vertices[i + 1];
-
-			this.vertices[currentVertexPosition++] = tempX;
-			this.vertices[currentVertexPosition++] = tempY;
-
+			final tempX = position.x + vertices[i];
+			final tempY = position.y + vertices[i + 1];
+			
+			this.vertices.push(tempX);
+			this.vertices.push(tempY);
+			
 			if (i == 0)
-			{
 				bounds.set(tempX, tempY, 0, 0);
-			}
 			else
-			{
 				inflateBounds(bounds, tempX, tempY);
-			}
-
+			
 			i += 2;
 		}
-
-		var indicesLength:Int = indices.length;
-		if (!cameraBounds.overlaps(bounds))
-		{
-			this.vertices.splice(this.vertices.length - verticesLength, verticesLength);
-		}
-		else
-		{
-			var uvtDataLength:Int = uvtData.length;
-			for (i in 0...uvtDataLength)
-			{
-				this.uvtData[prevUVTDataLength + i] = uvtData[i];
-			}
-
-			for (i in 0...indicesLength)
-			{
-				this.indices[prevIndicesLength + i] = indices[i] + prevNumberOfVertices;
-			}
-
-			if (colored)
-			{
-				for (i in 0...numberOfVertices)
-				{
-					this.colors[prevColorsLength + i] = colors[i];
-				}
-
-				colorsPosition += numberOfVertices;
-			}
-
-			verticesPosition += verticesLength;
-			indicesPosition += indicesLength;
-		}
-
+		
+		final inBounds = cameraBounds.overlaps(bounds);
+		
 		position.putWeak();
 		cameraBounds.putWeak();
-
-		#if !flash
-		for (_ in 0...indicesLength)
+		
+		if (!inBounds)
 		{
-			alphas.push(transform != null ? transform.alphaMultiplier : 1.0);
+			this.vertices.length -= verticesLength;
+			return;
 		}
-
+		
+		for (uvt in uvtData)
+			this.uvtData.push(uvt);
+		
+		for (index in indices)
+			this.indices.push(prevNumberOfVertices + index);
+		
+		final indicesLength = indices.length;
+		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
+		for (_ in 0...indicesLength)
+			alphas.push(alphaMultiplier);
+		
 		if (colored || hasColorOffsets)
 		{
-			if (colorMultipliers == null)
-				colorMultipliers = [];
-
-			if (colorOffsets == null)
-				colorOffsets = [];
-
+			var redMultiplier = 1.0;
+			var greenMultiplier = 1.0;
+			var blueMultiplier = 1.0;
+			
+			var redOffset = 1.0;
+			var greenOffset = 1.0;
+			var blueOffset = 1.0;
+			var alphaOffset = 1.0;
+			
+			if (transform != null)
+			{
+				redMultiplier = transform.redMultiplier;
+				greenMultiplier = transform.greenMultiplier;
+				blueMultiplier = transform.blueMultiplier;
+				
+				redOffset = transform.redOffset;
+				greenOffset = transform.greenOffset;
+				blueOffset = transform.blueOffset;
+				alphaOffset = transform.alphaOffset;
+			}
+			
 			for (_ in 0...indicesLength)
 			{
-				if(transform != null)
-				{
-					colorMultipliers.push(transform.redMultiplier);
-					colorMultipliers.push(transform.greenMultiplier);
-					colorMultipliers.push(transform.blueMultiplier);
-
-					colorOffsets.push(transform.redOffset);
-					colorOffsets.push(transform.greenOffset);
-					colorOffsets.push(transform.blueOffset);
-					colorOffsets.push(transform.alphaOffset);
-				}
-				else
-				{
-					colorMultipliers.push(1);
-					colorMultipliers.push(1);
-					colorMultipliers.push(1);
-	
-					colorOffsets.push(0);
-					colorOffsets.push(0);
-					colorOffsets.push(0);
-					colorOffsets.push(0);
-				}
-
+				colorMultipliers.push(redMultiplier);
+				colorMultipliers.push(greenMultiplier);
+				colorMultipliers.push(blueMultiplier);
 				colorMultipliers.push(1);
+				
+				colorOffsets.push(redOffset);
+				colorOffsets.push(greenOffset);
+				colorOffsets.push(blueOffset);
+				colorOffsets.push(alphaOffset);
 			}
 		}
-		#end
 	}
-
-	inline function setParameterValue(parameter:ShaderParameter<Bool>, value:Bool):Void
-	{
-		if (parameter.value == null)
-			parameter.value = [];
-		parameter.value[0] = value;
-	}
-
+	
 	public static inline function inflateBounds(bounds:FlxRect, x:Float, y:Float):FlxRect
 	{
 		if (x < bounds.x)
@@ -272,117 +233,121 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			bounds.width += bounds.x - x;
 			bounds.x = x;
 		}
-
+		
 		if (y < bounds.y)
 		{
 			bounds.height += bounds.y - y;
 			bounds.y = y;
 		}
-
-		if (x > bounds.x + bounds.width)
-		{
+		
+		if (x > bounds.right)
 			bounds.width = x - bounds.x;
-		}
-
-		if (y > bounds.y + bounds.height)
-		{
+		
+		if (y > bounds.bottom)
 			bounds.height = y - bounds.y;
-		}
-
+		
 		return bounds;
 	}
-
+	
 	override public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void
 	{
-		var prevVerticesPos:Int = verticesPosition;
-		var prevIndicesPos:Int = indicesPosition;
-		var prevColorsPos:Int = colorsPosition;
-		var prevNumberOfVertices:Int = numVertices;
-
-		var point = FlxPoint.get();
-		point.transform(matrix);
-
-		vertices[prevVerticesPos] = point.x;
-		vertices[prevVerticesPos + 1] = point.y;
-
-		uvtData[prevVerticesPos] = frame.uv.left;
-		uvtData[prevVerticesPos + 1] = frame.uv.top;
-
-		point.set(frame.frame.width, 0);
-		point.transform(matrix);
-
-		vertices[prevVerticesPos + 2] = point.x;
-		vertices[prevVerticesPos + 3] = point.y;
-
-		uvtData[prevVerticesPos + 2] = frame.uv.right;
-		uvtData[prevVerticesPos + 3] = frame.uv.top;
-
-		point.set(frame.frame.width, frame.frame.height);
-		point.transform(matrix);
-
-		vertices[prevVerticesPos + 4] = point.x;
-		vertices[prevVerticesPos + 5] = point.y;
-
-		uvtData[prevVerticesPos + 4] = frame.uv.right;
-		uvtData[prevVerticesPos + 5] = frame.uv.bottom;
-
-		point.set(0, frame.frame.height);
-		point.transform(matrix);
-
-		vertices[prevVerticesPos + 6] = point.x;
-		vertices[prevVerticesPos + 7] = point.y;
-
-		point.put();
-
-		uvtData[prevVerticesPos + 6] = frame.uv.left;
-		uvtData[prevVerticesPos + 7] = frame.uv.bottom;
-
-		indices[prevIndicesPos] = prevNumberOfVertices;
-		indices[prevIndicesPos + 1] = prevNumberOfVertices + 1;
-		indices[prevIndicesPos + 2] = prevNumberOfVertices + 2;
-		indices[prevIndicesPos + 3] = prevNumberOfVertices + 2;
-		indices[prevIndicesPos + 4] = prevNumberOfVertices + 3;
-		indices[prevIndicesPos + 5] = prevNumberOfVertices;
-
-		if (colored)
+		final prevNumberOfVertices = numVertices;
+		
+		inline function addVertex(x:Float, y:Float)
 		{
-			var red = 1.0;
-			var green = 1.0;
-			var blue = 1.0;
-			var alpha = 1.0;
-
+			point.set(x, y).transform(matrix);
+			vertices.push(point.x);
+			vertices.push(point.y);
+		}
+		
+		addVertex(0, 0);
+		addVertex(frame.frame.width, 0);
+		addVertex(frame.frame.width, frame.frame.height);
+		addVertex(0, frame.frame.height);
+		
+		uvtData.push(frame.uv.left);
+		uvtData.push(frame.uv.top);
+		uvtData.push(frame.uv.right);
+		uvtData.push(frame.uv.top);
+		uvtData.push(frame.uv.right);
+		uvtData.push(frame.uv.bottom);
+		uvtData.push(frame.uv.left);
+		uvtData.push(frame.uv.bottom);
+		
+		indices.push(prevNumberOfVertices);
+		indices.push(prevNumberOfVertices + 1);
+		indices.push(prevNumberOfVertices + 2);
+		indices.push(prevNumberOfVertices + 2);
+		indices.push(prevNumberOfVertices + 3);
+		indices.push(prevNumberOfVertices);
+		
+		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
+		for (_ in 0...INDICES_PER_QUAD)
+			alphas.push(alphaMultiplier);
+		
+		if (colored || hasColorOffsets)
+		{
+			var redMultiplier = 1.0;
+			var greenMultiplier = 1.0;
+			var blueMultiplier = 1.0;
+			
+			var redOffset = 1.0;
+			var greenOffset = 1.0;
+			var blueOffset = 1.0;
+			var alphaOffset = 1.0;
+			
 			if (transform != null)
 			{
-				red = transform.redMultiplier;
-				green = transform.greenMultiplier;
-				blue = transform.blueMultiplier;
-
-				#if !neko
-				alpha = transform.alphaMultiplier;
-				#end
+				redMultiplier = transform.redMultiplier;
+				greenMultiplier = transform.greenMultiplier;
+				blueMultiplier = transform.blueMultiplier;
+				
+				redOffset = transform.redOffset;
+				greenOffset = transform.greenOffset;
+				blueOffset = transform.blueOffset;
+				alphaOffset = transform.alphaOffset;
 			}
-
-			var color = FlxColor.fromRGBFloat(red, green, blue, alpha);
-
-			colors[prevColorsPos] = color;
-			colors[prevColorsPos + 1] = color;
-			colors[prevColorsPos + 2] = color;
-			colors[prevColorsPos + 3] = color;
-
-			colorsPosition += 4;
+			
+			for (_ in 0...INDICES_PER_QUAD)
+			{
+				colorMultipliers.push(redMultiplier);
+				colorMultipliers.push(greenMultiplier);
+				colorMultipliers.push(blueMultiplier);
+				colorMultipliers.push(1);
+				
+				colorOffsets.push(redOffset);
+				colorOffsets.push(greenOffset);
+				colorOffsets.push(blueOffset);
+				colorOffsets.push(alphaOffset);
+			}
 		}
-
-		verticesPosition += 8;
-		indicesPosition += 6;
 	}
-
+	
 	override function get_numVertices():Int
 	{
 		return Std.int(vertices.length / 2);
 	}
-
+	
 	override function get_numTriangles():Int
 	{
 		return Std.int(indices.length / 3);
+	}
+	
+	@:noCompletion
+	inline function get_verticesPosition():Int
+	{
+		return vertices.length;
+	}
+	
+	@:noCompletion
+	inline function get_indicesPosition():Int
+	{
+		return indices.length;
+	}
+	
+	@:noCompletion
+	inline function get_colorsPosition():Int
+	{
+		return 0;
 	}
 }

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -141,8 +141,8 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		// reset bounds outside camera view
 		bounds.set(Math.NaN, Math.NaN, Math.NaN, Math.NaN);
 		
-		final prevNumberOfVertices = numVertices;
-		final verticesLength = vertices.length;
+		final prevNumVertices = numVertices;
+		final verticesLength = Std.int(vertices.length / 2) * 2;
 		var i = 0;
 		
 		while (i < verticesLength)
@@ -161,25 +161,22 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			i += 2;
 		}
 		
-		final inBounds = cameraBounds.overlaps(bounds);
-		
 		position.putWeak();
-		cameraBounds.putWeak();
 		
-		if (!inBounds)
+		if (!bounds.overlaps(cameraBounds))
 		{
 			this.vertices.length -= verticesLength;
 			return;
 		}
 		
-		for (uvt in uvtData)
-			this.uvtData.push(uvt);
-		
-		for (index in indices)
-			this.indices.push(prevNumberOfVertices + index);
-		
-		final indicesLength = indices.length;
+		final indicesLength = Std.int(indices.length / 3) * 3;
 		final colorsLength = colors != null ? colors.length : -1;
+		
+		for (i in 0...verticesLength)
+			this.uvtData.push(uvtData[i]);
+		
+		for (i in 0...indicesLength)
+			this.indices.push(prevNumVertices + indices[i]);
 		
 		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
 		for (i in 0...indicesLength)
@@ -270,7 +267,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	
 	override public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void
 	{
-		final prevNumberOfVertices = numVertices;
+		final prevNumVertices = numVertices;
 		
 		inline function addVertex(x:Float, y:Float)
 		{
@@ -293,12 +290,12 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		uvtData.push(frame.uv.left);
 		uvtData.push(frame.uv.bottom);
 		
-		indices.push(prevNumberOfVertices);
-		indices.push(prevNumberOfVertices + 1);
-		indices.push(prevNumberOfVertices + 2);
-		indices.push(prevNumberOfVertices + 2);
-		indices.push(prevNumberOfVertices + 3);
-		indices.push(prevNumberOfVertices);
+		indices.push(prevNumVertices);
+		indices.push(prevNumVertices + 1);
+		indices.push(prevNumVertices + 2);
+		indices.push(prevNumVertices + 2);
+		indices.push(prevNumVertices + 3);
+		indices.push(prevNumVertices);
 		
 		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
 		for (_ in 0...INDICES_PER_QUAD)


### PR DESCRIPTION
## Changes list:
- `FLX_RENDER_TRIANGLE` now rendering correctly. (#3169)
- `right` and `top` values no longer swapped in `FlxUVRect`. (#3471)
- `FlxStrip.colors` now reimplemented. (#2263)
- `FlxFrame.clip` now updates `uv`.
- `FlxCamera.drawTriangles` now accounts for color transformation on `FlxG.renderBlit`.
- `FlxCamera.drawTriangles` now correctly accounts for camera bounds.
- Deprecated `colors`, `verticesPosition`, `indicesPosition` and `colorsPosition` in `FlxDrawTrianglesItem`.
- Some minor optimizations in draw items.

## Main changes (`FlxDrawTrianglesItem`)
`colors` vector is a part of `openfl-legacy` Graphics API that Flixel used to apply color transformation to traingles on `FlxG.renderTile`. Right now coloring on `FlxG.renderTile` is handled by shader, but `addTriangles` and `addQuad` hasn't been updated for this, resulting in `addTriangles` just "ignoring" `colors` (#2263) and `addQuad` (used for `FLX_RENDER_TRIANGLE`) being completely broken (#3169). Both functions were updated to fix respective issues: `addTriangles` now accounts for `colors` alsongside regular color transformation (Note: in `flixel-addons` some classes still use `colors` the old way, so this will need a fix pr when merged) and `addQuad` now properly stores color transformation.

Also deprecated `colors` and `colorsPosition` for not being used and `verticesPosition` and `indicesPosition` for being pretty much pointless.

## TODO (?)
- Deprecate `FlxStrip.repeat` since `FlxDrawTrianglesItem` just ignores it and [uses `REPEAT` for shader anyway.](https://github.com/HaxeFlixel/flixel/blob/c27d279dca03559e80f9419a6a680c9ec35fc516/flixel/graphics/tile/FlxDrawTrianglesItem.hx#L65C1-L65C114) 🤷‍♂️🤷‍♂️
- ... or make draw items respect repeat property.

## NOTE

Turns out `camera.alpha` doesn't affect transparency of triangles due to openfl bug. Might need workaround for that until it's fixed.
**Update:** in progress of being fixed. Thanks Redar! (https://github.com/openfl/openfl/pull/2799)