### PR TITLE
FlxSound: Add loopCount and loopUntil

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        haxe-version: ["4.2.5", "4.3.6"]
+        haxe-version: ["4.2.5", "4.3.7"]
         target: [html5, hl, neko, flash, cpp]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -121,8 +121,8 @@ class FlxSound extends FlxBasic
 	/**
 	 * Whether or not this sound should loop.
 	 * 
-	 * **NOTE:** The sound will loop even if this is `false` when `loopUntil > 0`.
-	 * This flag is set to `false` when `loopCount` reaches `loopUntil`
+	 * **NOTE:** If `loopUntil` is 0 or more, than the sound will only loop until
+	 * `loopCount` reaches `loopUntil`
 	 */
 	public var looped:Bool;
 	
@@ -135,8 +135,7 @@ class FlxSound extends FlxBasic
 	
 	/**
 	 * The number of times this sound should loop, where `-1` loops forever, and `1` is
-	 * repeated once. the `looped` flag does not need to be `true` for this to have an effect, but
-	 * will be set to `false` upon completion
+	 * repeated once. This field is ignored if `looped` is `false`
 	 * @since 6.2.0
 	 */
 	public var loopUntil:Int = -1;
@@ -765,16 +764,9 @@ class FlxSound extends FlxBasic
 		if (onComplete != null)
 			onComplete();
 		
-		if (looped && loopUntil == 0)
-			looped = false;
-		
-		final loop = looped || (loopUntil > 0 && loopCount < loopUntil);
-		
-		if (loop)
+		if (looped && (loopUntil == -1 || loopCount < loopUntil))
 		{
 			loopCount++;
-			if (loopUntil > 0 && loopCount >= loopUntil)
-				looped = false;
 			
 			cleanup(false);
 			play(false, loopTime, endTime);

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -256,6 +256,7 @@ class FlxSound extends FlxBasic
 		looped = false;
 		loopTime = 0.0;
 		loopCount = 0;
+		loopUntil = -1;
 		endTime = 0.0;
 		_target = null;
 		_radius = 0;
@@ -591,17 +592,17 @@ class FlxSound extends FlxBasic
 			return this;
 			
 		if (ForceRestart)
-		{
-			loopCount = 0;
 			cleanup(false, true);
-		}
 		else if (playing) // Already playing sound
 			return this;
 			
 		if (_paused)
 			resume();
 		else
+		{
+			loopCount = 0;
 			startSound(StartTime);
+		}
 			
 		endTime = EndTime;
 		return this;
@@ -768,11 +769,14 @@ class FlxSound extends FlxBasic
 		{
 			loopCount++;
 			
-			cleanup(false);
-			play(false, loopTime, endTime);
+			cleanup(false, false);
+			startSound(loopTime);
 		}
 		else
-			cleanup(autoDestroy);
+		{
+			_time = 0; // Remove this line in 7.0.0
+			cleanup(autoDestroy, false);
+		}
 	}
 	
 	/**
@@ -805,6 +809,7 @@ class FlxSound extends FlxBasic
 		{
 			_time = 0;
 			_paused = false;
+			loopCount = 0;
 		}
 	}
 	

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -120,11 +120,29 @@ class FlxSound extends FlxBasic
 	
 	/**
 	 * Whether or not this sound should loop.
+	 * 
+	 * **NOTE:** The sound will loop even if this is `false` when `loopUntil > 0`.
+	 * This flag is set to `false` when `loopCount` reaches `loopUntil`
 	 */
 	public var looped:Bool;
 	
 	/**
-	 * In case of looping, the point (in milliseconds) from where to restart the sound when it loops back
+	 * The number of times this sound was restarted, via the `looped` flag.
+	 * Automatically incremented on loops, and reset to 0 when restarted
+	 * @since 6.2.0
+	 */
+	public var loopCount(default, null):Int = 0;
+	
+	/**
+	 * The number of times this sound should loop, where `-1` loops forever, and `1` is
+	 * repeated once. the `looped` flag does not need to be `true` for this to have an effect, but
+	 * will be set to `false` upon completion
+	 * @since 6.2.0
+	 */
+	public var loopUntil:Int = -1;
+	
+	/**
+	 * The time (in milliseconds) from where to restart the sound when it loops back
 	 * @since 4.1.0
 	 */
 	public var loopTime:Float = 0;
