### PR TITLE
Deprecate renderBlit in favor of renderTile

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -743,6 +743,7 @@ class FlxCamera extends FlxBasic
 	public function drawPixels(?frame:FlxFrame, ?pixels:BitmapData, matrix:FlxMatrix, ?transform:ColorTransform, ?blend:BlendMode, ?smoothing:Bool = false,
 			?shader:FlxShader):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			_helperMatrix.copyFrom(matrix);
@@ -759,6 +760,7 @@ class FlxCamera extends FlxBasic
 			}
 		}
 		else
+		#end
 		{
 			var isColored = (transform != null #if !html5 && transform.hasRGBMultipliers() #end);
 			var hasColorOffsets:Bool = (transform != null && transform.hasRGBAOffsets());
@@ -775,6 +777,7 @@ class FlxCamera extends FlxBasic
 	public function copyPixels(?frame:FlxFrame, ?pixels:BitmapData, ?sourceRect:Rectangle, destPoint:Point, ?transform:ColorTransform, ?blend:BlendMode,
 			?smoothing:Bool = false, ?shader:FlxShader):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (pixels != null)
@@ -800,6 +803,7 @@ class FlxCamera extends FlxBasic
 			}
 		}
 		else
+		#end
 		{
 			_helperMatrix.identity();
 			_helperMatrix.translate(destPoint.x + frame.offset.x, destPoint.y + frame.offset.y);
@@ -821,6 +825,7 @@ class FlxCamera extends FlxBasic
 	{
 		final cameraBounds = _bounds.set(viewMarginLeft, viewMarginTop, viewWidth, viewHeight);
 		
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (position == null)
@@ -894,6 +899,7 @@ class FlxCamera extends FlxBasic
 			bounds.put();
 		}
 		else
+		#end
 		{
 			final isColored = (colors != null && colors.length != 0) || (transform != null && transform.hasRGBMultipliers());
 			final hasColorOffsets = (transform != null && transform.hasRGBAOffsets());
@@ -908,8 +914,12 @@ class FlxCamera extends FlxBasic
 	 * @param	rect	rectangle to prepare for rendering
 	 * @return	transformed rectangle with respect to camera's zoom factor
 	 */
+	#if FLX_NO_RENDER_BLIT 
+	@:deprecated("transformRect will be removed")
+	#end
 	function transformRect(rect:FlxRect):FlxRect
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			rect.offset(-viewMarginLeft, -viewMarginTop);
@@ -922,6 +932,7 @@ class FlxCamera extends FlxBasic
 				rect.height *= zoom;
 			}
 		}
+		#end
 
 		return rect;
 	}
@@ -931,8 +942,12 @@ class FlxCamera extends FlxBasic
 	 * @param	point		point to prepare for rendering
 	 * @return	transformed point with respect to camera's zoom factor
 	 */
+	#if FLX_NO_RENDER_BLIT 
+	@:deprecated("transformPoint will be removed")
+	#end
 	function transformPoint(point:FlxPoint):FlxPoint
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			point.subtract(viewMarginLeft, viewMarginTop);
@@ -940,6 +955,7 @@ class FlxCamera extends FlxBasic
 			if (_useBlitMatrix)
 				point.scale(zoom);
 		}
+		#end
 
 		return point;
 	}
@@ -949,10 +965,15 @@ class FlxCamera extends FlxBasic
 	 * @param	vector	relative position to prepare for rendering
 	 * @return	transformed vector with respect to camera's zoom factor
 	 */
+	#if FLX_NO_RENDER_BLIT 
+	@:deprecated("transformVector will be removed")
+	#end
 	inline function transformVector(vector:FlxPoint):FlxPoint
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit && _useBlitMatrix)
 			vector.scale(zoom);
+		#end
 
 		return vector;
 	}
@@ -1013,6 +1034,7 @@ class FlxCamera extends FlxBasic
 
 		pixelPerfectRender = FlxG.renderBlit;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			screen = new FlxSprite();
@@ -1024,6 +1046,7 @@ class FlxCamera extends FlxBasic
 			_fill = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
 		}
 		else
