### PR TITLE
Patch Sprite Color Batching and Default Sprite Color

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -745,7 +745,7 @@ class FlxCamera extends FlxBasic
 		}
 	}
 
-	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix, ?transform:ColorTransform, ?blend:BlendMode, ?smoothing:Bool = false,
+	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix, ?transform:ColorTransform, ?colored:Bool, ?blend:BlendMode, ?smoothing:Bool = false,
 			?shader:FlxShader):Void
 	{
 		if (FlxG.renderBlit)
@@ -765,7 +765,11 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			var isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
+			var isColored:Bool = false;
+			if(transform != null) {
+				if(#if !html5 transform.hasRGBMultipliers() #else true #end || colored)
+					isColored = true;
+			}
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
 
 			#if FLX_RENDER_TRIANGLE

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -262,9 +262,10 @@ class FlxSprite extends FlxObject
 	/**
 	 * Multiplies this sprite's image by the given red, green and blue components, alpha is ignored.
 	 * To change the opacity use `alpha`. Calling `setColorTransform` will also change this value.
+	 * defaults to flixel.FlxColor.TRANSPARENT for zero tint, to tint a sprite use a non transparent color.
 	 * @see https://snippets.haxeflixel.com/sprites/color/
 	 */
-	public var color(default, set):FlxColor = FlxColor.WHITE;
+	public var color(default, set):FlxColor = FlxColor.TRANSPARENT;
 	
 	/**
 	 * The color effects of this sprite, changes to `color` or `alpha` will be reflected here
@@ -368,6 +369,12 @@ class FlxSprite extends FlxObject
 	var _facingFlip:Map<FlxDirectionFlags, {x:Bool, y:Bool}> = new Map<FlxDirectionFlags, {x:Bool, y:Bool}>();
 
 	/**
+	 * Tells this `FlxSprite` to batch any color Tint that is not `flixel.FlxColor.TRANSPARENT`
+	 */
+	@:noCompletion
+	var _colored:Bool;
+
+	/**
 	 * Creates a `FlxSprite` at a specified position with a specified one-frame graphic.
 	 * If none is provided, a 16x16 image of the HaxeFlixel logo is used.
 	 *
@@ -440,6 +447,7 @@ class FlxSprite extends FlxObject
 		graphic = null;
 		_frame = FlxDestroyUtil.destroy(_frame);
 		_frameGraphic = FlxDestroyUtil.destroy(_frameGraphic);
+		_colored = false;
 
 		shader = null;
 	}
@@ -898,7 +906,7 @@ class FlxSprite extends FlxObject
 			matrix.ty = Math.floor(matrix.ty);
 		}
 		
-		camera.drawPixels(frame, framePixels, matrix, colorTransform, blend, antialiasing, shader);
+		camera.drawPixels(frame, framePixels, matrix, colorTransform, _colored, blend, antialiasing, shader);
 	}
 
 	/**
@@ -1537,12 +1545,19 @@ class FlxSprite extends FlxObject
 
 	@:noCompletion
 	function set_color(value:FlxColor):Int
-	{
-		if (color == value)
-			return value;
-		
-		color = value;
-		updateColorTransform();
+	{	
+		if(value == FlxColor.TRANSPARENT) {
+			_colored = false;
+			color = FlxColor.TRANSPARENT;
+		} else {
+			if (color == value)
+			{
+				return value;
+			}
+			color = value;
+			updateColorTransform();
+			_colored = true;
+		}
 		return color;
 	}
 


### PR DESCRIPTION
Currently, in HaxeFlixel, attempting to batch multiple FlxSprites with color transforms causes batching to break.
If any sprite has a color that is not pure white, it will batch. This causes sprites to be drawn in separate colored batches, even if the color is set.

This PR changes the default color of sprites to `FlxColor.TRANSPARENT` (effectively zero tinting) while still respecting all colors, including `FlxColor.WHITE`

With this change:
- Sprites set to `FlxColor.WHITE` will be batched together without altering their original colors.
- Sprites without a color (or with `FlxColor.TRANSPARENT`) will render with no tint, restoring previous behavior.
---
### Previous Behavior: 
<img width="800" height="603" alt="image" src="https://github.com/user-attachments/assets/2a2c8b28-23ac-40b9-a253-7cd1a23b412f" />

### New Behavior: 
<img width="804" height="634" alt="image" src="https://github.com/user-attachments/assets/39e5edbd-f4b7-4313-96cd-6ae5a0eac56c" />

---
Example project: 

```hx
package;

import flixel.FlxG;
import flixel.FlxSprite;
import flixel.util.FlxColor;
import flixel.group.FlxSpriteGroup;

class ColoringTest extends flixel.FlxState {

    var grp:FlxSpriteGroup;

    override public function create() {
        grp = new FlxSpriteGroup();

        var sprW = 16;
        var sprScale = 5;
        var spacing = sprW * sprScale;

        var screenW = FlxG.width; 
        var spritesPerRow = Math.floor(screenW / spacing);

        var totalSprites = 60;

        for (i in 0...totalSprites) {
            var row = Math.floor(i / spritesPerRow);
            var col = i % spritesPerRow;

            var spr = new FlxSprite(col * spacing, 20 + row * spacing);
            spr.scale.set(sprScale, sprScale);

            if (i == 0) {
                // First sprite is always white
                spr.color = FlxColor.WHITE;
            } else {
                // 20% chance to be white, otherwise random color
                if (Math.random() < 0.2) {
                    spr.color = FlxColor.WHITE;
                } else {
                    spr.color = FlxColor.fromRGB(
                        Std.int(Math.random() * 256),
                        Std.int(Math.random() * 256),
                        Std.int(Math.random() * 256)
                    );
                }
            }

            grp.add(spr);
        }

        grp.screenCenter();
        add(grp);
    }
}
```