### PR TITLE
FlxSound and FlxG.sound: Add support for music streaming

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -413,10 +413,10 @@ class FlxSound extends FlxBasic
 	{
 		cleanup(true);
 
-		if (FlxG.assets.exists(path, MUSIC))
-			_sound = FlxG.assets.getMusicUnsafe(path);
+		if (FlxG.assets.exists(path, SOUND))
+			_sound = FlxG.assets.streamSoundUnsafe(path);
 		else
-			FlxG.log.error('Could not find a Music asset with an ID of \'$path\'.');
+			FlxG.log.error('Could not find a Sound asset with an ID of \'$path\'.');
 		
 		// NOTE: can't pull ID3 info from embedded sound currently
 		return init(looped, autoDestroy, onComplete);

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -144,6 +144,9 @@ class FlxSound extends FlxBasic
 	 * Internal tracker for a Flash sound object.
 	 */
 	@:allow(flixel.system.frontEnds.SoundFrontEnd.load)
+	#if FLX_STREAM_MUSIC
+	@:allow(flixel.system.frontEnds.SoundFrontEnd.loadStreamed)
+	#end
 	var _sound:Sound;
 	
 	/**

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -412,12 +412,21 @@ class FlxSound extends FlxBasic
 		cleanup(true);
 
 		if (FlxG.assets.exists(path, SOUND))
-			_sound = FlxG.assets.streamSoundUnsafe(path);
+		{
+			if (FlxG.assets.canStreamSound(path))
+			{
+				_sound = FlxG.assets.streamSoundUnsafe(path);
+				
+				// NOTE: can't pull ID3 info from embedded sound currently
+				return init(looped, autoDestroy, onComplete);
+			}
+			
+			FlxG.log.error('Unable to stream SOUND asset with ID "$path". Expected a .OGG/Vorbis file');
+		}
 		else
 			FlxG.log.error('Could not find a Sound asset with an ID of \'$path\'.');
 		
-		// NOTE: can't pull ID3 info from embedded sound currently
-		return init(looped, autoDestroy, onComplete);
+		return this;
 	}
 	#end
 

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -370,7 +370,36 @@ class FlxSound extends FlxBasic
 		// NOTE: can't pull ID3 info from embedded sound currently
 		return init(Looped, AutoDestroy, OnComplete);
 	}
-	
+
+	/**
+	 * Loads a streamed sound from the provided file path.
+	 * This does not load sounds from web locations. Use `loadFromURL()` for that, instead.
+	 * 
+	 * If sound streaming is not supported, a normal sound will be returned.
+	 * 
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 * 
+	 * @param path The path to the sound asset.
+	 * @param looped Whether or not this sound should loop endlessly.
+	 * @param autoDestroy Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
+	 * @param onComplete Called when the sound finishes playing.
+	 * @return This FlxSound instance (nice for chaining stuff together, if you're into that).
+	 * 
+	 * @since 6.2.0
+	 */
+	public function loadStreamed(path:String, looped:Bool = false, autoDestroy:Bool = false, ?onComplete:Void->Void):FlxSound
+	{
+		cleanup(true);
+
+		if (FlxG.assets.exists(path, MUSIC))
+			_sound = FlxG.assets.getMusicUnsafe(path);
+		else
+			FlxG.log.error('Could not find a Sound asset with an ID of \'$path\'.');
+		
+		// NOTE: can't pull ID3 info from embedded sound currently
+		return init(looped, autoDestroy, onComplete);
+	}
+
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a URL.
 	 *

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -375,11 +375,12 @@ class FlxSound extends FlxBasic
 	 * Loads a streamed sound from the provided file path.
 	 * This does not load sounds from web locations. Use `loadFromURL()` for that, instead.
 	 * 
-	 * If sound streaming is not supported, a normal sound will be returned.
+	 * Audio streaming may not be supported for some targets or files. If audio streaming is 
+	 * not supported, the default sound loading behavior will be used as a fallback.
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
-	 * @param path The path to the sound asset.
+	 * @param path The ID or asset path to the sound asset.
 	 * @param looped Whether or not this sound should loop endlessly.
 	 * @param autoDestroy Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
 	 * @param onComplete Called when the sound finishes playing.
@@ -394,7 +395,7 @@ class FlxSound extends FlxBasic
 		if (FlxG.assets.exists(path, MUSIC))
 			_sound = FlxG.assets.getMusicUnsafe(path);
 		else
-			FlxG.log.error('Could not find a Sound asset with an ID of \'$path\'.');
+			FlxG.log.error('Could not find a Music asset with an ID of \'$path\'.');
 		
 		// NOTE: can't pull ID3 info from embedded sound currently
 		return init(looped, autoDestroy, onComplete);

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -382,12 +382,19 @@ class FlxSound extends FlxBasic
 		return init(looped, autoDestroy, onComplete);
 	}
 
