### PR TITLE
Collision regression

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -214,6 +214,11 @@ class FlxObject extends FlxBasic
 			final vel1 = object1.velocity.x;
 			final vel2 = object2.velocity.x;
 			
+			inline function sameDir(a:Float, b:Float)
+			{
+				return (a <= 0 && b <= 0) || (a >= 0 && b >= 0);
+			}
+			
 			if (!object1.immovable && !object2.immovable)
 			{
 				#if FLX_4_LEGACY_COLLISION
@@ -225,19 +230,25 @@ class FlxObject extends FlxBasic
 				final mass1 = object1.mass;
 				final mass2 = object2.mass;
 				final momentum = mass1 * vel1 + mass2 * vel2;
-				object1.velocity.x = (momentum + object1.elasticity * mass2 * (vel2 - vel1)) / (mass1 + mass2);
-				object2.velocity.x = (momentum + object2.elasticity * mass1 * (vel1 - vel2)) / (mass1 + mass2);
+				
+				if (sameDir(vel1, overlap))
+					object1.velocity.x = (momentum + object1.elasticity * mass2 * (vel2 - vel1)) / (mass1 + mass2);
+				
+				if (sameDir(vel2, -overlap))
+					object2.velocity.x = (momentum + object2.elasticity * mass1 * (vel1 - vel2)) / (mass1 + mass2);
 				#end
 			}
 			else if (!object1.immovable)
 			{
 				object1.x -= overlap;
-				object1.velocity.x = vel2 - vel1 * object1.elasticity;
+				if (sameDir(vel1, overlap))
+					object1.velocity.x = vel2 - vel1 * object1.elasticity;
 			}
 			else if (!object2.immovable)
 			{
 				object2.x += overlap;
-				object2.velocity.x = vel1 - vel2 * object2.elasticity;
+				if (sameDir(vel2, -overlap))
+					object2.velocity.x = vel1 - vel2 * object2.elasticity;
 			}
 			
 			// use collisionDrag properties to determine whether one object
@@ -266,6 +277,11 @@ class FlxObject extends FlxBasic
 			final vel1 = object1.velocity.y;
 			final vel2 = object2.velocity.y;
 			
+			inline function sameDir(a:Float, b:Float)
+			{
+				return (a <= 0 && b <= 0) || (a >= 0 && b >= 0);
+			}
+			
 			if (!object1.immovable && !object2.immovable)
 			{
 				#if FLX_4_LEGACY_COLLISION
@@ -279,19 +295,25 @@ class FlxObject extends FlxBasic
 				final momentum = mass1 * vel1 + mass2 * vel2;
 				final newVel1 = (momentum + object1.elasticity * mass2 * (vel2 - vel1)) / (mass1 + mass2);
 				final newVel2 = (momentum + object2.elasticity * mass1 * (vel1 - vel2)) / (mass1 + mass2);
-				object1.velocity.y = newVel1;
-				object2.velocity.y = newVel2;
+				
+				if (sameDir(vel1, overlap))
+					object1.velocity.y = newVel1;
+				
+				if (sameDir(vel2, -overlap))
+					object2.velocity.y = newVel2;
 				#end
 			}
 			else if (!object1.immovable)
 			{
 				object1.y -= overlap;
-				object1.velocity.y = vel2 - vel1 * object1.elasticity;
+				if (sameDir(vel1, overlap))
+					object1.velocity.y = vel2 - vel1 * object1.elasticity;
 			}
 			else if (!object2.immovable)
 			{
 				object2.y += overlap;
-				object2.velocity.y = vel1 - vel2 * object2.elasticity;
+				if (sameDir(vel2, -overlap))
+					object2.velocity.y = vel1 - vel2 * object2.elasticity;
 			}
 			
 			// use collisionDrag properties to determine whether one object

--- a/tests/unit/src/flixel/FlxObjectTest.hx
+++ b/tests/unit/src/flixel/FlxObjectTest.hx
@@ -209,6 +209,198 @@ class FlxObjectTest extends FlxTest
 		Assert.areEqual(5, object1.y);
 	}
 	
