### PR TITLE
Revert "Revert "FlxG: query maxTextureSize when window is created""

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -539,6 +539,10 @@ class FlxG
 		FlxG.height = height;
 
 		initRenderMethod();
+		#if FLX_OPENGL_AVAILABLE
+		// Query once when window is created and cache for later
+		bitmap.get_maxTextureSize();
+		#end
 
 		FlxG.initialWidth = width;
 		FlxG.initialHeight = height;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -343,6 +343,8 @@ class BitmapFrontEnd
 
 	#if FLX_OPENGL_AVAILABLE
 	static var _maxTextureSize = -1;
+
+	@:allow(flixel.FlxG)
 	function get_maxTextureSize():Int
 	{
 		if (_maxTextureSize < 0 && FlxG.stage.window.context.attributes.hardware)

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -347,8 +347,8 @@ class BitmapFrontEnd
 	@:allow(flixel.FlxG)
 	function get_maxTextureSize():Int
 	{
-		if (_maxTextureSize < 0 && FlxG.stage.window.context.attributes.hardware)
-			_maxTextureSize = cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		if (_maxTextureSize < 0)
+			_maxTextureSize = FlxG.renderTile ? cast GL.getParameter(GL.MAX_TEXTURE_SIZE) : 0;
 		
 		return _maxTextureSize;
 	}


### PR DESCRIPTION
Reverts HaxeFlixel/flixel#3525

I wonder what the largest revert-chain is in github

Also prevents a crash when lime incorrectly tells us that gl is being used (fixed via https://github.com/openfl/lime/pull/2002)