+		#end
 		{
 			canvas = new Sprite();
 			_scrollRect.addChild(canvas);
@@ -1054,6 +1077,7 @@ class FlxCamera extends FlxBasic
 	{
 		FlxDestroyUtil.removeChild(flashSprite, _scrollRect);
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			FlxDestroyUtil.removeChild(_scrollRect, _flashBitmap);
@@ -1063,6 +1087,7 @@ class FlxCamera extends FlxBasic
 			_fill = FlxDestroyUtil.dispose(_fill);
 		}
 		else
+		#end
 		{
 			#if FLX_DEBUG
 			FlxDestroyUtil.removeChild(_scrollRect, debugLayer);
@@ -1394,6 +1419,7 @@ class FlxCamera extends FlxBasic
 	 */
 	function updateInternalSpritePositions():Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (_flashBitmap != null)
@@ -1403,6 +1429,7 @@ class FlxCamera extends FlxBasic
 			}
 		}
 		else
+		#end
 		{
 			if (canvas != null)
 			{
@@ -1643,6 +1670,7 @@ class FlxCamera extends FlxBasic
 	 */
 	public function fill(Color:FlxColor, BlendAlpha:Bool = true, FxAlpha:Float = 1.0, ?graphics:Graphics):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (BlendAlpha)
@@ -1656,6 +1684,7 @@ class FlxCamera extends FlxBasic
 			}
 		}
 		else
+		#end
 		{
 			final targetGraphics = (graphics == null) ? canvas.graphics : graphics;
 
@@ -1677,6 +1706,7 @@ class FlxCamera extends FlxBasic
 		// Draw the "flash" special effect onto the buffer
 		if (_fxFlashAlpha > 0.0)
 		{
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				var color = _fxFlashColor;
@@ -1684,6 +1714,7 @@ class FlxCamera extends FlxBasic
 				fill(color);
 			}
 			else
+			#end
 			{
 				final alpha = _fxFlashColor.alphaFloat * _fxFlashAlpha;
 				fill(_fxFlashColor.rgb, true, alpha, canvas.graphics);
@@ -1693,6 +1724,7 @@ class FlxCamera extends FlxBasic
 		// Draw the "fade" special effect onto the buffer
 		if (_fxFadeAlpha > 0.0)
 		{
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				var color = _fxFadeColor;
@@ -1700,6 +1732,7 @@ class FlxCamera extends FlxBasic
 				fill(color);
 			}
 			else
+			#end
 			{
 				final alpha = _fxFadeColor.alphaFloat * _fxFadeAlpha;
 				fill(_fxFadeColor.rgb, true, alpha, canvas.graphics);
@@ -1708,8 +1741,12 @@ class FlxCamera extends FlxBasic
 	}
 
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("checkResize is deprecated");
+	#end
 	function checkResize():Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (width != buffer.width || height != buffer.height)
@@ -1728,8 +1765,12 @@ class FlxCamera extends FlxBasic
 
 			updateBlitMatrix();
 		}
+		#end
 	}
 
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("updateBlitMatrix is deprecated");
+	#end
 	inline function updateBlitMatrix():Void
 	{
 		_blitMatrix.identity();
@@ -1816,6 +1857,7 @@ class FlxCamera extends FlxBasic
 		totalScaleX = scaleX * FlxG.scaleMode.scale.x;
 		totalScaleY = scaleY * FlxG.scaleMode.scale.y;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			updateBlitMatrix();
@@ -1831,6 +1873,7 @@ class FlxCamera extends FlxBasic
 				_flashBitmap.scaleY = totalScaleY;
 			}
 		}
+		#end
 
 		calcMarginX();
 		calcMarginY();
@@ -1929,11 +1972,13 @@ class FlxCamera extends FlxBasic
 	function set_alpha(Alpha:Float):Float
 	{
 		alpha = FlxMath.bound(Alpha, 0, 1);
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			_flashBitmap.alpha = Alpha;
 		}
 		else
+		#end
 		{
 			canvas.alpha = Alpha;
 		}
@@ -1952,6 +1997,7 @@ class FlxCamera extends FlxBasic
 		color = Color;
 		var colorTransform:ColorTransform;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (_flashBitmap == null)
@@ -1961,6 +2007,7 @@ class FlxCamera extends FlxBasic
 			colorTransform = _flashBitmap.transform.colorTransform;
 		}
 		else
+		#end
 		{
 			colorTransform = canvas.transform.colorTransform;
 		}
@@ -1969,11 +2016,13 @@ class FlxCamera extends FlxBasic
 		colorTransform.greenMultiplier = color.greenFloat;
 		colorTransform.blueMultiplier = color.blueFloat;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			_flashBitmap.transform.colorTransform = colorTransform;
 		}
 		else