+	#if FLX_STREAM_MUSIC
 	/**
-	 * Loads a streamed sound from the provided file path.
-	 * This does not load sounds from web locations. Use `loadFromURL()` for that, instead.
+	 * Streams a sound from the given file path.
+	 * The default audio playback behavior is to load the entire sound into memory before playing it.
+	 * This is fine for shorter sounds like sound effects, but is not ideal for larger sounds like
+	 * music tracks because it may cause high memory usage and lag while loading.
+	 * In this case it is better to stream the music, which loads and unloads chunks of data as the
+	 * music plays, keeping memory usage low.
 	 * 
-	 * Audio streaming may not be supported for some targets or files. If audio streaming is 
-	 * not supported, the default sound loading behavior will be used as a fallback.
+	 * Due to a backend limitation, audio streaming is currently only available on native targets 
+	 * and OGG/Vorbis audio files.
+	 * 
+	 * This does not load sounds from web locations. Use `loadFromURL()` for that, instead.
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
@@ -411,6 +418,7 @@ class FlxSound extends FlxBasic
 		// NOTE: can't pull ID3 info from embedded sound currently
 		return init(looped, autoDestroy, onComplete);
 	}
+	#end
 
 	/**
 	 * Loads a sound from the provided URL.

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -387,12 +387,10 @@ class FlxSound extends FlxBasic
 
 	#if FLX_STREAM_SOUND
 	/**
-	 * Streams a sound from the given file path.
-	 * The default audio playback behavior is to load the entire sound into memory before playing it.
-	 * This is fine for shorter sounds like sound effects, but is not ideal for larger sounds like
-	 * music tracks because it may cause high memory usage and lag while loading.
-	 * In this case it is better to stream the music, which loads and unloads chunks of data as the
-	 * music plays, keeping memory usage low.
+	 * Streams a sound from the given file path. Unlike the `load` method, this will load and
+	 * unload chunks of data as the sound plays, keeping memory usage low. This is recommended for
+	 * longer sounds, like music tracks. For shorter sounds like sound effects, it is better to
+	 * use the `load` method, which loads the entire sound into memory before playing it.
 	 * 
 	 * Due to a backend limitation, audio streaming is currently only available on native targets 
 	 * and OGG/Vorbis audio files.
@@ -401,11 +399,11 @@ class FlxSound extends FlxBasic
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
-	 * @param path The ID or asset path to the sound asset.
-	 * @param looped Whether or not this sound should loop endlessly.
-	 * @param autoDestroy Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
-	 * @param onComplete Called when the sound finishes playing.
-	 * @return This FlxSound instance (nice for chaining stuff together, if you're into that).
+	 * @param   path         The ID or asset path to the sound asset.
+	 * @param   looped       Whether or not this sound should loop endlessly.
+	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
+	 * @param   onComplete   Called when the sound finishes playing.
+	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 * 
 	 * @since 6.2.0
 	 */

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -144,7 +144,7 @@ class FlxSound extends FlxBasic
 	 * Internal tracker for a Flash sound object.
 	 */
 	@:allow(flixel.system.frontEnds.SoundFrontEnd.load)
-	#if FLX_STREAM_MUSIC
+	#if FLX_STREAM_SOUND
 	@:allow(flixel.system.frontEnds.SoundFrontEnd.loadStreamed)
 	#end
 	var _sound:Sound;
@@ -385,7 +385,7 @@ class FlxSound extends FlxBasic
 		return init(looped, autoDestroy, onComplete);
 	}
 
