### PR TITLE
`FlxG.log`: Add FLX_LOG_THROW, FLX_LOG_PLAY_SOUND and FLX_LOG_OPEN_CONSOLE, FlxG.log.styles and FlxLogStyle

### DIFF
--- a/flixel/system/debug/console/ConsoleUtil.hx
+++ b/flixel/system/debug/console/ConsoleUtil.hx
@@ -3,9 +3,9 @@ package flixel.system.debug.console;
 import flixel.FlxG;
 import flixel.system.debug.log.LogStyle;
 
-using flixel.util.FlxStringUtil;
-using flixel.util.FlxArrayUtil;
 using StringTools;
+using flixel.util.FlxArrayUtil;
+using flixel.util.FlxStringUtil;
 
 #if hscript
 import hscript.Expr;
@@ -168,7 +168,7 @@ class ConsoleUtil
 	 */
 	public static inline function log(text:Dynamic):Void
 	{
-		FlxG.log.advanced([text], LogStyle.CONSOLE);
+		FlxG.log.advanced([text], FlxG.log.styles.console);
 	}
 }
 

--- a/flixel/system/debug/log/FlxLogStyle.hx
+++ b/flixel/system/debug/log/FlxLogStyle.hx
@@ -1,0 +1,114 @@
+package flixel.system.debug.log;
+
+import flixel.util.FlxSignal;
+import haxe.PosInfos;
+
+using flixel.util.FlxStringUtil;
+
+/**
+ * A class that allows you to create a custom style for `FlxG.log.advanced()`.
+ * Also used internally for the pre-defined styles.
+ */
+class FlxLogStyle
+{
+	/**
+	 * A prefix which is always attached to the start of the logged data
+	 */
+	public var prefix:String;
+
+	public var color:String;
+	public var size:Int;
+	public var bold:Bool;
+	public var italic:Bool;
+	public var underlined:Bool;
+
+	/**
+	 * A sound to be played when this LogStyle is used
+	 */
+	public var errorSound:String;
+
+	/**
+	 * Whether the console should be forced to open when this LogStyle is used
+	 */
+	public var openConsole:Bool;
+
+	/**
+	 * A callback function that is called when this LogStyle is used
+	 */
+	@:deprecated("callbackFunction is deprecated, use callback, instead")
+	public var callbackFunction:()->Void;
+	
+	/**
+	 * A callback function that is called when this LogStyle is used
+	 * **Note:** Unlike the deprecated `callbackFunction`, this is called every time,
+	 * even when logged with `once = true` and even in release mode.
+	 */
+	public final onLog = new FlxTypedSignal<(data:Any, ?pos:PosInfos) -> Void>();
+	
+	/**
+	 * Whether an exception is thrown when this LogStyle is used.
+	 * **Note**: Unlike other log style properties, this happens even in release mode.
+	 * @since 5.4.0
+	 */
+	public var throwException:Bool = false;
+	
+	/**
+	 * Create a new LogStyle to be used in conjunction with `FlxG.log.advanced()`
+	 *
+	 * @param   prefix            A prefix which is always attached to the start of the logged data
+	 * @param   color             The text color
+	 * @param   size              The text size
+	 * @param   bold              Whether the text is bold or not
+	 * @param   italic            Whether the text is italic or not
+	 * @param   underlined        Whether the text is underlined or not
+	 * @param   errorSound        A sound to be played when this LogStyle is used
+	 * @param   openConsole       Whether the console should be forced to open when this LogStyle is used
+	 * @param   callbackFunction  A callback function that is called when this LogStyle is used
+	 * @param   callback          A callback function that is called when this LogStyle is used
+	 * @param   throwError        Whether an error is thrown when this LogStyle is used
+	 */
+	 @:haxe.warning("-WDeprecated")
+	public function new(prefix = "", color = "FFFFFF", size = 12, bold = false, italic = false, underlined = false,
+			?errorSound:String, openConsole = false, throwException = false)
+	{
+		this.prefix = prefix;
+		this.color = color;
+		this.size = size;
+		this.bold = bold;
+		this.italic = italic;
+		this.underlined = underlined;
+		this.errorSound = errorSound;
+		this.openConsole = openConsole;
+		this.throwException = throwException;
+	}
+	
+	/**
+	 * Converts the data into a log message according to this style.
+	 * 
+	 * @param   data  The data being logged
+	 */
+	public function toLogString(data:Array<Any>)
+	{
+		// Format FlxPoints, Arrays, Maps or turn the data entry into a String
+		final texts = new Array<String>();
+		for (i in 0...data.length)
+		{
+			final text = Std.string(data[i]);
+			
+			// Make sure you can't insert html tags
+			texts.push(StringTools.htmlEscape(text));
+		}
+		
+		return prefix + texts.join(" ");
+	}
+	
+	/**
+	 * Converts the data into an html log message according to this style.
+	 * 
+	 * @param   data  The data being logged
+	 */
+	public inline function toHtmlString(data:Array<Any>)
+	{
+		return toLogString(data).htmlFormat(size, color, bold, italic, underlined);
+	}
+}

--- a/flixel/system/debug/log/FlxLogStyle.hx
+++ b/flixel/system/debug/log/FlxLogStyle.hx
@@ -1,5 +1,6 @@
 package flixel.system.debug.log;
 
+import flixel.util.FlxColor;
 import flixel.util.FlxSignal;
 import haxe.PosInfos;
 