+		#end
 		{
 			canvas.transform.colorTransform = colorTransform;
 		}
@@ -1984,10 +2033,12 @@ class FlxCamera extends FlxBasic
 	function set_antialiasing(Antialiasing:Bool):Bool
 	{
 		antialiasing = Antialiasing;
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			_flashBitmap.smoothing = Antialiasing;
 		}
+		#end
 		return Antialiasing;
 	}
 

--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1742,7 +1742,7 @@ class FlxCamera extends FlxBasic
 
 	@:allow(flixel.system.frontEnds.CameraFrontEnd)
 	#if FLX_NO_RENDER_BLIT
-	@:deprecated("checkResize is deprecated");
+	@:deprecated("checkResize is deprecated")
 	#end
 	function checkResize():Void
 	{
@@ -1769,7 +1769,7 @@ class FlxCamera extends FlxBasic
 	}
 
 	#if FLX_NO_RENDER_BLIT
-	@:deprecated("updateBlitMatrix is deprecated");
+	@:deprecated("updateBlitMatrix is deprecated")
 	#end
 	inline function updateBlitMatrix():Void
 	{

--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -143,6 +143,7 @@ class FlxG
 
 	public static var renderMethod(default, null):FlxRenderMethod;
 
+	@:deprecated("renderBlit will be removed")
 	public static var renderBlit(default, null):Bool;
 	public static var renderTile(default, null):Bool;
 
@@ -584,6 +585,7 @@ class FlxG
 
 	static function initRenderMethod():Void
 	{
+		#if FLX_RENDER_BLIT
 		#if !flash
 		renderMethod = switch (stage.window.context.type)
 		{
@@ -600,6 +602,9 @@ class FlxG
 
 		#if air
 		renderMethod = BLITTING;
+		#end
+		#else
+		renderMethod = DRAW_TILES;
 		#end
 
 		renderBlit = renderMethod == BLITTING;
@@ -747,5 +752,5 @@ class FlxG
 enum FlxRenderMethod
 {
 	DRAW_TILES;
-	BLITTING;
+	@:deprecated BLITTING;
 }

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1298,21 +1298,28 @@ class FlxObject extends FlxBasic
 
 	inline function beginDrawDebug(camera:FlxCamera):Graphics
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			FlxSpriteUtil.flashGfx.clear();
 			return FlxSpriteUtil.flashGfx;
 		}
 		else
+		#end
 		{
 			return camera.debugLayer.graphics;
 		}
 	}
 
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("endDrawDebug is deprecated")
+	#end
 	inline function endDrawDebug(camera:FlxCamera)
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
+		#end
 	}
 	#end
 

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -763,11 +763,13 @@ class FlxSprite extends FlxObject
 
 		centerOrigin();
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 			updateFramePixels();
 		}
+		#end
 	}
 
 	override public function update(elapsed:Float):Void
@@ -918,6 +920,7 @@ class FlxSprite extends FlxObject
 
 		var bitmapData:BitmapData = Brush.framePixels;
 
+		#if FLX_RENDER_BLIT
 		if (isSimpleRenderBlit()) // simple render
 		{
 			_flashPoint.x = X + frame.frame.x;
@@ -929,6 +932,7 @@ class FlxSprite extends FlxObject
 			_flashRect2.height = graphic.bitmap.height;
 		}
 		else // complex render
+		#end
 		{
 			_matrix.identity();
 			_matrix.translate(-Brush.origin.x, -Brush.origin.y);
@@ -942,11 +946,13 @@ class FlxSprite extends FlxObject
 			graphic.bitmap.draw(bitmapData, _matrix, null, brushBlend, null, Brush.antialiasing);
 		}
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 			calcFrame();
 		}
+		#end
 	}
 
 	/**
@@ -957,6 +963,7 @@ class FlxSprite extends FlxObject
 	 */
 	public function drawFrame(Force:Bool = false):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (Force || dirty)
@@ -966,6 +973,7 @@ class FlxSprite extends FlxObject
 			}
 		}
 		else
+		#end
 		{
 			dirty = true;
 			calcFrame(true);
@@ -1250,10 +1258,12 @@ class FlxSprite extends FlxObject
 			framePixels = _frame.paintRotatedAndFlipped(framePixels, _flashPointZero, FlxFrameAngle.ANGLE_0, doFlipX, doFlipY, false, true);
 		}
 		
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit && hasColorTransform())
 		{
 			framePixels.colorTransform(_flashRect, colorTransform);
 		}