-	#if FLX_STREAM_MUSIC
+	#if FLX_STREAM_SOUND
 	/**
 	 * Streams a sound from the given file path.
 	 * The default audio playback behavior is to load the entire sound into memory before playing it.

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -408,7 +408,7 @@ class AssetFrontEnd
 	 */
 	public dynamic function streamSoundUnsafe(id:String):Sound
 	{
-		return Assets.getMusic(id);
+		return Assets.getMusic(addSoundExtIf(id));
 	}
 
 	/**
@@ -438,7 +438,7 @@ class AssetFrontEnd
 		if (exists(id, SOUND))
 		{
 			if (isLocal(id, SOUND))
-				return streamSoundUnsafe(addSoundExtIf(id));
+				return streamSoundUnsafe(id);
 			
 			log('SOUND asset "$id" exists, but only asynchronously');
 			return null;
@@ -465,22 +465,7 @@ class AssetFrontEnd
 	 */
 	public function streamSoundAddExt(id:String, ?logStyle:LogStyle):Sound
 	{
-		if (logStyle == null)
-			logStyle = FlxG.log.styles.error;
-		
-		final log = FlxG.log.advanced.bind(_, logStyle);
-		
-		if (exists(id, SOUND))
-		{
-			if (isLocal(id, SOUND))
-				return streamSoundUnsafe(addSoundExt(id));
-			
-			log('SOUND asset "$id" exists, but only asynchronously');
-			return null;
-		}
-		
-		log('Could not find a SOUND asset with ID \'$id\'.');
-		return null;
+		return streamSound(addSoundExt(id));
 	}
 	
 	/**

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -437,7 +437,7 @@ class AssetFrontEnd
 		
 		if (exists(id, SOUND))
 		{
-			if (canStreamSound(id))
+			if (!canStreamSound(id))
 			{
 				log('Unable to stream SOUND asset with ID "$id". Expected a .OGG/Vorbis file');
 				return null;

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -461,7 +461,7 @@ class AssetFrontEnd
 	
 	inline function addSoundExt(id:String)
 	{
-		final needsExt = Path.extension(id) == "";
+		final needsExt = Path.extension(id).length == 0;
 		if (needsExt)
 			return id + defaultSoundExtension;
 			

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -128,9 +128,7 @@ class AssetFrontEnd
 			// Check cache
 			case IMAGE if (canUseCache && Assets.cache.hasBitmapData(id)):
 				Assets.cache.getBitmapData(id);
-			// Lime doesn't expose a way to detect if sound streaming is supported so we have to check ourselves
-			// MUSIC behaves like SOUND when sound streaming is unsupported.
-			case SOUND #if !lime_vorbis , MUSIC #end if (canUseCache && Assets.cache.hasSound(id)):
+			case SOUND, MUSIC if (canUseCache && Assets.cache.hasSound(id)):
 				Assets.cache.getSound(id);
 			case FONT if (canUseCache && Assets.cache.hasFont(id)):
 				Assets.cache.getFont(id);
@@ -141,19 +139,29 @@ class AssetFrontEnd
 				if (canUseCache)
 					Assets.cache.setBitmapData(id, bitmap);
 				bitmap;
-			case SOUND #if !lime_vorbis , MUSIC #end:
+			case SOUND:
 				final sound = Sound.fromFile(getPath(id));
 				if (canUseCache)
 					Assets.cache.setSound(id, sound);
 				sound;
-			#if lime_vorbis
 			case MUSIC:
-				// Ignore cache when streaming sounds
+				var sound:Sound;
+				#if lime_vorbis
 				final vorbisFile = VorbisFile.fromFile(getPath(id));
-				final buffer = AudioBuffer.fromVorbisFile(buffer);
-				final sound = Sound.fromAudioBuffer(buffer);
+				if (vorbisFile != null)
+				{
+					final buffer = AudioBuffer.fromVorbisFile(buffer);
+					sound = Sound.fromAudioBuffer(buffer);
+				}
+				else
+				#end
+				{
+					// can't stream this sound, fall back to default behavior
+					sound = Sound.fromFile(getPath(id));
+					if (canUseCache)
+						Assets.cache.setSound(id, sound);
+				}
 				sound;
-			#end
 			case FONT:
 				final font = Font.fromFile(getPath(id));
 				if (canUseCache)

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -485,7 +485,7 @@ class AssetFrontEnd
 	 * @return  Returns whether the sound can be streamed or not.
 	 * @since   6.2.0
 	 */
