### PR TITLE
Breaking Change: Rendering cleanup

### DIFF
--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -32,7 +32,7 @@ class FlxStrip extends FlxSprite
 
 	public var colors:DrawData<Int> = new DrawData<Int>();
 
-	public var repeat:Bool = false;
+	public var repeat:Bool = true;
 
 	override public function destroy():Void
 	{

--- a/flixel/graphics/tile/FlxDrawBaseItem.hx
+++ b/flixel/graphics/tile/FlxDrawBaseItem.hx
@@ -16,11 +16,6 @@ class FlxDrawBaseItem<T>
 	 */
 	public static var drawCalls:Int = 0;
 
-	public static function blendToInt(blend:BlendMode):Int
-	{
-		return 0; // no blend mode support in drawQuads()
-	}
-
 	public var nextTyped:T;
 
 	public var next:FlxDrawBaseItem<T>;
@@ -28,8 +23,6 @@ class FlxDrawBaseItem<T>
 	public var graphics:FlxGraphic;
 	public var antialiasing:Bool = false;
 	public var colored:Bool = false;
-	public var hasColorOffsets:Bool = false;
-	public var blending:Int = 0;
 	public var blend:BlendMode;
 
 	public var type:FlxDrawItemType;

--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -28,30 +28,20 @@ class FlxGraphicsShader extends GraphicsShader
 		}
 	", true)
 	@:glFragmentHeader("
-		uniform bool hasTransform;  // TODO: Is this still needed? Apparently, yes!
 		uniform bool hasColorTransform;
 		vec4 flixel_texture2D(sampler2D bitmap, vec2 coord)
 		{
 			vec4 color = texture2D(bitmap, coord);
-			if (!(hasTransform || openfl_HasColorTransform))
+            if (color.a == 0.0)
 				return color;
 			
-			if (color.a == 0.0)
-				return vec4(0.0, 0.0, 0.0, 0.0);
+            if (!(hasColorTransform || openfl_HasColorTransform))
+				return color * openfl_Alphav;
 			
-			if (openfl_HasColorTransform || hasColorTransform)
-			{
-				color = vec4 (color.rgb / color.a, color.a);
-				vec4 mult = vec4 (openfl_ColorMultiplierv.rgb, 1.0);
-				color = clamp (openfl_ColorOffsetv + (color * mult), 0.0, 1.0);
-				
-				if (color.a == 0.0)
-					return vec4 (0.0, 0.0, 0.0, 0.0);
-				
-				return vec4 (color.rgb * color.a * openfl_Alphav, color.a * openfl_Alphav);
-			}
-			
-			return color * openfl_Alphav;
+			color = vec4 (color.rgb / color.a, color.a);
+			vec4 mult = vec4 (openfl_ColorMultiplierv.rgb, 1.0);
+			color = clamp (openfl_ColorOffsetv + (color * mult), 0.0, 1.0);
+			return vec4 (color.rgb * color.a * openfl_Alphav, color.a * openfl_Alphav);
 		}
 	", true)
 	@:glFragmentBody("

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -403,8 +403,7 @@ class FlxBitmapText extends FlxSprite
 					camera.drawPixels(FlxG.bitmap.whitePixel, null, matrix, colorTransform, blend, antialiasing);
 				}
 				
-				final hasColorOffsets = (colorTransform != null && colorTransform.hasRGBAOffsets());
-				final drawItem = camera.startQuadBatch(font.parent, true, hasColorOffsets, blend, antialiasing, shader);
+				final drawItem = camera.startQuadBatch(font.parent, true, blend, antialiasing, shader);
 				function addQuad(charCode:Int, x:Float, y:Float, color:ColorTransform)
 				{
 					var frame = font.getCharFrame(charCode);

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1217,7 +1217,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	@:access(flixel.FlxCamera)
 	function drawTilemap(buffer:FlxTilemapBuffer, camera:FlxCamera):Void
 	{
-		var isColored:Bool = (alpha != 1) || (color != 0xffffff);
+		var isColored = (colorTransform != null #if !html5
+			&& (colorTransform.hasRGBMultipliers() || colorTransform.hasRGBAOffsets()) #end);
 
 		// only used for renderTile
 		var drawX:Float = 0;
@@ -1240,8 +1241,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			scaledWidth = scaledTileWidth;
 			scaledHeight = scaledTileHeight;
 
-			var hasColorOffsets:Bool = (colorTransform != null && colorTransform.hasRGBAOffsets());
-			drawItem = camera.startQuadBatch(graphic, isColored, hasColorOffsets, blend, antialiasing, shader);
+			drawItem = camera.startQuadBatch(graphic, isColored, blend, antialiasing, shader);
 		}
 
 		// Copy tile images into the tile buffer


### PR DESCRIPTION
For a while, HaxeFlixel has had remnants in it's rendering code of different approaches to rendering, deprecated openfl behaviour or features, among other things. This PR is meant as a cleanup of all of that unused/broken behaviour to have clean and straight to the point rendering code.

Its important to note that this PR contains breaking changes, therefore it should only be merged in a major version change, along with all the necessary fixes to external libraries like flixel-addons.

Here's a list of all the changes done:

* Replaced buffer clearing instances of ``splice`` with ``resize``.
* Removed unused ``blending`` and ``blendToInt``, as they're remnants from before openfl supported blends in the graphics api.
* BREAKING CHANGE: Removed ``hasColorOffsets`` from draw items. Even though this function was passed around it was never actually used with the original purpose of reducing the number of variables needed to push to the graphics vertex shader. I tried implementing it myself but it ended up being overcomplicated and only slowed down performance with all the extra checks it requires. Now its unified with the ``colored`` variable.
* Implemented FlxStrip's ``repeat`` value to tile rendering. If it's turned off it'll use the same wrap method as normal quad rendering.
* Brought some FlxDrawTrianglesItem code up to date with the methods used in FlxDrawQuadsItem.
* Reduced the number of checks in the graphics shader by changing slightly around the order of code.
* Reduced the number of checks in colored render items by first checking if the transform exists before starting the for loop. So it doesnt need to get checked for each vertex of the draw call. This also allows Haxe to inline the array pushes in FlxDrawQuadsItem, skipping the for loop completely.

Making this PR a draft first to make sure it works on all targets, so far I've tested desktop and web.
Feedback is appreciated!