### PR TITLE
`FlxGraphicsShader`: Remove redundant body glsl

### DIFF
--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -61,7 +61,7 @@ class FlxGraphicsShader extends GraphicsShader
 		{
 			gl_FragColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
 		}
-	")
+	", true)
 	public function new()
 	{
 		super();

--- a/flixel/graphics/tile/FlxGraphicsShader.hx
+++ b/flixel/graphics/tile/FlxGraphicsShader.hx
@@ -54,9 +54,14 @@ class FlxGraphicsShader extends GraphicsShader
 			return color * openfl_Alphav;
 		}
 	", true)
-	@:glFragmentBody("
-		gl_FragColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
-	", true)
+	@:glFragmentSource("
+		#pragma header
+
+		void main(void)
+		{
+			gl_FragColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
+		}
+	")
 	public function new()
 	{
 		super();


### PR DESCRIPTION
This issue stems from the code changes found when the implementation of ``camera.color`` was fixed. (https://github.com/HaxeFlixel/flixel/pull/3326)
For whatever reason, the original code for the fragment source was replaced for a fragment body insert, most likely due to an oversight. ``glFragmentBody`` does not replace the fragment body code, it only adds onto it, so instead of directly using ``flixel_texture2D`` the shader was running first the openfl fragment body code and then the flixel fragment body code. As seen here in this picture taken from a debugger of a flixel game compiled build:

<img width="875" height="712" alt="image" src="https://github.com/user-attachments/assets/6a01c9cb-d9b6-4022-8acf-7a7e5c4a0123" />

Here's how the shader looks like after these changes:

<img width="729" height="136" alt="image" src="https://github.com/user-attachments/assets/07565aec-1158-42ed-9636-a34ec31fe698" />


This fix has been tested and ``camera.color`` keeps working correctly.