-	public inline function canStreamSound(id:String):Bool
+	public function canStreamSound(id:String):Bool
 	{
 		#if lime_vorbis
 		// Check if file is really OGG/Vorbis

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -15,11 +15,6 @@ import openfl.utils.AssetType;
 import openfl.utils.Assets;
 import openfl.utils.Future;
 
-#if FLX_STREAM_SOUND
-import lime.media.vorbis.VorbisFile;
-import lime.media.AudioBuffer;
-#end
-
 using StringTools;
 
 /**
@@ -501,13 +496,12 @@ class AssetFrontEnd
 	 */
 	public inline function canStreamSound(id:String):Bool
 	{
-		#if FLX_STREAM_SOUND
+		#if lime_vorbis
 		// Check if file is really OGG/Vorbis
-		var vorbis = VorbisFile.fromFile(Assets.getPath(addSoundExtIf(id)));
+		final vorbis = lime.media.vorbis.VorbisFile.fromFile(Assets.getPath(addSoundExtIf(id)));
 		if (vorbis != null)
 		{
 			vorbis.clear();
-			vorbis = null;
 
 			return true;
 		}

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -15,7 +15,7 @@ import openfl.utils.AssetType;
 import openfl.utils.Assets;
 import openfl.utils.Future;
 
-#if lime_vorbis
+#if FLX_STREAM_SOUND
 import lime.media.vorbis.VorbisFile;
 import lime.media.AudioBuffer;
 #end
@@ -128,7 +128,7 @@ class AssetFrontEnd
 			// Check cache
 			case IMAGE if (canUseCache && Assets.cache.hasBitmapData(id)):
 				Assets.cache.getBitmapData(id);
-			case SOUND, MUSIC if (canUseCache && Assets.cache.hasSound(id)):
+			case SOUND if (canUseCache && Assets.cache.hasSound(id)):
 				Assets.cache.getSound(id);
 			case FONT if (canUseCache && Assets.cache.hasFont(id)):
 				Assets.cache.getFont(id);
@@ -143,28 +143,6 @@ class AssetFrontEnd
 				final sound = Sound.fromFile(getPath(id));
 				if (canUseCache)
 					Assets.cache.setSound(id, sound);
-				sound;
-			case MUSIC:
-				var sound:Sound;
-				#if lime_vorbis
-				final vorbisFile = VorbisFile.fromFile(getPath(id));
-				if (vorbisFile != null)
-				{
-					final buffer = AudioBuffer.fromVorbisFile(buffer);
-					sound = Sound.fromAudioBuffer(buffer);
-				}
-				else
-				#end
-				{
-					#if lime_vorbis
-					FlxG.log.error('Failed to stream MUSIC asset with an ID of "$id", is it a proper OGG/Vorbis file?');
-					#end
-
-					// can't stream this sound, fall back to default behavior
-					sound = Sound.fromFile(getPath(id));
-					if (canUseCache)
-						Assets.cache.setSound(id, sound);
-				}
 				sound;
 			case FONT:
 				final font = Font.fromFile(getPath(id));
@@ -186,13 +164,6 @@ class AssetFrontEnd
 			case BINARY: Assets.getBytes(id);
 			case IMAGE: Assets.getBitmapData(id, useCache);
 			case SOUND: Assets.getSound(id, useCache);
-			case MUSIC:
-				#if lime_vorbis
-				if (!canStreamSound(id))
-					FlxG.log.error('Failed to stream MUSIC asset with an ID of "$id", is it a proper OGG/Vorbis file?');
-				#end
-
-				Assets.getMusic(id, useCache);
 			case FONT: Assets.getFont(id, useCache);
 		}
 	}
@@ -256,7 +227,6 @@ class AssetFrontEnd
 			case BINARY: Assets.loadBytes(id);
 			case IMAGE: Assets.loadBitmapData(id, useCache);
 			case SOUND: Assets.loadSound(id, useCache);
-			case MUSIC: Assets.loadMusic(id, useCache);
 			case FONT: Assets.loadFont(id, useCache);
 		}
 	}
