### PR TITLE
FlxRect: Add overloaded `pad` methods

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1251,10 +1251,7 @@ class FlxObject extends FlxBasic
 		{
 			final PAD = 2;
 			final view = camera.getViewMarginRect();
-			view.left -= PAD;
-			view.top -= PAD;
-			view.right += PAD;
-			view.bottom += PAD;
+			view.pad(PAD);
 			rect.clipTo(view);
 			view.put();
 		}

--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1249,9 +1249,8 @@ class FlxObject extends FlxBasic
 		final rect = getBoundingBox(camera);
 		if (FlxG.renderTile)
 		{
-			final PAD = 2;
 			final view = camera.getViewMarginRect();
-			view.pad(PAD);
+			view.pad(2);
 			rect.clipTo(view);
 			view.put();
 		}

--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -1,6 +1,5 @@
 package flixel.math;
 
-import flixel.util.FlxPool.IFlxPooled;
 import flixel.util.FlxPool;
 import flixel.util.FlxStringUtil;
 import openfl.geom.Rectangle;
@@ -545,6 +544,51 @@ class FlxRect implements IFlxPooled
 	public function clipTo(rect:FlxRect):FlxRect
 	{
 		return rect.intersection(this, this);
+	}
+	
+	/**
+	 * 
+	 * Expands all four edges outward by the specified amounts. For example:
+	 * `rect.pad(10)` will increase the width and height by 20 (10 on each side).
+	 * 
+	 * **Note:** Negative numbers will shrink the edge.
+	 * 
+	 * @param amount The amount to extend the left, top, right and bottom edges
+	 */
+	overload public inline extern function pad(amount:Float)
+	{
+		return pad(amount, amount, amount, amount);
+	}
+	
+	/**
+	 * Expands all four edges outward by the specified amounts. For example:
+	 * `rect.pad(10, 5)` will increase the width by 20 (10 on each side) and the height by 10.
+	 * 
+	 * **Note:** Negative numbers will shrink the edges.
+	 * 
+	 * @param   leftAndRight  The amount to extend both the left and right
+	 * @param   topAndBottom  The amount to extend both the top and bottom
+	 */
+	overload public inline extern function pad(leftAndRight:Float, topAndBottom:Float)
+	{
+		return pad(leftAndRight, topAndBottom, leftAndRight, topAndBottom);
+	}
+	
+	/**
+	 * Expands all four edges outward by the specified amounts. For example:
+	 * `rect.pad(10, 5, 20, 5)` will increase the width by 30 (10 on the left and 20 on the right)
+	 * and the height by 10 (5 on both side).
+	 * 
+	 * **Note:** Negative numbers will shrink the edge.
+	 * 
+	 * @param   left    The amount to extend the left
+	 * @param   top     The amount to extend the top
+	 * @param   right   The amount to extend the right
+	 * @param   bottom  The amount to extend the bottom
+	 */
+	overload public inline extern function pad(left:Float, top:Float, right:Float, bottom:Float)
+	{
+		return set(x - left, y - top, width + left + right, height + top + bottom);
 	}
 	
 	/**

--- a/tests/unit/src/FlxAssert.hx
+++ b/tests/unit/src/FlxAssert.hx
@@ -3,6 +3,7 @@ package;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
+import flixel.util.FlxStringUtil;
 import haxe.PosInfos;
 import massive.munit.Assert;
 
@@ -22,17 +23,37 @@ class FlxAssert
 
 	public static function rectsNear(expected:FlxRect, actual:FlxRect, margin = 0.001, ?msg:String, ?info:PosInfos):Void
 	{
-		var areNear = areNearHelper(expected.x, actual.x, margin)
-			&& areNearHelper(expected.y, actual.y, margin)
-			&& areNearHelper(expected.width, actual.width, margin)
-			&& areNearHelper(expected.height, actual.height, margin);
+		rectsNearXYWH(expected.x, expected.y, expected.width, expected.height, actual, margin, msg, info);
+	}
+	
+	public static function rectsNearLTRD(expectedL:Float, expectedT:Float, expectedR:Float, expectedD:Float, actual:FlxRect, margin = 0.001, ?msg:String, ?info:PosInfos):Void
+	{
+		rectsNearXYWH(expectedL, expectedT, expectedR - expectedL, expectedD - expectedT, actual, margin, msg, info);
+	}
+	
+	public static function rectsNearXYWH(expectedX:Float, expectedY:Float, expectedW:Float, expectedH:Float, actual:FlxRect, margin = 0.001, ?msg:String, ?info:PosInfos):Void
+	{
+		var areNear = areNearHelper(expectedX, actual.x, margin)
+			&& areNearHelper(expectedY, actual.y, margin)
+			&& areNearHelper(expectedW, actual.width, margin)
+			&& areNearHelper(expectedH, actual.height, margin);
 		
 		if (areNear)
 			Assert.assertionCount++;
 		else if (msg != null)
 			Assert.fail(msg, info);
 		else
-			Assert.fail('Value [$actual] is not within [$margin] of [$expected]', info);
+			Assert.fail('Value [$actual] is not within [$margin] of [${toRectString(expectedX, expectedY, expectedW, expectedH)}]', info);
+	}
+	
+	static function toRectString(x:Float, y:Float, w:Float, h:Float):String
+	{
+		return FlxStringUtil.getDebugString([
+			LabelValuePair.weak("x", x),
+			LabelValuePair.weak("y", y),
+			LabelValuePair.weak("w", w),
+			LabelValuePair.weak("h", h)
+		]);
 	}
 
 	static function areNearHelper(expected:Float, actual:Float, margin = 0.001):Bool

--- a/tests/unit/src/flixel/math/FlxRectTest.hx
+++ b/tests/unit/src/flixel/math/FlxRectTest.hx
@@ -179,16 +179,13 @@ class FlxRectTest extends FlxTest
 	@Test
 	function testPad()
 	{
-		rect1.setBounds(50, 50, 100, 100);
-		rect1.pad(1, 2, 3, 4);
+		rect1.setBounds(50, 50, 100, 100).pad(1, 2, 3, 4);
 		FlxAssert.rectsNearLTRD(50 - 1, 50 - 2, 100 + 3, 100 + 4, rect1);
 		
-		rect1.setBounds(50, 50, 100, 100);
-		rect1.pad(10, 20);
+		rect1.setBounds(50, 50, 100, 100).pad(10, 20);
 		FlxAssert.rectsNearLTRD(50 - 10, 50 - 20, 100 + 10, 100 + 20, rect1);
 		
-		rect1.setBounds(50, 50, 100, 100);
-		rect1.pad(10);
+		rect1.setBounds(50, 50, 100, 100).pad(10);
 		FlxAssert.rectsNearLTRD(50 - 10, 50 - 10, 100 + 10, 100 + 10, rect1);
 	}
 }

--- a/tests/unit/src/flixel/math/FlxRectTest.hx
+++ b/tests/unit/src/flixel/math/FlxRectTest.hx
@@ -152,7 +152,7 @@ class FlxRectTest extends FlxTest
 	}
 	
 	@Test
-	function testContins()
+	function testContains()
 	{
 		rect1.set(0, 0, 100, 100);
 		
@@ -173,5 +173,22 @@ class FlxRectTest extends FlxTest
 		assertNotContains(51, 51);
 		assertContains(0, 0, 100, 100);
 		assertNotContains(-1, -1, 101, 101);
+	}
+	
+	
+	@Test
+	function testPad()
+	{
+		rect1.setBounds(50, 50, 100, 100);
+		rect1.pad(1, 2, 3, 4);
+		FlxAssert.rectsNearLTRD(50 - 1, 50 - 2, 100 + 3, 100 + 4, rect1);
+		
+		rect1.setBounds(50, 50, 100, 100);
+		rect1.pad(10, 20);
+		FlxAssert.rectsNearLTRD(50 - 10, 50 - 20, 100 + 10, 100 + 20, rect1);
+		
+		rect1.setBounds(50, 50, 100, 100);
+		rect1.pad(10);
+		FlxAssert.rectsNearLTRD(50 - 10, 50 - 10, 100 + 10, 100 + 10, rect1);
 	}
 }


### PR DESCRIPTION
Closes #3495

Adds `rect.pad(l, t, r, d)` with overloads `rect.pad(lr, td)` and `rect.pad(ltrd)`.
Also adds unit tests