@@ -238,6 +256,7 @@ class FlxSound extends FlxBasic
 		_volumeAdjust = 1.0;
 		looped = false;
 		loopTime = 0.0;
+		loopCount = 0;
 		endTime = 0.0;
 		_target = null;
 		_radius = 0;
@@ -573,7 +592,10 @@ class FlxSound extends FlxBasic
 			return this;
 			
 		if (ForceRestart)
+		{
+			loopCount = 0;
 			cleanup(false, true);
+		}
 		else if (playing) // Already playing sound
 			return this;
 			
@@ -742,9 +764,15 @@ class FlxSound extends FlxBasic
 	{
 		if (onComplete != null)
 			onComplete();
-			
-		if (looped)
+		
+		final loop = looped || (loopUntil > -1 && loopCount < loopUntil);
+		
+		if (loop)
 		{
+			loopCount++;
+			if (loopUntil > -1 && loopCount >= loopUntil)
+				looped = false;
+			
 			cleanup(false);
 			play(false, loopTime, endTime);
 		}

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -765,12 +765,15 @@ class FlxSound extends FlxBasic
 		if (onComplete != null)
 			onComplete();
 		
-		final loop = looped || (loopUntil > -1 && loopCount < loopUntil);
+		if (looped && loopUntil == 0)
+			looped = false;
+		
+		final loop = looped || (loopUntil > 0 && loopCount < loopUntil);
 		
 		if (loop)
 		{
 			loopCount++;
-			if (loopUntil > -1 && loopCount >= loopUntil)
+			if (loopUntil > 0 && loopCount >= loopUntil)
 				looped = false;
 			
 			cleanup(false);

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -11,16 +11,4 @@ class FlxSoundTest extends FlxTest
 		sound.load("assets/invalid");
 		sound.play();
 	}
-	
-	@Test
-	@Ignore("Unable to unit test sounds")
-	function testPlay()
-	{
-		var sound = new FlxSound();
-		sound.load("flxiel/sounds/flixel");
-		sound.play();
-		// step();
-		
-		Assert.isTrue(sound.playing);
-	}
 }

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -1,6 +1,8 @@
 package flixel.sound;
 
-class FlxSoundTest
+import massive.munit.Assert;
+
+class FlxSoundTest extends FlxTest
 {
 	@Test // #1511
 	function testLoadInvalidSoundPathNoCrash()
@@ -8,5 +10,17 @@ class FlxSoundTest
 		var sound = new FlxSound();
 		sound.load("assets/invalid");
 		sound.play();
+	}
+	
+	@Test
+	@Ignore("Unable to unit test sounds")
+	function testPlay()
+	{
+		var sound = new FlxSound();
+		sound.load("flxiel/sounds/flixel");
+		sound.play();
+		// step();
+		
+		Assert.isTrue(sound.playing);
 	}
 }


### PR DESCRIPTION
Alternative to #3478

Test state:
```hx
import flixel.FlxG;
import flixel.sound.FlxSound;

class SoundLoopTestState extends flixel.FlxState
{
    var sound:FlxSound;
    override function create()
    {
        super.create();
        
        sound = FlxG.sound.load("assets/sounds/long-sound.mp3", 1.0);
        sound.looped = true;
        sound.loopUntil = 2;
        sound.onComplete = ()->trace('Completed, loops: ${sound.loopCount} < ${sound.loopUntil}');
        sound.play();
    }
    
    override function update(elapsed)
    {
        super.update(elapsed);
        
        if (FlxG.keys.justPressed.SPACE)
            sound.play(true); // sets loopCount back to 0
    }
}
```

We can't unit test sounds, for now