+		#end
 		
 		if (FlxG.renderTile && useFramePixels)
 		{
@@ -1329,10 +1339,14 @@ class FlxSprite extends FlxObject
 	 */
 	public function isSimpleRender(?camera:FlxCamera):Bool
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderTile)
 			return false;
 
 		return isSimpleRenderBlit(camera);
+		#else
+		return false;
+		#end
 	}
 
 	/**
@@ -1343,6 +1357,9 @@ class FlxSprite extends FlxObject
 	 *
 	 * @param   camera   If a camera is passed its `pixelPerfectRender` flag is taken into account
 	 */
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("isSimpleRenderBlit is deprecated")
+	#end
 	public function isSimpleRenderBlit(?camera:FlxCamera):Bool
 	{
 		var result:Bool = (angle == 0 || bakedRotationAngle > 0) && scale.x == 1 && scale.y == 1 && blend == null;

--- a/flixel/FlxSubState.hx
+++ b/flixel/FlxSubState.hx
@@ -63,6 +63,7 @@ class FlxSubState extends FlxState
 	override public function draw():Void
 	{
 		// Draw background
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			for (camera in getCamerasLegacy())
@@ -71,6 +72,7 @@ class FlxSubState extends FlxState
 			}
 		}
 		else // FlxG.renderTile
+		#end
 		{
 			if (_bgSprite != null && _bgSprite.visible)
 			{

--- a/flixel/effects/particles/FlxEmitter.hx
+++ b/flixel/effects/particles/FlxEmitter.hx
@@ -264,9 +264,11 @@ class FlxTypedEmitter<T:FlxSprite & IFlxParticle> extends FlxTypedGroup<T>
 		var particle:T = Type.createInstance(particleClass, []);
 		var frame = Multiple ? FlxG.random.int(0, totalFrames - 1) : -1;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit && bakedRotationAngles > 0)
 			particle.loadRotatedGraphic(Graphics, bakedRotationAngles, frame, false, AutoBuffer);
 		else
+		#end
 			particle.loadGraphic(Graphics, Multiple);
 
 		if (Multiple)

--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -279,11 +279,13 @@ class FlxFrame implements IFlxDestroyable
 	 */
 	public function prepareMatrix(mat:FlxMatrix, rotation:FlxFrameAngle = FlxFrameAngle.ANGLE_0, flipX:Bool = false, flipY:Bool = false):FlxMatrix
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			mat.identity();
 			return mat;
 		}
+		#end
 
 		tileMatrix.copyTo(mat);
 

--- a/flixel/graphics/tile/FlxDrawQuadsItem.hx
+++ b/flixel/graphics/tile/FlxDrawQuadsItem.hx
@@ -109,12 +109,12 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 		}
 	}
 
-	#if !flash
 	override public function render(camera:FlxCamera):Void
 	{
 		if (rects.length == 0)
 			return;
 		
+		#if !flash
 		// TODO: catch this error when the dev actually messes up, not in the draw phase
 		if (shader == null && graphics.isDestroyed)
 			throw 'Attempted to render an invalid FlxDrawItem, did you destroy a cached sprite?';
@@ -135,10 +135,14 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 
 		camera.canvas.graphics.overrideBlendMode(blend);
 		camera.canvas.graphics.beginShaderFill(shader);
+		#else
+		camera.canvas.graphics.beginBitmapFill(graphics.bitmap, null, true, (camera.antialiasing || antialiasing));
+		#end
 		camera.canvas.graphics.drawQuads(rects, null, transforms);
 		camera.canvas.graphics.endFill();
 		super.render(camera);
 	}
+	
 
 	inline function setParameterValue(parameter:ShaderParameter<Bool>, value:Bool):Void
 	{
@@ -146,5 +150,4 @@ class FlxDrawQuadsItem extends FlxDrawBaseItem<FlxDrawQuadsItem>
 			parameter.value = [];
 		parameter.value[0] = value;
 	}
-	#end
 }

--- a/flixel/path/FlxBasePath.hx
+++ b/flixel/path/FlxBasePath.hx
@@ -320,12 +320,14 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 	{
 		// Set up our global flash graphics object to draw out the path
 		var gfx:Graphics = null;
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			gfx = FlxSpriteUtil.flashGfx;
 			gfx.clear();
 		}
 		else
+		#end
 		{
 			gfx = camera.debugLayer.graphics;
 		}
