### PR TITLE
FlxBitmapFont: allow extra whitespace when parsing bmfont rows

### DIFF
--- a/flixel/graphics/frames/bmfont/BMFontUtil.hx
+++ b/flixel/graphics/frames/bmfont/BMFontUtil.hx
@@ -16,7 +16,7 @@ class BMFontUtil
 		while (attFinder.match(text.substr(index)))
 		{
 			final key = attFinder.matched(1);
-			final value = attFinder.matched(3);
+			final value = attFinder.matched(4);
 			callback(key, value);
 			
 			final nextIndex = text.length - attFinder.matchedRight().length;

--- a/flixel/graphics/frames/bmfont/BMFontUtil.hx
+++ b/flixel/graphics/frames/bmfont/BMFontUtil.hx
@@ -8,7 +8,7 @@ using StringTools;
 @:noCompletion
 class BMFontUtil
 {
-	static var attFinder = ~/(\w+?)=("?)(.*?)\2(?=\s|$)/;
+	static var attFinder = ~/(\w+?)=(\s*)("?)(.*?)\3(?=\s|$)/;
 	
 	public static function forEachAttribute(text:UnicodeString, callback:(key:String, value:UnicodeString)->Void)
 	{

--- a/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
@@ -14,11 +14,11 @@ class BMFontTest extends FlxTest
 		+ '\npage id=0 file="arial_black_0.png"'
 		+ '\nchars count=3'
 		+ '\nchar id=64   x=0     y=0     width=25    height=24    xoffset=-5    yoffset=7     xadvance=17    page=0  chnl=15'
-			+ '\nchar id= 65   x=27    y=0     width=26    height=21    xoffset=-5    yoffset=7     xadvance=18    page=0  chnl=15'
-			+ '\nchar id=  84   x=55    y=0     width=23    height=21    xoffset=-4    yoffset=7     xadvance=16    page=0  chnl=15'
+		+ '\nchar id= 65   x= 27    y= 0     width= 26    height= 21    xoffset= -5    yoffset= 7     xadvance= 18    page= 0  chnl= 15'
+		+ '\nchar id=  84   x=55    y=0     width=23    height=21    xoffset=-4    yoffset=7     xadvance=16    page=0  chnl=15'
 		+ '\nkernings count=2'
 		+ '\nkerning first=84  second=65  amount=-2  '
-		+ '\nkerning first=65  second=84  amount=-2  ';
+		+ '\nkerning first= 65  second= 84  amount=-2  ';
 		
 		var font = BMFont.parse(cast text);
 		assertFont(font);

--- a/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
@@ -15,10 +15,10 @@ class BMFontTest extends FlxTest
 		+ '\nchars count=3'
 		+ '\nchar id=64   x=0     y=0     width=25    height=24    xoffset=-5    yoffset=7     xadvance=17    page=0  chnl=15'
 		+ '\nchar id= 65   x= 27    y= 0     width= 26    height= 21    xoffset= -5    yoffset= 7     xadvance= 18    page= 0  chnl= 15'
-		+ '\nchar id=  84   x=55    y=0     width=23    height=21    xoffset=-4    yoffset=7     xadvance=16    page=0  chnl=15'
+		+ '\nchar id=  84   x=  55    y=  0     width=  23    height=  21    xoffset=  -4    yoffset=  7     xadvance=  16    page=  0  chnl=  15'
 		+ '\nkernings count=2'
 		+ '\nkerning first=84  second=65  amount=-2  '
-		+ '\nkerning first= 65  second= 84  amount=-2  ';
+		+ '\nkerning first= 65  second= 84  amount= -2  ';
 		
 		var font = BMFont.parse(cast text);
 		assertFont(font);

--- a/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
@@ -14,8 +14,8 @@ class BMFontTest extends FlxTest
 		+ '\npage id=0 file="arial_black_0.png"'
 		+ '\nchars count=3'
 		+ '\nchar id=64   x=0     y=0     width=25    height=24    xoffset=-5    yoffset=7     xadvance=17    page=0  chnl=15'
-		+ '\nchar id=65   x=27    y=0     width=26    height=21    xoffset=-5    yoffset=7     xadvance=18    page=0  chnl=15'
-		+ '\nchar id=84   x=55    y=0     width=23    height=21    xoffset=-4    yoffset=7     xadvance=16    page=0  chnl=15'
+			+ '\nchar id= 65   x=27    y=0     width=26    height=21    xoffset=-5    yoffset=7     xadvance=18    page=0  chnl=15'
+			+ '\nchar id=  84   x=55    y=0     width=23    height=21    xoffset=-4    yoffset=7     xadvance=16    page=0  chnl=15'
 		+ '\nkernings count=2'
 		+ '\nkerning first=84  second=65  amount=-2  '
 		+ '\nkerning first=65  second=84  amount=-2  ';

--- a/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
+++ b/tests/unit/src/flixel/graphics/frames/bmfont/BMFontTest.hx
@@ -14,11 +14,30 @@ class BMFontTest extends FlxTest
 		+ '\npage id=0 file="arial_black_0.png"'
 		+ '\nchars count=3'
 		+ '\nchar id=64   x=0     y=0     width=25    height=24    xoffset=-5    yoffset=7     xadvance=17    page=0  chnl=15'
-		+ '\nchar id= 65   x= 27    y= 0     width= 26    height= 21    xoffset= -5    yoffset= 7     xadvance= 18    page= 0  chnl= 15'
-		+ '\nchar id=  84   x=  55    y=  0     width=  23    height=  21    xoffset=  -4    yoffset=  7     xadvance=  16    page=  0  chnl=  15'
+		+ '\nchar id=65   x=27    y=0     width=26    height=21    xoffset=-5    yoffset=7     xadvance=18    page=0  chnl=15'
+		+ '\nchar id=84   x=55    y=0     width=23    height=21    xoffset=-4    yoffset=7     xadvance=16    page=0  chnl=15'
 		+ '\nkernings count=2'
 		+ '\nkerning first=84  second=65  amount=-2  '
-		+ '\nkerning first= 65  second= 84  amount= -2  ';
+		+ '\nkerning first=65  second=84  amount=-2  ';
+		
+		var font = BMFont.parse(cast text);
+		assertFont(font);
+	}
+	
+	@Test
+	function testTextFormatWithSpaces()
+	{
+		var text =
+		'info face="Arial Black" size=32 bold=0 italic=0 charset="" unicode=1 stretchH=100 smooth=1 aa=1 padding=1,2,3,4 spacing=2,1 outline=0'
+		+ '\ncommon lineHeight=32 base=25 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=1 redChnl=0 greenChnl=0 blueChnl=0'
+		+ '\npage id=0 file="arial_black_0.png"'
+		+ '\nchars count=3'
+		+ '\nchar id=64   x=0     y=0     width=25    height=24    xoffset=-5    yoffset=7     xadvance=17    page=0   chnl=15'
+		+ '\nchar id= 65  x= 27   y= 0    width= 26   height= 21   xoffset= -5   yoffset= 7    xadvance= 18   page= 0  chnl= 15'
+		+ '\nchar id=  84 x=  55  y=  0   width=  23  height=  21  xoffset=  -4  yoffset=  7   xadvance=  16  page=  0 chnl=  15'
+		+ '\nkernings count=2'
+		+ '\nkerning first=84  second=65  amount=-2  '
+		+ '\nkerning first= 65 second= 84 amount= -2 ';
 		
 		var font = BMFont.parse(cast text);
 		assertFont(font);


### PR DESCRIPTION
Some exporters can align the columns so that the file is easier to view as a human:
```
char id=  32 x=    1 y=    1 width=    8 height=    8 xoffset=    0 yoffset=    0 xadvance=    8 page=0 chnl=15
char id=  33 x=   10 y=    1 width=    5 height=    8 xoffset=    0 yoffset=    0 xadvance=    5 page=0 chnl=15
char id= 101 x=   46 y=   37 width=    8 height=    8 xoffset=    0 yoffset=    0 xadvance=    8 page=0 chnl=15
```

The previous parsing did not allow for spaces after the `=`, such as this example:
```
char id=98 x=19 y=37 width=8 height=8 xoffset=0 yoffset=0 xadvance=8 page=0 chnl=15
char id=99 x=28 y=37 width=8 height=8 xoffset=0 yoffset=0 xadvance=8 page=0 chnl=15
char id=100 x=37 y=37 width=8 height=8 xoffset=0 yoffset=0 xadvance=8 page=0 chnl=15
```