### PR TITLE
BaseScaleMode: Add `setGlobalSize` to allow derived classes to modify `FlxG.width` / `height`

### DIFF
--- a/flixel/system/scaleModes/BaseScaleMode.hx
+++ b/flixel/system/scaleModes/BaseScaleMode.hx
@@ -31,8 +31,7 @@ class BaseScaleMode
 
 	public function onMeasure(Width:Int, Height:Int):Void
 	{
-		FlxG.width = FlxG.initialWidth;
-		FlxG.height = FlxG.initialHeight;
+		setGlobalSize(FlxG.initialWidth, FlxG.initialHeight);
 
 		updateGameSize(Width, Height);
 		updateDeviceSize(Width, Height);

--- a/flixel/system/scaleModes/BaseScaleMode.hx
+++ b/flixel/system/scaleModes/BaseScaleMode.hx
@@ -114,4 +114,13 @@ class BaseScaleMode
 		}
 		return value;
 	}
+
+	/**
+	 * Helper function to change FlxG width / height.
+	 */
+	function setGlobalSize(width:Int, height:Int):Void
+	{
+		FlxG.width = width;
+		FlxG.height = height;
+	}
 }


### PR DESCRIPTION
Hello,
following to my issue #3510, I made this pull request to allow the change of FlxG width / height in a subclass of BaseScaleMode. I can make any change if needed.