### PR TITLE
FlxCallbackPoint: Fix duplicate calls and call xy when x or y is set directly

### DIFF
--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -539,8 +539,8 @@ import openfl.geom.Point;
 	/**
 	 * Helper function, just copies the values from this point to the specified point.
 	 *
-	 * @param   p   optional point to copy this point to
-	 * @return  copy of this point
+	 * @param   p  An optional point to copy this point to
+	 * @return  The new point
 	 */
 	public overload inline extern function copyTo(?p:FlxPoint):FlxPoint
 	{
@@ -555,8 +555,8 @@ import openfl.geom.Point;
 	 * Helper function, just copies the values from this point to the specified Flash point.
 	 * @since 6.0.0
 	 *
-	 * @param   p  Any Point.
-	 * @return  A reference to the altered point parameter.
+	 * @param   p  The point to copy this point to
+	 * @return  The new point
 	 */
 	public overload inline extern function copyTo(p:Point):Point
 	{
@@ -1366,8 +1366,8 @@ import openfl.geom.Point;
 	/**
 	 * Copies this point.
 	 *
-	 * @param   p   optional point to copy this point to
-	 * @return  copy of this point
+	 * @param   p  An optional point to copy this point to
+	 * @return  The new point
 	 */
 	public inline function clone(?p:FlxPoint):FlxPoint
 	{

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -310,9 +310,7 @@ import openfl.geom.Point;
 	 */
 	public inline function set(x:Float = 0, y:Float = 0):FlxPoint
 	{
-		this.x = x;
-		this.y = y;
-		return this;
+		return this.set(x, y);
 	}
 
 	/**
@@ -324,9 +322,7 @@ import openfl.geom.Point;
 	 */
 	public overload extern inline function add(x:Float = 0, y:Float = 0):FlxPoint
 	{
-		this.x += x;
-		this.y += y;
-		return this;
+		return set(this.x + x, this.y + y);
 	}
 
 	/**
@@ -352,10 +348,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function add(p:Point):FlxPoint
 	{
-		x += p.x;
-		y += p.y;
-		
-		return this;
+		return add(p.x, p.y);
 	}
 	
 	/**
@@ -379,9 +372,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function subtract(x:Float = 0, y:Float = 0):FlxPoint
 	{
-		this.x -= x;
-		this.y -= y;
-		return this;
+		return set(this.x - x, this.y - y);
 	}
 
 	/**
@@ -434,9 +425,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function scale(x:Float, y:Float):FlxPoint
 	{
-		this.x *= x;
-		this.y *= y;
-		return this;
+		return set(this.x * x, this.y * y);
 	}
 	
 	/**
@@ -448,9 +437,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function scale(amount:Float):FlxPoint
 	{
-		this.x *= amount;
-		this.y *= amount;
-		return this;
+		return scale(amount, amount);
 	}
 	
 	/**
@@ -462,8 +449,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function scale(point:Point):FlxPoint
 	{
-		scale(point.x, point.y);
-		return this;
+		return scale(point.x, point.y);
 	}
 
 	/**
@@ -535,7 +521,7 @@ import openfl.geom.Point;
 	 */
 	public overload inline extern function copyFrom(p:Point):FlxPoint
 	{
-		return this.set(p.x, p.y);
+		return set(p.x, p.y);
 	}
 
 	/**
@@ -547,7 +533,7 @@ import openfl.geom.Point;
 	// @:deprecated("copyFromFlash is deprecated, use copyFrom, instead")// 6.0.0
 	public inline function copyFromFlash(p:Point):FlxPoint
 	{
-		return this.set(p.x, p.y);
+		return set(p.x, p.y);
 	}
 
 	/**
@@ -624,9 +610,7 @@ import openfl.geom.Point;
 	 */
 	public inline function floor():FlxPoint
 	{
-		x = Math.floor(x);
-		y = Math.floor(y);
-		return this;
+		return set(Math.floor(x), Math.floor(y));
 	}
 
 	/**
@@ -634,9 +618,7 @@ import openfl.geom.Point;
 	 */
 	public inline function ceil():FlxPoint
 	{
-		x = Math.ceil(x);
-		y = Math.ceil(y);
-		return this;
+		return set(Math.ceil(x), Math.ceil(y));
 	}
 
 	/**
@@ -644,9 +626,7 @@ import openfl.geom.Point;
 	 */
 	public inline function round():FlxPoint
 	{
-		x = Math.round(x);
-		y = Math.round(y);
-		return this;
+		return set(Math.round(x), Math.round(y));
 	}
 
 	/**
@@ -945,8 +925,7 @@ import openfl.geom.Point;
 	 */
 	public inline function zero():FlxPoint
 	{
-		x = y = 0;
-		return this;
+		return set(0, 0);
 	}
 
 	/**
@@ -979,12 +958,7 @@ import openfl.geom.Point;
 	{
 		var s:Float = Math.sin(rads);
 		var c:Float = Math.cos(rads);
-		var tempX:Float = x;
-
-		x = tempX * c - y * s;
-		y = tempX * s + y * c;
-
-		return this;
+		return set(x * c - y * s, x * s + y * c);
 	}
 
 	/**
@@ -1007,10 +981,7 @@ import openfl.geom.Point;
 	 */
 	public inline function rotateWithTrig(sin:Float, cos:Float):FlxPoint
 	{
-		var tempX:Float = x;
-		x = tempX * cos - y * sin;
-		y = tempX * sin + y * cos;
-		return this;
+		return set(x * cos - y * sin, x * sin + y * cos);
 	}
 
 	/**
@@ -1024,9 +995,7 @@ import openfl.geom.Point;
 	 */
 	public function setPolarRadians(length:Float, radians:Float):FlxPoint
 	{
-		x = length * Math.cos(radians);
-		y = length * Math.sin(radians);
-		return this;
+		return set(length * Math.cos(radians), length * Math.sin(radians));
 	}
 
 	/**
@@ -1074,9 +1043,7 @@ import openfl.geom.Point;
 	 */
 	public inline function negate():FlxPoint
 	{
-		x *= -1;
-		y *= -1;
-		return this;
+		return set(x * -1, y * -1);
 	}
 
 	public inline function negateNew():FlxPoint
@@ -1360,8 +1327,7 @@ import openfl.geom.Point;
 	public inline function bounce(normal:FlxPoint, bounceCoeff:Float = 1):FlxPoint
 	{
 		var d:Float = (1 + bounceCoeff) * dotProductWeak(normal);
-		x -= d * normal.x;
-		y -= d * normal.y;
+		set(x - d * normal.x, y - d * normal.y);
 		normal.putWeak();
 		return this;
 	}
@@ -1382,10 +1348,9 @@ import openfl.geom.Point;
 		var bounceY:Float = -p2.y;
 		var frictionX:Float = p1.x;
 		var frictionY:Float = p1.y;
-		x = bounceX * bounceCoeff + frictionX * friction;
-		y = bounceY * bounceCoeff + frictionY * friction;
 		normal.putWeak();
-		return this;
+		
+		return set(bounceX * bounceCoeff + frictionX * friction, bounceY * bounceCoeff + frictionY * friction);
 	}
 
 	/**
@@ -1455,8 +1420,7 @@ import openfl.geom.Point;
 		if (!isZero())
 		{
 			var a:Float = radians;
-			x = l * Math.cos(a);
-			y = l * Math.sin(a);
+			set(l * Math.cos(a), l * Math.sin(a));
 		}
 		return l;
 	}
@@ -1486,8 +1450,7 @@ import openfl.geom.Point;
 	{
 		var len:Float = length;
 
-		x = len * Math.cos(rads);
-		y = len * Math.sin(rads);
+		set(len * Math.cos(rads), len * Math.sin(rads));
 		return rads;
 	}
 
@@ -1726,8 +1689,8 @@ abstract FlxReadOnlyPoint(FlxPoint) from FlxPoint
 class FlxCallbackPoint extends FlxBasePoint
 {
 	var _setXCallback:FlxPoint->Void;
-	var _setYCallback:FlxPoint->Void;
-	var _setXYCallback:FlxPoint->Void;
+	var _setYCallback:Null<FlxPoint->Void>;
+	var _setXYCallback:Null<FlxPoint->Void>;
 
 	/**
 	 * If you only specify one callback function, then the remaining two will use the same.
@@ -1739,41 +1702,60 @@ class FlxCallbackPoint extends FlxBasePoint
 	public function new(setXCallback:FlxPoint->Void, ?setYCallback:FlxPoint->Void, ?setXYCallback:FlxPoint->Void)
 	{
 		super();
-
-		_setXCallback = setXCallback;
-		_setYCallback = setXYCallback;
-		_setXYCallback = setXYCallback;
-
-		if (_setXCallback != null)
+		
+		// TODO: operator overloading?
+		if (setXCallback != null && setYCallback == null && setXYCallback == null)
 		{
-			if (_setYCallback == null)
-				_setYCallback = setXCallback;
-			if (_setXYCallback == null)
-				_setXYCallback = setXCallback;
+			_setXYCallback = setXCallback;
+		}
+		else
+		{
+			_setXCallback = setXCallback;
+			_setYCallback = setYCallback;
+			_setXYCallback = setXYCallback;
 		}
 	}
 
 	override public function set(x:Float = 0, y:Float = 0):FlxCallbackPoint
 	{
-		super.set(x, y);
+		@:bypassAccessor this.x = x;
+		@:bypassAccessor this.y = y;
+		
+		if (_setXCallback != null)
+			_setXCallback(this);
+		
+		if (_setYCallback != null)
+			_setYCallback(this);
+		
 		if (_setXYCallback != null)
 			_setXYCallback(this);
+		
 		return this;
 	}
 
 	override function set_x(value:Float):Float
 	{
 		super.set_x(value);
+		
 		if (_setXCallback != null)
 			_setXCallback(this);
+		
+		if (_setXYCallback != null)
+			_setXYCallback(this);
+		
 		return value;
 	}
 
 	override function set_y(value:Float):Float
 	{
 		super.set_y(value);
+		
 		if (_setYCallback != null)
 			_setYCallback(this);
+		
+		if (_setXYCallback != null)
+			_setXYCallback(this);
+		
 		return value;
 	}
 

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -447,6 +447,18 @@ import openfl.geom.Point;
 	 * @param   point  The x and y scale coefficient
 	 * @return  this point
 	 */
+	public overload inline extern function scale(point:FlxPoint):FlxPoint
+	{
+		return scale(point.x, point.y);
+	}
+	
+	/**
+	 * Scale this point by another point.
+	 * @since 6.0.0
+	 *
+	 * @param   point  The x and y scale coefficient
+	 * @return  this point
+	 */
 	public overload inline extern function scale(point:Point):FlxPoint
 	{
 		return scale(point.x, point.y);

--- a/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
@@ -1,24 +1,341 @@
 package flixel.math;
 
-import massive.munit.Assert;
+import Math.PI;
+import flixel.math.FlxMath.SQUARE_ROOT_OF_TWO as sqrt2;
+import flixel.math.FlxMatrix;
 import flixel.math.FlxPoint;
+import haxe.PosInfos;
+import massive.munit.Assert;
+import openfl.geom.Point;
 
 class FlxCallbackPointTest extends FlxTest
 {
-	var point:FlxCallbackPoint;
-	var a:Int;
-
-	@Before
-	function before()
-	{
-		point = new FlxCallbackPoint(function(_) a = 5);
-		a = 0;
-	}
-
 	@Test
-	function testCallback()
+	@:haxe.warning("-WDeprecated")
+	function testAll3Callbacks()
 	{
-		point.set(10, 10);
-		Assert.isTrue(a == 5);
+		var sets = 0;
+		var xSets = 0;
+		var ySets = 0;
+		
+		function assertChecked(expectedSets:Int, ?expectedXSets:Int, ?expectedYSets:Int, ?pos:PosInfos)
+		{
+			if (expectedXSets == null)
+				expectedXSets = expectedSets;
+			
+			if (expectedYSets == null)
+				expectedYSets = expectedSets;
+			
+			Assert.areEqual(expectedSets , sets , 'The point was set [${    sets}] times compared to the expected [$expectedSets] times', pos);
+			Assert.areEqual(expectedXSets, xSets, 'The point\'s X was set [$xSets] times compared to the expected [$expectedXSets] times', pos);
+			Assert.areEqual(expectedYSets, ySets, 'The point\'s Y was set [$ySets] times compared to the expected [$expectedYSets] times', pos);
+			
+			sets = 0;
+			xSets = 0;
+			ySets = 0;
+		}
+		
+		final p:FlxPoint = new FlxCallbackPoint((_)->xSets++, (_)->ySets++, (_)->sets++);
+		final norm = new FlxPoint(sqrt2, sqrt2);
+		final p2 = new FlxPoint(1, 1);
+		final fp = new Point(1, 1);
+		
+		// These should not call set
+		p.inCoords(0, 0, 10, 10)                ; assertChecked(0);
+		p.inRect(new FlxRect(0, 0, 10, 10))     ; assertChecked(0);
+		p.distanceTo(p2)                        ; assertChecked(0);
+		p.distanceTo(p2.x, p2.y)                ; assertChecked(0);
+		p.distanceSquaredTo(p2)                 ; assertChecked(0);
+		p.distanceSquaredTo(p2.x, p2.y)         ; assertChecked(0);
+		p.radiansTo(p2)                         ; assertChecked(0);
+		p.radiansFrom(p2)                       ; assertChecked(0);
+		p.degreesTo(p2)                         ; assertChecked(0);
+		p.degreesFrom(p2)                       ; assertChecked(0);
+		p.dot(p2)                               ; assertChecked(0);
+		p.dotProduct(p2)                        ; assertChecked(0);
+		p.dotProdWithNormalizing(p2)            ; assertChecked(0);
+		p.isPerpendicular(p2)                   ; assertChecked(0);
+		p.crossProductLength(p2)                ; assertChecked(0);
+		p.isParallel(p2)                        ; assertChecked(0);
+		p.isNormalized()                        ; assertChecked(0);
+		p.rightNormal()                         ; assertChecked(0);
+		p.leftNormal()                          ; assertChecked(0);
+		p.negateNew()                           ; assertChecked(0);
+		p.projectTo(p2)                         ; assertChecked(0);
+		p.projectToNormalized(p2)               ; assertChecked(0);
+		p.perpProduct(p2)                       ; assertChecked(0);
+		p.ratio(norm, norm, p2)                 ; assertChecked(0);
+		p.findIntersection(p2, p2, norm)        ; assertChecked(0);
+		p.findIntersectionInBounds(p2, p2, norm); assertChecked(0);
+		p.truncate(10)                          ; assertChecked(0);
+		p.radiansBetween(p2)                    ; assertChecked(0);
+		p.degreesBetween(p2)                    ; assertChecked(0);
+		p.sign(p2, norm)                        ; assertChecked(0);
+		p.dist(p2.x, p2.y)                      ; assertChecked(0);
+		p.dist(p2)                              ; assertChecked(0);
+		p.distSquared(p2)                       ; assertChecked(0);
+		p.distSquared(p2.x, p2.y)               ; assertChecked(0);
+		p.isValid()                             ; assertChecked(0);
+		p.clone()                               ; assertChecked(0);
+		p.equals(p2)                            ; assertChecked(0);
+		p.toString()                            ; assertChecked(0);
+		
+		// These should call each set, once
+		p.set(10, 5)                            ; assertChecked(1);
+		p.add(1, 2)                             ; assertChecked(1);
+		p.add(p2)                               ; assertChecked(1);
+		p.addPoint(p2)                          ; assertChecked(1);
+		p.subtract(2, 1)                        ; assertChecked(1);
+		p.subtract(p2)                          ; assertChecked(1);
+		p.subtractPoint(p2)                     ; assertChecked(1);
+		p.scale(2, 2)                           ; assertChecked(1);
+		// p.scale(p2)                             ; assertChecked(1);
+		p.scalePoint(p2)                        ; assertChecked(1);
+		p.copyFrom(p2)                          ; assertChecked(1);
+		p.copyFromFlash(fp)                     ; assertChecked(1);
+		p.floor()                               ; assertChecked(1);
+		p.ceil()                                ; assertChecked(1);
+		p.round()                               ; assertChecked(1);
+		p.pivotRadians(p2, PI / 3)              ; assertChecked(1);
+		p.pivotDegrees(p2, 60)                  ; assertChecked(1);
+		p.transform(new FlxMatrix())            ; assertChecked(1);
+		p.zero()                                ; assertChecked(1);
+		p.rotateByRadians(PI / 3)               ; assertChecked(1);
+		p.rotateByDegrees(60)                   ; assertChecked(1);
+		p.rotateWithTrig(1, 0)                  ; assertChecked(1);
+		p.setPolarRadians(10, PI / 3)           ; assertChecked(1);
+		p.setPolarDegrees(10, 45)               ; assertChecked(1);
+		p.negate()                              ; assertChecked(1);
+		p.truncate(10)                          ; assertChecked(1);
+		p.bounce(norm)                          ; assertChecked(1);
+		p.bounceWithFriction(norm, 0.5, 0.25)   ; assertChecked(1);
+		// normalise only sets if p is not zero
+		p.set(0, 0)                             ; assertChecked(1);
+		p.normalize()                           ; assertChecked(0);
+		p.set(10, 10)                           ; assertChecked(1);
+		p.normalize()                           ; assertChecked(1);
+		// Check setters/getters
+		p.x++                                   ; assertChecked(1, 1, 0);
+		p.y++                                   ; assertChecked(1, 0, 1);
+		p.length = 90                           ; assertChecked(1);
+		p.degrees = 90                          ; assertChecked(1);
+		p.radians = 90                          ; assertChecked(1);
+		
+		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
+		assertChecked(0);
+	}
+	
+	@Test
+	@:haxe.warning("-WDeprecated")
+	function testLoneCallback()
+	{
+		var sets = 0;
+		
+		function assertChecked(expectedSets:Int, ?pos:PosInfos)
+		{
+			Assert.areEqual(expectedSets , sets , 'The point was set [$sets] times compared to the expected [$expectedSets] times', pos);
+			
+			sets = 0;
+		}
+		
+		final p:FlxPoint = new FlxCallbackPoint((_)->sets++);
+		final norm = new FlxPoint(sqrt2, sqrt2);
+		final p2 = new FlxPoint(1, 1);
+		final fp = new Point(1, 1);
+		
+		// These should not call set
+		p.inCoords(0, 0, 10, 10)                ; assertChecked(0);
+		p.inRect(new FlxRect(0, 0, 10, 10))     ; assertChecked(0);
+		p.distanceTo(p2)                        ; assertChecked(0);
+		p.distanceTo(p2.x, p2.y)                ; assertChecked(0);
+		p.distanceSquaredTo(p2)                 ; assertChecked(0);
+		p.distanceSquaredTo(p2.x, p2.y)         ; assertChecked(0);
+		p.radiansTo(p2)                         ; assertChecked(0);
+		p.radiansFrom(p2)                       ; assertChecked(0);
+		p.degreesTo(p2)                         ; assertChecked(0);
+		p.degreesFrom(p2)                       ; assertChecked(0);
+		p.dot(p2)                               ; assertChecked(0);
+		p.dotProduct(p2)                        ; assertChecked(0);
+		p.dotProdWithNormalizing(p2)            ; assertChecked(0);
+		p.isPerpendicular(p2)                   ; assertChecked(0);
+		p.crossProductLength(p2)                ; assertChecked(0);
+		p.isParallel(p2)                        ; assertChecked(0);
+		p.isNormalized()                        ; assertChecked(0);
+		p.rightNormal()                         ; assertChecked(0);
+		p.leftNormal()                          ; assertChecked(0);
+		p.negateNew()                           ; assertChecked(0);
+		p.projectTo(p2)                         ; assertChecked(0);
+		p.projectToNormalized(p2)               ; assertChecked(0);
+		p.perpProduct(p2)                       ; assertChecked(0);
+		p.ratio(norm, norm, p2)                 ; assertChecked(0);
+		p.findIntersection(p2, p2, norm)        ; assertChecked(0);
+		p.findIntersectionInBounds(p2, p2, norm); assertChecked(0);
+		p.truncate(10)                          ; assertChecked(0);
+		p.radiansBetween(p2)                    ; assertChecked(0);
+		p.degreesBetween(p2)                    ; assertChecked(0);
+		p.sign(p2, norm)                        ; assertChecked(0);
+		p.dist(p2.x, p2.y)                      ; assertChecked(0);
+		p.dist(p2)                              ; assertChecked(0);
+		p.distSquared(p2)                       ; assertChecked(0);
+		p.distSquared(p2.x, p2.y)               ; assertChecked(0);
+		p.isValid()                             ; assertChecked(0);
+		p.clone()                               ; assertChecked(0);
+		p.equals(p2)                            ; assertChecked(0);
+		p.toString()                            ; assertChecked(0);
+		
+		// These should call each set, once
+		p.set(10, 5)                            ; assertChecked(1);
+		p.add(1, 2)                             ; assertChecked(1);
+		p.add(p2)                               ; assertChecked(1);
+		p.addPoint(p2)                          ; assertChecked(1);
+		p.subtract(2, 1)                        ; assertChecked(1);
+		p.subtract(p2)                          ; assertChecked(1);
+		p.subtractPoint(p2)                     ; assertChecked(1);
+		p.scale(2, 2)                           ; assertChecked(1);
+		// p.scale(p2)                             ; assertChecked(1);
+		p.scalePoint(p2)                        ; assertChecked(1);
+		p.copyFrom(p2)                          ; assertChecked(1);
+		p.copyFromFlash(fp)                     ; assertChecked(1);
+		p.floor()                               ; assertChecked(1);
+		p.ceil()                                ; assertChecked(1);
+		p.round()                               ; assertChecked(1);
+		p.pivotRadians(p2, PI / 3)              ; assertChecked(1);
+		p.pivotDegrees(p2, 60)                  ; assertChecked(1);
+		p.transform(new FlxMatrix())            ; assertChecked(1);
+		p.zero()                                ; assertChecked(1);
+		p.rotateByRadians(PI / 3)               ; assertChecked(1);
+		p.rotateByDegrees(60)                   ; assertChecked(1);
+		p.rotateWithTrig(1, 0)                  ; assertChecked(1);
+		p.setPolarRadians(10, PI / 3)           ; assertChecked(1);
+		p.setPolarDegrees(10, 45)               ; assertChecked(1);
+		p.negate()                              ; assertChecked(1);
+		p.truncate(10)                          ; assertChecked(1);
+		p.bounce(norm)                          ; assertChecked(1);
+		p.bounceWithFriction(norm, 0.5, 0.25)   ; assertChecked(1);
+		// normalise only sets if p is not zero
+		p.set(0, 0)                             ; assertChecked(1);
+		p.normalize()                           ; assertChecked(0);
+		p.set(10, 10)                           ; assertChecked(1);
+		p.normalize()                           ; assertChecked(1);
+		// Check setters/getters
+		p.x++                                   ; assertChecked(1);
+		p.y++                                   ; assertChecked(1);
+		p.length = 90                           ; assertChecked(1);
+		p.degrees = 90                          ; assertChecked(1);
+		p.radians = 90                          ; assertChecked(1);
+		
+		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
+		assertChecked(0);
+	}
+	
+	
+	@Test
+	@:haxe.warning("-WDeprecated")
+	function testXandYCallbacks()
+	{
+		
+		var xSets = 0;
+		var ySets = 0;
+		
+		function assertChecked(expectedXSets:Int, ?expectedYSets:Int, ?pos:PosInfos)
+		{
+			if (expectedYSets == null)
+				expectedYSets = expectedXSets;
+			
+			Assert.areEqual(expectedXSets, xSets, 'The point\'s X was set [$xSets] times compared to the expected [$expectedXSets] times', pos);
+			Assert.areEqual(expectedYSets, ySets, 'The point\'s Y was set [$ySets] times compared to the expected [$expectedYSets] times', pos);
+			
+			xSets = 0;
+			ySets = 0;
+		}
+		
+		final p:FlxPoint = new FlxCallbackPoint((_)->xSets++, (_)->ySets++);
+		final norm = new FlxPoint(sqrt2, sqrt2);
+		final p2 = new FlxPoint(1, 1);
+		final fp = new Point(1, 1);
+		
+		// These should not call set
+		p.inCoords(0, 0, 10, 10)                ; assertChecked(0);
+		p.inRect(new FlxRect(0, 0, 10, 10))     ; assertChecked(0);
+		p.distanceTo(p2)                        ; assertChecked(0);
+		p.distanceTo(p2.x, p2.y)                ; assertChecked(0);
+		p.distanceSquaredTo(p2)                 ; assertChecked(0);
+		p.distanceSquaredTo(p2.x, p2.y)         ; assertChecked(0);
+		p.radiansTo(p2)                         ; assertChecked(0);
+		p.radiansFrom(p2)                       ; assertChecked(0);
+		p.degreesTo(p2)                         ; assertChecked(0);
+		p.degreesFrom(p2)                       ; assertChecked(0);
+		p.dot(p2)                               ; assertChecked(0);
+		p.dotProduct(p2)                        ; assertChecked(0);
+		p.dotProdWithNormalizing(p2)            ; assertChecked(0);
+		p.isPerpendicular(p2)                   ; assertChecked(0);
+		p.crossProductLength(p2)                ; assertChecked(0);
+		p.isParallel(p2)                        ; assertChecked(0);
+		p.isNormalized()                        ; assertChecked(0);
+		p.rightNormal()                         ; assertChecked(0);
+		p.leftNormal()                          ; assertChecked(0);
+		p.negateNew()                           ; assertChecked(0);
+		p.projectTo(p2)                         ; assertChecked(0);
+		p.projectToNormalized(p2)               ; assertChecked(0);
+		p.perpProduct(p2)                       ; assertChecked(0);
+		p.ratio(norm, norm, p2)                 ; assertChecked(0);
+		p.findIntersection(p2, p2, norm)        ; assertChecked(0);
+		p.findIntersectionInBounds(p2, p2, norm); assertChecked(0);
+		p.truncate(10)                          ; assertChecked(0);
+		p.radiansBetween(p2)                    ; assertChecked(0);
+		p.degreesBetween(p2)                    ; assertChecked(0);
+		p.sign(p2, norm)                        ; assertChecked(0);
+		p.dist(p2.x, p2.y)                      ; assertChecked(0);
+		p.dist(p2)                              ; assertChecked(0);
+		p.distSquared(p2)                       ; assertChecked(0);
+		p.distSquared(p2.x, p2.y)               ; assertChecked(0);
+		p.isValid()                             ; assertChecked(0);
+		p.clone()                               ; assertChecked(0);
+		p.equals(p2)                            ; assertChecked(0);
+		p.toString()                            ; assertChecked(0);
+		
+		// These should call each set, once
+		p.set(10, 5)                            ; assertChecked(1);
+		p.add(1, 2)                             ; assertChecked(1);
+		p.add(p2)                               ; assertChecked(1);
+		p.addPoint(p2)                          ; assertChecked(1);
+		p.subtract(2, 1)                        ; assertChecked(1);
+		p.subtract(p2)                          ; assertChecked(1);
+		p.subtractPoint(p2)                     ; assertChecked(1);
+		p.scale(2, 2)                           ; assertChecked(1);
+		// p.scale(p2)                             ; assertChecked(1);
+		p.scalePoint(p2)                        ; assertChecked(1);
+		p.copyFrom(p2)                          ; assertChecked(1);
+		p.copyFromFlash(fp)                     ; assertChecked(1);
+		p.floor()                               ; assertChecked(1);
+		p.ceil()                                ; assertChecked(1);
+		p.round()                               ; assertChecked(1);
+		p.pivotRadians(p2, PI / 3)              ; assertChecked(1);
+		p.pivotDegrees(p2, 60)                  ; assertChecked(1);
+		p.transform(new FlxMatrix())            ; assertChecked(1);
+		p.zero()                                ; assertChecked(1);
+		p.rotateByRadians(PI / 3)               ; assertChecked(1);
+		p.rotateByDegrees(60)                   ; assertChecked(1);
+		p.rotateWithTrig(1, 0)                  ; assertChecked(1);
+		p.setPolarRadians(10, PI / 3)           ; assertChecked(1);
+		p.setPolarDegrees(10, 45)               ; assertChecked(1);
+		p.negate()                              ; assertChecked(1);
+		p.truncate(10)                          ; assertChecked(1);
+		p.bounce(norm)                          ; assertChecked(1);
+		p.bounceWithFriction(norm, 0.5, 0.25)   ; assertChecked(1);
+		// normalise only sets if p is not zero
+		p.set(0, 0)                             ; assertChecked(1);
+		p.normalize()                           ; assertChecked(0);
+		p.set(10, 10)                           ; assertChecked(1);
+		p.normalize()                           ; assertChecked(1);
+		// Check setters/getters
+		p.x++                                   ; assertChecked(1, 0);
+		p.y++                                   ; assertChecked(0, 1);
+		p.length = 90                           ; assertChecked(1);
+		p.degrees = 90                          ; assertChecked(1);
+		p.radians = 90                          ; assertChecked(1);
+		
+		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
+		assertChecked(0);
 	}
 }

--- a/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
@@ -120,7 +120,12 @@ class FlxCallbackPointTest extends FlxTest
 		p.length = 90                           ; assertChecked(1);
 		p.degrees = 90                          ; assertChecked(1);
 		p.radians = 90                          ; assertChecked(1);
-		
+		// Check operators
+		p += norm                               ; assertChecked(1);
+		p -= norm                               ; assertChecked(1);
+		p *= 2                                  ; assertChecked(1);
+		final newP = ((p + norm) - norm) * 2    ; assertChecked(0);
+		// check getters
 		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
 		assertChecked(0);
 	}
@@ -223,7 +228,12 @@ class FlxCallbackPointTest extends FlxTest
 		p.length = 90                           ; assertChecked(1);
 		p.degrees = 90                          ; assertChecked(1);
 		p.radians = 90                          ; assertChecked(1);
-		
+		// Check operators
+		p += norm                               ; assertChecked(1);
+		p -= norm                               ; assertChecked(1);
+		p *= 2                                  ; assertChecked(1);
+		final newP = ((p + norm) - norm) * 2    ; assertChecked(0);
+		// check getters
 		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
 		assertChecked(0);
 	}
@@ -334,7 +344,12 @@ class FlxCallbackPointTest extends FlxTest
 		p.length = 90                           ; assertChecked(1);
 		p.degrees = 90                          ; assertChecked(1);
 		p.radians = 90                          ; assertChecked(1);
-		
+		// Check operators
+		p += norm                               ; assertChecked(1);
+		p -= norm                               ; assertChecked(1);
+		p *= 2                                  ; assertChecked(1);
+		final newP = ((p + norm) - norm) * 2    ; assertChecked(0);
+		// check getters
 		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
 		assertChecked(0);
 	}

