### PR TITLE
`FlxInputText`: Honor `selectionColor.alphaFloat`

### DIFF
--- a/flixel/text/FlxInputText.hx
+++ b/flixel/text/FlxInputText.hx
@@ -1408,6 +1408,7 @@ class FlxInputText extends FlxText implements IFlxInputText
 					{
 						box = _selectionBoxes[i] = new FlxSprite();
 						box.color = selectionColor;
+						box.alpha = selectionColor.alphaFloat;
 					}
 
 					var boxRect = FlxRect.get(startBoundaries.x - scrollH, startBoundaries.y - scrollVOffset,
@@ -2137,7 +2138,10 @@ class FlxInputText extends FlxText implements IFlxInputText
 			for (box in _selectionBoxes)
 			{
 				if (box != null)
+				{
 					box.color = selectionColor;
+					box.alpha = selectionColor.alphaFloat;
+				}
 			}
 		}
 		


### PR DESCRIPTION
Recently I was working on a search engine using the new input text component, and modified the selection color to the value seen in Chrome browsers. I realized though that this color contrasted very poorly at 100% alpha, and from what I can tell there is no way to change it currently.

Simple test case:
```haxe
package;

import flixel.FlxSprite;
import flixel.util.FlxColor;
import flixel.FlxG;
import flixel.text.FlxInputText;
import flixel.FlxState;

class PlayState extends FlxState
{
	override public function create()
	{
		super.create();

		camera.bgColor = FlxColor.WHITE;

		var bg:FlxSprite = new FlxSprite().makeGraphic(FlxG.width, 44, FlxColor.RED);
		bg.screenCenter();
		add(bg);

		var text:FlxInputText = new FlxInputText(0.0, 0.0, FlxG.width, "", 32, FlxColor.BLACK, FlxColor.TRANSPARENT);
		text.color = FlxColor.WHITE;
		text.text = "Hello!";
		// 0.3 alpha
		text.selectionColor = 0x4D0074FF;
		text.screenCenter();
		add(text);
	}
}
```
Before:
<img width="802" height="640" alt="image" src="https://github.com/user-attachments/assets/6a16edcc-f043-446a-95e8-2327d92e8bb9" />
After:
<img width="802" height="640" alt="image" src="https://github.com/user-attachments/assets/1728a39c-c9fd-42fa-a2b8-e69b368266bf" />
Although color alpha isn't typically honored with `FlxSprite`s (not really sure why this is the case either), I think it would make much more sense to make color alpha valid here instead of creating a whole new `selectionAlpha` field or something along those lines.