@@ -272,7 +242,7 @@ class AssetFrontEnd
 	{
 		#if FLX_DEFAULT_SOUND_EXT
 		// add file extension
-		if (type == SOUND || type == MUSIC)
+		if (type == SOUND)
 			id = addSoundExt(id);
 		#end
 		
@@ -300,7 +270,7 @@ class AssetFrontEnd
 	{
 		#if FLX_DEFAULT_SOUND_EXT
 		// add file extension
-		if (type == SOUND || type == MUSIC)
+		if (type == SOUND)
 			id = addSoundExt(id);
 		#end
 		
@@ -380,22 +350,6 @@ class AssetFrontEnd
 	{
 		return cast getAssetUnsafe(addSoundExtIf(id), SOUND, useCache);
 	}
-
-	/**
-	 * Gets an instance of a streamed sound. Unlike its "safe" counterpart, there is no log on missing assets
-	 * 
-	 * Audio streaming may not be supported for some targets or files. If audio streaming is
-	 * not supported, a `SOUND` asset will be returned instead.
-	 * 
-	 * @param   id        The ID or asset path for the sound
-	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
-	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
-	 * @since 6.2.0
-	 */
-	public inline function getMusicUnsafe(id:String, useCache = true):Sound
-	{
-		return cast getAssetUnsafe(addSoundExtIf(id), MUSIC, useCache);
-	}
 	
 	/**
 	 * Gets an instance of a sound, logs when the asset is not found.
@@ -411,25 +365,6 @@ class AssetFrontEnd
 	{
 		return cast getAsset(addSoundExtIf(id), SOUND, useCache, logStyle);
 	}
-
-	/**
-	 * Gets an instance of a streamed sound, logs when the asset is not found.
-	 * 
-	 * Audio streaming may not be supported for some targets or files. If audio streaming is
-	 * not supported, a `SOUND` asset will be returned instead.
-	 * 
-	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
-	 * 
-	 * @param   id        The ID or asset path for the sound
-	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
-	 * @param   logStyle  How to log, if the asset is not found. Uses `LogStyle.ERROR` by default
-	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
-	 * @since 6.2.0
-	 */
-	public inline function getMusic(id:String, useCache = true, ?logStyle:LogStyle):Sound
-	{
-		return cast getAsset(addSoundExtIf(id), MUSIC, useCache, logStyle);
-	}
 	
 	/**
 	 * Gets an instance of a sound, logs when the asset is not found
@@ -442,23 +377,6 @@ class AssetFrontEnd
 	public inline function getSoundAddExt(id:String, useCache = true, ?logStyle:LogStyle):Sound
 	{
 		return getSound(addSoundExt(id), useCache, logStyle);
-	}
-
-	/**
-	 * Gets an instance of a streamed sound, logs when the asset is not found
-	 * 
-	 * Audio streaming may not be supported for some targets or files. If audio streaming is
-	 * not supported, a `SOUND` asset will be returned instead.
-	 * 
-	 * @param   id        The ID or asset path for the sound
-	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
-	 * @param   logStyle  How to log, if the asset is not found. Uses `LogStyle.ERROR` by default
-	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
-	 * @since 6.2.0
-	 */
-	public inline function getMusicAddExt(id:String, useCache = true, ?logStyle:LogStyle):Sound
-	{
-		return getMusic(addSoundExt(id), useCache, logStyle);
 	}
 	
 	inline function addSoundExtIf(id:String)
@@ -478,7 +396,120 @@ class AssetFrontEnd
 			
 		return id;
 	}
+
+	/**
+	 * Gets an instance of a streamed sound. Unlike its "safe" counterpart, there is no log on missing assets.
+	 * 
+	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
+	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
+	 * 
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * 
+	 * @param   id        The ID or asset path for the sound
+	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
+	 * @since   6.2.0
+	 */
+	public dynamic function streamSoundUnsafe(id:String):Sound
+	{
+		return Assets.getMusic(id);
+	}
+
+	/**
+	 * Gets an instance of a streamed sound, logs when the asset is not found.
+	 * 
+	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
+	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
+	 * 
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * 
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 * 
+	 * @param   id        The ID or asset path for the sound
+	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
+	 * @param   logStyle  How to log, if the asset is not found. Uses `LogStyle.ERROR` by default
+	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
+	 * @since   6.2.0
+	 */
+	public function streamSound(id:String, ?logStyle:LogStyle):Sound
+	{
+		if (logStyle == null)
+			logStyle = FlxG.log.styles.error;
+		
+		final log = FlxG.log.advanced.bind(_, logStyle);
+		
+		if (exists(id, SOUND))
+		{
+			if (isLocal(id, SOUND))
+				return streamSoundUnsafe(addSoundExtIf(id));
+			
+			log('SOUND asset "$id" exists, but only asynchronously');
+			return null;
+		}
+		
+		log('Could not find a SOUND asset with ID \'$id\'.');
+		return null;
+	}
+
+	/**
+	 * Gets an instance of a streamed sound, logs when the asset is not found.
+	 * 
+	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
+	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
+	 * 
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * 
+	 * @param   id        The ID or asset path for the sound
+	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
+	 * @param   logStyle  How to log, if the asset is not found. Uses `LogStyle.ERROR` by default
+	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
+	 * @since   6.2.0
+	 */
+	public function streamSoundAddExt(id:String, ?logStyle:LogStyle):Sound
+	{
+		if (logStyle == null)
+			logStyle = FlxG.log.styles.error;
+		
+		final log = FlxG.log.advanced.bind(_, logStyle);
+		
+		if (exists(id, SOUND))
+		{
+			if (isLocal(id, SOUND))
+				return streamSoundUnsafe(addSoundExt(id));
+			
+			log('SOUND asset "$id" exists, but only asynchronously');
+			return null;
+		}
+		
+		log('Could not find a SOUND asset with ID \'$id\'.');
+		return null;
+	}
 	
+	/**
+	 * Checks whether the sound asset with the specified ID can be streamed.
+	 * 
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * 
+	 * @param   file   The ID or asset path for the asset
+	 * @return  Returns whether the sound can be streamed or not.
+	 * @since   6.2.0
+	 */
+	public inline function canStreamSound(id:String):Bool
+	{
+		#if FLX_STREAM_SOUND
+		// Check if file is really OGG/Vorbis
+		var vorbis = VorbisFile.fromFile(getPath(id));
+		if (vorbis != null)
+		{
+			vorbis.clear();
+			vorbis = null;
+
+			return true;
+		}
+		#end
+
+		return false;
+	}
+
 	/**
 	 * Gets the contents of a text-based asset. Unlike its "safe" counterpart, there is no log
 	 * on missing assets
@@ -642,22 +673,6 @@ class AssetFrontEnd
 	{
 		return cast loadAsset(id, SOUND, useCache);
 	}
-
-	/**
-	 * Loads a streamed sound asset asynchronously
-	 * 
-	 * Audio streaming may not be supported for some targets or files. If audio streaming is
-	 * not supported, a `SOUND` asset will be returned instead.
-	 * 
-	 * @param   id        The ID or asset path for the asset
-	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
-	 * @return  Returns a `Future` which allows listeners to be added via methods like `onComplete`
-	 * @since 6.2.0
-	 */
-	public inline function loadMusic(id:String, useCache = true):Future<Sound>
-	{
-		return cast loadAsset(id, MUSIC, useCache);
-	}
 	
 	/**
 	 * Loads a text asset asynchronously
@@ -753,23 +768,6 @@ class AssetFrontEnd
 		
 		return promise.future;
 	}
-
-	inline function canStreamSound(file:String):Bool
-	{
-		#if lime_vorbis
-		// Check if file is really OGG/Vorbis
-		var vorbis = VorbisFile.fromFile(file);
-		if (vorbis != null)
-		{
-			vorbis.clear();
-			vorbis = null;
-
-			return true;
-		}
-		#end
-		
-		return false;
-	}
 }
 
 /**
@@ -790,9 +788,6 @@ enum abstract FlxAssetType(String)
 	
 	/** Audio assets, such as *.ogg or *.wav files */
 	var SOUND = "sound";
-
-	/** Streamed audio assets, such as *.ogg or *.wav files */
-	var MUSIC = "music";
 	
 	/** Text assets */
 	var TEXT = "text";
@@ -805,7 +800,6 @@ enum abstract FlxAssetType(String)
 			case FONT: AssetType.FONT;
 			case IMAGE: AssetType.IMAGE;
 			case SOUND: AssetType.SOUND;
-			case MUSIC: AssetType.MUSIC;
 			case TEXT: AssetType.TEXT;
 		}
 	}

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -399,11 +399,13 @@ class AssetFrontEnd
 
 	/**
 	 * Gets an instance of a streamed sound. Unlike its "safe" counterpart, there is no log on missing assets.
-	 * 
+	 * Can be set to a custom function to avoid the existing asset system.
+	 *
 	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
 	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
 	 * 
 	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * Trying to stream an unsupported file format will fall back to regular sound loading behavior.
 	 * 
 	 * @param   id        The ID or asset path for the sound
 	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
@@ -421,6 +423,7 @@ class AssetFrontEnd
 	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
 	 * 
 	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * Trying to stream an unsupported file format will fall back to regular sound loading behavior.
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
@@ -457,6 +460,7 @@ class AssetFrontEnd
 	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
 	 * 
 	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * Trying to stream an unsupported file format will fall back to regular sound loading behavior.
 	 * 
 	 * @param   id        The ID or asset path for the sound
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
@@ -489,6 +493,8 @@ class AssetFrontEnd
 	 * 
 	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
 	 * 
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 * 
 	 * @param   file   The ID or asset path for the asset
 	 * @return  Returns whether the sound can be streamed or not.
 	 * @since   6.2.0
@@ -497,7 +503,7 @@ class AssetFrontEnd
 	{
 		#if FLX_STREAM_SOUND
 		// Check if file is really OGG/Vorbis
-		var vorbis = VorbisFile.fromFile(getPath(id));
+		var vorbis = VorbisFile.fromFile(Assets.getPath(addSoundExtIf(id)));
 		if (vorbis != null)
 		{
 			vorbis.clear();

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -437,6 +437,12 @@ class AssetFrontEnd
 		
 		if (exists(id, SOUND))
 		{
+			if (canStreamSound(id))
+			{
+				log('Unable to stream SOUND asset with ID "$id". Expected a .OGG/Vorbis file');
+				return null;
+			}
+			
 			if (isLocal(id, SOUND))
 				return streamSoundUnsafe(id);
 			

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -390,6 +390,7 @@ class AssetFrontEnd
 	 * @param   id        The ID or asset path for the sound
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
 	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
+	 * @since 6.2.0
 	 */
 	public inline function getMusicUnsafe(id:String, useCache = true):Sound
 	{
@@ -423,6 +424,7 @@ class AssetFrontEnd
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
 	 * @param   logStyle  How to log, if the asset is not found. Uses `LogStyle.ERROR` by default
 	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
+	 * @since 6.2.0
 	 */
 	public inline function getMusic(id:String, useCache = true, ?logStyle:LogStyle):Sound
 	{
@@ -452,6 +454,7 @@ class AssetFrontEnd
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
 	 * @param   logStyle  How to log, if the asset is not found. Uses `LogStyle.ERROR` by default
 	 * @return  A new `Sound` object Note: Does not return a `FlxSound`
+	 * @since 6.2.0
 	 */
 	public inline function getMusicAddExt(id:String, useCache = true, ?logStyle:LogStyle):Sound
 	{
@@ -649,6 +652,7 @@ class AssetFrontEnd
 	 * @param   id        The ID or asset path for the asset
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
 	 * @return  Returns a `Future` which allows listeners to be added via methods like `onComplete`
+	 * @since 6.2.0
 	 */
 	public inline function loadMusic(id:String, useCache = true):Future<Sound>
 	{
@@ -762,11 +766,9 @@ class AssetFrontEnd
 
 			return true;
 		}
-
-		return false;
-		#else
-		return false;
 		#end
+		
+		return false;
 	}
 }
 

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -404,7 +404,7 @@ class AssetFrontEnd
 	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
 	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
 	 * 
-	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work on native targets and OGG/Vorbis files.
 	 * Trying to stream an unsupported file format will fall back to regular sound loading behavior.
 	 * 
 	 * @param   id        The ID or asset path for the sound
@@ -422,7 +422,7 @@ class AssetFrontEnd
 	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
 	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
 	 * 
-	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work on native targets and OGG/Vorbis files.
 	 * Trying to stream an unsupported file format will fall back to regular sound loading behavior.
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
@@ -459,7 +459,7 @@ class AssetFrontEnd
 	 * Streamed sounds load and unload chunks of audio data during playback, keeping memory usage low.
 	 * The usage of streamed sounds is only recommended for larger audio tracks, such as music.
 	 * 
-	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work on native targets and OGG/Vorbis files.
 	 * Trying to stream an unsupported file format will fall back to regular sound loading behavior.
 	 * 
 	 * @param   id        The ID or asset path for the sound
@@ -491,7 +491,7 @@ class AssetFrontEnd
 	/**
 	 * Checks whether the sound asset with the specified ID can be streamed.
 	 * 
-	 * **Note**: Due to a backend limitation, streamed sounds currently only work with OGG/Vorbis files.
+	 * **Note**: Due to a backend limitation, streamed sounds currently only work on native targets and OGG/Vorbis files.
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -376,7 +376,8 @@ class AssetFrontEnd
 	/**
 	 * Gets an instance of a streamed sound. Unlike its "safe" counterpart, there is no log on missing assets
 	 * 
-	 * If sound streaming is not supported a normal sound will be returned instead.
+	 * Audio streaming may not be supported for some targets or files. If audio streaming is
+	 * not supported, a `SOUND` asset will be returned instead.
 	 * 
 	 * @param   id        The ID or asset path for the sound
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
@@ -405,7 +406,8 @@ class AssetFrontEnd
 	/**
 	 * Gets an instance of a streamed sound, logs when the asset is not found.
 	 * 
-	 * If sound streaming is not supported a normal sound will be returned instead.
+	 * Audio streaming may not be supported for some targets or files. If audio streaming is
+	 * not supported, a `SOUND` asset will be returned instead.
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
@@ -435,7 +437,8 @@ class AssetFrontEnd
 	/**
 	 * Gets an instance of a streamed sound, logs when the asset is not found
 	 * 
-	 * If sound streaming is not supported a normal sound will be returned instead.
+	 * Audio streaming may not be supported for some targets or files. If audio streaming is
+	 * not supported, a `SOUND` asset will be returned instead.
 	 * 
 	 * @param   id        The ID or asset path for the sound
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)
@@ -632,7 +635,8 @@ class AssetFrontEnd
 	/**
 	 * Loads a streamed sound asset asynchronously
 	 * 
-	 * If sound streaming is not supported a normal sound will be returned instead.
+	 * Audio streaming may not be supported for some targets or files. If audio streaming is
+	 * not supported, a `SOUND` asset will be returned instead.
 	 * 
 	 * @param   id        The ID or asset path for the asset
 	 * @param   useCache  Whether to allow use of the asset cache (if one exists)

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -156,6 +156,10 @@ class AssetFrontEnd
 				else
 				#end
 				{
+					#if lime_vorbis
+					FlxG.log.error('Failed to stream MUSIC asset with an ID of "$id", is it a proper OGG/Vorbis file?');
+					#end
+
 					// can't stream this sound, fall back to default behavior
 					sound = Sound.fromFile(getPath(id));
 					if (canUseCache)
@@ -182,7 +186,13 @@ class AssetFrontEnd
 			case BINARY: Assets.getBytes(id);
 			case IMAGE: Assets.getBitmapData(id, useCache);
 			case SOUND: Assets.getSound(id, useCache);
-			case MUSIC: Assets.getMusic(id, useCache);
+			case MUSIC:
+				#if lime_vorbis
+				if (!canStreamSound(id))
+					FlxG.log.error('Failed to stream MUSIC asset with an ID of "$id", is it a proper OGG/Vorbis file?');
+				#end
+
+				Assets.getMusic(id, useCache);
 			case FONT: Assets.getFont(id, useCache);
 		}
 	}
@@ -738,6 +748,25 @@ class AssetFrontEnd
 		future.onProgress((progress, total)->promise.progress(progress, total));
 		
 		return promise.future;
+	}
+
+	inline function canStreamSound(file:String):Bool
+	{
+		#if lime_vorbis
+		// Check if file is really OGG/Vorbis
+		var vorbis = VorbisFile.fromFile(file);
+		if (vorbis != null)
+		{
+			vorbis.clear();
+			vorbis = null;
+
+			return true;
+		}
+
+		return false;
+		#else
+		return false;
+		#end
 	}
 }
 

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -190,9 +190,31 @@ class SoundFrontEnd
 	}
 
 	#if FLX_STREAM_SOUND
-	public function loadStreamed(id:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?onComplete:Void->Void):FlxSound 
+	/**
+	 * Streams a sound from the given file path. Unlike the `load` method, this will load and
+	 * unload chunks of data as the sound plays, keeping memory usage low. This is recommended for
+	 * longer sounds, like music tracks. For shorter sounds like sound effects, it is better to
+	 * use the `load` method, which loads the entire sound into memory before playing it.
+	 * 
+	 * Due to a backend limitation, audio streaming is currently only available on native targets 
+	 * and OGG/Vorbis audio files.
+	 * 
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 * 
+	 * @param   id           The ID or asset path to the sound asset.
+	 * @param   volume       How loud to play it (0 to 1).
+	 * @param   looped       Whether or not this sound should loop endlessly.
+	 * @param   group        The group to add this sound to.
+	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
+	 * @param   autoPlay     Whether to play the sound.
+	 * @param   onComplete   Called when the sound finishes playing.
+	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
+	 * 
+	 * @since 6.2.0
+	 */
+	public function loadStreamed(id:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?onComplete:()->Void):FlxSound 
 	{
-		var sound:FlxSound = list.recycle(FlxSound);
+		final sound = list.recycle(FlxSound);
 		sound.loadStreamed(id, looped, autoDestroy, onComplete);
 		loadHelper(sound, volume, group, autoPlay);
 		return sound;

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -189,7 +189,7 @@ class SoundFrontEnd
 		return sound;
 	}
 
-	#if FLX_STREAM_MUSIC
+	#if FLX_STREAM_SOUND
 	public function loadStreamed(id:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?onComplete:Void->Void):FlxSound 
 	{
 		var sound:FlxSound = list.recycle(FlxSound);

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -189,6 +189,16 @@ class SoundFrontEnd
 		return sound;
 	}
 
+	#if FLX_STREAM_MUSIC
+	public function loadStreamed(id:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?onComplete:Void->Void):FlxSound 
+	{
+		var sound:FlxSound = list.recycle(FlxSound);
+		sound.loadStreamed(id, looped, autoDestroy, onComplete);
+		loadHelper(sound, volume, group, autoPlay);
+		return sound;
+	}
+	#end
+
 	function loadHelper(sound:FlxSound, volume:Float, group:FlxSoundGroup, autoPlay = false):FlxSound
 	{
 		if (group == null)

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -134,7 +134,7 @@ private enum HelperDefine
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
 	FLX_NO_DEFAULT_SOUND_EXT;
 	/** Enables audio streaming related APIs */
-	FLX_STREAM_MUSIC;
+	FLX_STREAM_SOUND;
 }
 
 class FlxDefines
@@ -330,7 +330,7 @@ class FlxDefines
 			define(FLX_STANDARD_ASSETS_DIRECTORY);
 
 		#if lime_vorbis
-		define(FLX_STREAM_MUSIC);
+		define(FLX_STREAM_SOUND);
 		#end
 		
 		validateLogLevel(FLX_LOG_THROW);

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -133,6 +133,8 @@ private enum HelperDefine
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
 	FLX_NO_DEFAULT_SOUND_EXT;
+	/** Enables audio streaming related APIs */
+	FLX_STREAM_MUSIC;
 }
 
 class FlxDefines
