### PR TITLE
Fix `FLX_RENDER_TRIANGLE` not rendering anything

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -775,9 +775,9 @@ class FlxCamera extends FlxBasic
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
 
 			#if FLX_RENDER_TRIANGLE
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend);
+			final drawItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
 			#else
-			var drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
+			final drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#end
 			drawItem.addQuad(frame, matrix, transform);
 		}
@@ -818,10 +818,10 @@ class FlxCamera extends FlxBasic
 			var isColored = (transform != null && transform.hasRGBMultipliers());
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
 
-			#if !FLX_RENDER_TRIANGLE
-			var drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
+			#if FLX_RENDER_TRIANGLE
+			final drawItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
 			#else
-			var drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend);
+			final drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#end
 			drawItem.addQuad(frame, _helperMatrix, transform);
 		}

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -11,6 +11,7 @@ import openfl.geom.Rectangle;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.frames.FlxFrame;
 import flixel.graphics.tile.FlxDrawBaseItem;
+import flixel.graphics.tile.FlxDrawQuadsItem;
 import flixel.graphics.tile.FlxDrawTrianglesItem;
 import flixel.math.FlxMath;
 import flixel.math.FlxMatrix;
@@ -26,8 +27,6 @@ import openfl.display.BlendMode;
 import openfl.filters.BitmapFilter;
 
 using flixel.util.FlxColorTransformUtil;
-
-private typedef FlxDrawItem = flixel.graphics.tile.FlxDrawQuadsItem;
 
 /**
  * The camera class is used to display the game's visuals.
@@ -537,7 +536,7 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Last draw tiles item
 	 */
-	var _headTiles:FlxDrawItem;
+	var _headTiles:FlxDrawQuadsItem;
 
 	/**
 	 * Last draw triangles item
@@ -547,7 +546,7 @@ class FlxCamera extends FlxBasic
 	/**
 	 * Draw tiles stack items that can be reused
 	 */
