### PR TITLE
FlxMouse: Fix visibility when starting the game unfocused

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -583,6 +583,8 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		// Call set_visible with the value visible has been initialized with
 		// (unless set in create() of the initial state)
 		set_visible(visible);
+
+		_visibleWhenFocusLost = visible;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2237 

This PR fixes an issue with the mouse always being visible when the game starts unfocused. This issue is fixed by setting `_visibleWhenFocusLost` to `visible` upon the game starting.