+	/**
+	 * Object overlapping the top of an object, with upwards veocity
+	 */
+	@Test
+	function testSeparateOppositeVelocityUp():Void
+	{
+		function reset()
+		{
+			object1.last.set(0, -10);
+			object1.setSize(10, 10);
+			object1.x = object1.last.x;
+			object1.y = object1.last.y + 2;
+			object1.velocity.y = -100;
+			object2.last.set(0, 0);
+			object2.setPosition(0, 0);
+			object2.setSize(10, 10);
+		}
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-9, object1.y);
+		Assert.areEqual(-100, object1.velocity.y);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-9, object1.y);
+		Assert.areEqual(-100, object1.velocity.y);
+		
+		// test with immovable b
+		object2.immovable = true;
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-10, object1.y);
+		Assert.areEqual(-100, object1.velocity.y);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-10, object1.y);
+		Assert.areEqual(-100, object1.velocity.y);
+	}
+	
+	/**
+	 * Object overlapping the bottom of an object, with downwards veocity
+	 */
+	@Test
+	function testSeparateOppositeVelocityDown():Void
+	{
+		function reset()
+		{
+			object1.last.set(0, 10);
+			object1.setSize(10, 10);
+			object1.x = object1.last.x;
+			object1.y = object1.last.y - 2;
+			object1.velocity.y = 100;
+			object2.last.set(0, 0);
+			object2.setPosition(0, 0);
+			object2.setSize(10, 10);
+		}
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(9, object1.y);
+		Assert.areEqual(100, object1.velocity.y);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(9, object1.y);
+		Assert.areEqual(100, object1.velocity.y);
+		
+		// test with immovable b
+		object2.immovable = true;
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(10, object1.y);
+		Assert.areEqual(100, object1.velocity.y);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(10, object1.y);
+		Assert.areEqual(100, object1.velocity.y);
+	}
+	
+	/**
+	 * Object overlapping the left side of an object, with leftwards veocity
+	 */
+	@Test
+	function testSeparateOppositeVelocityLeft():Void
+	{
+		function reset()
+		{
+			object1.last.set(-10, 0);
+			object1.setSize(10, 10);
+			object1.x = object1.last.x + 2;
+			object1.y = object1.last.y;
+			object1.velocity.x = -100;
+			object2.last.set(0, 0);
+			object2.setPosition(0, 0);
+			object2.setSize(10, 10);
+		}
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-9, object1.x);
+		Assert.areEqual(-100, object1.velocity.x);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-9, object1.x);
+		Assert.areEqual(-100, object1.velocity.x);
+		
+		// test with immovable b
+		object2.immovable = true;
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-10, object1.x);
+		Assert.areEqual(-100, object1.velocity.x);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(-10, object1.x);
+		Assert.areEqual(-100, object1.velocity.x);
+	}
+	
+	/**
+	 * Object overlapping the right side of an object, with rightwards veocity
+	 */
+	@Test
+	function testSeparateOppositeVelocityRight():Void
+	{
+		function reset()
+		{
+			object1.last.set(10, 0);
+			object1.setSize(10, 10);
+			object1.x = object1.last.x - 2;
+			object1.y = object1.last.y;
+			object1.velocity.x = 100;
+			object2.last.set(0, 0);
+			object2.setPosition(0, 0);
+			object2.setSize(10, 10);
+		}
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(9, object1.x);
+		Assert.areEqual(100, object1.velocity.x);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(9, object1.x);
+		Assert.areEqual(100, object1.velocity.x);
+		
+		// test with immovable b
+		object2.immovable = true;
+		
+		reset();
+		Assert.isTrue(FlxObject.separate(object1, object2));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(10, object1.x);
+		Assert.areEqual(100, object1.velocity.x);
+		
+		// test with swapped a/b
+		reset();
+		Assert.isTrue(FlxObject.separate(object2, object1));
+		// object1 is separated, but maintains velocity
+		Assert.areEqual(10, object1.x);
+		Assert.areEqual(100, object1.velocity.x);
+	}
+	
 	@Ignore("Reverted #3418 as it breaks moving platforms")
 	@Test
 	function testSeparateOnBothAxisNewlyOverlapping():Void


### PR DESCRIPTION
Reverts #3418, removing the ability to detect overlaps where both axes start overlapping on the same frame. This change broke [standing on moving platforms](https://snippets.haxeflixel.com/collision/moving-platforms/).

Fixes bug introduced in #3158 where jumping didn't work depending on order of super.update() and collide calls.
The reproducing code is a copy of the [Jumping snippet](https://snippets.haxeflixel.com/movement/jumping/) but with the input detection before the collide call)
```hx
package states;

import flixel.FlxG;
import flixel.FlxSprite;
import flixel.ui.FlxVirtualPad;

class JumpTestState extends flixel.FlxState
{
    var sprite:FlxSprite;
    var box:FlxSprite;
    var pad:FlxVirtualPad;
    
    override function create()
    {
        super.create();
        
        sprite = new FlxSprite();
        sprite.makeGraphic(24, 24);
        sprite.x = FlxG.width / 2 - sprite.width / 2;
        sprite.acceleration.y = 900;
        sprite.maxVelocity.y = 300;
        add(sprite);
        
        box = new FlxSprite();
        box.makeGraphic(40, 40);
        box.x = FlxG.width / 2 - box.width / 2;
        box.y = FlxG.height * 0.75 - box.height / 2;
        box.immovable = true;
        add(box);
        
        pad = new FlxVirtualPad(FlxDPadMode.NONE, FlxActionMode.A);
        add(pad);
    }
    
    override function update(elapsed:Float)
    {
        // call super.update first, as it sets touching flags to NONE
        super.update(elapsed);
        
        // jump if touching the box, and jump is pressed
        if (sprite.wasTouching.down && pad.getButton(A).justPressed)
        {
            sprite.velocity.y = -300;
        }
        
        // If sprite is resting on box it will set its touching to DOWN
        FlxG.collide(box, sprite);
    }
}
```