### PR TITLE
FlxBitmapText: Fix alignment when changing text width

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1037,7 +1037,7 @@ class FlxBitmapText extends FlxSprite
 		for (i in 0...numLines)
 		{
 			line = _lines[i];
-			lineWidth = _linesWidth[i];
+			lineWidth = getLineWidth(i);
 
 			// LEFT
 			ox = font.minOffsetX;


### PR DESCRIPTION
CENTER alignment is off for flxbitmaptext after changing the text.

before the change, changing the text resulted in the text to look off-center
see the 'Upgrades' text on the top, this gif is prior to the change
![pre-change](https://github.com/user-attachments/assets/3d6fb445-b365-44d6-b949-f6f5045cb570)


change it to call getLineWidth on the line rather than use the pre-stored line widths so the new text can be aligned properly
![post-change](https://github.com/user-attachments/assets/0f87db72-7360-4cbf-b727-7f3f15f9ebe1)


it may be better to simply update the `_linesWidth` upon changing the text, but this seems to fix in this case