### PR TITLE
FlxSprite: Fix null camera check on clipToViewBounds.

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -866,7 +866,7 @@ class FlxSprite extends FlxObject
 		if (clipRect == null)
 			clipRect = new FlxRect();
 		
-		if (camera != null)
+		if (camera == null)
 			camera = getDefaultCamera();
 		
 		final p1 = viewToFramePosition(left, top, camera);


### PR DESCRIPTION
I assume this is wrong behavior for the null check?