### PR TITLE
FlxAnimationController: fix off-by-one and negative modulo bugs

### DIFF
--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -3,7 +3,6 @@ package flixel.animation;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxFrame;
-import flixel.math.FlxMath;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSignal;
 
@@ -820,7 +819,17 @@ class FlxAnimationController implements IFlxDestroyable
 	{
 		if (_sprite.frames != null && numFrames > 0)
 		{
-			Frame = Std.int(FlxMath.mod(Frame, numFrames));
+			if (Frame < 0)
+			{
+				FlxG.log.warn('frameIndex must be a positive number, got $Frame, using 0, instead');
+				Frame = 0;
+			}
+			else if (Frame >= numFrames)
+			{
+				FlxG.log.warn('frameIndex must be less than $numFrames, got $Frame, wrapping to ${Frame % numFrames}, instead');
+				Frame = Frame % numFrames;
+			}
+
 			_sprite.frame = _sprite.frames.frames[Frame];
 			frameIndex = Frame;
 			fireCallback();

--- a/flixel/animation/FlxAnimationController.hx
+++ b/flixel/animation/FlxAnimationController.hx
@@ -3,6 +3,7 @@ package flixel.animation;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxFrame;
+import flixel.math.FlxMath;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxSignal;
 
@@ -241,7 +242,7 @@ class FlxAnimationController implements IFlxDestroyable
 		var framesToAdd:Array<Int> = frames;
 		var hasInvalidFrames = false;
 		var i = framesToAdd.length;
-		while (i-- >= 0)
+		while (i-- > 0)
 		{
 			final frame = framesToAdd[i];
 			if (frame >= numFrames)
@@ -819,7 +820,7 @@ class FlxAnimationController implements IFlxDestroyable
 	{
 		if (_sprite.frames != null && numFrames > 0)
 		{
-			Frame = Frame % numFrames;
+			Frame = Std.int(FlxMath.mod(Frame, numFrames));
 			_sprite.frame = _sprite.frames.frames[Frame];
 			frameIndex = Frame;
 			fireCallback();

--- a/tests/unit/src/flixel/animation/FlxAnimationControllerTest.hx
+++ b/tests/unit/src/flixel/animation/FlxAnimationControllerTest.hx
@@ -278,6 +278,74 @@ class FlxAnimationControllerTest extends FlxTest
 		Assert.isTrue (sprite.animation.exists("anim4"), 'missing "anim4"');
 	}
 
+	@Test // #3554
+	function testAddAllValidFrames()
+	{
+		var bitmapData = new BitmapData(4, 1);
+		sprite.loadGraphic(bitmapData, true, 1, 1);
+		
+		sprite.animation.add("test", [0, 1, 2, 3]);
+		
+		var anim = sprite.animation.getByName("test");
+		Assert.isNotNull(anim);
+		FlxAssert.arraysEqual([0, 1, 2, 3], anim.frames);
+	}
+	
+	@Test // #3554
+	function testAddSomeInvalidFrames()
+	{
+		var bitmapData = new BitmapData(4, 1);
+		sprite.loadGraphic(bitmapData, true, 1, 1);
+		
+		sprite.animation.add("test", [0, 4, 2, 5, 3]);
+		
+		var anim = sprite.animation.getByName("test");
+		Assert.isNotNull(anim);
+		FlxAssert.arraysEqual([0, 2, 3], anim.frames);
+	}
+	
+	@Test // #3554
+	function testAddSingleValidFrame()
+	{
+		var bitmapData = new BitmapData(4, 1);
+		sprite.loadGraphic(bitmapData, true, 1, 1);
+		
+		sprite.animation.add("test", [0]);
+		
+		var anim = sprite.animation.getByName("test");
+		Assert.isNotNull(anim);
+		FlxAssert.arraysEqual([0], anim.frames);
+	}
+	
+	@Test // #3554
+	function testAddAllInvalidFrames()
+	{
+		loadSpriteSheet();
+		
+		sprite.animation.add("test", [5, 6, 7]);
+		
+		var anim = sprite.animation.getByName("test");
+		Assert.isNull(anim);
+	}
+	
+	@Test // #3554
+	function testFrameIndexNegativeWraps()
+	{
+		#if !js
+		var bitmapData = new BitmapData(4, 1);
+		sprite.loadGraphic(bitmapData, true, 1, 1);
+		
+		sprite.animation.add("test", [0, 1, 2, 3]);
+		sprite.animation.play("test");
+		
+		sprite.animation.frameIndex = -1;
+		Assert.areEqual(3, sprite.animation.frameIndex);
+		
+		sprite.animation.frameIndex = -4;
+		Assert.areEqual(0, sprite.animation.frameIndex);
+		#end
+	}
+
 	function loadSpriteSheet():Void
 	{
 		var bitmapData = new BitmapData(2, 1);

--- a/tests/unit/src/flixel/animation/FlxAnimationControllerTest.hx
+++ b/tests/unit/src/flixel/animation/FlxAnimationControllerTest.hx
@@ -329,9 +329,8 @@ class FlxAnimationControllerTest extends FlxTest
 	}
 	
 	@Test // #3554
-	function testFrameIndexNegativeWraps()
+	function testFrameIndexNegativeClampsToZero()
 	{
-		#if !js
 		var bitmapData = new BitmapData(4, 1);
 		sprite.loadGraphic(bitmapData, true, 1, 1);
 		
@@ -339,11 +338,10 @@ class FlxAnimationControllerTest extends FlxTest
 		sprite.animation.play("test");
 		
 		sprite.animation.frameIndex = -1;
-		Assert.areEqual(3, sprite.animation.frameIndex);
 		
+		Assert.areEqual(0, sprite.animation.frameIndex);
 		sprite.animation.frameIndex = -4;
 		Assert.areEqual(0, sprite.animation.frameIndex);
-		#end
 	}
 
 	function loadSpriteSheet():Void


### PR DESCRIPTION
fixes bugs in FixAnimationController

- corrected off-by-one error in add() frame validation
  (while (i-- >= 0) -> while (i-- > 0))
- fixed negative frame index handling in set_frameIndex:
  negative values are now clamped to 0 with a log warning,
  values >= numFrames are wrapped with a log warning