### PR TITLE
FlxG: query maxTextureSize when window is created

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -539,6 +539,10 @@ class FlxG
 		FlxG.height = height;
 
 		initRenderMethod();
+		#if FLX_OPENGL_AVAILABLE
+		// Query once when window is created and cache for later
+		bitmap.get_maxTextureSize();
+		#end
 
 		FlxG.initialWidth = width;
 		FlxG.initialHeight = height;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -343,6 +343,8 @@ class BitmapFrontEnd
 
 	#if FLX_OPENGL_AVAILABLE
 	static var _maxTextureSize = -1;
+
+	@:allow(flixel.FlxG)
 	function get_maxTextureSize():Int
 	{
 		if (_maxTextureSize < 0 && FlxG.stage.window.context.attributes.hardware)


### PR DESCRIPTION
This fixes a crash in a project where threaded caching of assets is done immediately upon load. Because it's on a thread, OpenGL freaks out and crashes, though it's interesting to note that the crash only happened on macOS.

I think it's best to just let Flixel query this once when the window is created and then it'll be cached