### PR TITLE
FlxStringUtil: Optimize and improve bitmapToCSV and prevent errors when farbling

### DIFF
--- a/flixel/tile/FlxBaseTilemap.hx
+++ b/flixel/tile/FlxBaseTilemap.hx
@@ -953,38 +953,139 @@ abstract class FlxBaseTilemap<Tile:FlxObject> extends FlxObject
 		loadMapHelper(tileGraphic, tileWidth, tileHeight, autoTile, startingIndex, drawIndex, collideIndex);
 		return this;
 	}
-
+	
 	/**
 	 * Load the tilemap with image data and a tile graphic.
-	 * Black pixels are flagged as 'solid' by default, non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
-	 * @param   mapGraphic      The image you want to use as a source of map data, where each pixel is a tile (or more than one tile if you change Scale's default value). Preferably black and white.
-	 * @param   invert          Load white pixels as solid instead.
-	 * @param   scale           Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
-	 * @param   colorMap        An array of color values (alpha values are ignored) in the order they're intended to be assigned as indices
+	 * Black pixels are flagged as 'solid' by default, non-black pixels are set as non-colliding.
+	 * @param   mapGraphic      The image you want to use as a source of map data, where each
+	 *                          pixel is a tile or chunk of tiles.
+	 * @param   whiteIsSolid    Whether to load white pixels as solid and black and empty
+	 * @param   scale           Default is 1. `scale` of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param   colorMap        An array of color values (ignores alpha) in the
+	 *                          order they're intended to be assigned as indices
 	 * @param   tileGraphic     All the tiles you want to use, arranged in a strip corresponding to the numbers in MapData.
 	 * @param   tileWidth       The width of your tiles (e.g. 8) - defaults to height of the tile graphic if unspecified.
 	 * @param   tileHeight      The height of your tiles (e.g. 8) - defaults to width if unspecified.
 	 * @param   autoTile        Whether to load the map using an automatic tile placement algorithm (requires 16 tiles!).
-	 *                          Setting this to either AUTO or ALT will override any values you put for StartingIndex, DrawIndex, or CollideIndex.
+	 *                          Setting this to either `AUTO` or `ALT` will override any values you
+	 *                          put for `startingIndex`, `drawIndex`, or `collideIndex`.
 	 * @param   startingIndex   Used to sort of insert empty tiles in front of the provided graphic.
-	 *                          Default is 0, usually safest ot leave it at that.  Ignored if AutoTile is set.
+	 *                          Default is 0, usually safest ot leave it at that.  Ignored if `autoTile` is set.
 	 * @param   drawIndex       Initializes all tile objects equal to and after this index as visible.
-	 *                          Default value is 1. Ignored if AutoTile is set.
+	 *                          Default value is 1. Ignored if `autoTile` is set.
 	 * @param   collideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
-	 *                          Default value is 1.  Ignored if AutoTile is set.
-	 *                          Can override and customize per-tile-type collision behavior using setTileProperties().
+	 *                          Default value is 1.  Ignored if `autoTile` is set.
+	 *                          Can override and customize per-tile-type collision behavior using `setTileProperties()`.
 	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
 	 * @since   4.1.0
 	 */