@@ -326,6 +328,10 @@ class FlxDefines
 		}
 		else // define boolean inversion
 			define(FLX_STANDARD_ASSETS_DIRECTORY);
+
+		#if lime_vorbis
+		define(FLX_STREAM_MUSIC);
+		#end
 		
 		validateLogLevel(FLX_LOG_THROW);
 		validateLogLevel(FLX_LOG_PLAY_SOUND);


### PR DESCRIPTION
Been testing this internally and it's been working well so I thought it'd be time to do a PR.

In short:
- Adds the `FLX_STREAM_SOUND` define, which is used to check when sound streaming is supported
- `AssetsFrontEnd`
  - Adds `streamSoundUnsafe()`, `streamSound()`, `streamSoundAddExt()`, `canStreamSound()`
- `FlxSound`: adds the `FlxSound.loadStreamed()` method which uses audio streaming under the hood. Very useful for large audio tracks as it loads chunks of data while it plays which results in small memory usage.
  - Also adds `FlxG.sound.loadStreamed()` which is a helper for this!

Audio streaming is currently only supported when targeting native and using OGG files, this is due to a limitation with Lime. I've been poking around trying to get streaming to work on HTML5 as well. I have a proof of concept, but it might require changes to OpenFL, so it'll be implemented in a later PR once that's all figured out.

Further considerations:
- Should `FlxG.sound.playMusic()` use streaming?
- ~~Should we add a helper method akin to `FlxG.sound.load()` but for streamed sounds?~~