### PR TITLE
add `scaleGraphicSize`

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -733,6 +733,18 @@ class FlxSprite extends FlxObject
 	}
 
 	/**
+	 * Helper function to scale the graphic's dimensions, allowing to scale the based on the width/height.
+	 * Meant to be a shortcut to `sprite.setGraphicSize(sprite.width * 0.67)`.
+	 * @param x = 0.0 the amount of scaling in the x axis. if this variable is set to 0.0, it'll be omitted to the y axis.
+	 * @param y = 0.0 the amount of scaling in the y axis. if this variable is set to 0.0, it'll be omitted to the x axis.
+	 * @param absolute = false Checks if the image scaling should be relative to the scaled dimensions like `width` or the raw frame dimensions like `frameWidth`
+	 */
+	public extern inline function scaleGraphicSize(x = 0.0, y = 0.0, absolute = false)
+	{
+		setGraphicSize( ((absolute) ? frameWidth : width) * ((x != 0.) ? x : y), ((absolute) ? frameHeight : height) * ((y != 0.) ? y : x) );
+	}
+
+	/**
 	 * Updates the sprite's hitbox (`width`, `height`, `offset`) according to the current `scale`.
 	 * Also calls `centerOrigin()`.
 	 */


### PR DESCRIPTION
I've been using `setGraphicSize` as a way to scale up/down images. While this gets the job done, of course, it's a bit tedious and setting the scale via `sprite.scale.scale(0.5)` isn't as convenient since it scales it in an absolute level, not in a relative-like width, up and down.


This fixes it, plus it doesn't affect it that much since it's mostly an extern inline to the already established `setGraphicSize`.