### PR TITLE
Use scrollRect to clip filters and position game window

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -487,7 +487,7 @@ class FlxG
 	 */
 	public static function addChildBelowMouse<T:DisplayObject>(child:T, indexModifier = 0):T
 	{
-		var index = game.getChildIndex(game._inputContainer);
+		var index = game.getChildIndex(game.inputContainer);
 		var max = game.numChildren;
 
 		index = FlxMath.maxAdd(index, indexModifier, max);
@@ -551,7 +551,7 @@ class FlxG
 		#end
 
 		#if FLX_MOUSE
-		mouse = inputs.addInput(new FlxMouse(game._inputContainer));
+		mouse = inputs.addInput(new FlxMouse(game.inputContainer));
 		#end
 
 		#if FLX_TOUCH

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -156,7 +156,7 @@ class FlxGame extends Sprite
 	/**
 	 * Mouse cursor.
 	 */
-	@:deprecated("_inputContainer is deprecated, use")
+	@:deprecated("_inputContainer is deprecated, use inputContainer")
 	final _inputContainer:Sprite;
 	
 	/**

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -325,8 +325,6 @@ class FlxDebugger extends openfl.display.Sprite
 		resetButtonLayout();
 		resetLayout();
 		scaleX = scaleY = scale;
-		x = -FlxG.scaleMode.offset.x;
-		y = -FlxG.scaleMode.offset.y;
 	}
 
 	function updateBounds():Void

--- a/flixel/system/debug/FlxDebugger.hx
+++ b/flixel/system/debug/FlxDebugger.hx
@@ -327,6 +327,8 @@ class FlxDebugger extends openfl.display.Sprite
 		resetButtonLayout();
 		resetLayout();
 		scaleX = scaleY = scale;
+		x = -FlxG.scaleMode.offset.x;
+		y = -FlxG.scaleMode.offset.y;
 	}
 
 	function updateBounds():Void

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -1,11 +1,11 @@
 package flixel.system.frontEnds;
 
-import openfl.geom.Rectangle;
 import flixel.FlxCamera;
 import flixel.FlxG;
 import flixel.util.FlxAxes;
 import flixel.util.FlxColor;
 import flixel.util.FlxSignal.FlxTypedSignal;
+import openfl.geom.Rectangle;
 
 using flixel.util.FlxArrayUtil;
 
@@ -62,17 +62,17 @@ class CameraFrontEnd
 	 *                            `FlxBasics` will not render to it unless you add it to their `cameras` list.
 	 * @return	This FlxCamera instance.
 	 */
-	public function add<T:FlxCamera>(NewCamera:T, DefaultDrawTarget:Bool = true):T
+	public function add<T:FlxCamera>(cam:T, defaultDrawTarget = true):T
 	{
-		FlxG.game.addChildAt(NewCamera.flashSprite, FlxG.game.getChildIndex(FlxG.game._inputContainer));
+		FlxG.game.cameraContainer.addChild(cam.flashSprite);
 		
-		list.push(NewCamera);
-		if (DefaultDrawTarget)
-			defaults.push(NewCamera);
+		list.push(cam);
+		if (defaultDrawTarget)
+			defaults.push(cam);
 		
-		NewCamera.ID = list.length - 1;
-		cameraAdded.dispatch(NewCamera);
-		return NewCamera;
+		cam.ID = list.length - 1;
+		cameraAdded.dispatch(cam);
+		return cam;
 	}
 	
 	/**

--- a/flixel/system/scaleModes/BaseScaleMode.hx
+++ b/flixel/system/scaleModes/BaseScaleMode.hx
@@ -89,8 +89,9 @@ class BaseScaleMode
 		if (FlxG.game == null)
 			return;
 
-		FlxG.game.x = offset.x;
-		FlxG.game.y = offset.y;
+		final rect = FlxG.game.filteredContainer.scrollRect;
+		rect.setTo(-offset.x, -offset.y, deviceSize.x, deviceSize.y);
+		FlxG.game.filteredContainer.scrollRect = rect;
 	}
 
 	function set_horizontalAlign(value:FlxHorizontalAlign):FlxHorizontalAlign

--- a/flixel/system/scaleModes/BaseScaleMode.hx
+++ b/flixel/system/scaleModes/BaseScaleMode.hx
@@ -88,8 +88,11 @@ class BaseScaleMode
 		if (FlxG.game == null)
 			return;
 
+		FlxG.game.x = offset.x;
+		FlxG.game.y = offset.y;
+
 		final rect = FlxG.game.filteredContainer.scrollRect;
-		rect.setTo(-offset.x, -offset.y, deviceSize.x, deviceSize.y);
+		rect.setTo(0, 0, gameSize.x, gameSize.y);
 		FlxG.game.filteredContainer.scrollRect = rect;
 	}
 

--- a/flixel/system/scaleModes/FillScaleMode.hx
+++ b/flixel/system/scaleModes/FillScaleMode.hx
@@ -8,10 +8,4 @@ import flixel.FlxG;
  * 
  * To enable it in your project, use `FlxG.scaleMode = new FillScaleMode();`.
  */
-class FillScaleMode extends BaseScaleMode
-{
-	override function updateGamePosition():Void
-	{
-		FlxG.game.x = FlxG.game.y = 0;
-	}
-}
+class FillScaleMode extends BaseScaleMode {}


### PR DESCRIPTION
Fixes https://github.com/HaxeFlixel/flixel/issues/2258

Adds a scrollRect to the game to ensure that game filters are the expected size. Also adds public `filteredContainer`, `inputContainer` and `cameraContainer` fields to `FlxGame` while deprecating the old private `_inputContainer` field. This  is both to show the debugger above the game filters and organize things better so that the dev can simply add filters to `FlxG.game.cameraContainer` directly.

I tested this with the [ScaleModes demo](https://haxeflixel.com/demos/ScaleModes/) and it seems to work for every mode.

TODO: figure out why resizing the window messes this up even though the rect values are as expected