@@ -368,11 +370,13 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 			prevNodeScreen.put();
 		}
 		
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			// then stamp the path down onto the game buffer
 			camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
 		}
+		#end
 	}
 	
 	@:access(flixel.FlxCamera)
@@ -386,11 +390,13 @@ class FlxTypedBasePath<TTarget:FlxBasic> extends FlxBasic implements IFlxDestroy
 			result.y -= camera.scroll.y * object.scrollFactor.y;
 		}
 		
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			result.x -= camera.viewMarginX;
 			result.y -= camera.viewMarginY;
 		}
+		#end
 		
 		camera.transformPoint(result);
 		return result;

--- a/flixel/system/debug/interaction/Interaction.hx
+++ b/flixel/system/debug/interaction/Interaction.hx
@@ -377,13 +377,18 @@ class Interaction extends Window
 			drawItemsSelection();
 	}
 
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("getDebugGraphics is deprecated")
+	#end
 	public function getDebugGraphics():Graphics
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			FlxSpriteUtil.flashGfx.clear();
 			return FlxSpriteUtil.flashGfx;
 		}
+		#end
 
 		#if FLX_DEBUG
 		return FlxG.camera.debugLayer.graphics;
@@ -410,9 +415,11 @@ class Interaction extends Window
 			}
 		}
 
+		#if FLX_RENDER_BLIT
 		// Draw the debug info to the main camera buffer.
 		if (FlxG.renderBlit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
+		#end
 	}
 
 	/**

--- a/flixel/system/debug/interaction/tools/Pointer.hx
+++ b/flixel/system/debug/interaction/tools/Pointer.hx
@@ -149,9 +149,11 @@ class Pointer extends Tool
 				rect.put();
 		}
 		
+		#if FLX_RENDER_BLIT
 		// Render everything into the camera buffer
 		if (FlxG.renderBlit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
+		#end
 	}
 	
 	static function setAbsRect(rect:FlxRect, x1:Float, y1:Float, x2:Float, y2:Float)

--- a/flixel/system/debug/interaction/tools/Transform.hx
+++ b/flixel/system/debug/interaction/tools/Transform.hx
@@ -240,9 +240,11 @@ class Transform extends Tool
 		drawSelection(gfx, target.getDefaultCamera());
 		Marker.draw(target.x + target.origin.x, target.y + target.origin.y, false, gfx);
 		
+		#if FLX_RENDER_BLIT
 		// Draw the debug info to the main camera buffer.
 		if (FlxG.renderBlit)
 			FlxG.camera.buffer.draw(FlxSpriteUtil.flashGfxSprite);
+		#end
 	}
 	
 	function drawSelection(gfx:Graphics, camera:FlxCamera)

--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -262,6 +262,7 @@ class CameraFrontEnd
 				continue;
 			}
 
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				camera.checkResize();
@@ -271,6 +272,7 @@ class CameraFrontEnd
 					camera.buffer.lock();
 				}
 			}
+			#end
 
 			if (FlxG.renderTile)
 			{
@@ -282,12 +284,14 @@ class CameraFrontEnd
 				#end
 			}
 
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				camera.fill(camera.bgColor, camera.useBgAlphaBlending);
 				camera.screen.dirty = true;
 			}
 			else
+			#end
 			{
 				camera.fill(camera.bgColor.rgb, camera.useBgAlphaBlending, camera.bgColor.alphaFloat);
 			}
@@ -324,6 +328,7 @@ class CameraFrontEnd
 
 			camera.drawFX();
 
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				if (useBufferLocking)
@@ -333,6 +338,7 @@ class CameraFrontEnd
 
 				camera.screen.dirty = true;
 			}
+			#end
 		}
 	}
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -280,7 +280,7 @@ class FlxDefines
 		// #end
 
 		if (!defined(FLX_NO_RENDER_BLIT))
-			define(FLX_RENDER_BLIT)
+			define(FLX_RENDER_BLIT);
 		
 		if (defined(FLX_TRACK_POOLS) && !defined("debug"))
 			abort("Can only define FLX_TRACK_POOLS on debug mode", (macro null).pos);

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -66,6 +66,11 @@ private enum UserDefines
 	 * Used to make the debug windows bigger
 	 */
 	FLX_DEBUGGER_SCALE;