--- a/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
@@ -89,7 +89,7 @@ class FlxCallbackPointTest extends FlxTest
 		p.subtract(p2)                          ; assertChecked(1);
 		p.subtractPoint(p2)                     ; assertChecked(1);
 		p.scale(2, 2)                           ; assertChecked(1);
-		// p.scale(p2)                             ; assertChecked(1);
+		p.scale(p2)                             ; assertChecked(1);
 		p.scalePoint(p2)                        ; assertChecked(1);
 		p.copyFrom(p2)                          ; assertChecked(1);
 		p.copyFromFlash(fp)                     ; assertChecked(1);
@@ -192,7 +192,7 @@ class FlxCallbackPointTest extends FlxTest
 		p.subtract(p2)                          ; assertChecked(1);
 		p.subtractPoint(p2)                     ; assertChecked(1);
 		p.scale(2, 2)                           ; assertChecked(1);
-		// p.scale(p2)                             ; assertChecked(1);
+		p.scale(p2)                             ; assertChecked(1);
 		p.scalePoint(p2)                        ; assertChecked(1);
 		p.copyFrom(p2)                          ; assertChecked(1);
 		p.copyFromFlash(fp)                     ; assertChecked(1);
@@ -303,7 +303,7 @@ class FlxCallbackPointTest extends FlxTest
 		p.subtract(p2)                          ; assertChecked(1);
 		p.subtractPoint(p2)                     ; assertChecked(1);
 		p.scale(2, 2)                           ; assertChecked(1);
-		// p.scale(p2)                             ; assertChecked(1);
+		p.scale(p2)                             ; assertChecked(1);
 		p.scalePoint(p2)                        ; assertChecked(1);
 		p.copyFrom(p2)                          ; assertChecked(1);
 		p.copyFromFlash(fp)                     ; assertChecked(1);


### PR DESCRIPTION
Alternative to https://github.com/HaxeFlixel/flixel/pull/3514 (Most code was copied from this)

Changing a point's x should trigger the x and xy callback, once (if non-null), same with y, any method that changes both should call all 3 callbacks, once.

- The y callback arg was never being used, so setting xy called the xy callback twice.
- Every operation function now calls set() rather than setting x and y individually.
- Setting x and y individually now calls the xy callback as well.
- Added a unit test to verify the number of sets for each method with each number of callbacks