### PR TITLE
FlxPoint: Add setXY, deprecate one-arg set(x)

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1,13 +1,5 @@
 package flixel;
 
-import openfl.display.Bitmap;
-import openfl.display.BitmapData;
-import openfl.display.DisplayObject;
-import openfl.display.Graphics;
-import openfl.display.Sprite;
-import openfl.geom.ColorTransform;
-import openfl.geom.Point;
-import openfl.geom.Rectangle;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.frames.FlxFrame;
 import flixel.graphics.tile.FlxDrawBaseItem;
@@ -23,8 +15,16 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
 import openfl.Vector;
+import openfl.display.Bitmap;
+import openfl.display.BitmapData;
 import openfl.display.BlendMode;
+import openfl.display.DisplayObject;
+import openfl.display.Graphics;
+import openfl.display.Sprite;
 import openfl.filters.BitmapFilter;
+import openfl.geom.ColorTransform;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
 
 using flixel.util.FlxColorTransformUtil;
 
@@ -824,7 +824,7 @@ class FlxCamera extends FlxBasic
 		if (FlxG.renderBlit)
 		{
 			if (position == null)
-				position = renderPoint.set();
+				position = renderPoint.zero();
 
 			var verticesLength:Int = vertices.length;
 			var currentVertexPosition:Int = 0;
@@ -1018,7 +1018,7 @@ class FlxCamera extends FlxBasic
 			screen = new FlxSprite();
 			buffer = new BitmapData(width, height, true, 0);
 			screen.pixels = buffer;
-			screen.origin.set();
+			screen.origin.zero();
 			_flashBitmap = new Bitmap(buffer);
 			_scrollRect.addChild(_flashBitmap);
 			_fill = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
@@ -1717,7 +1717,7 @@ class FlxCamera extends FlxBasic
 				var oldBuffer:FlxGraphic = screen.graphic;
 				buffer = new BitmapData(width, height, true, 0);
 				screen.pixels = buffer;
-				screen.origin.set();
+				screen.origin.zero();
 				_flashBitmap.bitmapData = buffer;
 				_flashRect.width = width;
 				_flashRect.height = height;

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1102,7 +1102,7 @@ class FlxObject extends FlxBasic
 		wasTouching = FlxDirectionFlags.NONE;
 		setPosition(x, y);
 		last.set(this.x, this.y);
-		velocity.set();
+		velocity.zero();
 		revive();
 	}
 

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -130,7 +130,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			?cameraBounds:FlxRect, ?transform:ColorTransform):Void
 	{
 		if (position == null)
-			position = point.set();
+			position = point.zero();
 
 		if (cameraBounds == null)
 			cameraBounds = rect.set(0, 0, FlxG.width, FlxG.height);

--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -1,7 +1,5 @@
 package flixel.group;
 
-import openfl.display.BitmapData;
-import openfl.display.BlendMode;
 import flixel.FlxCamera;
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxFrame;
@@ -15,6 +13,8 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxDirectionFlags;
 import flixel.util.FlxSort;
+import openfl.display.BitmapData;
+import openfl.display.BlendMode;
 
 /**
  * `FlxSpriteGroup` is a special `FlxSprite` that can be treated like a single sprite even if it's
@@ -597,7 +597,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		x = X;
 		y = Y;
 		// last.set(x, y); // null on sprite groups
-		velocity.set();
+		velocity.zero();
 		super.revive();
 		
 		_skipTransformChildren = false;

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -301,20 +301,48 @@ import openfl.geom.Point;
 	{
 		this = FlxPoint.get(x, y);
 	}
-
+	
+	/**
+	 * Set the coordinates of this point object.
+	 *
+	 * @param   n  The X and Y coordinate of the point in space.
+	 */
+	public inline function setXY(n:Float):FlxBasePoint
+	{
+		return set(n, n);
+	}
+	
+	
 	/**
 	 * Set the coordinates of this point object.
 	 *
 	 * @param   x  The X-coordinate of the point in space.
 	 * @param   y  The Y-coordinate of the point in space.
 	 */
-	public inline function set(x:Float = 0, y:Float = 0):FlxPoint
+	overload public inline extern function set(x:Float, y:Float):FlxPoint
 	{
-		this.x = x;
-		this.y = y;
-		return this;
+		return this.set(x, y);
 	}
-
+	
+	/**
+	 * Sets the x coordinate of this point and zeroes the y coordinate.
+	 *
+	 * @param   x  The X-coordinate of the point in space.
+	 */
+	@:deprecated("set(n) is deprecated, use the two-arged set(n, 0), instead")
+	overload public inline extern function set(x:Float):FlxPoint
+	{
+		return set(x, 0);
+	}
+	
+	/**
+	 * Set the coordinates of this point to zero.
+	 */
+	overload public inline extern function set():FlxPoint
+	{
+		return set(0, 0);
+	}
+	
 	/**
 	 * Adds to the coordinates of this point.
 	 *
@@ -1577,18 +1605,45 @@ class FlxBasePoint implements IFlxPooled
 	{
 		set(x, y);
 	}
-
+	
+	/**
+	 * Necessary for FlxCallbackPoint.
+	 */
+	function setHelper(x:Float, y:Float):FlxBasePoint
+	{
+		this.x = x;
+		this.y = y;
+		return this;
+	}
+	
 	/**
 	 * Set the coordinates of this point object.
 	 *
 	 * @param   x  The X-coordinate of the point in space.
 	 * @param   y  The Y-coordinate of the point in space.
 	 */
-	public function set(x:Float = 0, y:Float = 0):FlxBasePoint
+	overload public inline extern function set(x:Float, y:Float):FlxBasePoint
 	{
-		this.x = x;
-		this.y = y;
-		return this;
+		return setHelper(x, y);
+	}
+	
+	/**
+	 * Sets the x coordinate of this point and zeroes the y coordinate.
+	 *
+	 * @param   x  The X-coordinate of the point in space.
+	 */
+	@:deprecated("set(n) is deprecated, use the two-arged set(n, 0), instead")
+	overload public inline extern function set(x:Float):FlxBasePoint
+	{
+		return set(x, 0);
+	}
+	
+	/**
+	 * Set the coordinates of this point to zero.
+	 */
+	overload public inline extern function set():FlxBasePoint
+	{
+		return set(0, 0);
 	}
 
 	/**
@@ -1690,7 +1745,9 @@ abstract FlxReadOnlyPoint(FlxPoint) from FlxPoint
 	inline function get_degrees():Float return this.degrees;
 	
 	// hide underlying mutators
-	inline function set(x = 0, y = 0):FlxReadOnlyPoint return this.set(x, y);
+	overload inline extern function set(x, y):FlxReadOnlyPoint return this.set(x, y);
+	overload inline extern function set(x):FlxReadOnlyPoint return this.set(x);
+	overload inline extern function set():FlxReadOnlyPoint return this.set();
 	inline function add(x = 0, y = 0):FlxReadOnlyPoint return this.add(x, y);
 	inline function addPoint(point):FlxReadOnlyPoint return this.add(point);
 	inline function subtract(x = 0, y = 0):FlxReadOnlyPoint return this.subtract(x, y);
@@ -1753,9 +1810,9 @@ class FlxCallbackPoint extends FlxBasePoint
 		}
 	}
 
-	override public function set(x:Float = 0, y:Float = 0):FlxCallbackPoint
+	override function setHelper(x:Float, y:Float):FlxCallbackPoint
 	{
-		super.set(x, y);
+		super.setHelper(x, y);
 		if (_setXYCallback != null)
 			_setXYCallback(this);
 		return this;

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -307,7 +307,7 @@ import openfl.geom.Point;
 	 *
 	 * @param   n  The X and Y coordinate of the point in space.
 	 */
-	public inline function setXY(n:Float):FlxBasePoint
+	public inline function setXY(n:Float):FlxPoint
 	{
 		return set(n, n);
 	}

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -336,7 +336,7 @@ import openfl.geom.Point;
 	 *
 	 * @param   x  The X-coordinate of the point in space.
 	 */
-	@:deprecated("set(n) with one arg, is deprecated, use the two-arged set(n, 0), instead")
+	@:deprecated("set(n) with one arg, is deprecated, use the two-arged set(n, 0), instead") // 6.2.0
 	overload public inline extern function set(x:Float):FlxPoint
 	{
 		return set(x, 0);
@@ -345,7 +345,7 @@ import openfl.geom.Point;
 	/**
 	 * Set the coordinates of this point to zero.
 	 */
-	@:deprecated("set() with no args, is deprecated, use the two-arged set(0, 0) or zero(), instead")
+	// @:deprecated("set() with no args, is deprecated, use the two-arged set(0, 0), setXY(0) or zero(), instead")
 	overload public inline extern function set():FlxPoint
 	{
 		return set(0, 0);

--- a/flixel/path/FlxPath.hx
+++ b/flixel/path/FlxPath.hx
@@ -53,7 +53,7 @@ private class AnchorTools
 		if (result == null)
 			result = FlxPoint.get();
 		else
-			result.set();
+			result.zero();
 		
 		return switch (mode)
 		{
@@ -363,7 +363,7 @@ class FlxPath extends FlxBasePath
 		}
 		else
 		{
-			object.velocity.set();
+			object.velocity.zero();
 		}
 
 		// then set object rotation if necessary

--- a/flixel/system/FlxBGSprite.hx
+++ b/flixel/system/FlxBGSprite.hx
@@ -12,7 +12,7 @@ class FlxBGSprite extends FlxSprite
 		super();
 		// TODO: Use unique:false, now that we're not editing the pixels
 		makeGraphic(1, 1, FlxColor.WHITE, true, FlxG.bitmap.getUniqueKey("bg_graphic_"));
-		scrollFactor.set();
+		scrollFactor.zero();
 	}
 
 	/**

--- a/flixel/system/debug/log/BitmapLog.hx
+++ b/flixel/system/debug/log/BitmapLog.hx
@@ -165,7 +165,7 @@ class BitmapLog extends Window
 	inline function resetSettings()
 	{
 		zoom = 1;
-		canvasOffset.set();
+		canvasOffset.zero();
 	}
 	
 	function indexOf(bitmap:BitmapData)

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -1,6 +1,5 @@
 package flixel.ui;
 
-import openfl.events.MouseEvent;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.atlas.FlxAtlas;
@@ -14,6 +13,7 @@ import flixel.math.FlxPoint;
 import flixel.sound.FlxSound;
 import flixel.text.FlxText;
 import flixel.util.FlxDestroyUtil;
+import openfl.events.MouseEvent;
 #if FLX_TOUCH
 import flixel.input.touch.FlxTouch;
 #end
@@ -270,7 +270,7 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 		status = NORMAL;
 
 		// Since this is a UI element, the default scrollFactor is (0, 0)
-		scrollFactor.set();
+		scrollFactor.zero();
 
 		#if FLX_MOUSE
 		FlxG.stage.addEventListener(MouseEvent.MOUSE_UP, onUpEventListener);

--- a/flixel/ui/FlxVirtualPad.hx
+++ b/flixel/ui/FlxVirtualPad.hx
@@ -1,11 +1,11 @@
 package flixel.ui;
 
-import flixel.ui.FlxAnalog;
 import flixel.FlxG;
 import flixel.graphics.frames.FlxTileFrames;
 import flixel.group.FlxSpriteContainer;
 import flixel.math.FlxPoint;
 import flixel.system.FlxAssets;
+import flixel.ui.FlxAnalog;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSpriteUtil;
@@ -78,7 +78,7 @@ class FlxVirtualPad extends FlxSpriteContainer
 	public function new(dPadMode = FlxDPadMode.FULL, actionMode = FlxActionMode.A_B_C)
 	{
 		super();
-		scrollFactor.set();
+		scrollFactor.zero();
 		
 		add(actions = new FlxVirtualActionButtons(0, 0, actionMode));
 		actions.x = FlxG.width - actions.width;
@@ -120,7 +120,7 @@ class FlxVirtualPadButtons extends FlxTypedSpriteContainer<FlxVirtualPadButton>
 	public function new (x = 0.0, y = 0.0)
 	{
 		super(x, y);
-		scrollFactor.set();
+		scrollFactor.zero();
 		
 		#if FLX_DEBUG
 		this.ignoreDrawDebug = true;

--- a/tests/unit/src/FlxAssert.hx
+++ b/tests/unit/src/FlxAssert.hx
@@ -1,5 +1,6 @@
 package;
 
+import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
 import haxe.PosInfos;
@@ -89,6 +90,16 @@ class FlxAssert
 			Assert.fail("Value [" + actual + "] was not equal to expected value [" + expected + "]", info);
 	}
 
+	public static function pointsEqualXY(expectedX:Float, expectedY:Float, actual:FlxPoint, ?msg:String, ?info:PosInfos)
+	{
+		if (FlxMath.equal(expectedX, actual.x) && FlxMath.equal(expectedY, actual.y))
+			Assert.assertionCount++;
+		else if (msg != null)
+			Assert.fail(msg, info);
+		else
+			Assert.fail('Value [$actual] was not equal to expected value [( x: $expectedX | y: $expectedY )]', info);
+	}
+	
 	public static function pointsNotEqual(expected:FlxPoint, actual:FlxPoint, ?msg:String, ?info:PosInfos)
 	{
 		if (!expected.equals(actual))
@@ -96,7 +107,17 @@ class FlxAssert
 		else if (msg != null)
 			Assert.fail(msg, info);
 		else
-			Assert.fail("Value [" + actual + "] was equal to value [" + expected + "]", info);
+			Assert.fail('Value [$actual] was equal to value [$expected]', info);
+	}
+	
+	public static function pointsNotEqualXY(expectedX:Float, expectedY:Float, actual:FlxPoint, ?msg:String, ?info:PosInfos)
+	{
+		if (!FlxMath.equal(expectedX, actual.x) || !FlxMath.equal(expectedY, actual.y))
+			Assert.assertionCount++;
+		else if (msg != null)
+			Assert.fail(msg, info);
+		else
+			Assert.fail('Value [$actual] was equal to value [( x: $expectedX | y: $expectedY )]', info);
 	}
 
 	public static function pointsNear(expected:FlxPoint, actual:FlxPoint, margin:Float = 0.001, ?msg:String, ?info:PosInfos)

--- a/tests/unit/src/flixel/math/FlxPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxPointTest.hx
@@ -216,17 +216,22 @@ class FlxPointTest extends FlxTest
 		point2.set(-1, -1);
 		assertPointNearlyEquals(point1.pivotDegrees(point2, 45), -1, 14.55);
 	}
+	
+	@Test
+	function testSetXY()
+	{
+		point1.set(1, 2);
+		point1.setXY(10);
+		FlxAssert.pointNearXY(10, 10, point1);
+	}
 
 	function assertPointEquals(p:FlxPoint, x:Float, y:Float, ?msg:String, ?info:PosInfos)
 	{
-		assertPointNearlyEquals(p, x, y, 0.0, msg, info);
+		FlxAssert.pointsEqualXY(x, y, p, msg, info);
 	}
 
 	function assertPointNearlyEquals(p:FlxPoint, x:Float, y:Float, tolerance:Float = .01, ?msg:String, ?info:PosInfos)
 	{
-		if (msg == null)
-			msg = 'Expected (x: $x | y: $y) but was $p';
-
-		Assert.isTrue(Math.abs(x - p.x) <= tolerance && Math.abs(y -p.y) <= tolerance, msg, info);
+		FlxAssert.pointNearXY(x, y, p, tolerance, msg, info);
 	}
 }


### PR DESCRIPTION
Adds `point.setXY(n)` which is equivalent to `set(n, n)`. also deprecates the single-arg use of `point.set(n)` where `x` is set to `n` and `y` is set to `0`.

Eventually, in the next major version, set(x) will be deleted and in a later minor version it will be readded to behave like `setXY` which will then be deprecated