+
+	/**
+	 * Disables the blitting renderer. Tile rendering will be used on all targets instead.
+	 */
+	FLX_NO_RENDER_BLIT;
 }
 
 /**
@@ -115,6 +120,7 @@ private enum HelperDefines
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
 	FLX_NO_DEFAULT_SOUND_EXT;
+	FLX_RENDER_BLIT;
 }
 
 class FlxDefines
@@ -217,6 +223,7 @@ class FlxDefines
 		defineInversion(FLX_DEFAULT_SOUND_EXT, FLX_NO_DEFAULT_SOUND_EXT);
 		// defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS); // special case
 		// defineInversion(FLX_NO_HEALTH, FLX_HEALTH);
+		defineInversion(FLX_NO_RENDER_BLIT, FLX_RENDER_BLIT);
 		if (!defined(FLX_NO_HEALTH) && !defined(FLX_HEALTH))
 		{
 			define(FLX_HEALTH_NOT_DEFINED);
@@ -271,6 +278,9 @@ class FlxDefines
 		// should always be defined as of 5.5.1 and, therefore, deprecated
 		define(FLX_DRAW_QUADS);
 		// #end
+
+		if (!defined(FLX_NO_RENDER_BLIT))
+			define(FLX_RENDER_BLIT)
 		
 		if (defined(FLX_TRACK_POOLS) && !defined("debug"))
 			abort("Can only define FLX_TRACK_POOLS on debug mode", (macro null).pos);

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -235,11 +235,13 @@ class FlxBitmapText extends FlxSprite
 
 		this.font = (font == null) ? FlxBitmapFont.getDefaultFont() : font;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			pixels = new BitmapData(1, 1, true, FlxColor.TRANSPARENT);
 		}
 		else
+		#end
 		{
 			textData = [];
 			textDrawData = [];
@@ -284,10 +286,12 @@ class FlxBitmapText extends FlxSprite
 		}
 		pendingTextBitmapChange = pendingTextBitmapChange || Force;
 		checkPendingChanges(false);
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			super.drawFrame(Force);
 		}
+		#end
 	}
 	
 	override function updateHitbox()
@@ -298,10 +302,12 @@ class FlxBitmapText extends FlxSprite
 
 	function checkPendingChanges(useTiles:Bool = false):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
+		#end
 
 		if (pendingTextChange)
 		{
@@ -329,12 +335,14 @@ class FlxBitmapText extends FlxSprite
 	static final frameDrawHelper = new ReusableFrame();
 	override function draw()
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			checkPendingChanges(false);
 			super.draw();
 		}
 		else
+		#end
 		{
 			checkPendingChanges(true);
 			
@@ -452,7 +460,7 @@ class FlxBitmapText extends FlxSprite
 	override function set_clipRect(Rect:FlxRect):FlxRect
 	{
 		super.set_clipRect(Rect);
-		if (!FlxG.renderBlit)
+		if (FlxG.renderTile)
 		{
 			pendingTextBitmapChange = true;
 		}
@@ -462,20 +470,24 @@ class FlxBitmapText extends FlxSprite
 	override function set_color(Color:FlxColor):FlxColor
 	{
 		super.set_color(Color);
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			pendingTextBitmapChange = true;
 		}
+		#end
 		return color;
 	}
 
 	override function set_alpha(value:Float):Float
 	{
 		super.set_alpha(value);
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			pendingTextBitmapChange = true;
 		}
+		#end
 		return value;
 	}
 
@@ -484,10 +496,12 @@ class FlxBitmapText extends FlxSprite
 		if (textColor != value)
 		{
 			textColor = value;
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				pendingPixelsChange = true;
 			}
+			#end
 		}
 
 		return value;
@@ -498,10 +512,12 @@ class FlxBitmapText extends FlxSprite
 		if (useTextColor != value)
 		{
 			useTextColor = value;
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				pendingPixelsChange = true;
 			}
+			#end
 		}
 
 		return value;
@@ -1001,10 +1017,12 @@ class FlxBitmapText extends FlxSprite
 	{
 		computeTextSize();
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
+		#end
 
 		if (!useTiles)
 		{
@@ -1172,6 +1190,7 @@ class FlxBitmapText extends FlxSprite
 		var colorForFill:Int = background ? backgroundColor : FlxColor.TRANSPARENT;
 		var bitmap:BitmapData = null;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (pixels == null || (frameWidth != pixels.width || frameHeight != pixels.height))
@@ -1186,6 +1205,7 @@ class FlxBitmapText extends FlxSprite
 			bitmap = pixels;
 		}
 		else
+		#end
 		{
 			if (!useTiles)
 			{
@@ -1224,10 +1244,12 @@ class FlxBitmapText extends FlxSprite
 			bitmap.unlock();
 		}
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 		}
+		#end
 
 		if (pendingPixelsChange)
 			throw "pendingPixelsChange was changed to true while processing changed pixels";
@@ -1319,10 +1341,12 @@ class FlxBitmapText extends FlxSprite
 	
 	function drawText(posX:Int, posY:Int, isFront:Bool = true, ?bitmap:BitmapData, useTiles:Bool = false):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			useTiles = false;
 		}
+		#end
 
 		if (useTiles)
 		{
@@ -1553,10 +1577,12 @@ class FlxBitmapText extends FlxSprite
 		if (background != value)
 		{
 			background = value;
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				pendingPixelsChange = true;
 			}
+			#end
 		}
 
 		return value;
@@ -1567,10 +1593,12 @@ class FlxBitmapText extends FlxSprite
 		if (backgroundColor != value)
 		{
 			backgroundColor = value;
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				pendingPixelsChange = true;
 			}
+			#end
 		}
 
 		return value;
@@ -1592,10 +1620,12 @@ class FlxBitmapText extends FlxSprite
 		if (borderColor != value)
 		{
 			borderColor = value;
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				pendingPixelsChange = true;
 			}
+			#end
 		}
 
 		return value;

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -305,8 +305,10 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		debugBoundingBoxColorPartial = FlxColor.PINK;
 		debugBoundingBoxColorNotSolid = FlxColor.TRANSPARENT;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 			FlxG.debugger.drawDebugChanged.add(onDrawDebugChanged);
+		#end
 		#end
 	}
 
@@ -321,6 +323,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		_tileObjects = FlxDestroyUtil.destroyArray(_tileObjects);
 		_buffers = FlxDestroyUtil.destroyArray(_buffers);
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			#if FLX_DEBUG
@@ -331,6 +334,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 			#end
 		}
 		else
+		#end
 		{
 			_helperPoint = null;
 			_matrix = null;
@@ -350,7 +354,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		FlxG.cameras.cameraRemoved.remove(onCameraChanged);
 		FlxG.cameras.cameraResized.remove(onCameraChanged);
 
-		#if FLX_DEBUG
+		#if (FLX_DEBUG && FLX_RENDER_BLIT)
 		if (FlxG.renderBlit)
 			FlxG.debugger.drawDebugChanged.remove(onDrawDebugChanged);
 		#end
@@ -529,7 +533,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 	override function updateMap():Void
 	{
-		#if FLX_DEBUG
+		#if (FLX_DEBUG && FLX_RENDER_BLIT)
 		if (FlxG.renderBlit)
 			_debugRect = new Rectangle(0, 0, tileWidth, tileHeight);
 		#end
@@ -656,6 +660,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 
 			buffer = _buffers[i];
 
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 			{
 				if (buffer.isDirty(this, camera))
@@ -665,6 +670,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 				buffer.draw(camera, _flashPoint, scale.x, scale.y);
 			}
 			else
+			#end
 			{
 				drawTilemap(buffer, camera);
 			}
@@ -1214,11 +1220,13 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		var scaledHeight:Float = 0;
 		var drawItem = null;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			buffer.fill();
 		}
 		else
+		#end
 		{
 			getScreenPosition(_point, camera).subtractPoint(offset).copyTo(_helperPoint);
 
@@ -1268,6 +1276,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 				{
 					frame = tile.frame;
 
+					#if FLX_RENDER_BLIT
 					if (FlxG.renderBlit)
 					{
 						frame.paint(buffer.pixels, _flashPoint, true);
@@ -1295,6 +1304,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 						#end
 					}
 					else
+					#end
 					{
 						drawX = _helperPoint.x + (columnIndex % widthInTiles) * scaledWidth;
 						drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * scaledHeight;
@@ -1316,26 +1326,33 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 					}
 				}
 
+				#if FLX_RENDER_BLIT
 				if (FlxG.renderBlit)
 					_flashPoint.x += tileWidth;
+				#end
 
 				columnIndex++;
 			}
 
+			#if FLX_RENDER_BLIT
 			if (FlxG.renderBlit)
 				_flashPoint.y += tileHeight;
+			#end
+
 			rowIndex += widthInTiles;
 		}
 
 		buffer.x = screenXInTiles * scaledTileWidth;
 		buffer.y = screenYInTiles * scaledTileHeight;
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			if (isColored)
 				buffer.colorTransform(colorTransform);
 			buffer.blend = blend;
 		}
+		#end
 
 		buffer.dirty = false;
 	}
@@ -1345,14 +1362,21 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 	 * Just generates a wireframe box the size of a tile with the specified color.
 	 */
 	#if FLX_DEBUG
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("makeDebugTile is deprecated")
+	#end
 	function makeDebugTile(color:FlxColor):BitmapData
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderTile)
 			return null;
 
 		var debugTile = new BitmapData(tileWidth, tileHeight, true, 0);
 		drawDebugTile(debugTile, color);
 		return debugTile;
