### PR TITLE
FlxTilemap: Improve debug draw with `FlxG.renderBlit`

### DIFF
--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -511,10 +511,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		if (tileBitmap == null)
 			tileBitmap = makeDebugTile(color);
 		else
-		{
-			tileBitmap.fillRect(tileBitmap.rect, FlxColor.TRANSPARENT);
 			drawDebugTile(tileBitmap, color);
-		}
 
 		setDirty();
 		return tileBitmap;
@@ -1360,18 +1357,15 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 	function drawDebugTile(debugTile:BitmapData, color:FlxColor):Void
 	{
-		if (color != FlxColor.TRANSPARENT)
+		if (color == FlxColor.TRANSPARENT)
 		{
-			var gfx:Graphics = FlxSpriteUtil.flashGfx;
-			gfx.clear();
-			gfx.moveTo(0, 0);
-			gfx.lineStyle(1, color, 0.5);
-			gfx.lineTo(tileWidth - 1, 0);
-			gfx.lineTo(tileWidth - 1, tileHeight - 1);
-			gfx.lineTo(0, tileHeight - 1);
-			gfx.lineTo(0, 0);
-
-			debugTile.draw(FlxSpriteUtil.flashGfxSprite);
+			debugTile.fillRect(debugTile.rect, FlxColor.TRANSPARENT);
+		}
+		else
+		{
+			// 0.5 alpha
+			debugTile.fillRect(debugTile.rect, (0x80 << 24) | color.rgb);
+			debugTile.fillRect(new Rectangle(1, 1, tileWidth - 2, tileHeight - 2), 0x0);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/HaxeFlixel/flixel/issues/3508
Old:
<img width="538" height="410" alt="image" src="https://github.com/user-attachments/assets/3d761150-a968-4884-a751-83325be9bdad" />

New:
<img width="253" height="213" alt="Screenshot 2025-10-10 at 12 59 48 PM" src="https://github.com/user-attachments/assets/08c6c3b6-7d86-40e1-bd43-ccb89b8da927" />

Note: the color is slightly different as well, I believe the new one is "more correct" and the old one was lighter because it drew lines between two pixels, I also think the new way is more performant, though that difference is negligible since the debug tile is drawn once and cached.