@@ -8,6 +9,7 @@ using flixel.util.FlxStringUtil;
 /**
  * A class that allows you to create a custom style for `FlxG.log.advanced()`.
  * Also used internally for the pre-defined styles.
+ * @since 6.2.0
  */
 class FlxLogStyle
 {
@@ -15,23 +17,22 @@ class FlxLogStyle
 	 * A prefix which is always attached to the start of the logged data
 	 */
 	public var prefix:String;
-
-	public var color:String;
-	public var size:Int;
-	public var bold:Bool;
-	public var italic:Bool;
-	public var underlined:Bool;
-
+	
+	/**
+	 * The formatting applied to the text
+	 */
+	public var format:FlxLogFormat;
+	
 	/**
 	 * A sound to be played when this LogStyle is used
 	 */
 	public var errorSound:String;
-
+	
 	/**
 	 * Whether the console should be forced to open when this LogStyle is used
 	 */
 	public var openConsole:Bool;
-
+	
 	/**
 	 * A callback function that is called when this LogStyle is used
 	 */
@@ -56,27 +57,17 @@ class FlxLogStyle
 	 * Create a new LogStyle to be used in conjunction with `FlxG.log.advanced()`
 	 *
 	 * @param   prefix            A prefix which is always attached to the start of the logged data
-	 * @param   color             The text color
-	 * @param   size              The text size
-	 * @param   bold              Whether the text is bold or not
-	 * @param   italic            Whether the text is italic or not
-	 * @param   underlined        Whether the text is underlined or not
+	 * @param   style             The formatting applied to the text
 	 * @param   errorSound        A sound to be played when this LogStyle is used
 	 * @param   openConsole       Whether the console should be forced to open when this LogStyle is used
-	 * @param   callbackFunction  A callback function that is called when this LogStyle is used
 	 * @param   callback          A callback function that is called when this LogStyle is used
 	 * @param   throwError        Whether an error is thrown when this LogStyle is used
 	 */
 	 @:haxe.warning("-WDeprecated")
-	public function new(prefix = "", color = "FFFFFF", size = 12, bold = false, italic = false, underlined = false,
-			?errorSound:String, openConsole = false, throwException = false)
+	public function new(prefix = "", ?format:FlxLogFormat, ?errorSound:String, openConsole = false, throwException = false)
 	{
 		this.prefix = prefix;
-		this.color = color;
-		this.size = size;
-		this.bold = bold;
-		this.italic = italic;
-		this.underlined = underlined;
+		this.format = format != null ? format : {};
 		this.errorSound = errorSound;
 		this.openConsole = openConsole;
 		this.throwException = throwException;
@@ -109,6 +100,36 @@ class FlxLogStyle
 	 */
 	public inline function toHtmlString(data:Array<Any>)
 	{
-		return toLogString(data).htmlFormat(size, color, bold, italic, underlined);
+		return toLogString(data).htmlFormat(format.size, format.getColorString(), format.bold, format.italic, format.underlined);
+	}
+}
+
+@:structInit
+class FlxLogFormat
+{
+	public var color = FlxColor.WHITE;
+	public var size = 12;
+	public var bold = false;
+	public var italic = false;
+	public var underlined = false;
+	
+	public function new(color = FlxColor.WHITE, size = 12, bold = false, italic = false, underlined = false)
+	{
+		this.color = color;
+		this.size = size;
+		this.bold = bold;
+		this.italic = italic;
+		this.underlined = underlined;
+	}
+	
+	public function getColorString(prefix = "")
+	{
+		return color.toHexString(prefix, false);
+	}
+	
+	public function setColorString(value:String)
+	{
+		color = FlxColor.fromString('#$value');
+		return value;
 	}
 }

--- a/flixel/system/debug/log/Log.hx
+++ b/flixel/system/debug/log/Log.hx
@@ -57,7 +57,7 @@ class Log extends Window
 	 * @param   style     The LogStyle to be used
 	 * @param   fireOnce  If true, the log history is checked for matching logs
 	 */
-	public function add(data:Array<Dynamic>, style:LogStyle, fireOnce = false):Bool
+	public function add(data:Array<Dynamic>, style:FlxLogStyle, fireOnce = false):Bool
 	{
 		if (data == null)
 		{
@@ -65,11 +65,7 @@ class Log extends Window
 		}
 		
 		// Apply text formatting
-		#if (!js && !lime_console)
 		final text = style.toHtmlString(data);
-		#else
-		final text = style.toLogString(data);
-		#end
 		
 		// Check if the text has been added yet already
 		if (fireOnce)
@@ -99,21 +95,11 @@ class Log extends Window
 			{
 				newText += _lines[i] + LINE_BREAK;
 			}
-			// TODO: Make htmlText work on HTML5 target
-			#if (!js && !lime_console)
 			_text.htmlText = newText;
-			#else
-			_text.text = newText;
-			#end
 		}
 		else
 		{
-			// TODO: Make htmlText work on HTML5 target
-			#if (!js && !lime_console)
 			_text.htmlText += (text + LINE_BREAK);
-			#else
-			_text.text += text + LINE_BREAK;
-			#end
 		}
 
 		_text.scrollV = Std.int(_text.maxScrollV);

--- a/flixel/system/debug/log/LogStyle.hx
+++ b/flixel/system/debug/log/LogStyle.hx
@@ -1,123 +1,67 @@
 package flixel.system.debug.log;
 
-import flixel.util.FlxSignal;
 import haxe.PosInfos;
-
-using flixel.util.FlxStringUtil;
 
 /**
  * A class that allows you to create a custom style for `FlxG.log.advanced()`.
  * Also used internally for the pre-defined styles.
  */
-class LogStyle
+@:forward
+@:deprecated("LogStyle is deprecated, use FlxLogStyle, instead")
+abstract LogStyle(FlxLogStyle) from FlxLogStyle to FlxLogStyle
 {
-	public static var NORMAL:LogStyle = new LogStyle();
-	public static var WARNING:LogStyle = new LogStyle("[WARNING] ", "D9F85C", 12, false, false, false, "flixel/sounds/beep", true);
-	public static var ERROR:LogStyle = new LogStyle("[ERROR] ", "FF8888", 12, false, false, false, "flixel/sounds/beep", true);
-	public static var NOTICE:LogStyle = new LogStyle("[NOTICE] ", "5CF878", 12, false);
-	public static var CONSOLE:LogStyle = new LogStyle("> ", "5A96FA", 12, false);
-
-	/**
-	 * A prefix which is always attached to the start of the logged data
-	 */
-	public var prefix:String;
-
-	public var color:String;
-	public var size:Int;
-	public var bold:Bool;
-	public var italic:Bool;
-	public var underlined:Bool;
-
-	/**
-	 * A sound to be played when this LogStyle is used
-	 */
-	public var errorSound:String;
-
-	/**
-	 * Whether the console should be forced to open when this LogStyle is used
-	 */
-	public var openConsole:Bool;
-
-	/**
-	 * A callback function that is called when this LogStyle is used
-	 */
-	@:deprecated("callbackFunction is deprecated, use callback, instead")
-	public var callbackFunction:()->Void;
+	@:deprecated("LogStyle.NORMAL is deprecated, use FlxG.log.styles.NORMAL, instead")
+	public static var NORMAL (default, set):LogStyle;
+	static function set_NORMAL(style:LogStyle)
+	{
+		@:bypassAccessor
+		FlxG.log.styles.normal = style;
+		return NORMAL = style;
+	}
 	
-	/**
-	 * A callback function that is called when this LogStyle is used
-	 * **Note:** Unlike the deprecated `callbackFunction`, this is called every time,
-	 * even when logged with `once = true` and even in release mode.
-	 */
-	public final onLog = new FlxTypedSignal<(data:Any, ?pos:PosInfos) -> Void>();
+	@:deprecated("LogStyle.WARNING is deprecated, use FlxG.log.styles.WARNING, instead")
+	public static var WARNING(default, set):LogStyle;
+	static function set_WARNING(style:LogStyle)
+	{
+		@:bypassAccessor
+		FlxG.log.styles.warning = style;
+		return WARNING = style;
+	}
 	
-	/**
-	 * Whether an exception is thrown when this LogStyle is used.
-	 * **Note**: Unlike other log style properties, this happens even in release mode.
-	 * @since 5.4.0
-	 */
-	public var throwException:Bool = false;
+	@:deprecated("LogStyle.ERROR is deprecated, use FlxG.log.styles.ERROR, instead")
+	public static var ERROR  (default, set):LogStyle;
+	static function set_ERROR(style:LogStyle)
+	{
+		@:bypassAccessor
+		FlxG.log.styles.error = style;
+		return ERROR = style;
+	}
 	
-	/**
-	 * Create a new LogStyle to be used in conjunction with `FlxG.log.advanced()`
-	 *
-	 * @param   prefix            A prefix which is always attached to the start of the logged data
-	 * @param   color             The text color
-	 * @param   size              The text size
-	 * @param   bold              Whether the text is bold or not
-	 * @param   italic            Whether the text is italic or not
-	 * @param   underlined        Whether the text is underlined or not
-	 * @param   errorSound        A sound to be played when this LogStyle is used
-	 * @param   openConsole       Whether the console should be forced to open when this LogStyle is used
-	 * @param   callbackFunction  A callback function that is called when this LogStyle is used
-	 * @param   callback          A callback function that is called when this LogStyle is used
-	 * @param   throwError        Whether an error is thrown when this LogStyle is used
-	 */
-	 @:haxe.warning("-WDeprecated")
+	@:deprecated("LogStyle.NOTICE is deprecated, use FlxG.log.styles.NOTICE, instead")
+	public static var NOTICE (default, set):LogStyle;
+	static function set_NOTICE(style:LogStyle)
+	{
+		@:bypassAccessor
+		FlxG.log.styles.notice = style;
+		return NOTICE = style;
+	}
+	
+	@:deprecated("LogStyle.CONSOLE is deprecated, use FlxG.log.styles.CONSOLE, instead")
+	public static var CONSOLE(default, set):LogStyle;
+	static function set_CONSOLE(style:LogStyle)
+	{
+		@:bypassAccessor
+		FlxG.log.styles.console = style;
+		return CONSOLE = style;
+	}
+	
 	public function new(prefix = "", color = "FFFFFF", size = 12, bold = false, italic = false, underlined = false,
 			?errorSound:String, openConsole = false, ?callbackFunction:()->Void, ?callback:(Any, ?PosInfos)->Void, throwException = false)
 	{
-		this.prefix = prefix;
-		this.color = color;
-		this.size = size;
-		this.bold = bold;
-		this.italic = italic;
-		this.underlined = underlined;
-		this.errorSound = errorSound;
-		this.openConsole = openConsole;
+		this = new FlxLogStyle(prefix, color, size, bold, italic, underlined, errorSound, openConsole, throwException);
+		
 		this.callbackFunction = callbackFunction;
 		if (callback != null)
-			onLog.add(callback);
-		this.throwException = throwException;
-	}
-	
-	/**
-	 * Converts the data into a log message according to this style.
-	 * 
-	 * @param   data  The data being logged
-	 */
-	public function toLogString(data:Array<Any>)
-	{
-		// Format FlxPoints, Arrays, Maps or turn the data entry into a String
-		final texts = new Array<String>();
-		for (i in 0...data.length)
-		{
-			final text = Std.string(data[i]);
-			
-			// Make sure you can't insert html tags
-			texts.push(StringTools.htmlEscape(text));
-		}
-		
-		return prefix + texts.join(" ");
-	}
-	
-	/**
-	 * Converts the data into an html log message according to this style.
-	 * 
-	 * @param   data  The data being logged
-	 */
-	public inline function toHtmlString(data:Array<Any>)
-	{
-		return toLogString(data).htmlFormat(size, color, bold, italic, underlined);
+			this.onLog.add(callback);
 	}
 }

--- a/flixel/system/debug/log/LogStyle.hx
+++ b/flixel/system/debug/log/LogStyle.hx
@@ -7,7 +7,6 @@ import haxe.PosInfos;
  * Also used internally for the pre-defined styles.
  */
 @:forward
-@:deprecated("LogStyle is deprecated, use FlxLogStyle, instead")
 abstract LogStyle(FlxLogStyle) from FlxLogStyle to FlxLogStyle
 {
 	@:deprecated("LogStyle.NORMAL is deprecated, use FlxG.log.styles.NORMAL, instead")
@@ -55,6 +54,7 @@ abstract LogStyle(FlxLogStyle) from FlxLogStyle to FlxLogStyle
 		return CONSOLE = style;
 	}
 	
+	@:deprecated("LogStyle is deprecated, use FlxLogStyle, instead")
 	public function new(prefix = "", color = "FFFFFF", size = 12, bold = false, italic = false, underlined = false,
 			?errorSound:String, openConsole = false, ?callbackFunction:()->Void, ?callback:(Any, ?PosInfos)->Void, throwException = false)
 	{

--- a/flixel/system/debug/log/LogStyle.hx
+++ b/flixel/system/debug/log/LogStyle.hx
@@ -1,5 +1,7 @@
 package flixel.system.debug.log;
 
+import flixel.system.debug.log.FlxLogStyle;
+import flixel.util.FlxColor;
 import haxe.PosInfos;
 
 /**
@@ -7,6 +9,7 @@ import haxe.PosInfos;
  * Also used internally for the pre-defined styles.
  */
 @:forward
+@:deprecated("LogStyle is deprecated, use FlxLogStyle, instead")
 abstract LogStyle(FlxLogStyle) from FlxLogStyle to FlxLogStyle
 {
 	@:deprecated("LogStyle.NORMAL is deprecated, use FlxG.log.styles.NORMAL, instead")
@@ -54,11 +57,34 @@ abstract LogStyle(FlxLogStyle) from FlxLogStyle to FlxLogStyle
 		return CONSOLE = style;
 	}
 	
+	
+	public var color(get, set):String;
+	inline function get_color() return this.format.getColorString();
+	inline function set_color(value:String) return this.format.setColorString(value);
+	
+	public var size(get, set):Int;
+	inline function get_size() return this.format.size;
+	inline function set_size(value:Int) return this.format.size = value;
+	
+	public var bold(get, set):Bool;
+	inline function get_bold() return this.format.bold;
+	inline function set_bold(value:Bool) return this.format.bold = value;
+	
+	public var italic(get, set):Bool;
+	inline function get_italic() return this.format.italic;
+	inline function set_italic(value:Bool) return this.format.italic = value;
+	
+	public var underlined(get, set):Bool;
+	inline function get_underlined() return this.format.underlined;
+	inline function set_underlined(value:Bool) return this.format.underlined = value;
+	
+	
 	@:deprecated("LogStyle is deprecated, use FlxLogStyle, instead")
 	public function new(prefix = "", color = "FFFFFF", size = 12, bold = false, italic = false, underlined = false,
 			?errorSound:String, openConsole = false, ?callbackFunction:()->Void, ?callback:(Any, ?PosInfos)->Void, throwException = false)
 	{
-		this = new FlxLogStyle(prefix, color, size, bold, italic, underlined, errorSound, openConsole, throwException);
+		final format = new FlxLogFormat(FlxColor.fromString('#$color'), size, bold, italic, underlined);
+		this = new FlxLogStyle(prefix, format, errorSound, openConsole, throwException);
 		
 		this.callbackFunction = callbackFunction;
 		if (callback != null)

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -3,17 +3,17 @@ package flixel.system.frontEnds;
 import flixel.FlxG;
 import flixel.system.FlxAssets;
 import flixel.system.debug.log.LogStyle;
+import haxe.Json;
 import haxe.io.Bytes;
 import haxe.io.Path;
-import haxe.Json;
 import haxe.xml.Access;
 import openfl.display.BitmapData;
 import openfl.media.Sound;
-import openfl.utils.Assets;
-import openfl.utils.AssetType;
-import openfl.utils.AssetCache;
-import openfl.utils.Future;
 import openfl.text.Font;
+import openfl.utils.AssetCache;
+import openfl.utils.AssetType;
+import openfl.utils.Assets;
+import openfl.utils.Future;
 
 using StringTools;
 
@@ -173,12 +173,10 @@ class AssetFrontEnd
 	 */
 	public function getAsset(id:String, type:FlxAssetType, useCache = true, ?logStyle:LogStyle):Null<Any>
 	{
-		inline function log(message:String)
-		{
-			if (logStyle == null)
-				logStyle = LogStyle.ERROR;
-			FlxG.log.advanced(message, logStyle);
-		}
+		if (logStyle == null)
+			logStyle = FlxG.log.styles.error;
+		
+		final log = FlxG.log.advanced.bind(_, logStyle);
 		
 		if (exists(id, type))
 		{

--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -1,9 +1,69 @@
 package flixel.system.frontEnds;
 
 import flixel.FlxG;
-import flixel.system.debug.log.LogStyle;
 import flixel.system.FlxAssets;
+import flixel.system.debug.log.FlxLogStyle;
+import flixel.system.debug.log.LogStyle;
 import haxe.PosInfos;
+
+class FlxLogStylesList
+{
+	public var normal (default, set):FlxLogStyle;
+	public var warning(default, set):FlxLogStyle;
+	public var error  (default, set):FlxLogStyle;
+	public var notice (default, set):FlxLogStyle;
+	public var console(default, set):FlxLogStyle;
+	
+	@:haxe.warning("-WDeprecated")
+	public function new ()
+	{
+		normal  = new FlxLogStyle();
+		warning = new FlxLogStyle("[WARNING] ", "D9F85C", 12, false, false, false, "flixel/sounds/beep", true);
+		error   = new FlxLogStyle("[ERROR] ", "FF8888", 12, false, false, false, "flixel/sounds/beep", true);
+		notice  = new FlxLogStyle("[NOTICE] ", "5CF878", 12, false);
+		console = new FlxLogStyle("> ", "5A96FA", 12, false);
+		
+		#if FLX_THROW_ERRORS
+		error.throwException = true;
+		#end
+	}
+	
+	@:haxe.warning("-WDeprecated")
+	function set_normal (style:FlxLogStyle)
+	{
+		@:bypassAccessor LogStyle.NORMAL = style;
+		return this.normal = style;
+	}
+	
+	@:haxe.warning("-WDeprecated")
+	function set_warning(style:FlxLogStyle)
+	{
+		@:bypassAccessor LogStyle.WARNING = style;
+		return this.warning = style;
+	}
+	
+	@:haxe.warning("-WDeprecated")
+	function set_error  (style:FlxLogStyle)
+	{
+		@:bypassAccessor LogStyle.ERROR = style;
+		return this.error = style;
+	}
+	
+	@:haxe.warning("-WDeprecated")
+	function set_notice (style:FlxLogStyle)
+	{
+		@:bypassAccessor LogStyle.NOTICE = style;
+		return this.notice = style;
+	}
+	
+	@:haxe.warning("-WDeprecated")
+	function set_console(style:FlxLogStyle)
+	{
+		@:bypassAccessor LogStyle.CONSOLE = style;
+		return this.console = style;
+	}
+	
+}
 
 /**
  * Accessed via `FlxG.log`.
@@ -14,27 +74,29 @@ class LogFrontEnd
 	 * Whether everything you trace() is being redirected into the log window.
 	 */
 	public var redirectTraces(default, set):Bool = false;
+	
+	public final styles:FlxLogStylesList;
 
 	var _standardTraceFunction:(Dynamic, ?PosInfos)->Void;
 	
 	public inline function add(data:Dynamic, ?pos:PosInfos):Void
 	{
-		advanced(data, LogStyle.NORMAL, false, pos);
+		advanced(data, styles.normal, false, pos);
 	}
 	
 	public inline function warn(data:Dynamic, ?pos:PosInfos):Void
 	{
-		advanced(data, LogStyle.WARNING, true, pos);
+		advanced(data, styles.warning, true, pos);
 	}
 	
 	public inline function error(data:Dynamic, ?pos:PosInfos):Void
 	{
-		advanced(data, LogStyle.ERROR, true, pos);
+		advanced(data, styles.error, true, pos);
 	}
 	
 	public inline function notice(data:Dynamic, ?pos:PosInfos):Void
 	{
-		advanced(data, LogStyle.NOTICE, false, pos);
+		advanced(data, styles.notice, false, pos);
 	}
 	
 	/**
@@ -97,6 +159,7 @@ class LogFrontEnd
 	function new()
 	{
 		_standardTraceFunction = haxe.Log.trace;
+		styles = new FlxLogStylesList();
 	}
 
 	inline function set_redirectTraces(redirect:Bool):Bool
@@ -123,6 +186,6 @@ class LogFrontEnd
 			}
 		}
 
-		advanced(paramArray, LogStyle.NORMAL);
+		advanced(paramArray, styles.normal);
 	}
 }

--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -18,10 +18,10 @@ class FlxLogStylesList
 	public function new ()
 	{
 		normal  = new FlxLogStyle();
-		warning = new FlxLogStyle("[WARNING] ", "D9F85C", 12, false, false, false, "flixel/sounds/beep", true);
-		error   = new FlxLogStyle("[ERROR] ", "FF8888", 12, false, false, false, "flixel/sounds/beep", true);
-		notice  = new FlxLogStyle("[NOTICE] ", "5CF878", 12, false);
-		console = new FlxLogStyle("> ", "5A96FA", 12, false);
+		warning = new FlxLogStyle("[WARNING] ", { color: 0xD9F85C }, "flixel/sounds/beep", true);
+		error   = new FlxLogStyle("[ERROR] ", { color: 0xFF8888 }, "flixel/sounds/beep", true);
+		notice  = new FlxLogStyle("[NOTICE] ", { color: 0x5CF878 });
+		console = new FlxLogStyle("> ", { color: 0x5A96FA });
 		
 		#if FLX_THROW_ERRORS
 		error.throwException = true;

--- a/flixel/system/frontEnds/LogFrontEnd.hx
+++ b/flixel/system/frontEnds/LogFrontEnd.hx
@@ -17,15 +17,45 @@ class FlxLogStylesList
 	@:haxe.warning("-WDeprecated")
 	public function new ()
 	{
+		final sound = "flixel/sounds/beep";
+		
 		normal  = new FlxLogStyle();
-		warning = new FlxLogStyle("[WARNING] ", { color: 0xD9F85C }, "flixel/sounds/beep", true);
-		error   = new FlxLogStyle("[ERROR] ", { color: 0xFF8888 }, "flixel/sounds/beep", true);
 		notice  = new FlxLogStyle("[NOTICE] ", { color: 0x5CF878 });
+		warning = new FlxLogStyle("[WARNING] ", { color: 0xD9F85C }, sound, true);
+		error   = new FlxLogStyle("[ERROR] ", { color: 0xFF8888 }, sound, true);
 		console = new FlxLogStyle("> ", { color: 0x5A96FA });
 		
-		#if FLX_THROW_ERRORS
-		error.throwException = true;
+		final order = [normal, notice, warning, error];
+		#if FLX_LOG_THROW
+		final level = getLevel('${haxe.macro.Compiler.getDefine("FLX_LOG_THROW")}');
+		for (i in 0...order.length)
+			order[i].throwException = i >= level;
 		#end
+		
+		#if FLX_LOG_PLAY_SOUND
+		final level = getLevel('${haxe.macro.Compiler.getDefine("FLX_LOG_PLAY_SOUND")}');
+		for (i in 0...order.length)
+			order[i].errorSound = i >= level ? sound : null;
+		#end
+		
+		#if FLX_LOG_OPEN_CONSOLE
+		final level = getLevel('${haxe.macro.Compiler.getDefine("FLX_LOG_OPEN_CONSOLE")}');
+		for (i in 0...order.length)
+			order[i].openConsole = i >= level;
+		#end
+	}
+	
+	static function getLevel(definedValue:String)
+	{
+		return switch definedValue.toUpperCase()
+		{
+			case "ERROR"  : 3;
+			case "WARNING": 2;
+			case "NOTICE" : 1;
+			case "NORMAL" : 0;
+			case "NONE"   : 4;
+			default       : 4;
+		}
 	}
 	
 	@:haxe.warning("-WDeprecated")

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -12,7 +12,7 @@ import flixel.addons.system.macros.FlxAddonDefines;
 
 
 
-private enum UserDefines
+private enum UserDefine
 {
 	FLX_NO_MOUSE_ADVANCED;
 	FLX_NO_GAMEPAD;
@@ -68,9 +68,22 @@ private enum UserDefines
 	FLX_DEBUGGER_SCALE;
 	
 	/**
-	 * Whether `FlxG.log.error` calls will throw an exception
+	 * Determines which `FlxG.log` calls will throw an exception. Use values `ERROR`, `WARNING`,
+	 * `NOTICE`, `NORMAL` or `NONE`. If undefined, `NONE` is used.
 	 */
-	FLX_THROW_ERRORS;
+	FLX_LOG_THROW;
+	
+	/**
+	 * Determines which `FlxG.log` calls will play a sound. Use values `ERROR`, `WARNING`,
+	 * `NOTICE`, `NORMAL` or `NONE`. If undefined, `WARNING` is used.
+	 */
+	FLX_LOG_PLAY_SOUND;
+	
+	/**
+	 * Determines which `FlxG.log` calls will show the debugger. Use values `ERROR`, `WARNING`,
+	 * `NOTICE`, `NORMAL` or `NONE`. Ignored if `FLX_NO_DEBUG` is defined. If undefined, `NOTICE` is used.
+	 */
+	FLX_LOG_OPEN_CONSOLE;
 }
 
 /**
@@ -78,7 +91,7 @@ private enum UserDefines
  * are shortened into a single define to avoid the redundancy
  * that comes with using them frequently.
  */
-private enum HelperDefines
+private enum HelperDefine
 {
 	FLX_GAMEPAD;
 	FLX_MOUSE;
@@ -120,7 +133,6 @@ private enum HelperDefines
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
 	FLX_NO_DEFAULT_SOUND_EXT;
-	FLX_NO_THROW_ERRORS;
 }
 
 class FlxDefines
@@ -135,7 +147,7 @@ class FlxDefines
 		#end
 		
 		defineInversions();
-		defineHelperDefines();
+		defineHelperDefine();
 		
 		#if (flixel_addons >= "3.2.2")
 		flixel.addons.system.macros.FlxAddonDefines.run();
@@ -181,7 +193,7 @@ class FlxDefines
 
 	static function checkDefines()
 	{
-		for (define in HelperDefines.getConstructors())
+		for (define in HelperDefine.getConstructors())
 			abortIfDefined(define);
 
 		for (define in Context.getDefines().keys())
@@ -193,7 +205,7 @@ class FlxDefines
 		}
 	}
 	
-	static var userDefinable = UserDefines.getConstructors();
+	static var userDefinable = UserDefine.getConstructors();
 	static function isValidUserDefine(define:String)
 	{
 		return (define.startsWith("FLX_") && userDefinable.indexOf(define) == -1)
@@ -230,7 +242,7 @@ class FlxDefines
 		}
 	}
 
-	static function defineHelperDefines()
+	static function defineHelperDefine()
 	{
 		if (defined(FLX_UNIT_TEST) || defined(FLX_COVERAGE_TEST) || defined(FLX_SWF_VERSION_TEST))
 			define(FLX_CI);
@@ -291,7 +303,6 @@ class FlxDefines
 		#end
 		
 		defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS);
-		defineInversion(FLX_THROW_ERRORS, FLX_NO_THROW_ERRORS);
 		
 		if (defined(FLX_CUSTOM_ASSETS_DIRECTORY))
 		{
@@ -315,9 +326,31 @@ class FlxDefines
 		}
 		else // define boolean inversion
 			define(FLX_STANDARD_ASSETS_DIRECTORY);
+		
+		validateLogLevel(FLX_LOG_THROW);
+		validateLogLevel(FLX_LOG_PLAY_SOUND);
+		validateLogLevel(FLX_LOG_OPEN_CONSOLE);
+	}
+	
+	static function validateLogLevel(userDefine:UserDefine)
+	{
+		if (defined(userDefine))
+		{
+			switch definedValue(userDefine).toUpperCase()
+			{
+				case "NORMAL"
+					| "NOTICE"
+					| "WARNING"
+					| "ERROR"
+					| "NONE":
+				
+				case unexpected:
+					abort('$userDefine must be: "NORMAL", "NOTICE", "WARNING", "ERROR" or "NONE", got "$unexpected"', (macro null).pos);
+			}
+		}
 	}
 
-	static function defineInversion(userDefine:UserDefines, invertedDefine:HelperDefines)
+	static function defineInversion(userDefine:UserDefine, invertedDefine:HelperDefine)
 	{
 		if (!defined(userDefine))
 			define(invertedDefine);
@@ -333,7 +366,7 @@ class FlxDefines
 		swfVersionError("Gamepad input is", "11.8", FLX_NO_GAMEPAD);
 	}
 
-	static function swfVersionError(feature:String, version:String, define:UserDefines)
+	static function swfVersionError(feature:String, version:String, define:UserDefine)
 	{
 		var errorMessage = '$feature only supported in Flash Player version $version or higher. '
 			+ 'Define ${define.getName()} to disable this feature or add <set name="SWF_VERSION" value="$version" /> to your Project.xml.';

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -66,6 +66,11 @@ private enum UserDefines
 	 * Used to make the debug windows bigger
 	 */
 	FLX_DEBUGGER_SCALE;
+	
+	/**
+	 * Whether `FlxG.log.error` calls will throw an exception
+	 */
+	FLX_THROW_ERRORS;
 }
 
 /**
@@ -115,6 +120,7 @@ private enum HelperDefines
 	/** The normalized, absolute path of `FLX_CUSTOM_ASSETS_DIRECTORY`, used internally */
 	FLX_CUSTOM_ASSETS_DIRECTORY_ABS;
 	FLX_NO_DEFAULT_SOUND_EXT;
+	FLX_NO_THROW_ERRORS;
 }
 
 class FlxDefines