+		#else
+		return null;
+		#end
 	}
 
 	function drawDebugTile(debugTile:BitmapData, color:FlxColor):Void

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -117,6 +117,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 		updateColumns(tileWidth, widthInTiles, scaleX, camera);
 		updateRows(tileHeight, heightInTiles, scaleY, camera);
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			final newWidth = Std.int(columns * tileWidth);
@@ -137,6 +138,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 				dirty = true;
 			}
 		}
+		#end
 	}
 	
 	/**
@@ -144,6 +146,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 */
 	public function destroy():Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			pixels = FlxDestroyUtil.dispose(pixels);
@@ -151,6 +154,7 @@ class FlxTilemapBuffer implements IFlxDestroyable
 			_matrix = null;
 			_flashRect = null;
 		}
+		#end
 	}
 	
 	/**
@@ -159,12 +163,17 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	 *
 	 * @param   color  What color to fill with, in 0xAARRGGBB hex format.
 	 */
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("fill is deprecated")
+	#end
 	public function fill(color = FlxColor.TRANSPARENT):Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			pixels.fillRect(_flashRect, color);
 		}
+		#end
 	}
 	
 	/**

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -172,6 +172,7 @@ class FlxBar extends FlxSprite
 
 		_filledBarPoint = new Point();
 		_filledBarRect = new Rectangle();
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			_zeroOffset = new Point();
@@ -179,6 +180,7 @@ class FlxBar extends FlxSprite
 			makeGraphic(width, height, FlxColor.TRANSPARENT, true);
 		}
 		else
+		#end
 		{
 			_filledFlxRect = FlxRect.get();
 		}
@@ -742,13 +744,18 @@ class FlxBar extends FlxSprite
 	/**
 	 * Stamps health bar background on its pixels
 	 */
