### PR TITLE
Make sure onFocusLost gets called on substates.

### DIFF
--- a/flixel/FlxState.hx
+++ b/flixel/FlxState.hx
@@ -202,13 +202,17 @@ class FlxState extends FlxContainer
 	 * This method is called after the game loses focus.
 	 * Can be useful for third party libraries, such as tweening engines.
 	 */
-	public function onFocusLost():Void {}
+	public function onFocusLost():Void {
+		if (subState != null) subState.onFocusLost();
+	}
 
 	/**
 	 * This method is called after the game receives focus.
 	 * Can be useful for third party libraries, such as tweening engines.
 	 */
-	public function onFocus():Void {}
+	public function onFocus():Void {
+		if (subState != null) subState.onFocus();
+	}
 
 	/**
 	 * This function is called whenever the window size has been changed.


### PR DESCRIPTION
It took me longer to make a commit that wasn't filled with whitespace changes automatically made by HXFormat than it did to write the actual PR.

Resolves #3520.