-	static var _storageTilesHead:FlxDrawItem;
+	static var _storageTilesHead:FlxDrawQuadsItem;
 
 	/**
 	 * Draw triangles stack items that can be reused
@@ -601,7 +600,7 @@ class FlxCamera extends FlxBasic
 		}
 		else
 		{
-			itemToReturn = new FlxDrawItem();
+			itemToReturn = new FlxDrawQuadsItem();
 		}
 		
 		// TODO: catch this error when the dev actually messes up, not in the draw phase

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -765,9 +765,9 @@ class FlxCamera extends FlxBasic
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
 
 			#if FLX_RENDER_TRIANGLE
-			final drawItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
+			final drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
 			#else
-			final drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
+			final drawItem:FlxDrawQuadsItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#end
 			drawItem.addQuad(frame, matrix, transform);
 		}
@@ -809,9 +809,9 @@ class FlxCamera extends FlxBasic
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
 
 			#if FLX_RENDER_TRIANGLE
-			final drawItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
+			final drawItem:FlxDrawTrianglesItem = startTrianglesBatch(frame.parent, smoothing, isColored, blend, hasColorOffsets, shader);
 			#else
-			final drawItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
+			final drawItem:FlxDrawQuadsItem = startQuadBatch(frame.parent, isColored, hasColorOffsets, blend, smoothing, shader);
 			#end
 			drawItem.addQuad(frame, _helperMatrix, transform);
 		}

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -328,7 +328,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		indices[prevIndicesPos + 4] = prevNumberOfVertices + 2;
 		indices[prevIndicesPos + 5] = prevNumberOfVertices + 3;
 
-		#if !flash
 		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
 		for (i in 0...INDICES_PER_QUAD)
 			alphas.push(alphaMultiplier);
@@ -369,7 +368,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 				colorMultipliers.push(1);
 			}
 		}
-		#end
 
 		verticesPosition += 8;
 		indicesPosition += 6;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -20,6 +20,7 @@ typedef DrawData<T> = openfl.Vector<T>;
  */
 class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 {
+	static inline final INDICES_PER_QUAD = 6;
 	static var point:FlxPoint = FlxPoint.get();
 	static var rect:FlxRect = FlxRect.get();
 
@@ -296,7 +297,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	{
 		var prevVerticesPos:Int = verticesPosition;
 		var prevIndicesPos:Int = indicesPosition;
-		var prevColorsPos:Int = colorsPosition;
 		var prevNumberOfVertices:Int = numVertices;
 
 		var point = FlxPoint.get();
@@ -344,33 +344,48 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		indices[prevIndicesPos + 4] = prevNumberOfVertices + 3;
 		indices[prevIndicesPos + 5] = prevNumberOfVertices;
 
-		if (colored)
+		#if !flash
+		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
+		for (i in 0...INDICES_PER_QUAD)
+			alphas.push(alphaMultiplier);
+			
+		if (colored || hasColorOffsets)
 		{
-			var red = 1.0;
-			var green = 1.0;
-			var blue = 1.0;
-			var alpha = 1.0;
-
-			if (transform != null)
+			if (colorMultipliers == null)
+				colorMultipliers = [];
+				
+			if (colorOffsets == null)
+				colorOffsets = [];
+				
+			for (i in 0...INDICES_PER_QUAD)
 			{
-				red = transform.redMultiplier;
-				green = transform.greenMultiplier;
-				blue = transform.blueMultiplier;
-
-				#if !neko
-				alpha = transform.alphaMultiplier;
-				#end
+				if (transform != null)
+				{
+					colorMultipliers.push(transform.redMultiplier);
+					colorMultipliers.push(transform.greenMultiplier);
+					colorMultipliers.push(transform.blueMultiplier);
+					
+					colorOffsets.push(transform.redOffset);
+					colorOffsets.push(transform.greenOffset);
+					colorOffsets.push(transform.blueOffset);
+					colorOffsets.push(transform.alphaOffset);
+				}
+				else
+				{
+					colorMultipliers.push(1);
+					colorMultipliers.push(1);
+					colorMultipliers.push(1);
+					
+					colorOffsets.push(0);
+					colorOffsets.push(0);
+					colorOffsets.push(0);
+					colorOffsets.push(0);
+				}
+				
+				colorMultipliers.push(1);
 			}
-
-			var color = FlxColor.fromRGBFloat(red, green, blue, alpha);
-
-			colors[prevColorsPos] = color;
-			colors[prevColorsPos + 1] = color;
-			colors[prevColorsPos + 2] = color;
-			colors[prevColorsPos + 3] = color;
-
-			colorsPosition += 4;
 		}
+		#end
 
 		verticesPosition += 8;
 		indicesPosition += 6;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -295,11 +295,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 	override public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void
 	{
-		var prevVerticesPos:Int = verticesPosition;
-		var prevIndicesPos:Int = indicesPosition;
-		var prevNumberOfVertices:Int = numVertices;
+		final prevVerticesPos = verticesPosition;
+		final prevIndicesPos = indicesPosition;
+		final prevNumberOfVertices = numVertices;
 
-		var point = FlxPoint.get();
+		point.set(0, 0);
 		point.transform(matrix);
 
 		vertices[prevVerticesPos] = point.x;
@@ -317,32 +317,30 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		uvtData[prevVerticesPos + 2] = frame.uv.right;
 		uvtData[prevVerticesPos + 3] = frame.uv.top;
 
-		point.set(frame.frame.width, frame.frame.height);
+		point.set(0, frame.frame.height);
 		point.transform(matrix);
 
 		vertices[prevVerticesPos + 4] = point.x;
 		vertices[prevVerticesPos + 5] = point.y;
 
-		uvtData[prevVerticesPos + 4] = frame.uv.right;
+		uvtData[prevVerticesPos + 4] = frame.uv.left;
 		uvtData[prevVerticesPos + 5] = frame.uv.bottom;
 
-		point.set(0, frame.frame.height);
+		point.set(frame.frame.width, frame.frame.height);
 		point.transform(matrix);
 
 		vertices[prevVerticesPos + 6] = point.x;
 		vertices[prevVerticesPos + 7] = point.y;
 
-		point.put();
-
-		uvtData[prevVerticesPos + 6] = frame.uv.left;
+		uvtData[prevVerticesPos + 6] = frame.uv.right;
 		uvtData[prevVerticesPos + 7] = frame.uv.bottom;
 
 		indices[prevIndicesPos] = prevNumberOfVertices;
 		indices[prevIndicesPos + 1] = prevNumberOfVertices + 1;
 		indices[prevIndicesPos + 2] = prevNumberOfVertices + 2;
-		indices[prevIndicesPos + 3] = prevNumberOfVertices + 2;
-		indices[prevIndicesPos + 4] = prevNumberOfVertices + 3;
-		indices[prevIndicesPos + 5] = prevNumberOfVertices;
+		indices[prevIndicesPos + 3] = prevNumberOfVertices + 1;
+		indices[prevIndicesPos + 4] = prevNumberOfVertices + 2;
+		indices[prevIndicesPos + 5] = prevNumberOfVertices + 3;
 
 		#if !flash
 		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -272,13 +272,11 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		final prevVerticesPos = verticesPosition;
 		final prevNumberOfVertices = numVertices;
 		
-		final point = FlxPoint.get();
 		inline function addVertices(index:Int, x:Float, y:Float)
 		{
 			final i = (index << 1) + prevVerticesPos;
-			point.set(x, y).transform(matrix);
-			vertices[i + 0] = point.x;
-			vertices[i + 1] = point.y;
+			vertices[i + 0] = matrix.transformX(x, y);
+			vertices[i + 1] = matrix.transformY(x, y);
 		}
 		
 		final w = frame.frame.width;
@@ -287,7 +285,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		addVertices(1, w, 0); // top-right
 		addVertices(2, 0, h); // bottom-left
 		addVertices(3, w, h); // bottom-right
-		point.put();
 		
 		uvtData[prevVerticesPos + 0] = frame.uv.left;
 		uvtData[prevVerticesPos + 1] = frame.uv.top;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -37,6 +37,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 	public var verticesPosition:Int = 0;
 	public var indicesPosition:Int = 0;
+	@:deprecated("colorsPosition is deprecated")
 	public var colorsPosition:Int = 0;
 
 	var bounds:FlxRect = FlxRect.get();
@@ -105,7 +106,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 		verticesPosition = 0;
 		indicesPosition = 0;
-		colorsPosition = 0;
+		 = 0;
 		alphas.splice(0, alphas.length);
 		if (colorMultipliers != null)
 			colorMultipliers.splice(0, colorMultipliers.length);

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -273,7 +273,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		final prevIndicesPos = indicesPosition;
 		final prevNumberOfVertices = numVertices;
 
-		point.set(0, 0);
+		final point = FlxPoint.get();
 		point.transform(matrix);
 
 		vertices[prevVerticesPos] = point.x;
@@ -305,7 +305,9 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 		vertices[prevVerticesPos + 6] = point.x;
 		vertices[prevVerticesPos + 7] = point.y;
-
+		
+		point.put();
+		
 		uvtData[prevVerticesPos + 6] = frame.uv.right;
 		uvtData[prevVerticesPos + 7] = frame.uv.bottom;
 

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -32,6 +32,7 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	public var vertices:DrawData<Float> = new DrawData<Float>();
 	public var indices:DrawData<Int> = new DrawData<Int>();
 	public var uvtData:DrawData<Float> = new DrawData<Float>();
+	@:deprecated("colors is deprecated, use colorMultipliers and colorOffsets")
 	public var colors:DrawData<Int> = new DrawData<Int>();
 
 	public var verticesPosition:Int = 0;
@@ -101,7 +102,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		vertices.length = 0;
 		indices.length = 0;
 		uvtData.length = 0;
-		colors.length = 0;
 
 		verticesPosition = 0;
 		indicesPosition = 0;
@@ -120,7 +120,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		vertices = null;
 		indices = null;
 		uvtData = null;
-		colors = null;
 		bounds = null;
 		alphas = null;
 		colorMultipliers = null;
@@ -141,7 +140,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		var numberOfVertices:Int = Std.int(verticesLength / 2);
 		var prevIndicesLength:Int = this.indices.length;
 		var prevUVTDataLength:Int = this.uvtData.length;
-		var prevColorsLength:Int = this.colors.length;
 		var prevNumberOfVertices:Int = this.numVertices;
 
 		var tempX:Float, tempY:Float;
@@ -184,16 +182,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 			for (i in 0...indicesLength)
 			{
 				this.indices[prevIndicesLength + i] = indices[i] + prevNumberOfVertices;
-			}
-
-			if (colored)
-			{
-				for (i in 0...numberOfVertices)
-				{
-					this.colors[prevColorsLength + i] = colors[i];
-				}
-
-				colorsPosition += numberOfVertices;
 			}
 			
 			final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -106,7 +106,6 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 
 		verticesPosition = 0;
 		indicesPosition = 0;
-		 = 0;
 		alphas.splice(0, alphas.length);
 		if (colorMultipliers != null)
 			colorMultipliers.splice(0, colorMultipliers.length);

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -270,53 +270,41 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 	override public function addQuad(frame:FlxFrame, matrix:FlxMatrix, ?transform:ColorTransform):Void
 	{
 		final prevVerticesPos = verticesPosition;
-		final prevIndicesPos = indicesPosition;
 		final prevNumberOfVertices = numVertices;
-
-		final point = FlxPoint.get();
-		point.transform(matrix);
-
-		vertices[prevVerticesPos] = point.x;
-		vertices[prevVerticesPos + 1] = point.y;
-
-		uvtData[prevVerticesPos] = frame.uv.left;
-		uvtData[prevVerticesPos + 1] = frame.uv.top;
-
-		point.set(frame.frame.width, 0);
-		point.transform(matrix);
-
-		vertices[prevVerticesPos + 2] = point.x;
-		vertices[prevVerticesPos + 3] = point.y;
-
-		uvtData[prevVerticesPos + 2] = frame.uv.right;
-		uvtData[prevVerticesPos + 3] = frame.uv.top;
-
-		point.set(0, frame.frame.height);
-		point.transform(matrix);
-
-		vertices[prevVerticesPos + 4] = point.x;
-		vertices[prevVerticesPos + 5] = point.y;
-
-		uvtData[prevVerticesPos + 4] = frame.uv.left;
-		uvtData[prevVerticesPos + 5] = frame.uv.bottom;
-
-		point.set(frame.frame.width, frame.frame.height);
-		point.transform(matrix);
-
-		vertices[prevVerticesPos + 6] = point.x;
-		vertices[prevVerticesPos + 7] = point.y;
 		
+		final point = FlxPoint.get();
+		inline function addVertices(index:Int, x:Float, y:Float)
+		{
+			final i = (index << 1) + prevVerticesPos;
+			point.set(x, y).transform(matrix);
+			vertices[i + 0] = point.x;
+			vertices[i + 1] = point.y;
+		}
+		
+		final w = frame.frame.width;
+		final h = frame.frame.height;
+		addVertices(0, 0, 0); // top-left
+		addVertices(1, w, 0); // top-right
+		addVertices(2, 0, h); // bottom-left
+		addVertices(3, w, h); // bottom-right
 		point.put();
 		
+		uvtData[prevVerticesPos + 0] = frame.uv.left;
+		uvtData[prevVerticesPos + 1] = frame.uv.top;
+		uvtData[prevVerticesPos + 2] = frame.uv.right;
+		uvtData[prevVerticesPos + 3] = frame.uv.top;
+		uvtData[prevVerticesPos + 4] = frame.uv.left;
+		uvtData[prevVerticesPos + 5] = frame.uv.bottom;
 		uvtData[prevVerticesPos + 6] = frame.uv.right;
 		uvtData[prevVerticesPos + 7] = frame.uv.bottom;
-
-		indices[prevIndicesPos] = prevNumberOfVertices;
-		indices[prevIndicesPos + 1] = prevNumberOfVertices + 1;
-		indices[prevIndicesPos + 2] = prevNumberOfVertices + 2;
-		indices[prevIndicesPos + 3] = prevNumberOfVertices + 1;
-		indices[prevIndicesPos + 4] = prevNumberOfVertices + 2;
-		indices[prevIndicesPos + 5] = prevNumberOfVertices + 3;
+		
+		final prevIndicesPos = indicesPosition;
+		indices[prevIndicesPos + 0] = prevNumberOfVertices + 0; // TL
+		indices[prevIndicesPos + 1] = prevNumberOfVertices + 1; // TR
+		indices[prevIndicesPos + 2] = prevNumberOfVertices + 2; // BL
+		indices[prevIndicesPos + 3] = prevNumberOfVertices + 1; // TR
+		indices[prevIndicesPos + 4] = prevNumberOfVertices + 2; // BL
+		indices[prevIndicesPos + 5] = prevNumberOfVertices + 3; // BR
 
 		final alphaMultiplier = transform != null ? transform.alphaMultiplier : 1.0;
 		for (i in 0...INDICES_PER_QUAD)

--- a/flixel/graphics/tile/FlxDrawTrianglesItem.hx
+++ b/flixel/graphics/tile/FlxDrawTrianglesItem.hx
@@ -272,19 +272,16 @@ class FlxDrawTrianglesItem extends FlxDrawBaseItem<FlxDrawTrianglesItem>
 		final prevVerticesPos = verticesPosition;
 		final prevNumberOfVertices = numVertices;
 		
-		inline function addVertices(index:Int, x:Float, y:Float)
-		{
-			final i = (index << 1) + prevVerticesPos;
-			vertices[i + 0] = matrix.transformX(x, y);
-			vertices[i + 1] = matrix.transformY(x, y);
-		}
-		
 		final w = frame.frame.width;
 		final h = frame.frame.height;
-		addVertices(0, 0, 0); // top-left
-		addVertices(1, w, 0); // top-right
-		addVertices(2, 0, h); // bottom-left
-		addVertices(3, w, h); // bottom-right
+		vertices[prevVerticesPos + 0] = matrix.transformX(0, 0); // left
+		vertices[prevVerticesPos + 1] = matrix.transformY(0, 0); // top
+		vertices[prevVerticesPos + 2] = matrix.transformX(w, 0); // right
+		vertices[prevVerticesPos + 3] = matrix.transformY(w, 0); // top
+		vertices[prevVerticesPos + 4] = matrix.transformX(0, h); // left
+		vertices[prevVerticesPos + 5] = matrix.transformY(0, h); // bottom
+		vertices[prevVerticesPos + 6] = matrix.transformX(w, h); // right
+		vertices[prevVerticesPos + 7] = matrix.transformY(w, h); // bottom
 		
 		uvtData[prevVerticesPos + 0] = frame.uv.left;
 		uvtData[prevVerticesPos + 1] = frame.uv.top;


### PR DESCRIPTION
Fixes #3169
Fixes #2263

The problem was with use of `colors` vector for storing color transformations. As can be seen [here](https://github.com/HaxeFlixel/flixel/blob/6aaeafbe36fed18295bd67ddf937c17150451bde/flixel/graphics/tile/FlxDrawTrianglesItem.hx#L63C1-L67C7) it was a part of Graphics API in legacy versions of OpenFL and was eventually replaced by shader in #2671. Now `addQuad` stores color transformations in `colorMultipliers` and `colorOffsets`.