+	#if FLX_NO_RENDER_BLIT
+	@:deprecated("updateEmptyBar is deprecated")
+	#end
 	public function updateEmptyBar():Void
 	{
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			pixels.copyPixels(_emptyBar, _emptyBarRect, _zeroOffset);
 			dirty = true;
 		}
+		#end
 	}
 
 	/**
@@ -806,11 +813,13 @@ class FlxBar extends FlxSprite
 					_filledBarPoint.y = Std.int((barHeight - _filledBarRect.height) / 2);
 			}
 
+			#if FLX_RENDER_BLIT			
 			if (FlxG.renderBlit)
 			{
 				pixels.copyPixels(_filledBar, _filledBarRect, _filledBarPoint, null, null, true);
 			}
 			else
+			#end
 			{
 				if (frontFrames != null)
 				{
@@ -823,10 +832,12 @@ class FlxBar extends FlxSprite
 			}
 		}
 
+		#if FLX_RENDER_BLIT
 		if (FlxG.renderBlit)
 		{
 			dirty = true;
 		}
+		#end
 	}
 
 	override public function update(elapsed:Float):Void


### PR DESCRIPTION
See #3468 for a more in-depth explanation

Adds `FLX_NO_RENDER_BLIT`, a user defined compile conditional which completely disables Flixel's blit renderer and instead relies on OpenFL's software rendering implementation of the Graphics API. Any code intended for `renderTile` will also work in cases where hardware acceleration is unavailable. This actually leads to a big performance improvement when targeting HTML5 (probably the only target where software rendering matters nowadays).

This implementation is quite ugly IMO, but it should only be here temporarily. Ideally we'd merge this ASAP to make it possible for people to test it out and then in 7.0.0 get rid of `renderBlit` completely and make this the default.

This is a draft and will probably require testing to make sure everything's on par with the current blitting renderer.
- [ ] Deprecate other various blitting related functions and properties
- [ ] Hide loads of internal deprecation warnings