@@ -285,6 +291,7 @@ class FlxDefines
 		#end
 		
 		defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS);
+		defineInversion(FLX_THROW_ERRORS, FLX_NO_THROW_ERRORS);
 		
 		if (defined(FLX_CUSTOM_ASSETS_DIRECTORY))
 		{

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -1,8 +1,8 @@
 package flixel.util;
 
-import flixel.tweens.FlxEase;
 import flixel.math.FlxMath;
 import flixel.system.macros.FlxMacroUtil;
+import flixel.tweens.FlxEase;
 
 /**
  * Class representing a color, based on Int. Provides a variety of methods for creating and converting colors.
@@ -373,14 +373,26 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	/**
 	 * Return a String representation of the color in the format
 	 *
-	 * @param Alpha Whether to include the alpha value in the hex string
-	 * @param Prefix Whether to include "0x" prefix at start of string
+	 * @param   alpha   Whether to include the alpha value in the hex string
+	 * @param   usePrefix  Whether to include "0x" prefix at start of string
 	 * @return	A string of length 10 in the format 0xAARRGGBB
 	 */
-	public inline function toHexString(Alpha:Bool = true, Prefix:Bool = true):String
+	overload public inline extern function toHexString(alpha:Bool, usePrefix:Bool):String
 	{
-		return (Prefix ? "0x" : "") + (Alpha ? StringTools.hex(alpha,
-			2) : "") + StringTools.hex(red, 2) + StringTools.hex(green, 2) + StringTools.hex(blue, 2);
+		return toHexString(usePrefix ? "0x" : "", alpha);
+	}
+
+	/**
+	 * Return a String representation of the color in the format
+	 *
+	 * @param   includeAlpha  Whether to include the alpha value in the hex string
+	 * @param   prefix        Optional color prefix
+	 * @since 6.2.0
+	 */
+	overload public inline extern function toHexString(prefix:String = "0x", includeAlpha = true):String
+	{
+		inline function hex(n) return StringTools.hex(n, 2);
+		return prefix + (includeAlpha ? hex(alpha) : "") + hex(red) + hex(green) + hex(blue);
 	}
 
 	/**

--- a/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
+++ b/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
@@ -79,8 +79,8 @@ class FlxLogStyleTest
 		Assert.isTrue(FlxG.debugger.visible, "Expected debugger to be visible");
 	}
 	
-	inline function log(msg:Any = "test", ?pos:PosInfos)
+	inline function log(msg:Any = "test", fireOnce = false, ?pos:PosInfos)
 	{
-		FlxG.log.advanced(msg, style, pos);
+		FlxG.log.advanced(msg, style, fireOnce, pos);
 	}
 }

--- a/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
+++ b/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
@@ -1,18 +1,18 @@
 package flixel.system.debug.log;
 
 import flixel.FlxG;
-import flixel.system.debug.log.LogStyle;
+import flixel.system.debug.log.FlxLogStyle;
 import haxe.PosInfos;
 import massive.munit.Assert;
 
 class FlxLogStyleTest
 {
-	var style:LogStyle;
+	var style:FlxLogStyle;
 	
 	@Before
 	function before():Void
 	{
-		style = new LogStyle();
+		style = new FlxLogStyle();
 	}
 	
 	@Test

--- a/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
+++ b/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
@@ -21,7 +21,7 @@ class FlxLogStyleTest
 		style.throwException = true;
 		try
 		{
-			log();
+			log('testThrowException-1');
 			Assert.fail("Expected log() to throw an exception");
 		}
 		catch(e)
@@ -32,12 +32,12 @@ class FlxLogStyleTest
 		style.throwException = false;
 		try
 		{
-			log(style);
+			log('testThrowException-2');
 			Assert.assertionCount++;
 		}
 		catch(e)
 		{
-			Assert.fail("Unexpected exception thrown by log()");
+			Assert.fail('Unexpected exception thrown by log() - "${e.message}"');
 		}
 	}
 	
@@ -45,14 +45,14 @@ class FlxLogStyleTest
 	function testOnLog()
 	{
 		var called = false;
-		style.prefix = "Specific Prefix";
+		style.prefix = "some-prefix";
 		style.onLog.addOnce(function (msg, ?_)
 		{
-			Assert.areEqual("Specific Message", msg);
+			Assert.areEqual("testOnLog", msg);
 			called = true;
 		});
 		
-		log("Specific Message");
+		log("testOnLog");
 		Assert.isTrue(called, "Expected style.onLog to be dispatched");
 	}
 	
@@ -64,7 +64,7 @@ class FlxLogStyleTest
 		var called = false;
 		style.callbackFunction = ()->called = true;
 		
-		log();
+		log('testCallbackFunction');
 		Assert.isTrue(called, "Expected callbackFunction to be caled, it was not");
 	}
 	
@@ -75,11 +75,11 @@ class FlxLogStyleTest
 		FlxG.debugger.visible = false;
 		
 		style.openConsole = true;
-		log();
+		log("testOpenConsole");
 		Assert.isTrue(FlxG.debugger.visible, "Expected debugger to be visible");
 	}
 	
-	inline function log(msg:Any = "test", fireOnce = false, ?pos:PosInfos)
+	inline function log(msg:Any, fireOnce = false, ?pos:PosInfos)
 	{
 		FlxG.log.advanced(msg, style, fireOnce, pos);
 	}

--- a/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
+++ b/tests/unit/src/flixel/system/debug/log/FlxLogStyleTest.hx
@@ -1,0 +1,86 @@
+package flixel.system.debug.log;
+
+import flixel.FlxG;
+import flixel.system.debug.log.LogStyle;
+import haxe.PosInfos;
+import massive.munit.Assert;
+
+class FlxLogStyleTest
+{
+	var style:LogStyle;
+	
+	@Before
+	function before():Void
+	{
+		style = new LogStyle();
+	}
+	
+	@Test
+	function testThrowException()
+	{
+		style.throwException = true;
+		try
+		{
+			log();
+			Assert.fail("Expected log() to throw an exception");
+		}
+		catch(e)
+		{
+			Assert.assertionCount++;
+		}
+		
+		style.throwException = false;
+		try
+		{
+			log(style);
+			Assert.assertionCount++;
+		}
+		catch(e)
+		{
+			Assert.fail("Unexpected exception thrown by log()");
+		}
+	}
+	
+	@Test
+	function testOnLog()
+	{
+		var called = false;
+		style.prefix = "Specific Prefix";
+		style.onLog.addOnce(function (msg, ?_)
+		{
+			Assert.areEqual("Specific Message", msg);
+			called = true;
+		});
+		
+		log("Specific Message");
+		Assert.isTrue(called, "Expected style.onLog to be dispatched");
+	}
+	
+	@Test
+	#if FLX_NO_DEBUG @Ignore("FLX_NO_DEBUG") #end
+	@:haxe.warning("-WDeprecated")
+	function testCallbackFunction()
+	{
+		var called = false;
+		style.callbackFunction = ()->called = true;
+		
+		log();
+		Assert.isTrue(called, "Expected callbackFunction to be caled, it was not");
+	}
+	
+	@Test
+	#if FLX_NO_DEBUG @Ignore("FLX_NO_DEBUG") #end
+	function testOpenConsole()
+	{
+		FlxG.debugger.visible = false;
+		
+		style.openConsole = true;
+		log();
+		Assert.isTrue(FlxG.debugger.visible, "Expected debugger to be visible");
+	}
+	
+	inline function log(msg:Any = "test", ?pos:PosInfos)
+	{
+		FlxG.log.advanced(msg, style, pos);
+	}
+}

--- a/tests/unit/src/flixel/system/frontEnds/LogFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/LogFrontEndTest.hx
@@ -1,0 +1,46 @@
+package flixel.system.frontEnds;
+
+import flixel.FlxG;
+import flixel.system.debug.log.LogStyle;
+import massive.munit.Assert;
+
+class LogFrontEndTest
+{
+	@Test
+	// #if FLX_NO_DEBUG @Ignore("FLX_NO_DEBUG") #end
+	@:haxe.warning("-WDeprecated")
+	function testEquality()
+	{
+		final oldLog = FlxG.log.styles.normal;
+		Assert.areEqual(FlxG.log.styles.normal, LogStyle.NORMAL);
+		FlxG.log.styles.normal = new LogStyle();
+		Assert.areEqual(FlxG.log.styles.normal, LogStyle.NORMAL);
+		LogStyle.NORMAL = oldLog;
+		Assert.areEqual(FlxG.log.styles.normal, LogStyle.NORMAL);
+	}
+	
+	@Test
+	function testThrowDefault()
+	{
+		#if FLX_THROW_ERRORS
+		Assert.isTrue(FlxG.log.styles.error.throwException);
+		#else
+		Assert.isFalse(FlxG.log.styles.error.throwException);
+		#end
+	}
+	
+	@Test
+	function testRedirectTraces()
+	{
+		final oldValue = FlxG.log.redirectTraces;
+		
+		FlxG.log.redirectTraces = true;
+		var called = false;
+		FlxG.log.styles.normal.onLog.addOnce((_,?_)->called = true);
+		trace("test");
+		Assert.isTrue(called, "Expected trace to call log.normal, when it did not");
+		
+		// reset value
+		FlxG.log.redirectTraces = oldValue;
+	}
+}


### PR DESCRIPTION
Closes #3450

TODO:
- [x] Rename `FLX_THROW_ERRORS`
- [x] Make all the font fields of log style a sub type
- [x] Enable htmlText on web targets
- [ ] test htmlText
    - [x] chrome
    - [x] firefox
    - [ ] edge - who cares
    - [x] safari