### PR TITLE
Remove exists check when calling `FlxSpriteGroup.

### DIFF
--- a/flixel/group/FlxSpriteGroup.hx
+++ b/flixel/group/FlxSpriteGroup.hx
@@ -663,7 +663,7 @@ class FlxTypedSpriteGroup<T:FlxSprite> extends FlxSprite
 		var lambda:T->V->Void;
 		for (sprite in group.members)
 		{
-			if ((sprite != null) && sprite.exists)
+			if (sprite != null)
 			{
 				for (i in 0...numProps)
 				{


### PR DESCRIPTION
Prior to removing this check, killing a group object, and then updating the group position caused some strange behavior, which can be recreated through this sample:

```haxe
package;

import flixel.FlxG;
import flixel.util.FlxColor;
import flixel.FlxSprite;
import flixel.group.FlxSpriteGroup;
import flixel.FlxState;

class PlayState extends FlxState
{
	var sprite:FlxSprite;

	override public function create()
	{
		super.create();

		FlxG.camera.bgColor = FlxColor.WHITE;

		var group:FlxSpriteGroup = new FlxSpriteGroup();

		group.setPosition(64, 64);

		add(group);

		sprite = new FlxSprite();

		sprite.makeGraphic(64, 64, FlxColor.RED);

		// Commenting this line fixes issue
		sprite.kill();

		group.add(sprite);

		// Despite updating group position, sprite stays at 64x64y
		group.setPosition(128, 128);
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);

		if (FlxG.keys.justPressed.SPACE)
			sprite.revive();
	}
}
```

At first glance this check makes sense, don't transform objects that don't exist. But I feel like this check falls under the category of premature optimization and it caused be a really aggravating hour long debug session trying to figure out why my group objects weren't updating.

I'm not sure if this will be accepted considering the current status and seemingly pending removal of FlxSpriteGroup, but I'd rather not migrate all my code to use some extension or alternative class and I feel like it makes sense to just push it here