### PR TITLE
FlxPoint: Deprecate old fields

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1054,6 +1054,7 @@ class FlxSprite extends FlxObject
 	/**
 	 * Whether this sprite has a color transform, menaing any of the following: less than full
 	 * `alpha`, a `color` tint, or a `colorTransform` whos values are not the default.
+	 * @since 6.1.0
 	 */
 	@:haxe.warning("-WDeprecated")
 	public function hasColorTransform()

--- a/flixel/FlxStrip.hx
+++ b/flixel/FlxStrip.hx
@@ -56,7 +56,8 @@ class FlxStrip extends FlxSprite
 			if (!camera.visible || !camera.exists)
 				continue;
 
-			getScreenPosition(_point, camera).subtractPoint(offset);
+			getScreenPosition(_point, camera);
+			_point -= offset;
 			camera.drawTriangles(graphic, vertices, indices, uvtData, colors, _point, blend, repeat, antialiasing, colorTransform, shader);
 		}
 	}

--- a/flixel/graphics/frames/FlxTileFrames.hx
+++ b/flixel/graphics/frames/FlxTileFrames.hx
@@ -1,7 +1,5 @@
 package flixel.graphics.frames;
 
-import openfl.display.BitmapData;
-import openfl.geom.Point;
 import flixel.graphics.FlxGraphic;
 import flixel.graphics.frames.FlxFramesCollection.FlxFrameCollectionType;
 import flixel.math.FlxPoint;
