### PR TITLE
FlxG.Assets: Check any sound extension before appending in getSoundAddExt

### DIFF
--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -1,5 +1,6 @@
 package flixel.system;
 
+import haxe.io.Path;
 import haxe.macro.Expr;
 #if !macro
 import flixel.FlxG;
@@ -378,7 +379,8 @@ class FlxAssets
 	 */
 	public static function getSoundAddExtension(id:String, useCache = true):Sound
 	{
-		if (!id.endsWith(".mp3") && !id.endsWith(".ogg") && !id.endsWith(".wav"))
+		final needsExt = Path.extension(id).length == 0;
+		if (needsExt)
 			id += "." + defaultSoundExtension;
 
 		return FlxG.assets.getSoundUnsafe(id, useCache);

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -387,7 +387,8 @@ class AssetFrontEnd
 	
 	inline function addSoundExt(id:String)
 	{
-		if (!id.endsWith(".mp3") && !id.endsWith(".ogg") && !id.endsWith(".wav"))
+		final needsExt = Path.extension(id).length == 0;
+		if (needsExt)
 			return id + defaultSoundExtension;
 			
 		return id;


### PR DESCRIPTION
Otherwise, passing in something like `sound.m4a` would result in `sound.m4a.ogg` despite the fact that `m4a` is a valid sound extension.