### PR TITLE
FlxBasic, FlxGroup: Render Order Support

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -38,13 +38,13 @@ class FlxBasic implements IFlxDestroyable
 	 * Controls whether `draw()` is automatically called by `FlxState`/`FlxGroup`.
 	 */
 	public var visible(default, set):Bool = true;
-
+	#if !FLX_NO_RENDER_ORDER
 	/**
 	 * An index that sorts the FlxBasic when `draw()` is called by `FlxState`/`FlxGroup`.
 	 * This produces easy layer sorting, not being needed to rely on `add()` or `insert()`.
 	 */
 	public var renderOrder:Int = 0;
-
+	#end
 	/**
 	 * Useful state for many game objects - "dead" (`!alive`) vs `alive`. `kill()` and
 	 * `revive()` both flip this switch (along with `exists`, but you can override that).

--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -40,6 +40,12 @@ class FlxBasic implements IFlxDestroyable
 	public var visible(default, set):Bool = true;
 
 	/**
+	 * An index that sorts the FlxBasic when `draw()` is called by `FlxState`/`FlxGroup`.
+	 * This produces easy layer sorting, not being needed to rely on `add()` or `insert()`.
+	 */
+	public var renderOrder:Int = 0;
+
+	/**
 	 * Useful state for many game objects - "dead" (`!alive`) vs `alive`. `kill()` and
 	 * `revive()` both flip this switch (along with `exists`, but you can override that).
 	 */

--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -136,6 +136,7 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 		camera.canvas.graphics.overrideBlendMode(blend);
 		camera.canvas.graphics.beginShaderFill(shader);
 		camera.canvas.graphics.drawQuads(rects, null, transforms);
+		camera.canvas.graphics.endFill();
 		super.render(camera);
 	}
 

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -174,8 +174,12 @@ class FlxTypedGroup<T:FlxBasic> extends FlxBasic
 			FlxCamera._defaultCameras = _cameras;
 		}
 
-		for (basic in members)
+		var renderOrderedArray = [for (i in 0...members.length) i];
+		renderOrderedArray.sort((a, b) -> members[a].renderOrder - members[b].renderOrder);
+		
+		for (i in renderOrderedArray)
 		{
+			var basic = members[i];
 			if (basic != null && basic.exists && basic.visible)
 				basic.draw();
 		}

--- a/flixel/group/FlxGroup.hx
+++ b/flixel/group/FlxGroup.hx
@@ -985,6 +985,10 @@ class FlxTypedGroupIterator<T>
 }
 
 #if !FLX_NO_RENDER_ORDER
+/**
+ * An enum that provides the ways to order the rendering of a `FlxGroup`.
+ * Use it with bitwise operators.
+ */
 enum abstract FlxRenderingMode(Int) from Int to Int
 {
 	var NONE = 0;

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -23,6 +23,7 @@ private enum UserDefines
 	FLX_NO_SOUND_SYSTEM;
 	FLX_NO_SOUND_TRAY;
 	FLX_NO_FOCUS_LOST_SCREEN;
+	FLX_NO_RENDER_ORDER;
 	FLX_NO_DEBUG;
 	/* Removes FlxObject.health */
 	FLX_NO_HEALTH;
@@ -81,6 +82,7 @@ private enum HelperDefines
 	FLX_KEYBOARD;
 	FLX_SOUND_SYSTEM;
 	FLX_FOCUS_LOST_SCREEN;
+	FLX_RENDER_ORDER;
 	FLX_DEBUG;
 	FLX_STEAMWRAP;
 
@@ -208,6 +210,7 @@ class FlxDefines
 		defineInversion(FLX_NO_KEYBOARD, FLX_KEYBOARD);
 		defineInversion(FLX_NO_SOUND_SYSTEM, FLX_SOUND_SYSTEM);
 		defineInversion(FLX_NO_FOCUS_LOST_SCREEN, FLX_FOCUS_LOST_SCREEN);
+		defineInversion(FLX_NO_RENDER_ORDER, FLX_RENDER_ORDER);
 		defineInversion(FLX_NO_DEBUG, FLX_DEBUG);
 		defineInversion(FLX_NO_POINT_POOL, FLX_POINT_POOL);
 		defineInversion(FLX_UNIT_TEST, FLX_NO_UNIT_TEST);


### PR DESCRIPTION
Haxeflixel has lacked an easy way to layer objects in the groups when drawing.
The current way was to use `add()` if you never moved it or `insert()` but this required knowing what object was where in the group.

By using a `renderOrder` variable, now added into FlxBasic, you can sort the draw call order.
In `FlxGroup.draw()` i created an array of indices for each member, and sort them based on the member's `renderObject` value.
This is the fastest and least expensive method i could think of, i made tje index array local which might've been a bad idea.
It also has a new `renderOrderMode` public variable, that uses bitwise operators to determine what type of sorting should happen. (Currently only renderOrder based is implemented)

Example:

```haxe
var sprite1 = new FlxSprite(0,0).makeGraphic(30, 30);
sprite1.renderOrder = 3;
var sprite2 = new FlxSprite(0,0).makeGraphic(30, 30);
sprite2.renderOrder = 1;
add(sprite1);
add(sprite2);
```

In this example, `sprite1` will always draw over `sprite2`

I also added a FlxDefine called `FLX_NO_RENDER_ORDER` to disable the render ordering incase projects don't need it.

I don't expect this to be approved, but i hope this feature would be put on some todo list for the future, as this is a pretty helpful feature.

## TESTS
I have tested the code on Windows 11 cpp target.