@@ -10,6 +8,8 @@ import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxBitmapDataUtil;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import openfl.display.BitmapData;
+import openfl.geom.Point;
 
 /**
  * Spritesheet frame collection. It is used for tilemaps and animated sprites.
@@ -91,7 +91,7 @@ class FlxTileFrames extends FlxFramesCollection
 			borderY = Std.int(tileBorder.y);
 		}
 
-		var tileFrames:FlxTileFrames = FlxTileFrames.fromGraphic(result, FlxPoint.get().addPoint(tileSize).add(2 * borderX, 2 * borderY), null, tileSpacing);
+		var tileFrames:FlxTileFrames = FlxTileFrames.fromGraphic(result, FlxPoint.get().add(tileSize).add(2 * borderX, 2 * borderY), null, tileSpacing);
 
 		if (tileBorder == null)
 			return tileFrames;

--- a/flixel/input/FlxPointer.hx
+++ b/flixel/input/FlxPointer.hx
@@ -75,7 +75,7 @@ class FlxPointer
 			camera = FlxG.camera;
 		
 		result = getViewPosition(camera, result);
-		result.addPoint(camera.scroll);
+		result.add(camera.scroll);
 		return result;
 	}
 	

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -71,12 +71,19 @@ import openfl.geom.Point;
  */
 @:forward abstract FlxPoint(FlxBasePoint) to FlxBasePoint from FlxBasePoint 
 {
+	
+	/**
+	 * Vector components less than this are considered zero, to account for rounding errors
+	 */
 	public static inline var EPSILON:Float = 0.0000001;
 	public static inline var EPSILON_SQUARED:Float = EPSILON * EPSILON;
+	
+	/**
+	 * Vector lengths less than this are considered zero, to account for rounding errors
+	 */
+	public static inline var EPSILON_LENGTH:Float = EPSILON * FlxMath.SQUARE_ROOT_OF_TWO;
 
 	static var _point1 = new FlxPoint();
-	static var _point2 = new FlxPoint();
-	static var _point3 = new FlxPoint();
 
 	/**
 	 * Recycle or create new FlxPoint.
@@ -861,9 +868,10 @@ import openfl.geom.Point;
 	 */
 	public inline function dotProdWithNormalizing(p:FlxPoint):Float
 	{
-		var normalized:FlxPoint = p.clone(_point1).normalize();
+		final length = p.length;
+		final result = length < EPSILON_LENGTH ? 0 : dotProductXY(p.x / length, p.y / length);
 		p.putWeak();
-		return dotProductWeak(normalized);
+		return result;
 	}
 
 	/**
@@ -1365,12 +1373,13 @@ import openfl.geom.Point;
 	 */
 	public inline function bounceWithFriction(normal:FlxPoint, bounceCoeff:Float = 1, friction:Float = 0):FlxPoint
 	{
-		var p1:FlxPoint = projectToNormalizedWeak(normal.rightNormal(_point3), _point1);
-		var p2:FlxPoint = projectToNormalizedWeak(normal, _point2);
-		var bounceX:Float = -p2.x;
-		var bounceY:Float = -p2.y;
-		var frictionX:Float = p1.x;
-		var frictionY:Float = p1.y;
+		final dp = dotProductWeak(normal);
+		final bounceX = -normal.x * dp;
+		final bounceY = -normal.y * dp;
+		final pp = perpProductWeak(normal);
+		final frictionX = normal.rx * pp;
+		final frictionY = normal.ry * pp;
+		
 		normal.putWeak();
 		
 		return set(bounceX * bounceCoeff + frictionX * friction, bounceY * bounceCoeff + frictionY * friction);

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -504,7 +504,7 @@ import openfl.geom.Point;
 	 */
 	public inline function addNew(p:FlxPoint):FlxPoint
 	{
-		return clone().addPoint(p);
+		return clone().add(p);
 	}
 
 	/**

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -934,7 +934,8 @@ import openfl.geom.Point;
 	 */
 	public inline function isZero():Bool
 	{
-		return Math.abs(x) < EPSILON && Math.abs(y) < EPSILON;
+		// i.e: x*x < EPSILON_SQUARED && y*y < EPSILON_SQUARED;
+		return lengthSquared < 2 * EPSILON_SQUARED;
 	}
 
 	/**
@@ -1038,7 +1039,7 @@ import openfl.geom.Point;
 		{
 			p = get();
 		}
-		p.set(-y, x);
+		p.set(rx, ry);
 		return p;
 	}
 
@@ -1051,7 +1052,7 @@ import openfl.geom.Point;
 		{
 			p = get();
 		}
-		p.set(y, -x);
+		p.set(lx, ly);
 		return p;
 	}
 

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -845,7 +845,12 @@ import openfl.geom.Point;
 	 */
 	inline function dotProductWeak(p:FlxPoint):Float
 	{
-		return x * p.x + y * p.y;
+		return dotProductXY(p.x, p.y);
+	}
+	
+	inline function dotProductXY(x:Float, y:Float):Float
+	{
+		return this.x * x + this.y * y;
 	}
 
 	/**
@@ -1136,7 +1141,12 @@ import openfl.geom.Point;
 	 */
 	inline function perpProductWeak(p:FlxPoint):Float
 	{
-		return lx * p.x + ly * p.y;
+		return perpProductXY(p.x, p.y);
+	}
+	
+	inline function perpProductXY(x:Float, y:Float):Float
+	{
+		return lx * x + ly * y;
 	}
 
 	/**

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -162,7 +162,7 @@ import openfl.geom.Point;
 	@:op(A += B)
 	static inline function plusEqualOp(a:FlxPoint, b:FlxPoint):FlxPoint
 	{
-		return a.addPoint(b);
+		return a.add(b);
 	}
 
 	/**
@@ -172,7 +172,7 @@ import openfl.geom.Point;
 	@:op(A -= B)
 	static inline function minusEqualOp(a:FlxPoint, b:FlxPoint):FlxPoint
 	{
-		return a.subtractPoint(b);
+		return a.subtract(b);
 	}
 
 	/**
@@ -357,7 +357,7 @@ import openfl.geom.Point;
 	 * @param   point  The point to add to this point
 	 * @return  This point.
 	 */
-	// @:deprecated("addPoint is deprecated, use add(point), instead")// 6.0.0
+	@:deprecated("addPoint is deprecated, use add(point), instead")// 6.1.2
 	public inline function addPoint(point:FlxPoint):FlxPoint
 	{
 		return add(point);
@@ -408,7 +408,7 @@ import openfl.geom.Point;
 	 * @param   point  The point to subtract from this point
 	 * @return  This point.
 	 */
-	// @:deprecated("subtractPoint is deprecated, use subtract(point), instead")// 6.0.0
+	@:deprecated("subtractPoint is deprecated, use subtract(point), instead")// 6.1.2
 	public inline function subtractPoint(point:FlxPoint):FlxPoint
 	{
 		subtract(point.x, point.y);
@@ -470,7 +470,7 @@ import openfl.geom.Point;
 	 * @param   point  The x and y scale coefficient
 	 * @return  scaled point
 	 */
-	// @:deprecated("scalePoint is deprecated, use scale(point), instead")// 6.0.0
+	@:deprecated("scalePoint is deprecated, use scale(point), instead")// 6.1.2
 	public inline function scalePoint(point:FlxPoint):FlxPoint
 	{
 		scale(point.x, point.y);
@@ -508,7 +508,7 @@ import openfl.geom.Point;
 	 */
 	public inline function subtractNew(p:FlxPoint):FlxPoint
 	{
-		return clone().subtractPoint(p);
+		return clone().subtract(p);
 	}
 
 	/**
@@ -542,7 +542,7 @@ import openfl.geom.Point;
 	 * @param   p  Any Point.
 	 * @return  A reference to itself.
 	 */
-	// @:deprecated("copyFromFlash is deprecated, use copyFrom, instead")// 6.0.0
+	@:deprecated("copyFromFlash is deprecated, use copyFrom, instead")// 6.1.2
 	public inline function copyFromFlash(p:Point):FlxPoint
 	{
 		return set(p.x, p.y);
@@ -583,7 +583,7 @@ import openfl.geom.Point;
 	 * @param   p  Any Point.
 	 * @return  A reference to the altered point parameter.
 	 */
-	// @:deprecated("copyToFlash is deprecated, use copyTo, instead")// 6.0.0
+	@:deprecated("copyToFlash is deprecated, use copyTo, instead")// 6.1.2
 	public inline function copyToFlash(?p:Point):Point
 	{
 		return copyTo(p != null ? p : new Point());
@@ -677,7 +677,7 @@ import openfl.geom.Point;
 	 */
 	public function pivotRadians(pivot:FlxPoint, radians:Float):FlxPoint
 	{
-		_point1.copyFrom(this).subtractPoint(pivot);
+		_point1.copyFrom(this).subtract(pivot);
 		_point1.radians += radians;
 		set(_point1.x + pivot.x, _point1.y + pivot.y);
 		pivot.putWeak();

--- a/flixel/math/FlxPoint.hx
+++ b/flixel/math/FlxPoint.hx
@@ -1063,9 +1063,9 @@ import openfl.geom.Point;
 		return set(x * -1, y * -1);
 	}
 
-	public inline function negateNew():FlxPoint
+	public inline function negateNew(?result:FlxPoint):FlxPoint
 	{
-		return clone().negate();
+		return clone(result).negate();
 	}
 
 	/**

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -374,7 +374,7 @@ class FlxBitmapText extends FlxSprite
 					continue;
 				}
 
-				getScreenPosition(screenPos, camera).subtractPoint(offset);
+				getScreenPosition(screenPos, camera).subtract(offset);
 
 				if (isPixelPerfectRender(camera))
 				{

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1220,7 +1220,7 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		}
 		else
 		{
-			getScreenPosition(_point, camera).subtractPoint(offset).copyTo(_helperPoint);
+			getScreenPosition(_point, camera).subtract(offset).copyTo(_helperPoint);
 
 			_helperPoint.x = isPixelPerfectRender(camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
 			_helperPoint.y = isPixelPerfectRender(camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;

--- a/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxCallbackPointTest.hx
@@ -120,10 +120,12 @@ class FlxCallbackPointTest extends FlxTest
 		p.length = 90                           ; assertChecked(1);
 		p.degrees = 90                          ; assertChecked(1);
 		p.radians = 90                          ; assertChecked(1);
+		#if (haxe >= version("4.3.0"))
 		// Check operators
 		p += norm                               ; assertChecked(1);
 		p -= norm                               ; assertChecked(1);
 		p *= 2                                  ; assertChecked(1);
+		#end
 		final newP = ((p + norm) - norm) * 2    ; assertChecked(0);
 		// check getters
 		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
@@ -228,10 +230,12 @@ class FlxCallbackPointTest extends FlxTest
 		p.length = 90                           ; assertChecked(1);
 		p.degrees = 90                          ; assertChecked(1);
 		p.radians = 90                          ; assertChecked(1);
+		#if (haxe >= version("4.3.0"))
 		// Check operators
 		p += norm                               ; assertChecked(1);
 		p -= norm                               ; assertChecked(1);
 		p *= 2                                  ; assertChecked(1);
+		#end
 		final newP = ((p + norm) - norm) * 2    ; assertChecked(0);
 		// check getters
 		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;
@@ -344,10 +348,12 @@ class FlxCallbackPointTest extends FlxTest
 		p.length = 90                           ; assertChecked(1);
 		p.degrees = 90                          ; assertChecked(1);
 		p.radians = 90                          ; assertChecked(1);
+		#if (haxe >= version("4.3.0"))
 		// Check operators
 		p += norm                               ; assertChecked(1);
 		p -= norm                               ; assertChecked(1);
 		p *= 2                                  ; assertChecked(1);
+		#end
 		final newP = ((p + norm) - norm) * 2    ; assertChecked(0);
 		// check getters
 		final sum = p.dx + p.dy + p.rx + p.ry + p.lx + p.ly + p.lengthSquared;

--- a/tests/unit/src/flixel/math/FlxPointTest.hx
+++ b/tests/unit/src/flixel/math/FlxPointTest.hx
@@ -168,6 +168,7 @@ class FlxPointTest extends FlxTest
 	}
 
 	@Test
+	@:haxe.warning("-WDeprecated")
 	function testOperators()
 	{
 		point1.set(1, 2);


### PR DESCRIPTION
Found some of these while doing #3524 

- Deprecates some old methods for the new overloaded methods
- Add a missing arg to negateNew
- Small optimizations