-	public function loadMapFromGraphic(mapGraphic:FlxGraphicAsset, invert = false, scale = 1, ?colorMap:Array<FlxColor>,
+	@:deprecated("loadMapFromGraphic with both bitmap and colorMap is deprecated, use a different overload of loadMapFromGraphic")
+	overload public inline extern function loadMapFromGraphic(mapGraphic:FlxGraphicAsset, whiteIsSolid:Bool, scale:Int, colorMap:Null<Array<FlxColor>>,
 			tileGraphic:FlxTilemapGraphicAsset, tileWidth = 0, tileHeight = 0, ?autoTile:FlxTilemapAutoTiling,
 			startingIndex = 0, drawIndex = 1, collideIndex = 1)
 	{
-		var mapBitmap:BitmapData = FlxAssets.resolveBitmapData(mapGraphic);
-		var mapData:String = FlxStringUtil.bitmapToCSV(mapBitmap, invert, scale, colorMap);
+		final mapData = if (colorMap == null)
+			FlxStringUtil.imageToCSV(mapGraphic, whiteIsSolid, scale);
+		else
+			FlxStringUtil.imageToCSV(mapGraphic, scale, colorMap);
+		
 		return loadMapFromCSV(mapData, tileGraphic, tileWidth, tileHeight, autoTile, startingIndex, drawIndex, collideIndex);
 	}
-
+	
+	/**
+	 * Load the tilemap with image data and a tile graphic.
+	 * Black pixels are flagged as 'solid' by default, non-black pixels are set as non-colliding.
+	 * @param   mapGraphic      The image you want to use as a source of map data, where each
+	 *                          pixel is a tile or chunk of tiles.
+	 * @param   scale           Default is 1. `scale` of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param   colorMap        An array of rb color values (ignores alpha) in the
+	 *                          order they're intended to be assigned as indices
+	 * @param   tileGraphic     All the tiles you want to use, arranged in a strip corresponding to the numbers in MapData.
+	 * @param   tileWidth       The width of your tiles (e.g. 8) - defaults to height of the tile graphic if unspecified.
+	 * @param   tileHeight      The height of your tiles (e.g. 8) - defaults to width if unspecified.
+	 * @param   autoTile        Whether to load the map using an automatic tile placement algorithm (requires 16 tiles!).
+	 *                          Setting this to either `AUTO` or `ALT` will override any values you
+	 *                          put for `startingIndex`, `drawIndex`, or `collideIndex`.
+	 * @param   startingIndex   Used to sort of insert empty tiles in front of the provided graphic.
+	 *                          Default is 0, usually safest ot leave it at that.  Ignored if `autoTile` is set.
+	 * @param   drawIndex       Initializes all tile objects equal to and after this index as visible.
+	 *                          Default value is 1. Ignored if `autoTile` is set.
+	 * @param   collideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
+	 *                          Default value is 1.  Ignored if `autoTile` is set.
+	 *                          Can override and customize per-tile-type collision behavior using `setTileProperties()`.
+	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
+	 * @since   6.2.0
+	 */
+	overload public inline extern function loadMapFromGraphic(mapGraphic:FlxGraphicAsset, scale = 1, colorMap:Array<FlxColor>,
+			tileGraphic:FlxTilemapGraphicAsset, tileWidth = 0, tileHeight = 0, ?autoTile:FlxTilemapAutoTiling,
+			startingIndex = 0, drawIndex = 1, collideIndex = 1)
+	{
+		final mapData:String = FlxStringUtil.imageToCSV(mapGraphic, scale, colorMap);
+		return loadMapFromCSV(mapData, tileGraphic, tileWidth, tileHeight, autoTile, startingIndex, drawIndex, collideIndex);
+	}
+	
+	/**
+	 * Load the tilemap with image data and a tile graphic.
+	 * Black pixels are flagged as 'solid' by default, non-black pixels are set as non-colliding.
+	 * @param   mapGraphic      The image you want to use as a source of map data, where each
+	 *                          pixel is a tile or chunk of tiles.
+	 * @param   scale           Default is 1. `scale` of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param   colorMap        An array of rgba color values in the order they're intended to be assigned as indices
+	 * @param   tileGraphic     All the tiles you want to use, arranged in a strip corresponding to the numbers in MapData.
+	 * @param   tileWidth       The width of your tiles (e.g. 8) - defaults to height of the tile graphic if unspecified.
+	 * @param   tileHeight      The height of your tiles (e.g. 8) - defaults to width if unspecified.
+	 * @param   autoTile        Whether to load the map using an automatic tile placement algorithm (requires 16 tiles!).
+	 *                          Setting this to either `AUTO` or `ALT` will override any values you
+	 *                          put for `startingIndex`, `drawIndex`, or `collideIndex`.
+	 * @param   startingIndex   Used to sort of insert empty tiles in front of the provided graphic.
+	 *                          Default is 0, usually safest ot leave it at that.  Ignored if `autoTile` is set.
+	 * @param   drawIndex       Initializes all tile objects equal to and after this index as visible.
+	 *                          Default value is 1. Ignored if `autoTile` is set.
+	 * @param   collideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
+	 *                          Default value is 1.  Ignored if `autoTile` is set.
+	 *                          Can override and customize per-tile-type collision behavior using `setTileProperties()`.
+	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
+	 * @since   6.2.0
+	 */
+	public function loadMap32FromGraphic(mapGraphic:FlxGraphicAsset, scale = 1, colorMap:Array<FlxColor>,
+			tileGraphic:FlxTilemapGraphicAsset, tileWidth = 0, tileHeight = 0, ?autoTile:FlxTilemapAutoTiling,
+			startingIndex = 0, drawIndex = 1, collideIndex = 1)
+	{
+		final mapData:String = FlxStringUtil.image32ToCSV(mapGraphic, scale, colorMap);
+		return loadMapFromCSV(mapData, tileGraphic, tileWidth, tileHeight, autoTile, startingIndex, drawIndex, collideIndex);
+	}
+	
+	/**
+	 * Load the tilemap with image data and a tile graphic.
+	 * Black pixels are flagged as 'solid' by default, non-black pixels are set as non-colliding.
+	 * @param   mapGraphic      The image you want to use as a source of map data, where each
+	 *                          pixel is a tile or chunk of tiles
+	 * @param   whiteIsSolid    Whether to load white pixels as solid and black and empty
+	 * @param   scale           Default is 1. `scale` of 2 means each pixel forms a 2x2 block of tiles, and so on
+	 * @param   tileGraphic     All the tiles you want to use, arranged in a strip corresponding to the numbers in MapData
+	 * @param   tileWidth       The width of your tiles (e.g. 8) - defaults to height of the tile graphic if unspecified
+	 * @param   tileHeight      The height of your tiles (e.g. 8) - defaults to width if unspecified
+	 * @param   autoTile        Whether to load the map using an automatic tile placement algorithm (requires 16 tiles!).
+	 *                          Setting this to either `AUTO` or `ALT` will override any values you
+	 *                          put for `startingIndex`, `drawIndex`, or `collideIndex`
+	 * @param   startingIndex   Used to sort of insert empty tiles in front of the provided graphic.
+	 *                          Default is 0, usually safest ot leave it at that.  Ignored if `autoTile` is set
+	 * @param   drawIndex       Initializes all tile objects equal to and after this index as visible.
+	 *                          Default value is 1. Ignored if `autoTile` is set
+	 * @param   collideIndex    Initializes all tile objects equal to and after this index as allowCollisions = ANY.
+	 *                          Default value is 1.  Ignored if `autoTile` is set.
+	 *                          Can override and customize per-tile-type collision behavior using `setTileProperties()`
+	 * @return  A reference to this instance of FlxTilemap, for chaining as usual :)
+	 * @since   6.2.0
+	 */
+	overload public inline extern function loadMapFromGraphic(mapGraphic:FlxGraphicAsset, whiteIsSolid = false, scale = 1,
+			tileGraphic:FlxTilemapGraphicAsset, tileWidth = 0, tileHeight = 0, ?autoTile:FlxTilemapAutoTiling,
+			startingIndex = 0, drawIndex = 1, collideIndex = 1)
+	{
+		final mapData:String = FlxStringUtil.imageToCSV(mapGraphic, whiteIsSolid, scale);
+		return loadMapFromCSV(mapData, tileGraphic, tileWidth, tileHeight, autoTile, startingIndex, drawIndex, collideIndex);
+	}
+	
 	function loadMapHelper(tileGraphic:FlxTilemapGraphicAsset, tileWidth = 0, tileHeight = 0, ?autoTile:FlxTilemapAutoTiling,
 			startingIndex = 0, drawIndex = 1, collideIndex = 1)
 	{

--- a/flixel/util/FlxArrayUtil.hx
+++ b/flixel/util/FlxArrayUtil.hx
@@ -168,6 +168,115 @@ class FlxArrayUtil
 				result.push(element);
 		return result;
 	}
+	
+	/**
+	 * For each nested array, duplicates each item the specifed `amount`, and then duplicates the
+	 * arrays themselves.
+	 * 
+	 * For example: 
+	 * ```haxe
+	 * final arr =
+	 * [
+	 *     [0, 2, 6],
+	 *     [1, 3, 7],
+	 *     [0, 0, 0]
+	 * ];
+	 * trace(FlxArrayUtil.scale(arr, 2, 3).join("\n"));
+	 * // output:
+	 * // 0,0,2,2,6,6
+	 * // 0,0,2,2,6,6
+	 * // 1,1,3,3,7,7
+	 * // 1,1,3,3,7,7
+	 * // 0,0,0,0,0,0
+	 * // 0,0,0,0,0,0
+	 * ```
+	 * 
+	 * **NOTE:** Each added array is a unique instance, unlike the following, which will contain
+	 * the same array instances:
+	 * ```haxe
+	 * FlxArrayUtil.scale(array.map((subArray)->FlxArrayUtil.scale(subArray, amount)), amount);
+	 * ```
+	 * 
+	 * @param   data    The array to be scaled
+	 * @param   amount  The amount to duplicate each array and sub-array item
+	 * 
+	 * @since 6.2.0
+	 */
+	overload public static inline extern function scale<T>(data:Array<Array<T>>, amount:Int):Array<Array<T>>
+	{
+		return scale(data, amount, amount);
+	}
+	
+	/**
+	 * For each nested array, duplicates each item by the specifed `subAmount`, and then duplicates
+	 * the arrays by the specified `amount`.
+	 * 
+	 * For example: 
+	 * ```haxe
+	 * final arr =
+	 * [
+	 *     [0, 2, 6],
+	 *     [1, 3, 7],
+	 *     [0, 0, 0]
+	 * ];
+	 * trace(FlxArrayUtil.scale(arr, 3, 2).join("\n"));
+	 * // outputs:
+	 * // 0,0,0,2,2,2,6,6,6
+	 * // 0,0,0,2,2,2,6,6,6
+	 * // 1,1,1,3,3,3,7,7,7
+	 * // 1,1,1,3,3,3,7,7,7
+	 * // 0,0,0,0,0,0,0,0,0
+	 * // 0,0,0,0,0,0,0,0,0
+	 * ```
+	 * @since 6.2.0
+	 * 
+	 * **NOTE:** Each added array is a unique instance, unlike the following, which will contain
+	 * the same array instances:
+	 * ```haxe
+	 * FlxArrayUtil.scale(array.map((subArray)->FlxArrayUtil.scale(subArray, subAmount)), amount);
+	 * ```
+	 * 
+	 * @param   data       The array to be scaled
+	 * @param   subAmount  The amount to duplicate each sub-array item
+	 * @param   amount     The amount to duplicate each array
+	 * 
+	 * @since 6.2.0
+	 */
+	overload public static inline extern function scale<T>(data:Array<Array<T>>, subAmount:Int, amount:Int):Array<Array<T>>
+	{
+		return scale2dHelper(data, subAmount, amount);
+	}
+	
+	static function scale2dHelper<T>(data:Array<Array<T>>, subAmount:Int, amount:Int):Array<Array<T>>
+	{
+		final result:Array<Array<T>> = [];
+		for (row in data)
+		{
+			final scaledRow = scale(row, subAmount);
+			for (s in 0...amount)
+				result.push(s == 0 ? scaledRow : scaledRow.copy());
+		}
+		return result;
+	}
+	
+	/**
+	 * Takes an array and turns every duplicates item the specified `amount`.
+	 * For example `scale([0, 9, 5], 3)` becomes `[0, 0, 0, 9, 9, 9, 5, 5, 5]`
+	 * 
+	 * **NOTE:** Duplicated items will be the same instance, even if the data is an array of arrays
+	 * 
+	 * @since 6.2.0
+	 */
+	overload public static inline extern function scale<T>(data:Array<T>, amount:Int):Array<T>
+	{
+		final result:Array<T> = [];
+		for (value in data)
+		{
+			for (s in 0...amount)
+				result.push(value);
+		}
+		return result;
+	}
 
 	/**
 	 * Compares the contents with `==` to see if the two arrays are the same.

--- a/flixel/util/FlxColor.hx
+++ b/flixel/util/FlxColor.hx
@@ -302,6 +302,71 @@ abstract FlxColor(Int) from Int from UInt to Int to UInt
 	{
 		return FlxColor.fromRGB(lhs.red - rhs.red, lhs.green - rhs.green, lhs.blue - rhs.blue);
 	}
+	
+	/**
+	 * Returns the sum of the absolute differences of each channel between this and the specified color.
+	 * For instance `FlxColor.RED.getDistance(0xFFf80080)` is `135`, or `(0xff - 0xf8) + (0x80 - 0x00)`
+	 * 
+	 * @since 6.2.0
+	 */
+	public function getDistance(color:FlxColor)
+	{
+		inline function abs(n:Int):Int
+		{
+			return n < 0 ? -n : n;
+		}
+		
+		return abs(color.red - red)
+			+ abs(color.green - green)
+			+ abs(color.blue - blue)
+			+ abs(color.alpha - alpha);
+	}
+	
+	/**
+	 * Searches the list of colors and returns the one whos rgba components are closets to this color.
+	 * If colors is empty, the result is `null`
+	 * 
+	 * @since 6.2.0
+	 */
+	overload public inline extern function nearest(colors:Array<FlxColor>):Null<FlxColor>
+	{
+		return getNearest(this, colors.iterator());
+	}
+	
+	/**
+	 * Searches the list of colors and returns the one whos rgba components are closets to this color.
+	 * If colors is empty, the result is `null`
+	 * 
+	 * @since 6.2.0
+	 */
+	overload public inline extern function nearest(colors:Iterator<FlxColor>):Null<FlxColor>
+	{
+		return getNearest(this, colors);
+	}
+	
+	static function getNearest(target:FlxColor, colors:Iterator<FlxColor>):Null<FlxColor>
+	{
+		var closest:Null<FlxColor> = null;
+		var closestDiff = -1;
+		
+		for (color in colors)
+		{
+			if (color == target)
+			{
+				closest = target;
+				break;
+			}
+			
+			final diff = color.getDistance(target);
+			if (closest == null || diff < closestDiff)
+			{
+				closest = color;
+				closestDiff = diff;
+			}
+		}
+		
+		return closest;
+	}
 
 	/**
 	 * Returns a Complementary Color Harmony of this color.

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -447,7 +447,10 @@ class FlxStringUtil
 
 	/**
 	 * Converts a BitmapData object to a comma-separated string.
-	 *
+	 * 
+	 * **NOTE:** Due to OpenFL premultiplying all pixel colors on set,
+	 * any pixel with a 0 alpha and non-zero color components will be treated as 0x00000000
+	 * 
 	 * @param	bitmap   A Flash BitmapData object, preferably black and white.
 	 * @param	scale    Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
 	 * @param	colorMap An array of rgba color values in the order they're intended to be assigned as indices

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -378,64 +378,27 @@ class FlxStringUtil
 	/**
 	 * Converts a one-dimensional array of tile data to a comma-separated string.
 	 *
-	 * @param	Data		An array full of integer tile references.
-	 * @param	Width		The number of tiles in each row.
-	 * @param	Invert		Recommended only for 1-bit arrays - changes 0s to 1s and vice versa.
-	 * @return	A comma-separated string containing the level data in a FlxTilemap-friendly format.
+	 * @param   data    An array full of integer tile references.
+	 * @param   width   The number of tiles in each row.
+	 * @param   invert  Recommended only for 1-bit arrays - changes 0s to 1s and vice versa.
+	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format.
 	 */
-	public static function arrayToCSV(Data:Array<Int>, Width:Int, Invert:Bool = false):String
+	public static function arrayToCSV(data:Array<Int>, width:Int, invert = false):String
 	{
-		var row:Int = 0;
-		var column:Int;
-		var csv:String = "";
-		var height:Int = Std.int(Data.length / Width);
-		var index:Int;
-		var offset:Int = 0;
-
-		while (row < height)
-		{
-			column = 0;
-
-			while (column < Width)
-			{
-				index = Data[offset];
-
-				if (Invert)
-				{
-					if (index == 0)
-					{
-						index = 1;
-					}
-					else if (index == 1)
-					{
-						index = 0;
-					}
-				}
-
-				if (column == 0)
-				{
-					if (row == 0)
-					{
-						csv += index;
-					}
-					else
-					{
-						csv += "\n" + index;
-					}
-				}
-				else
-				{
-					csv += ", " + index;
-				}
-
-				column++;
-				offset++;
-			}
-
-			row++;
-		}
-
-		return csv;
+		return arrayToCSVHelper(invert ? data.map(t->t == 0 ? 1 : 0) : data, width);
+	}
+	
+	static function arrayToCSVHelper<T>(data:Array<T>, width:Int):String
+	{
+		final rows = Std.int(data.length / width);
+		return [ for (row in 0...rows)
+			data.slice(width * row, (1 + row) * width).join(", ")
+		].join("\n");
+	}
+	
+	static function array2DToCSVHelper<T>(data:Array<Array<T>>):String
+	{
+		return data.map(row->row.join(", ")).join("\n");
 	}
 
 	/**
@@ -503,46 +466,51 @@ class FlxStringUtil
 	static function bitmapToCSVHelper(bitmap:BitmapData, scale:Int, colors:Array<FlxColor>, ignoreAlpha:Bool):String
 	{
 		final colorMap = generateColorMapFromArray(colors, ignoreAlpha);
-		
+		final array = bitmapToArray2dHelper(bitmap, scale, colorMap, ignoreAlpha, 0);
+		return array2DToCSVHelper(array);
+	}
+	
+	static function bitmapToArray2dHelper<T>(bitmap:BitmapData, scale:Int, colorMap:Map<FlxColor, T>, ignoreAlpha:Bool, backupValue:T):Array<Array<T>>
+	{
 		final bitmapColors = bitmap.getVector(bitmap.rect);
 		final columns = bitmap.width;
 		final rows = bitmap.height;
-		final result = new Array<String>();
+		final result:Array<Array<T>> = [];
 		for (row in 0...rows)
 		{
-			final rowData = new Array<Int>();
+			final rowData:Array<T> = [];
 			for (column in 0...columns)
 			{
 				final rgba:FlxColor = bitmapColors[row * columns + column];
 				final color = ignoreAlpha ? rgba.rgb : rgba;
-				final index = if (colorMap.exists(color))
+				final value = if (colorMap.exists(color))
 				{
 					colorMap[color];
 				}
 				else if (isBrowserManipulatingImages)
 				{
-					final backupIndex = getNearestColorIndex(color, colorMap);
-					colorMap[color] = backupIndex;
+					final nearestColor = color.nearest(colorMap.keys());
+					colorMap[color] = colorMap[nearestColor];
 					FlxG.log.notice('Bitmap contains unexpected color ${color.toHexString()}, '
-						+ 'likely due to your browser\'s privacy settings. Assuming index $backupIndex');
-					backupIndex;
+						+ 'likely due to your browser\'s privacy settings. Using nearest color $nearestColor.toHexString()}');
+					colorMap[nearestColor];
 				}
 				else
 				{
-					colorMap[color] = 0;
-					FlxG.log.error('Error creating csv, unmapped color ${color.toHexString()}. Assuming index 0');
-					0;
+					colorMap[color] = backupValue;
+					FlxG.log.error('Error creating csv, unmapped color ${color.toHexString()}. Defaulting to $backupValue');
+					backupValue;
 				}
 				
 				for (s in 0...scale)
-					rowData.push(index);
+					rowData.push(value);
 			}
 			
-			final stringData = rowData.join(", ");
 			for (s in 0...scale)
-				result.push(stringData);
+				result.push(rowData);
 		}
-		return result.join("\n");
+		
+		return result;
 	}
 	
 	#if html5 
@@ -634,37 +602,6 @@ class FlxStringUtil
 		#end
 		
 		return colorMap;
-	}
-	
-	static inline function getNearestColorIndex(targetColor:FlxColor, map:Map<FlxColor, Int>):Int
-	{
-		if (map.exists(targetColor))
-			return map[targetColor];
-		
-		var closest = -1;
-		var closestDiff = -1;
-		
-		inline function abs(a:Int):Int
-		{
-			return a < 0 ? -1 : a;
-		}
-		
-		for (color => index in map)
-		{
-			final diff
-				= abs(color.red - targetColor.red)
-				+ abs(color.green - targetColor.green)
-				+ abs(color.blue - targetColor.blue)
-				+ abs(color.alpha - targetColor.alpha);
-			
-			if (closest == -1 || diff < closestDiff)
-			{
-				closest = index;
-				closestDiff = diff;
-			}
-		}
-		
-		return closest;
 	}
 
 	/**

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -1,11 +1,11 @@
 package flixel.util;
 
-import openfl.display.BitmapData;
 import flixel.FlxG;
 import flixel.math.FlxMath;
 import flixel.system.FlxAssets;
 import flixel.util.FlxDestroyUtil.IFlxDestroyable;
 import flixel.util.typeLimit.OneOfTwo;
+import openfl.display.BitmapData;
 
 using StringTools;
 
@@ -442,129 +442,291 @@ class FlxStringUtil
 	 * Converts a BitmapData object to a comma-separated string. Black pixels are flagged as 'solid' by default,
 	 * non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
 	 *
-	 * @param	Bitmap		A Flash BitmapData object, preferably black and white.
-	 * @param	Invert		Load white pixels as solid instead.
-	 * @param	Scale		Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
-	 * @param	ColorMap	An array of color values (alpha values are ignored) in the order they're intended to be assigned as indices
+	 * @param   bitmap        A Flash BitmapData object, preferably black and white.
+	 * @param   whiteIsSolid  Whether to load white pixels as solid and black and empty
+	 * @param   scale         Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param	colorMap  	  An array of color values (ignores alpha) in the order they're intended to be assigned as indices
+	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format.
+	 */
+	@:deprecated("bitmapToCSV with both bitmap and colorMap is deprecated, use a different overload of bitmapToCSV")
+	overload public static inline extern function bitmapToCSV(bitmap:BitmapData, whiteIsSolid:Bool, scale:Int, colorMap:Null<Array<FlxColor>>):String
+	{
+		if (colorMap == null)
+			colorMap = whiteIsSolid ? invertColorMap : defaultColorMap;
+		
+		return bitmapToCSVHelper(bitmap, scale, colorMap, true);
+	}
+	
+	/**
+	 * Converts a BitmapData object to a comma-separated string. Black pixels are flagged as
+	 * 'solid' by default, non-black pixels are set as non-colliding. Black pixels must be PURE BLACK
+	 *
+	 * @param   bitmap        A Flash BitmapData object, preferably black and white
+	 * @param   whiteIsSolid  Whether to load white pixels as solid and black and empty
+	 * @param   scale         Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles
+	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format
+	 */
+	overload public static inline extern function bitmapToCSV(bitmap:BitmapData, whiteIsSolid = false, scale = 1):String
+	{
+		return bitmapToCSVHelper(bitmap, scale, whiteIsSolid ? invertColorMap : defaultColorMap, true);
+	}
+	
+	static final defaultColorMap = [FlxColor.WHITE, FlxColor.BLACK];
+	static final invertColorMap = [FlxColor.BLACK, FlxColor.WHITE];
+
+	/**
+	 * Converts a BitmapData object to a comma-separated string.
+	 *
+	 * @param	bitmap   A Flash BitmapData object, preferably black and white.
+	 * @param	scale    Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param	colorMap An array of rgb color values in the order, they're intended to be assigned as indices
 	 * @return	A comma-separated string containing the level data in a FlxTilemap-friendly format.
 	 */
-	public static function bitmapToCSV(Bitmap:BitmapData, Invert:Bool = false, Scale:Int = 1, ?ColorMap:Array<FlxColor>):String
+	overload public static inline extern function bitmapToCSV(bitmap:BitmapData, scale = 1, colorMap:Array<FlxColor>):String
 	{
-		if (Scale < 1)
+		return bitmapToCSVHelper(bitmap, scale, colorMap, true);
+	}
+
+	/**
+	 * Converts a BitmapData object to a comma-separated string.
+	 *
+	 * @param	bitmap   A Flash BitmapData object, preferably black and white.
+	 * @param	scale    Default is 1. Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param	colorMap An array of rgba color values in the order they're intended to be assigned as indices
+	 * @return	A comma-separated string containing the level data in a FlxTilemap-friendly format.
+	 */
+	public static inline function bitmap32ToCSV(bitmap:BitmapData, scale = 1, colorMap:Array<FlxColor>):String
+	{
+		return bitmapToCSVHelper(bitmap, scale, colorMap, false);
+	}
+	
+	static function bitmapToCSVHelper(bitmap:BitmapData, scale:Int, colors:Array<FlxColor>, ignoreAlpha:Bool):String
+	{
+		final colorMap = generateColorMapFromArray(colors, ignoreAlpha);
+		
+		final bitmapColors = bitmap.getVector(bitmap.rect);
+		final columns = bitmap.width;
+		final rows = bitmap.height;
+		final result = new Array<String>();
+		for (row in 0...rows)
 		{
-			Scale = 1;
-		}
-
-		// Import and scale image if necessary
-		if (Scale > 1)
-		{
-			var bd:BitmapData = Bitmap;
-			Bitmap = new BitmapData(Bitmap.width * Scale, Bitmap.height * Scale);
-
-			#if !flash
-			var bdW:Int = bd.width;
-			var bdH:Int = bd.height;
-			var pCol:Int = 0;
-
-			for (i in 0...bdW)
+			final rowData = new Array<Int>();
+			for (column in 0...columns)
 			{
-				for (j in 0...bdH)
+				final rgba:FlxColor = bitmapColors[row * columns + column];
+				final color = ignoreAlpha ? rgba.rgb : rgba;
+				final index = if (colorMap.exists(color))
 				{
-					pCol = bd.getPixel(i, j);
-
-					for (k in 0...Scale)
-					{
-						for (m in 0...Scale)
-						{
-							Bitmap.setPixel(i * Scale + k, j * Scale + m, pCol);
-						}
-					}
+					colorMap[color];
 				}
-			}
-			#else
-			var mtx = new Matrix();
-			mtx.scale(Scale, Scale);
-			Bitmap.draw(bd, mtx);
-			#end
-		}
-
-		if (ColorMap != null)
-		{
-			for (i in 0...ColorMap.length)
-			{
-				ColorMap[i] = ColorMap[i].rgb;
-			}
-		}
-
-		// Walk image and export pixel values
-		var row:Int = 0;
-		var column:Int;
-		var pixel:Int;
-		var csv:String = "";
-		var bitmapWidth:Int = Bitmap.width;
-		var bitmapHeight:Int = Bitmap.height;
-
-		while (row < bitmapHeight)
-		{
-			column = 0;
-
-			while (column < bitmapWidth)
-			{
-				// Decide if this pixel/tile is solid (1) or not (0)
-				pixel = Bitmap.getPixel(column, row);
-
-				if (ColorMap != null)
+				else if (isBrowserManipulatingImages)
 				{
-					pixel = ColorMap.indexOf(pixel);
-				}
-				else if ((Invert && (pixel > 0)) || (!Invert && (pixel == 0)))
-				{
-					pixel = 1;
+					final backupIndex = getNearestColorIndex(color, colorMap);
+					colorMap[color] = backupIndex;
+					FlxG.log.notice('Bitmap contains unexpected color ${color.toHexString()}, '
+						+ 'likely due to your browser\'s privacy settings. Assuming index $backupIndex');
+					backupIndex;
 				}
 				else
 				{
-					pixel = 0;
+					colorMap[color] = 0;
+					FlxG.log.error('Error creating csv, unmapped color ${color.toHexString()}. Assuming index 0');
+					0;
 				}
-
-				// Write the result to the string
-				if (column == 0)
+				
+				for (s in 0...scale)
+					rowData.push(index);
+			}
+			
+			final stringData = rowData.join(", ");
+			for (s in 0...scale)
+				result.push(stringData);
+		}
+		return result.join("\n");
+	}
+	
+	#if html5 
+	static var _isBrowserManipulatingImages:Null<Bool> = null;
+	static var isBrowserManipulatingImages(get, null):Bool;
+	static function get_isBrowserManipulatingImages()
+	{
+		if (_isBrowserManipulatingImages == null)
+		{
+			final width = 100;
+			final height = 100;
+			final bmd = new openfl.display.BitmapData(width, height, true);
+			final pixels = width * height;
+			for (color in [FlxColor.WHITE, FlxColor.BLACK, FlxColor.MAGENTA])
+			{
+				bmd.fillRect(bmd.rect, color);
+				final pixels = bmd.getVector(bmd.rect);
+				for (i in 0...pixels.length)
 				{
-					if (row == 0)
+					final pixelColor:FlxColor = pixels[i];
+					if (pixelColor != color)
 					{
-						csv += pixel;
+						_isBrowserManipulatingImages = true;
+						return true;
+					}
+				}
+			}
+		}
+		
+		return _isBrowserManipulatingImages;
+	}
+	#else
+	static inline isBrowserManipulatingImages = false;
+	#end
+	
+	static function generateColorMapFromArray(colors:Array<FlxColor>, ignoreAlpha:Bool)
+	{
+		final colorMap = new Map<FlxColor, Int>();
+		for (index => color in colors)
+			colorMap[ignoreAlpha ? color.rgb : color] = index;
+		
+		#if html5
+		if (!isBrowserManipulatingImages)
+			return colorMap;
+		
+		// check for farbling, try to account
+		final width = 100;
+		final height = 100;
+		final bmd = new openfl.display.BitmapData(width, height, true);
+		final pixels = width * height;
+		var mapModified = false;
+		for (color => index in colorMap)
+		{
+			bmd.fillRect(bmd.rect, color);
+			var errorFound = false;
+			final newColors = new Array<FlxColor>();
+			final pixels = bmd.getVector(bmd.rect);
+			for (i in 0...pixels.length)
+			{
+				// final pixelColor:FlxColor = bmd.getPixel32(i % width, Std.int(i / width));
+				final pixelColor:FlxColor = pixels[i];
+				if (pixelColor != color && !newColors.contains(pixelColor))
+				{
+					if (colorMap.exists(pixelColor))
+					{
+						FlxG.log.error('Cannot reliably read bitmaps, due to your brower\'s privacy settings. '
+							+ 'Source pixels ${color.toHexString()}, may become ${pixelColor.toHexString()}');
+						
+						errorFound = true;
 					}
 					else
 					{
-						csv += "\n" + pixel;
+						FlxG.log.notice('Browser image manipulation detected. '
+							+ 'Source pixels [$index]${color.toHexString()}, may become ${pixelColor.toHexString()}');
+						newColors.push(pixelColor);
+						mapModified = true;
 					}
 				}
-				else
-				{
-					csv += ", " + pixel;
-				}
-
-				column++;
 			}
-
-			row++;
+			
+			// Make the modifed colors point to the same index
+			for (color in newColors)
+				colorMap[color] = index;
 		}
-
-		return csv;
+		
+		if (mapModified)
+			FlxG.log.add('Color map adjusted to compensate for your browser\'s privacy settings'
+				+ '${[for (color=>index in colorMap) '${color.toHexString()} => $index']}');
+		#end
+		
+		return colorMap;
+	}
+	
+	static inline function getNearestColorIndex(targetColor:FlxColor, map:Map<FlxColor, Int>):Int
+	{
+		if (map.exists(targetColor))
+			return map[targetColor];
+		
+		var closest = -1;
+		var closestDiff = -1;
+		
+		inline function abs(a:Int):Int
+		{
+			return a < 0 ? -1 : a;
+		}
+		
+		for (color => index in map)
+		{
+			final diff
+				= abs(color.red - targetColor.red)
+				+ abs(color.green - targetColor.green)
+				+ abs(color.blue - targetColor.blue)
+				+ abs(color.alpha - targetColor.alpha);
+			
+			if (closest == -1 || diff < closestDiff)
+			{
+				closest = index;
+				closestDiff = diff;
+			}
+		}
+		
+		return closest;
 	}
 
 	/**
 	 * Converts a resource image file to a comma-separated string. Black pixels are flagged as 'solid' by default,
 	 * non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
 	 *
-	 * @param   imageFile  An embedded graphic, preferably black and white.
-	 * @param   invert     Load white pixels as solid instead.
-	 * @param   scale      Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
-	 * @param   colorMap   An array of color values (alpha values are ignored) in the order they're intended to be assigned as indices
+	 * @param   graphic       An embedded graphic, preferably black and white.
+	 * @param   whiteIsSolid  Whether to load white pixels as solid and black and empty.
+	 * @param   scale         Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on.
+	 * @param   colorMap      An array of color values (ingoring alpha) in the order they're intended to be assigned as indices.
 	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format.
 	 */
-	public static function imageToCSV(graphic:FlxGraphicAsset, invert = false, scale = 1, ?colorMap:Array<FlxColor>):String
+	@:deprecated("imageToCSV with both whiteIsSolid and colorMap is deprecated, use a different overload of imageToCSV")
+	overload public static inline extern function imageToCSV(graphic:FlxGraphicAsset, whiteIsSolid:Bool, scale:Int, colorMap:Null<Array<FlxColor>>):String
 	{
-		return bitmapToCSV(graphic.resolveBitmapData(), invert, scale, colorMap);
+		if (colorMap != null)
+			colorMap = whiteIsSolid ? invertColorMap : defaultColorMap;
+		
+		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, colorMap, true);
+	}
+	
+	/**
+	 * Converts a resource image file to a comma-separated string. Black pixels are flagged as 'solid' by default,
+	 * non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
+	 *
+	 * @param   graphic       An embedded graphic, preferably black and white.
+	 * @param   whiteIsSolid  Whether to load white pixels as solid and black and empty
+	 * @param   scale         Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on
+	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format
+	 * @since 6.2.0
+	 */
+	overload public static inline extern function imageToCSV(graphic:FlxGraphicAsset, whiteIsSolid = false, scale = 1):String
+	{
+		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, whiteIsSolid ? invertColorMap : defaultColorMap, true);
+	}
+	
+	/**
+	 * Converts a resource image file to a comma-separated string
+	 *
+	 * @param   graphic   An embedded graphic, preferably black and white.
+	 * @param   scale     Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on
+	 * @param   colorMap  An array of color values (ingoring alpha) in the order they're intended to be assigned as indices
+	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format
+	 * @since 6.2.0
+	 */
+	overload public static inline extern function imageToCSV(graphic:FlxGraphicAsset, scale = 1, colorMap:Array<FlxColor>):String
+	{
+		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, colorMap, true);
+	}
+	
+	/**
+	 * Converts a resource image file to a comma-separated string
+	 *
+	 * @param   graphic   An embedded graphic, preferably black and white.
+	 * @param   scale     Default is 1.  Scale of 2 means each pixel forms a 2x2 block of tiles, and so on
+	 * @param   colorMap  An array of color values in the order they're intended to be assigned as indices
+	 * @return  A comma-separated string containing the level data in a FlxTilemap-friendly format
+	 * @since 6.2.0
+	 */
+	overload public static inline extern function image32ToCSV(graphic:FlxGraphicAsset, scale = 1, colorMap:Array<FlxColor>):String
+	{
+		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, colorMap, false);
 	}
 
 	/**

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -461,8 +461,9 @@ class FlxStringUtil
 	static function bitmapToCSVHelper(bitmap:BitmapData, scale:Int, colors:Array<FlxColor>, ignoreAlpha:Bool):String
 	{
 		final colorMap = generateColorMapFromArray(colors, ignoreAlpha);
-		final array = FlxArrayUtil.scale(bitmapToArray2d(bitmap, colorMap, ignoreAlpha, 0), scale);
-		return array.map(row->row.join(", ")).join("\n");
+		final array = bitmapToArray2d(bitmap, colorMap, ignoreAlpha, 0);
+		final scaledArray = FlxArrayUtil.scale(array, scale);
+		return scaledArray.map(row->row.join(", ")).join("\n");
 	}
 	
 	static function bitmapToArray2d<T>(bitmap:BitmapData, colorMap:Map<FlxColor, T>, ignoreAlpha:Bool, backupValue:T):Array<Array<T>>
@@ -490,7 +491,7 @@ class FlxStringUtil
 				else
 				{
 					colorMap[color] = backupValue;
-					FlxG.log.error('Error creating csv, unmapped color ${color.toHexString()}. Defaulting to $backupValue');
+					FlxG.log.error('Bitmap contains unexpected color ${color.toHexString()}. Defaulting to $backupValue');
 					backupValue;
 				}
 				value;
@@ -498,7 +499,9 @@ class FlxStringUtil
 		}];
 	}
 	
-	#if html5 
+	#if FLX_UNIT_TEST
+	public static var isBrowserManipulatingImages = false;
+	#elseif html5 
 	static var _isBrowserManipulatingImages:Null<Bool> = null;
 	static var isBrowserManipulatingImages(get, null):Bool;
 	static function get_isBrowserManipulatingImages()
@@ -535,7 +538,18 @@ class FlxStringUtil
 	{
 		final colorMap = new Map<FlxColor, Int>();
 		for (index => color in colors)
-			colorMap[ignoreAlpha ? color.rgb : color] = index;
+		{
+			final mappedColor = ignoreAlpha ? color.rgb : color;
+			if (colorMap.exists(mappedColor))
+			{
+				if (color == mappedColor) // argb matches
+					FlxG.log.error('Color map contains duplicates of ${color.toHexString()}');
+				else
+					FlxG.log.error('Color map contains duplicate rgb for ${color.toHexString()} and ${mappedColor.toHexString()}');
+			}
+			else
+				colorMap[mappedColor] = index;
+		}
 		
 		#if html5
 		if (!isBrowserManipulatingImages)

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -575,7 +575,7 @@ class FlxStringUtil
 		return _isBrowserManipulatingImages;
 	}
 	#else
-	static inline isBrowserManipulatingImages = false;
+	static inline var isBrowserManipulatingImages = false;
 	#end
 	
 	static function generateColorMapFromArray(colors:Array<FlxColor>, ignoreAlpha:Bool)

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -396,11 +396,6 @@ class FlxStringUtil
 		].join("\n");
 	}
 	
-	static function array2DToCSVHelper<T>(data:Array<Array<T>>):String
-	{
-		return data.map(row->row.join(", ")).join("\n");
-	}
-
 	/**
 	 * Converts a BitmapData object to a comma-separated string. Black pixels are flagged as 'solid' by default,
 	 * non-black pixels are set as non-colliding. Black pixels must be PURE BLACK.
@@ -466,20 +461,17 @@ class FlxStringUtil
 	static function bitmapToCSVHelper(bitmap:BitmapData, scale:Int, colors:Array<FlxColor>, ignoreAlpha:Bool):String
 	{
 		final colorMap = generateColorMapFromArray(colors, ignoreAlpha);
-		final array = bitmapToArray2dHelper(bitmap, scale, colorMap, ignoreAlpha, 0);
-		return array2DToCSVHelper(array);
+		final array = FlxArrayUtil.scale(bitmapToArray2d(bitmap, colorMap, ignoreAlpha, 0), scale);
+		return array.map(row->row.join(", ")).join("\n");
 	}
 	
-	static function bitmapToArray2dHelper<T>(bitmap:BitmapData, scale:Int, colorMap:Map<FlxColor, T>, ignoreAlpha:Bool, backupValue:T):Array<Array<T>>
+	static function bitmapToArray2d<T>(bitmap:BitmapData, colorMap:Map<FlxColor, T>, ignoreAlpha:Bool, backupValue:T):Array<Array<T>>
 	{
 		final bitmapColors = bitmap.getVector(bitmap.rect);
 		final columns = bitmap.width;
-		final rows = bitmap.height;
-		final result:Array<Array<T>> = [];
-		for (row in 0...rows)
+		return [ for (row in 0...bitmap.height)
 		{
-			final rowData:Array<T> = [];
-			for (column in 0...columns)
+			[ for (column in 0...columns)
 			{
 				final rgba:FlxColor = bitmapColors[row * columns + column];
 				final color = ignoreAlpha ? rgba.rgb : rgba;
@@ -501,16 +493,9 @@ class FlxStringUtil
 					FlxG.log.error('Error creating csv, unmapped color ${color.toHexString()}. Defaulting to $backupValue');
 					backupValue;
 				}
-				
-				for (s in 0...scale)
-					rowData.push(value);
-			}
-			
-			for (s in 0...scale)
-				result.push(rowData);
-		}
-		
-		return result;
+				value;
+			}];
+		}];
 	}
 	
 	#if html5 

--- a/tests/unit/src/flixel/tile/FlxTilemapTest.hx
+++ b/tests/unit/src/flixel/tile/FlxTilemapTest.hx
@@ -138,6 +138,7 @@ class FlxTilemapTest extends FlxTest
 	}
 	
 	@Test
+	@:haxe.warning("-WDeprecated")
 	function testLoadMapFromGraphic()
 	{
 		var map = new BitmapData(2, 2);

--- a/tests/unit/src/flixel/util/FlxArrayUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxArrayUtilTest.hx
@@ -104,6 +104,30 @@ class FlxArrayUtilTest
 	}
 
 	@Test
+	function testScale()
+	{
+		Assert.isTrue([0, 1, 2, 3, 4, 5].scale(2).equals([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]));
+	}
+
+	@Test
+	function testScale2d()
+	{
+		final actual = [[0, 1, 2], [3, 4, 5]].scale(2);
+		Assert.isTrue(actual[0].equals([0, 0, 1, 1, 2, 2]));
+		Assert.isTrue(actual[1].equals([0, 0, 1, 1, 2, 2]));
+		Assert.isTrue(actual[2].equals([3, 3, 4, 4, 5, 5]));
+		Assert.isTrue(actual[3].equals([3, 3, 4, 4, 5, 5]));
+		
+		final actual = [[0, 1, 2], [3, 4, 5]].scale(2, 3);
+		Assert.isTrue(actual[0].equals([0, 0, 1, 1, 2, 2]));
+		Assert.isTrue(actual[1].equals([0, 0, 1, 1, 2, 2]));
+		Assert.isTrue(actual[2].equals([0, 0, 1, 1, 2, 2]));
+		Assert.isTrue(actual[3].equals([3, 3, 4, 4, 5, 5]));
+		Assert.isTrue(actual[4].equals([3, 3, 4, 4, 5, 5]));
+		Assert.isTrue(actual[5].equals([3, 3, 4, 4, 5, 5]));
+	}
+
+	@Test
 	@:haxe.warning("-WDeprecated")
 	function testSetLength()
 	{

--- a/tests/unit/src/flixel/util/FlxColorTest.hx
+++ b/tests/unit/src/flixel/util/FlxColorTest.hx
@@ -87,6 +87,37 @@ class FlxColorTest extends FlxTest
 		asFloat(function(c) c.blue += 1);
 		asFloat(function(c) c.alpha += 1);
 	}
+	
+	@Test
+	function testDistance()
+	{
+		Assert.areEqual(8         , FlxColor.WHITE.getDistance(0xFFfffff7));
+		Assert.areEqual(8+16      , FlxColor.WHITE.getDistance(0xFFffeff7));
+		Assert.areEqual(8+16+32   , FlxColor.WHITE.getDistance(0xFFdfeff7));
+		Assert.areEqual(8+16+32+64, FlxColor.WHITE.getDistance(0xBFdfeff7));
+		
+		Assert.areEqual(8         , FlxColor.fromInt(0xFFfffff7).getDistance(FlxColor.WHITE));
+		Assert.areEqual(8+16      , FlxColor.fromInt(0xFFffeff7).getDistance(FlxColor.WHITE));
+		Assert.areEqual(8+16+32   , FlxColor.fromInt(0xFFdfeff7).getDistance(FlxColor.WHITE));
+		Assert.areEqual(8+16+32+64, FlxColor.fromInt(0xBFdfeff7).getDistance(FlxColor.WHITE));
+	}
+	
+	@Test
+	function testNearest()
+	{
+		inline function color(col:UInt):FlxColor return col;
+		
+		final colors = [FlxColor.WHITE, FlxColor.RED, FlxColor.GREEN, FlxColor.BLUE, FlxColor.BLACK];
+		
+		//                                               R     G     B     A
+		Assert.areEqual(FlxColor.WHITE, FlxColor.fromRGB(0xf8, 0xf8, 0xf8, 0xF8).nearest(colors));
+		Assert.areEqual(FlxColor.GREEN, FlxColor.fromRGB(0x00, 0xf8, 0x00, 0xF8).nearest(colors)); // note: GREEN is 0xFF008000, LIME is 0xFF00ff00
+		Assert.areEqual(FlxColor.GREEN, FlxColor.fromRGB(0x01, 0x40, 0x01, 0xF8).nearest(colors));
+		Assert.areEqual(FlxColor.RED  , FlxColor.fromRGB(0x81, 0x00, 0x00, 0xF8).nearest(colors));
+		Assert.areEqual(FlxColor.BLACK, FlxColor.fromRGB(0x79, 0x00, 0x00, 0xF8).nearest(colors));
+		Assert.areEqual(FlxColor.BLACK, FlxColor.fromRGB(0x01, 0x00, 0x00, 0xF8).nearest(colors));
+	}
+	
 
 	function asFloat(f:FlxColor->Void)
 	{

--- a/tests/unit/src/flixel/util/FlxStringUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxStringUtilTest.hx
@@ -1,11 +1,17 @@
 package flixel.util;
 
-import openfl.display.BitmapData;
 import flixel.system.debug.FlxDebugger.FlxDebuggerLayout;
 import massive.munit.Assert;
+import openfl.display.BitmapData;
 
 class FlxStringUtilTest
 {
+	@Before
+	function before()
+	{
+		FlxStringUtil.isBrowserManipulatingImages = false;
+	}
+	
 	@Test
 	function testBitmapToCSVSimple()
 	{
@@ -53,16 +59,93 @@ class FlxStringUtilTest
 		var bitmapData = new BitmapData(3, 3);
 		bitmapData.setPixel32(0, 0, FlxColor.BLACK);
 		bitmapData.setPixel32(1, 1, FlxColor.RED);
+		bitmapData.setPixel32(2, 1, 0x80ff0000); // ignore alpha
 		bitmapData.setPixel32(2, 2, FlxColor.YELLOW);
 
-		var expected = "1, 0, 0\n" + "0, 2, 0\n" + "0, 0, 3";
+		final expected = "1, 0, 0\n" + "0, 2, 2\n" + "0, 0, 3";
 
-		var colorMap = [FlxColor.WHITE, FlxColor.BLACK, FlxColor.RED, FlxColor.YELLOW];
-		var actual = FlxStringUtil.bitmapToCSV(bitmapData, false, 1, colorMap);
+		final colorMap = [FlxColor.WHITE, FlxColor.BLACK, FlxColor.RED, FlxColor.YELLOW];
+		final actual = FlxStringUtil.bitmapToCSV(bitmapData, 1, colorMap);
 
 		Assert.areEqual(expected, actual);
 	}
 
+	@Test
+	function testBitmap32ToCSV()
+	{
+		final bitmapData = new BitmapData(3, 3);
+		bitmapData.setPixel32(0, 0, FlxColor.BLACK);
+		bitmapData.setPixel32(1, 1, FlxColor.RED);
+		bitmapData.setPixel32(2, 1, 0x80ff0000); // honor alpha
+		bitmapData.setPixel32(2, 2, FlxColor.YELLOW);
+		
+		final expected = '1, 0, 0\n0, 2, 4\n0, 0, 3';
+		final colorMap = [FlxColor.WHITE, FlxColor.BLACK, FlxColor.RED, FlxColor.YELLOW, 0x80ff0000];
+		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, 1, colorMap);
+
+		Assert.areEqual(expected, actual);
+	}
+
+	@Test
+	@:haxe.warning("-WDeprecated")
+	function testBitmapToCSVOverloads()
+	{
+		final bitmapData = new BitmapData(3, 3);
+		final colorMap = [FlxColor.WHITE, FlxColor.BLACK, FlxColor.RED, FlxColor.YELLOW];
+		FlxStringUtil.bitmapToCSV(bitmapData, false, 1, colorMap); // deprecated
+		FlxStringUtil.bitmapToCSV(bitmapData, false, 1);
+		FlxStringUtil.bitmapToCSV(bitmapData, false);
+		FlxStringUtil.bitmapToCSV(bitmapData, 1, colorMap);
+		FlxStringUtil.bitmap32ToCSV(bitmapData, 1, colorMap);
+		FlxStringUtil.bitmapToCSV(bitmapData, 1);
+		#if !flash
+		FlxStringUtil.bitmapToCSV(bitmapData, colorMap);
+		FlxStringUtil.bitmap32ToCSV(bitmapData, colorMap);
+		#end
+	}
+	
+	@Test // https://github.com/HaxeFlixel/flixel/issues/3541
+	function testBitmapToCSVAntiFarbling()
+	{
+		final bitManips = [0x00000000, 0x01000000, 0x00010000, 0x00000100, 0x00000001];
+		final columns = bitManips.length;
+		final bitmapData = new BitmapData(columns, 2);
+		for (i in 0...columns * bitmapData.height)
+		{
+			final column = i % columns;
+			final row = Std.int(i / columns);
+			final color = (i < columns ? 0xFF000000 : 0xFFffffff) ^ bitManips[column];
+			bitmapData.setPixel32(column, row, color);
+		}
+		
+		// without farbling
+		var errorCount = 0;
+		FlxG.log.styles.error.onLog.add(function onError(data, ?pos) errorCount++);
+		FlxStringUtil.isBrowserManipulatingImages = false;
+		final expected = '0, 0, 0, 0, 0\n1, 0, 0, 0, 0';
+		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, [FlxColor.BLACK, FlxColor.WHITE]);
+		Assert.areEqual(expected, actual);
+		Assert.areEqual(8, errorCount);
+		FlxG.log.styles.error.onLog.remove(onError);
+		
+		// with farbling
+		var noticeCount = 0;
+		FlxG.log.styles.notice.onLog.add(function onNotice(_, ?_) noticeCount++);
+		FlxStringUtil.isBrowserManipulatingImages = true;
+		
+		final expected = '0, 0, 0, 0, 0\n1, 1, 1, 1, 1';
+		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, [FlxColor.BLACK, FlxColor.WHITE]);
+		Assert.areEqual(expected, actual);
+		Assert.areEqual(8, noticeCount);
+		FlxG.log.styles.notice.onLog.remove(onNotice);
+	}
+
+	@Test
+	function testArrayToCSV()
+	{
+		Assert.areEqual("0, 3, 4\n5, 0, 7", FlxStringUtil.arrayToCSV([0, 3, 4, 5, 0, 7], 3));
+	}
+	
 	@Test
 	function testFormatMoney()
 	{

--- a/tests/unit/src/flixel/util/FlxStringUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxStringUtilTest.hx
@@ -97,8 +97,8 @@ class FlxStringUtilTest
 		FlxStringUtil.bitmapToCSV(bitmapData, false);
 		FlxStringUtil.bitmapToCSV(bitmapData, 1, colorMap);
 		FlxStringUtil.bitmap32ToCSV(bitmapData, 1, colorMap);
-		FlxStringUtil.bitmapToCSV(bitmapData, 1);
 		#if !flash
+		FlxStringUtil.bitmapToCSV(bitmapData, 1);
 		FlxStringUtil.bitmapToCSV(bitmapData, colorMap);
 		FlxStringUtil.bitmap32ToCSV(bitmapData, colorMap);
 		#end
@@ -120,7 +120,9 @@ class FlxStringUtilTest
 		
 		// without farbling
 		var errorCount = 0;
-		FlxG.log.styles.error.onLog.add(function onError(data, ?pos) errorCount++);
+		function onError(data, ?pos) errorCount++;
+		
+		FlxG.log.styles.error.onLog.add(onError);
 		FlxStringUtil.isBrowserManipulatingImages = false;
 		final expected = '0, 0, 0, 0, 0\n1, 0, 0, 0, 0';
 		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, [FlxColor.BLACK, FlxColor.WHITE]);
@@ -130,7 +132,9 @@ class FlxStringUtilTest
 		
 		// with farbling
 		var noticeCount = 0;
-		FlxG.log.styles.notice.onLog.add(function onNotice(_, ?_) noticeCount++);
+		function onNotice(_, ?_) noticeCount++;
+		
+		FlxG.log.styles.notice.onLog.add(onNotice);
 		FlxStringUtil.isBrowserManipulatingImages = true;
 		
 		final expected = '0, 0, 0, 0, 0\n1, 1, 1, 1, 1';

--- a/tests/unit/src/flixel/util/FlxStringUtilTest.hx
+++ b/tests/unit/src/flixel/util/FlxStringUtilTest.hx
@@ -125,7 +125,7 @@ class FlxStringUtilTest
 		FlxG.log.styles.error.onLog.add(onError);
 		FlxStringUtil.isBrowserManipulatingImages = false;
 		final expected = '0, 0, 0, 0, 0\n1, 0, 0, 0, 0';
-		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, [FlxColor.BLACK, FlxColor.WHITE]);
+		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, 1, [FlxColor.BLACK, FlxColor.WHITE]);
 		Assert.areEqual(expected, actual);
 		Assert.areEqual(8, errorCount);
 		FlxG.log.styles.error.onLog.remove(onError);
@@ -138,7 +138,7 @@ class FlxStringUtilTest
 		FlxStringUtil.isBrowserManipulatingImages = true;
 		
 		final expected = '0, 0, 0, 0, 0\n1, 1, 1, 1, 1';
-		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, [FlxColor.BLACK, FlxColor.WHITE]);
+		final actual = FlxStringUtil.bitmap32ToCSV(bitmapData, 1, [FlxColor.BLACK, FlxColor.WHITE]);
 		Assert.areEqual(expected, actual);
 		Assert.areEqual(8, noticeCount);
 		FlxG.log.styles.notice.onLog.remove(onNotice);


### PR DESCRIPTION
Fixes #3541

- `FlxStringUtil`
    - Optimize `arrayToCSV` and therefore `imageToCSV` and `bitmapToCSV`
    - Detects browsers manipulating getPixel result for safety features and counteracts this in bitmapTo by getting the nearest mapped color
    - Add `bitmap32ToCSV`and `image32ToCSV` which does not ignore alpha
- `FlxTilemap`: Add overloads for `loadMapFromGraphic` deprecate the one that allows both `invert` and `colorMap` args
- `FlxArrayaUtil`: Add `scale` methods with overloads for arrays and 2d arrays
- `FlxColor`: Add `getDistance` and `nearest` methods for comparing differences in colors