### PR TITLE
FlxSound and FlxG.sound: Large refactor of sound initialization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        haxe-version: ["4.2.5", "4.3.6"]
+        haxe-version: ["4.2.5", "4.3.7"]
         target: [html5, hl, neko, flash, cpp]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,19 +9,47 @@ on:
     - cron: '0 4 * * *'
 
 jobs:
-  build:
+  linux:
     strategy:
       matrix:
-        haxe-version: ["4.2.5", "4.3.7"]
-        target: [html5, hl, neko, flash, cpp]
-      fail-fast: false
-    runs-on: macos-14
+        haxe-version: ["4.3.7"]
+        target: [html5, hl, flash, cpp]
+      fail-fast: true
+    runs-on: ubuntu-latest
     steps:
     - run: sudo apt-get update
     
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
-    - uses: krdlab/setup-haxe@v1
+    - uses: krdlab/setup-haxe@v2
+      with:
+        haxe-version: ${{matrix.haxe-version}}
+    
+    - name: "Configure Haxelib"
+      run: |
+        haxelib setup /home/runner/haxe/haxelib/
+        haxelib install haxelib 4.0.3
+        haxelib dev flixel .
+    
+    - uses: HaxeFlixel/setup-flixel@master
+      with:
+        flixel-versions: dev
+        test-location: local
+        target: ${{matrix.target}}
+        run-tests: true
+  
+  macos:
+    strategy:
+      matrix:
+        haxe-version: ["4.3.7"]
+        target: [html5, hl, flash, cpp]
+      fail-fast: true
+    runs-on: macos-14
+    steps:
+    
+    - uses: actions/checkout@v4
+    
+    - uses: krdlab/setup-haxe@v2
       with:
         haxe-version: ${{matrix.haxe-version}}
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         haxe-version: ["4.2.5", "4.3.7"]
         target: [html5, hl, neko, flash, cpp]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
     - run: sudo apt-get update
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,47 +9,19 @@ on:
     - cron: '0 4 * * *'
 
 jobs:
-  linux:
+  build:
     strategy:
       matrix:
-        haxe-version: ["4.3.7"]
-        target: [html5, hl, flash, cpp]
-      fail-fast: true
+        haxe-version: ["4.2.5", "4.3.7"]
+        target: [html5, hl, neko, flash, cpp]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
     - run: sudo apt-get update
     
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     
-    - uses: krdlab/setup-haxe@v2
-      with:
-        haxe-version: ${{matrix.haxe-version}}
-    
-    - name: "Configure Haxelib"
-      run: |
-        haxelib setup /home/runner/haxe/haxelib/
-        haxelib install haxelib 4.0.3
-        haxelib dev flixel .
-    
-    - uses: HaxeFlixel/setup-flixel@master
-      with:
-        flixel-versions: dev
-        test-location: local
-        target: ${{matrix.target}}
-        run-tests: true
-  
-  macos:
-    strategy:
-      matrix:
-        haxe-version: ["4.3.7"]
-        target: [html5, hl, flash, cpp]
-      fail-fast: true
-    runs-on: macos-14
-    steps:
-    
-    - uses: actions/checkout@v4
-    
-    - uses: krdlab/setup-haxe@v2
+    - uses: krdlab/setup-haxe@v1
       with:
         haxe-version: ${{matrix.haxe-version}}
     

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -121,8 +121,8 @@ class FlxSound extends FlxBasic
 	/**
 	 * Whether or not this sound should loop.
 	 * 
-	 * **NOTE:** The sound will loop even if this is `false` when `loopUntil > 0`.
-	 * This flag is set to `false` when `loopCount` reaches `loopUntil`
+	 * **NOTE:** If `loopUntil` is 0 or more, than the sound will only loop until
+	 * `loopCount` reaches `loopUntil`
 	 */
 	public var looped:Bool;
 	
@@ -135,8 +135,7 @@ class FlxSound extends FlxBasic
 	
 	/**
 	 * The number of times this sound should loop, where `-1` loops forever, and `1` is
-	 * repeated once. the `looped` flag does not need to be `true` for this to have an effect, but
-	 * will be set to `false` upon completion
+	 * repeated once. This field is ignored if `looped` is `false`
 	 * @since 6.2.0
 	 */
 	public var loopUntil:Int = -1;
@@ -765,16 +764,9 @@ class FlxSound extends FlxBasic
 		if (onComplete != null)
 			onComplete();
 		
-		if (looped && loopUntil == 0)
-			looped = false;
-		
-		final loop = looped || (loopUntil > 0 && loopCount < loopUntil);
-		
-		if (loop)
+		if (looped && (loopUntil == -1 || loopCount < loopUntil))
 		{
 			loopCount++;
-			if (loopUntil > 0 && loopCount >= loopUntil)
-				looped = false;
 			
 			cleanup(false);
 			play(false, loopTime, endTime);

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -349,20 +349,15 @@ class FlxSound extends FlxBasic
 	
 	/**
 	 * Loads a sound from the provided sound asset.
-	 * The asset can be an OpenFL Sound instance, embedded sound, file path or byte array.
+	 * The asset can be an OpenFL Sound instance, an asset ID or byte array.
 	 * 
-	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
-	 * 
-	 * @param   sound        The sound asset to load.
-	 * @param   looped       Whether or not this sound should loop endlessly.
-	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when
-	 *                       the sound finishes playing.
-	 * @param   onComplete   Called when the sound finishes playing.
+	 * @param   sound       The sound asset to load. For asset IDs the extention can be omitted
+	 * @param   allowCache  If `sound` is an asset ID, it will see a sound already exists
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 * 
 	 * @since 6.2.0
 	 */
-	public function load(sound:FlxSoundAsset, looped:Bool = false, autoDestroy:Bool = false, ?onComplete:Void->Void):FlxSound
+	public function load(asset:FlxSoundAsset, allowCache = true):FlxSound
 	{
 		if (asset == null)
 			FlxG.log.error("Expected sound asset, got null");
@@ -393,34 +388,37 @@ class FlxSound extends FlxBasic
 	 * 
 	 * This does not load sounds from web locations. Use `loadFromURL()` for that, instead.
 	 * 
-	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
-	 * 
-	 * @param   path         The ID or asset path to the sound asset.
-	 * @param   looped       Whether or not this sound should loop endlessly.
-	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
-	 * @param   onComplete   Called when the sound finishes playing.
+	 * @param   assetId  The ID or asset path to the sound asset. You may omit the file extension
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 * 
 	 * @since 6.2.0
 	 */
-	public function loadStreamed(path:String, looped:Bool = false, autoDestroy:Bool = false, ?onComplete:Void->Void):FlxSound
+	public function loadStreamed(assetId:String):FlxSound
 	{
-		cleanup(true);
+		return loadStreamedHelper(assetId, true).init(false, false, null);
+	}
+	
+	function loadStreamedHelper(assetId:String, destroy:Bool):FlxSound
+	{
+		cleanup(destroy);
+		
+		final fullAssetId = FlxG.assets.addSoundExt(assetId);
 
-		if (FlxG.assets.exists(path, SOUND))
+		if (FlxG.assets.exists(fullAssetId, SOUND))
 		{
-			if (FlxG.assets.canStreamSound(path))
+			if (FlxG.assets.canStreamSound(fullAssetId))
 			{
-				_sound = FlxG.assets.streamSoundUnsafe(path);
+				_sound = FlxG.assets.streamSoundUnsafe(fullAssetId);
+				onSoundSet();
 				
 				// NOTE: can't pull ID3 info from embedded sound currently
-				return init(looped, autoDestroy, onComplete);
+				return init(false, false, null);
 			}
 			
-			FlxG.log.error('Unable to stream SOUND asset with ID "$path". Expected a .OGG/Vorbis file');
+			FlxG.log.error('Unable to stream SOUND asset with ID "$fullAssetId". Expected a .OGG/Vorbis file');
 		}
 		else
-			FlxG.log.error('Could not find a Sound asset with an ID of \'$path\'.');
+			FlxG.log.error('Could not find a Sound asset with an ID of \'$assetId\'.');
 		
 		return this;
 	}
@@ -430,38 +428,44 @@ class FlxSound extends FlxBasic
 	 * Loads a sound from the provided URL.
 	 * 
 	 * @param   soundURL     A string representing the URL of the sound you want to play.
-	 * @param   looped       Whether or not this sound should loop endlessly.
-	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when
-	 *                       the sound finishes playing.
-	 * @param   onComplete   Called when the sound finishes playing.
 	 * @param   onLoad       Called when the sound finishes loading.
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 * 
 	 * @since 6.2.0
 	 */
-	public function loadFromURL(soundURL:String, looped:Bool = false, autoDestroy:Bool = false, ?onComplete:Void->Void, ?onLoad:Void->Void):FlxSound
+	public function loadFromURL(soundURL:String, ?onLoad:()->Void):FlxSound
+	{
+		return loadFromUrlHelper(soundURL, onLoad).init(false, false, null);
+	}
+	
+	function loadFromUrlHelper(soundURL:String, ?onLoad:()->Void):FlxSound
 	{
 		cleanup(true);
 		
-		_sound = new Sound();
-		_sound.addEventListener(Event.ID3, gotID3);
-		var loadCallback:Event->Void = null;
-		loadCallback = function(e:Event)
+		final sound = _sound = new Sound();
+		onSoundSet();
+		function loadCallback(e:Event)
 		{
-			(e.target : IEventDispatcher).removeEventListener(e.type, loadCallback);
+			sound.removeEventListener(e.type, loadCallback);
 			// Check if the sound was destroyed before calling. Weak ref doesn't guarantee GC.
-			if (_sound == e.target)
+			if (sound == e.target)
 			{
-				_length = _sound.length;
+				_length = sound.length;
 				if (onLoad != null)
 					onLoad();
 			}
 		}
 		// Use a weak reference so this can be garbage collected if destroyed before loading.
-		_sound.addEventListener(Event.COMPLETE, loadCallback, false, 0, true);
-		_sound.load(new URLRequest(soundURL));
+		sound.addEventListener(Event.COMPLETE, loadCallback, false, 0, true);
+		#if FLX_UNIT_TEST
+		// Don't actually load enternal on unit tests
+		if (onLoad != null)
+			onLoad();
+		#else
+		sound.load(new URLRequest(soundURL));
+		#end
 		
-		return init(looped, autoDestroy, onComplete);
+		return this;
 	}
 
 	/**
@@ -469,63 +473,99 @@ class FlxSound extends FlxBasic
 	 * 
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 * 
-	 * @param   EmbeddedSound  An embedded Class object representing an MP3 file.
-	 * @param   Looped         Whether or not this sound should loop endlessly.
-	 * @param   AutoDestroy    Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
-	 *                         Default value is false, but `FlxG.sound.play()` and `FlxG.sound.loadFromURL()` will set it to true by default.
-	 * @param   OnComplete     Called when the sound finished playing
+	 * @param   embeddedSound  An embedded Class object representing an MP3 file.
+	 * @param   looped         Whether or not this sound should loop endlessly.
+	 * @param   autoDestroy    Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
+	 *                         Default value is false, but `FlxG.sound.play()` and `FlxG.sound.playFromURL()` will set it to true by default.
+	 * @param   onComplete     Called when the sound finished playing
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
 	@:deprecated("loadEmbedded() is deprecated, use load() instead.")
-	public function loadEmbedded(EmbeddedSound:FlxSoundAsset, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
+	public function loadEmbedded(embeddedSound:FlxSoundAsset, looped = false, autoDestroy = false, ?onComplete:()->Void):FlxSound
 	{
-		return load(EmbeddedSound, Looped, AutoDestroy, OnComplete);
+		if (embeddedSound == null)
+			return this;
+		
+		return loadHelper(embeddedSound, true).init(looped, autoDestroy, onComplete);
 	}
 	
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a URL.
 	 * 
-	 * @param   SoundURL     A string representing the URL of the MP3 file you want to play.
-	 * @param   Looped       Whether or not this sound should loop endlessly.
-	 * @param   AutoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
+	 * @param   soundURL     A string representing the URL of the MP3 file you want to play.
+	 * @param   looped       Whether or not this sound should loop endlessly.
+	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
 	 *                       Default value is false, but `FlxG.sound.play()` and `FlxG.sound.loadFromURL()` will set it to true by default.
-	 * @param   OnComplete   Called when the sound finished playing
-	 * @param   OnLoad       Called when the sound finished loading.
+	 * @param   onComplete   Called when the sound finished playing
+	 * @param   onLoad       Called when the sound finished loading.
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
 	@:deprecated("loadStream() is deprecated, use loadFromURL() instead.")
-	public function loadStream(SoundURL:String, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void, ?OnLoad:Void->Void):FlxSound
+	public function loadStream(soundURL:String, looped = false, autoDestroy = false, ?onComplete:()->Void, ?onLoad:()->Void):FlxSound
 	{
-		return loadFromURL(SoundURL, Looped, AutoDestroy, OnComplete, OnLoad);
+		return loadFromUrlHelper(soundURL, onLoad).init(looped, autoDestroy, onComplete);
 	}
 	
 	/**
 	 * One of the main setup functions for sounds, this function loads a sound from a ByteArray.
 	 * 
-	 * @param   Bytes        A ByteArray object.
-	 * @param   Looped       Whether or not this sound should loop endlessly.
-	 * @param   AutoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
+	 * @param   bytes        A ByteArray object.
+	 * @param   looped       Whether or not this sound should loop endlessly.
+	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
 	 *                       Default value is false, but `FlxG.sound.play()` and `FlxG.sound.loadFromURL()` will set it to true by default.
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
 	@:deprecated("loadByteArray() is deprecated, use load() instead.")
-	public function loadByteArray(Bytes:ByteArray, Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
+	public function loadByteArray(bytes:ByteArray, looped:Bool = false, autoDestroy = false, ?onComplete:()->Void):FlxSound
 	{
-		return load(Bytes, Looped, AutoDestroy, OnComplete);
+		if (bytes == null)
+			return this;
+		
+		return loadHelper(bytes, true).init(looped, autoDestroy, onComplete);
 	}
 	
-	function init(Looped:Bool = false, AutoDestroy:Bool = false, ?OnComplete:Void->Void):FlxSound
+	/**
+	 * Handy method to set up all playing fields at once
+	 * 
+	 * @param volume       How loud this sound will play (0 to 1)
+	 * @param looped       Whether this sound will loop on completion
+	 * @param autoDestroy  Whether this sound will be destroyed upon completion
+	 * @param onComplete   Called upon completion
+	 * @since 6.2.0
+	 */
+	overload public inline extern function setup(volume = 1.0, looped = false, autoDestroy = false, ?onComplete:()->Void):FlxSound
 	{
-		looped = Looped;
-		autoDestroy = AutoDestroy;
+		this.volume = volume;
+		loopUntil = -1;
+		return init(looped, autoDestroy, onComplete);
+	}
+	
+	/**
+	 * Handy method to set up all playing fields at once
+	 * 
+	 * @param volume       How loud this sound will play (0 to 1)
+	 * @param loopUntil    The number of times this sound will restart
+	 * @param autoDestroy  Whether this sound will be destroyed upon completion
+	 * @param onComplete   Called upon completion
+	 * @since 6.2.0
+	 */
+	overload public inline extern function setup(volume = 1.0, loopUntil:Int, autoDestroy = false, ?onComplete:()->Void):FlxSound
+	{
+		this.volume = volume;
+		this.loopUntil = loopUntil;
+		return init(true, autoDestroy, onComplete);
+	}
+	
+	function init(looped:Bool, autoDestroy:Bool, onComplete:()->Void):FlxSound
+	{
+		this.looped = looped;
+		this.autoDestroy = autoDestroy;
+		this.onComplete = onComplete;
 		updateTransform();
 		exists = true;
-		onComplete = OnComplete;
 		#if FLX_PITCH
 		pitch = 1;
 		#end
-		_length = (_sound == null) ? 0 : _sound.length;
-		endTime = _length;
 		return this;
 	}
 	
@@ -562,12 +602,12 @@ class FlxSound extends FlxBasic
 	 * @param   EndTime        At which point to stop playing the sound, in milliseconds.
 	 *                         If not set / `null`, the sound completes normally.
 	 */
-	public function play(ForceRestart:Bool = false, StartTime:Float = 0.0, ?EndTime:Float):FlxSound
+	public function play(forceRestart = false, startTime = 0.0, ?endTime:Float):FlxSound
 	{
 		if (!exists)
 			return this;
-			
-		if (ForceRestart)
+		
+		if (forceRestart)
 			cleanup(false, true);
 		else if (playing) // Already playing sound
 			return this;
@@ -577,10 +617,10 @@ class FlxSound extends FlxBasic
 		else
 		{
 			loopCount = 0;
-			startSound(StartTime);
+			startSound(startTime);
 		}
 			
-		endTime = EndTime;
+		this.endTime = endTime;
 		return this;
 	}
 	
@@ -803,6 +843,13 @@ class FlxSound extends FlxBasic
 			_paused = false;
 			loopCount = 0;
 		}
+	}
+	
+	function onSoundSet()
+	{
+		_sound.addEventListener(Event.ID3, gotID3);
+		_length = _sound.length;
+		endTime = _length;
 	}
 	
 	/**

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -256,6 +256,7 @@ class FlxSound extends FlxBasic
 		looped = false;
 		loopTime = 0.0;
 		loopCount = 0;
+		loopUntil = -1;
 		endTime = 0.0;
 		_target = null;
 		_radius = 0;
@@ -591,17 +592,17 @@ class FlxSound extends FlxBasic
 			return this;
 			
 		if (ForceRestart)
-		{
-			loopCount = 0;
 			cleanup(false, true);
-		}
 		else if (playing) // Already playing sound
 			return this;
 			
 		if (_paused)
 			resume();
 		else
+		{
+			loopCount = 0;
 			startSound(StartTime);
+		}
 			
 		endTime = EndTime;
 		return this;
@@ -768,11 +769,14 @@ class FlxSound extends FlxBasic
 		{
 			loopCount++;
 			
-			cleanup(false);
-			play(false, loopTime, endTime);
+			cleanup(false, false);
+			startSound(loopTime);
 		}
 		else
-			cleanup(autoDestroy);
+		{
+			_time = 0; // Remove this line in 7.0.0
+			cleanup(autoDestroy, false);
+		}
 	}
 	
 	/**
@@ -805,6 +809,7 @@ class FlxSound extends FlxBasic
 		{
 			_time = 0;
 			_paused = false;
+			loopCount = 0;
 		}
 	}
 	

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -806,7 +806,7 @@ class FlxSound extends FlxBasic
 	 */
 	function gotID3(e:Event):Void
 	{
-		cast (e.target, EventDispatcher).removeEventListener(Event.ID3, gotID3);
+		cast (e.target, IEventDispatcher).removeEventListener(Event.ID3, gotID3);
 		
 		if (e.target == _sound)
 		{

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -812,11 +812,15 @@ class FlxSound extends FlxBasic
 	/**
 	 * Internal event handler for ID3 info (i.e. fetching the song name).
 	 */
-	function gotID3(_):Void
+	function gotID3(e:Event):Void
 	{
-		name = _sound.id3.songName;
-		artist = _sound.id3.artist;
-		_sound.removeEventListener(Event.ID3, gotID3);
+		cast (e.target, EventDispatcher).removeEventListener(Event.ID3, gotID3);
+		
+		if (e.target == _sound)
+		{
+			name = _sound.id3.songName;
+			artist = _sound.id3.artist;
+		}
 	}
 	
 	#if FLX_SOUND_SYSTEM

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -480,7 +480,7 @@ class FlxSound extends FlxBasic
 	 * @param   onComplete     Called when the sound finished playing
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
-	@:deprecated("loadEmbedded() is deprecated, use load() instead.")
+	@:deprecated("loadEmbedded() is deprecated, use load() instead.") // 6.2.0
 	public function loadEmbedded(embeddedSound:FlxSoundAsset, looped = false, autoDestroy = false, ?onComplete:()->Void):FlxSound
 	{
 		if (embeddedSound == null)
@@ -500,7 +500,7 @@ class FlxSound extends FlxBasic
 	 * @param   onLoad       Called when the sound finished loading.
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
-	@:deprecated("loadStream() is deprecated, use loadFromURL() instead.")
+	@:deprecated("loadStream() is deprecated, use loadFromURL() instead.") // 6.2.0
 	public function loadStream(soundURL:String, looped = false, autoDestroy = false, ?onComplete:()->Void, ?onLoad:()->Void):FlxSound
 	{
 		return loadFromUrlHelper(soundURL, onLoad).init(looped, autoDestroy, onComplete);
@@ -515,7 +515,7 @@ class FlxSound extends FlxBasic
 	 *                       Default value is false, but `FlxG.sound.play()` and `FlxG.sound.loadFromURL()` will set it to true by default.
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 */
-	@:deprecated("loadByteArray() is deprecated, use load() instead.")
+	@:deprecated("loadByteArray() is deprecated, use load() instead.") // 6.2.0
 	public function loadByteArray(bytes:ByteArray, looped:Bool = false, autoDestroy = false, ?onComplete:()->Void):FlxSound
 	{
 		if (bytes == null)

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -166,7 +166,7 @@ class FlxSound extends FlxBasic
 	/**
 	 * Internal tracker for a Flash sound object.
 	 */
-	var _sound:Sound;
+	var _sound:Null<Sound> = null;
 	
 	/**
 	 * Internal tracker for a Flash sound channel object.
@@ -369,8 +369,8 @@ class FlxSound extends FlxBasic
 	{
 		cleanup(destroy);
 		
-		final sound = asset.assertSound(allowCache, addExt);
-		if (sound != null)
+		_sound = asset.resolveSound(allowCache, addExt);
+		if (_sound != null)
 			onSoundSet();
 		
 		return this;

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -309,41 +309,32 @@ class FlxSound extends FlxBasic
 			
 		_time = _channel.position;
 		
-		var radialMultiplier:Float = 1.0;
+		updateProximity();
+		
+		if (endTime != null && _time >= endTime)
+			stopped();
+	}
+	
+	function updateProximity()
+	{
+		_volumeAdjust = 1.0;
 		
 		// Distance-based volume control
 		if (_target != null)
 		{
-			var targetPosition = _target.getPosition();
-			radialMultiplier = targetPosition.distanceTo(FlxPoint.weak(x, y)) / _radius;
+			final targetPosition = _target.getPosition();
+			final distRatio = targetPosition.distanceTo(FlxPoint.weak(x, y)) / _radius;
 			targetPosition.put();
-			radialMultiplier = 1 - FlxMath.bound(radialMultiplier, 0, 1);
+			_volumeAdjust = 1 - FlxMath.bound(distRatio, 0, 1);
 			
 			if (_proximityPan)
 			{
-				var d:Float = (x - _target.x) / _radius;
-				_transform.pan = FlxMath.bound(d, -1, 1);
+				final xDiff = (x - _target.x) / _radius;
+				_transform.pan = FlxMath.bound(xDiff, -1, 1);
 			}
 		}
 		
-		_volumeAdjust = radialMultiplier;
 		updateTransform();
-		
-		if (_transform.volume > 0)
-		{
-			amplitudeLeft = _channel.leftPeak / _transform.volume;
-			amplitudeRight = _channel.rightPeak / _transform.volume;
-			amplitude = (amplitudeLeft + amplitudeRight) * 0.5;
-		}
-		else
-		{
-			amplitudeLeft = 0;
-			amplitudeRight = 0;
-			amplitude = 0;
-		}
-		
-		if (endTime != null && _time >= endTime)
-			stopped();
 	}
 	
 	override public function kill():Void
@@ -568,6 +559,7 @@ class FlxSound extends FlxBasic
 		_target = TargetObject;
 		_radius = Radius;
 		_proximityPan = Pan;
+		updateProximity();
 		return this;
 	}
 	
@@ -697,6 +689,7 @@ class FlxSound extends FlxBasic
 	{
 		x = X;
 		y = Y;
+		updateProximity();
 	}
 	
 	/**
@@ -707,8 +700,23 @@ class FlxSound extends FlxBasic
 	{
 		_transform.volume = calcTransformVolume();
 		
-		if (_channel != null)
-			_channel.soundTransform = _transform;
+		if (_transform.volume > 0)
+		{
+			if (_channel != null)
+			{
+				_channel.soundTransform = _transform;
+				
+				amplitudeLeft = _channel.leftPeak * volume;
+				amplitudeRight = _channel.rightPeak * volume;
+				amplitude = (amplitudeLeft + amplitudeRight) * 0.5;
+			}
+		}
+		else
+		{
+			amplitudeLeft = 0;
+			amplitudeRight = 0;
+			amplitude = 0;
+		}
 	}
 	
 	function calcTransformVolume():Float

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -54,11 +54,15 @@ class FlxSound extends FlxBasic
 	
 	/**
 	 * Just the amplitude of the left stereo channel
+	 * 
+	 * **Note:** This only works when targeting flash
 	 */
 	public var amplitudeLeft(default, null):Float;
 	
 	/**
 	 * Just the amplitude of the right stereo channel
+	 * 
+	 * **Note:** This only works when targeting flash
 	 */
 	public var amplitudeRight(default, null):Float;
 	

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -120,11 +120,29 @@ class FlxSound extends FlxBasic
 	
 	/**
 	 * Whether or not this sound should loop.
+	 * 
+	 * **NOTE:** The sound will loop even if this is `false` when `loopUntil > 0`.
+	 * This flag is set to `false` when `loopCount` reaches `loopUntil`
 	 */
 	public var looped:Bool;
 	
 	/**
-	 * In case of looping, the point (in milliseconds) from where to restart the sound when it loops back
+	 * The number of times this sound was restarted, via the `looped` flag.
+	 * Automatically incremented on loops, and reset to 0 when restarted
+	 * @since 6.2.0
+	 */
+	public var loopCount(default, null):Int = 0;
+	
+	/**
+	 * The number of times this sound should loop, where `-1` loops forever, and `1` is
+	 * repeated once. the `looped` flag does not need to be `true` for this to have an effect, but
+	 * will be set to `false` upon completion
+	 * @since 6.2.0
+	 */
+	public var loopUntil:Int = -1;
+	
+	/**
+	 * The time (in milliseconds) from where to restart the sound when it loops back
 	 * @since 4.1.0
 	 */
 	public var loopTime:Float = 0;
@@ -238,6 +256,7 @@ class FlxSound extends FlxBasic
 		_volumeAdjust = 1.0;
 		looped = false;
 		loopTime = 0.0;
+		loopCount = 0;
 		endTime = 0.0;
 		_target = null;
 		_radius = 0;
@@ -573,7 +592,10 @@ class FlxSound extends FlxBasic
 			return this;
 			
 		if (ForceRestart)
+		{
+			loopCount = 0;
 			cleanup(false, true);
+		}
 		else if (playing) // Already playing sound
 			return this;
 			
@@ -742,9 +764,15 @@ class FlxSound extends FlxBasic
 	{
 		if (onComplete != null)
 			onComplete();
-			
-		if (looped)
+		
+		final loop = looped || (loopUntil > -1 && loopCount < loopUntil);
+		
+		if (loop)
 		{
+			loopCount++;
+			if (loopUntil > -1 && loopCount >= loopUntil)
+				looped = false;
+			
 			cleanup(false);
 			play(false, loopTime, endTime);
 		}

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -162,10 +162,6 @@ class FlxSound extends FlxBasic
 	/**
 	 * Internal tracker for a Flash sound object.
 	 */
-	@:allow(flixel.system.frontEnds.SoundFrontEnd.load)
-	#if FLX_STREAM_SOUND
-	@:allow(flixel.system.frontEnds.SoundFrontEnd.loadStreamed)
-	#end
 	var _sound:Sound;
 	
 	/**
@@ -824,7 +820,6 @@ class FlxSound extends FlxBasic
 	}
 	
 	#if FLX_SOUND_SYSTEM
-	@:allow(flixel.system.frontEnds.SoundFrontEnd)
 	function onFocus():Void
 	{
 		if (_resumeOnFocus)
@@ -834,7 +829,6 @@ class FlxSound extends FlxBasic
 		}
 	}
 	
-	@:allow(flixel.system.frontEnds.SoundFrontEnd)
 	function onFocusLost():Void
 	{
 		_resumeOnFocus = !_paused;

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -765,12 +765,15 @@ class FlxSound extends FlxBasic
 		if (onComplete != null)
 			onComplete();
 		
-		final loop = looped || (loopUntil > -1 && loopCount < loopUntil);
+		if (looped && loopUntil == 0)
+			looped = false;
+		
+		final loop = looped || (loopUntil > 0 && loopCount < loopUntil);
 		
 		if (loop)
 		{
 			loopCount++;
-			if (loopUntil > -1 && loopCount >= loopUntil)
+			if (loopUntil > 0 && loopCount >= loopUntil)
 				looped = false;
 			
 			cleanup(false);

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -360,37 +360,21 @@ class FlxSound extends FlxBasic
 	 */
 	public function load(sound:FlxSoundAsset, looped:Bool = false, autoDestroy:Bool = false, ?onComplete:Void->Void):FlxSound
 	{
-		if (sound == null)
-			return this;
-			
-		cleanup(true);
+		if (asset == null)
+			FlxG.log.error("Expected sound asset, got null");
 		
-		if ((sound is Sound))
-		{
-			_sound = sound;
-		}
-		else if ((sound is Class))
-		{
-			_sound = Type.createInstance(sound, []);
-		}
-		else if ((sound is String))
-		{
-			if (FlxG.assets.exists(sound, SOUND))
-				_sound = FlxG.assets.getSoundUnsafe(sound);
-			else
-				FlxG.log.error('Could not find a Sound asset with an ID of \'$sound\'.');
-		}
-		else if ((sound is ByteArrayData))
-		{
-			var bytes:ByteArray = cast sound;
-
-			_sound = new Sound();
-			_sound.addEventListener(Event.ID3, gotID3);
-			_sound.loadCompressedDataFromByteArray(bytes, bytes.length);
-		}
+		return loadHelper(asset, true, allowCache, true).init(false, false, null);
+	}
+	
+	function loadHelper(sound:FlxSoundAsset, destroy = false, allowCache = true, addExt = false):FlxSound
+	{
+		cleanup(destroy);
 		
-		// NOTE: can't pull ID3 info from embedded sound currently
-		return init(looped, autoDestroy, onComplete);
+		_sound = sound.resolveSound(allowCache, addExt);
+		if (_sound != null)
+			onSoundSet();
+		
+		return this;
 	}
 
 	#if FLX_STREAM_SOUND

--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -75,7 +75,7 @@ class FlxSound extends FlxBasic
 	 * Tracker for sound complete callback. If assigned, will be called
 	 * each time when sound reaches its end.
 	 */
-	public var onComplete:Void->Void;
+	public var onComplete:Null<()->Void> = null;
 	
 	/**
 	 * Pan amount. -1 = full left, 1 = full right. Proximity based panning overrides this.
@@ -365,12 +365,12 @@ class FlxSound extends FlxBasic
 		return loadHelper(asset, true, allowCache, true).init(false, false, null);
 	}
 	
-	function loadHelper(sound:FlxSoundAsset, destroy = false, allowCache = true, addExt = false):FlxSound
+	function loadHelper(asset:FlxSoundAsset, destroy = false, allowCache = true, addExt = false):FlxSound
 	{
 		cleanup(destroy);
 		
-		_sound = sound.resolveSound(allowCache, addExt);
-		if (_sound != null)
+		final sound = asset.assertSound(allowCache, addExt);
+		if (sound != null)
 			onSoundSet();
 		
 		return this;
@@ -556,7 +556,7 @@ class FlxSound extends FlxBasic
 		return init(true, autoDestroy, onComplete);
 	}
 	
-	function init(looped:Bool, autoDestroy:Bool, onComplete:()->Void):FlxSound
+	function init(looped:Bool, autoDestroy:Bool, onComplete:Null<()->Void>):FlxSound
 	{
 		this.looped = looped;
 		this.autoDestroy = autoDestroy;

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -41,15 +41,20 @@ typedef FlxBitmapFontGraphicAsset = OneOfFour<FlxFrame, FlxGraphic, BitmapData, 
 
 abstract FlxGraphicAsset(OneOfFour<FlxGraphic, BitmapData, String, Class<Dynamic>>) from FlxGraphic to FlxGraphic from BitmapData to BitmapData from String to String from Class<Dynamic> to Class<Dynamic>
 {
-	public inline function resolveBitmapData():Null<BitmapData>
+	public inline function resolveBitmapData(?log, ?pos):Null<BitmapData>
 	{
-		return FlxAssets.resolveBitmapData(cast this);
+		return FlxAssets.resolveBitmapData(cast this, log, pos);
+	}
+	
+	public inline function assertBitmapData():BitmapData
+	{
+		return FlxAssets.assertBitmapData(cast this);
 	}
 }
 
 abstract FlxSoundAsset(OneOfFour<String, Sound, Class<Sound>, ByteArray>) from String from Sound from Class<Sound> from ByteArray
 {
-	public inline function resolveSound(allowCache = true, addExt = false):Null<Sound>
+	public inline function resolveSound(allowCache = true, addExt = false):Sound
 	{
 		return FlxAssets.resolveSound(cast this, allowCache, addExt);
 	}
@@ -314,7 +319,19 @@ class FlxAssets
 	 * @param   graphic  input data to get BitmapData object for.
 	 * @return  BitmapData for specified Dynamic object.
 	 */
-	public static function resolveBitmapData(graphic:FlxGraphicAsset):Null<BitmapData>
+	public static function assertBitmapData(graphic:FlxGraphicAsset):BitmapData
+	{
+		if (graphic == null)
+			throw 'Cannot resolve null graphic asset, expected String, FlxGraphic, Class<Bitmap> or BitmapData';
+		
+		final data = resolveBitmapData(graphic, null);
+		if (data != null)
+			return data;
+		
+		throw 'Invalid graphic asset, expected String, FlxGraphic, Class<Bitmap> or BitmapData';
+	}
+	
+	public static function resolveBitmapData(graphic:FlxGraphicAsset, ?log, ?pos):Null<BitmapData>
 	{
 		if ((graphic is FlxGraphic))
 		{
@@ -332,11 +349,14 @@ class FlxAssets
 		{
 			return FlxG.assets.getBitmapData(cast graphic);
 		}
-
+		
+		if (log != null)
+			FlxG.log.advanced('Invalid graphic asset, expected String, FlxGraphic, Class<Bitmap> or BitmapData', log, pos);
+		
 		return null;
 	}
 	
-	public static function resolveSound(sound:FlxSoundAsset, allowCache = true, addExt = false):Null<Sound>
+	public static function resolveSound(sound:FlxSoundAsset, allowCache = true, addExt = false):Sound
 	{
 		if (sound == null)
 		{

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -54,9 +54,14 @@ abstract FlxGraphicAsset(OneOfFour<FlxGraphic, BitmapData, String, Class<Dynamic
 
 abstract FlxSoundAsset(OneOfFour<String, Sound, Class<Sound>, ByteArray>) from String from Sound from Class<Sound> from ByteArray
 {
-	public inline function resolveSound(allowCache = true, addExt = false):Sound
+	public inline function assertSound(allowCache = true, addExt = false):Sound
 	{
-		return FlxAssets.resolveSound(cast this, allowCache, addExt);
+		return FlxAssets.assertSound(cast this, allowCache, addExt);
+	}
+	
+	public inline function resolveSound(allowCache = true, addExt = false, ?log, ?pos):Sound
+	{
+		return FlxAssets.resolveSound(cast this, allowCache, addExt, log, pos);
 	}
 }
 
@@ -356,13 +361,9 @@ class FlxAssets
 		return null;
 	}
 	
-	public static function resolveSound(sound:FlxSoundAsset, allowCache = true, addExt = false):Sound
+	public static function resolveSound(sound:FlxSoundAsset, allowCache = true, addExt = false, ?log, ?pos):Null<Sound>
 	{
-		if (sound == null)
-		{
-			throw 'Cannot resolve null sound asset, expected String, Sound, Class<Sound> or ByteArray';
-		}
-		else if ((sound is Sound))
+		if ((sound is Sound))
 		{
 			return cast sound;
 		}
@@ -385,10 +386,31 @@ class FlxAssets
 			return result;
 		}
 		
+		if (log != null)
+		{
+			if (sound == null)
+				FlxG.log.advanced('Cannot resolve null sound asset, expected String, Sound, Class<Sound> or ByteArray', log, pos);
+			else
+				FlxG.log.advanced('Invalid sound asset, expected String, Sound, Class<Sound> or ByteArray, found: $sound', log, pos);
+		}
+		
+		return null;
+	}
+	
+	public static function assertSound(sound:FlxSoundAsset, allowCache = true, addExt = false):Sound
+	{
+		if (sound == null)
+		{
+			throw 'Cannot resolve null sound asset, expected String, Sound, Class<Sound> or ByteArray';
+		}
+		
+		final data = resolveSound(sound, allowCache, addExt);
+		if (data != null)
+			return data;
+		
 		throw 'Invalid sound asset, expected String, Sound, Class<Sound> or ByteArray, found: $sound';
 	}
 	
-
 	/**
 	 * Takes Dynamic object as a input and tries to find appropriate key String for its BitmapData:
 	 * 1) if the input is BitmapData, then it will return second (optional) argument (the Key);

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -36,7 +36,6 @@ class VirtualInputData extends #if nme ByteArray #else ByteArrayData #end {}
 
 typedef FlxTexturePackerJsonAsset = FlxJsonAsset<TexturePackerAtlas>;
 typedef FlxAsepriteJsonAsset = FlxJsonAsset<AseAtlas>;
-typedef FlxSoundAsset = OneOfFour<String, Sound, Class<Sound>, ByteArray>;
 typedef FlxTilemapGraphicAsset = OneOfFour<FlxFramesCollection, FlxGraphic, BitmapData, String>;
 typedef FlxBitmapFontGraphicAsset = OneOfFour<FlxFrame, FlxGraphic, BitmapData, String>;
 
@@ -45,6 +44,14 @@ abstract FlxGraphicAsset(OneOfFour<FlxGraphic, BitmapData, String, Class<Dynamic
 	public inline function resolveBitmapData():BitmapData
 	{
 		return FlxAssets.resolveBitmapData(cast this);
+	}
+}
+
+abstract FlxSoundAsset(OneOfFour<String, Sound, Class<Sound>, ByteArray>) from String from Sound from Class<Sound> from ByteArray
+{
+	public inline function resolveSound(allowCache = true, addExt = false):Null<Sound>
+	{
+		return FlxAssets.resolveSound(cast this, allowCache, addExt);
 	}
 }
 
@@ -328,6 +335,39 @@ class FlxAssets
 
 		return null;
 	}
+	
+	public static function resolveSound(sound:FlxSoundAsset, allowCache = true, addExt = false):Null<Sound>
+	{
+		if (sound == null)
+		{
+			throw 'Cannot resolve null sound asset, expected String, Sound, Class<Sound> or ByteArray';
+		}
+		else if ((sound is Sound))
+		{
+			return cast sound;
+		}
+		else if ((sound is Class))
+		{
+			return Type.createInstance((cast sound:Class<Sound>), []);
+		}
+		else if ((sound is String))
+		{
+			final id:String = (addExt ? FlxG.assets.addSoundExt(cast sound) : cast sound);
+			return FlxG.assets.getSound(id, allowCache, FlxG.log.styles.error);
+			// NOTE: can't pull ID3 info from embedded sound currently
+		}
+		else if ((sound is ByteArrayData))
+		{
+			final bytes:ByteArray = cast sound;
+			final result = new Sound();
+			result.loadCompressedDataFromByteArray(bytes, bytes.length);
+			trace(result.id3);
+			return result;
+		}
+		
+		throw 'Invalid sound asset, expected String, Sound, Class<Sound> or ByteArray, found: $sound';
+	}
+	
 
 	/**
 	 * Takes Dynamic object as a input and tries to find appropriate key String for its BitmapData:

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -41,7 +41,7 @@ typedef FlxBitmapFontGraphicAsset = OneOfFour<FlxFrame, FlxGraphic, BitmapData, 
 
 abstract FlxGraphicAsset(OneOfFour<FlxGraphic, BitmapData, String, Class<Dynamic>>) from FlxGraphic to FlxGraphic from BitmapData to BitmapData from String to String from Class<Dynamic> to Class<Dynamic>
 {
-	public inline function resolveBitmapData():BitmapData
+	public inline function resolveBitmapData():Null<BitmapData>
 	{
 		return FlxAssets.resolveBitmapData(cast this);
 	}
@@ -314,7 +314,7 @@ class FlxAssets
 	 * @param   graphic  input data to get BitmapData object for.
 	 * @return  BitmapData for specified Dynamic object.
 	 */
-	public static function resolveBitmapData(graphic:FlxGraphicAsset):BitmapData
+	public static function resolveBitmapData(graphic:FlxGraphicAsset):Null<BitmapData>
 	{
 		if ((graphic is FlxGraphic))
 		{

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -382,7 +382,6 @@ class FlxAssets
 			final bytes:ByteArray = cast sound;
 			final result = new Sound();
 			result.loadCompressedDataFromByteArray(bytes, bytes.length);
-			trace(result.id3);
 			return result;
 		}
 		

--- a/flixel/system/FlxSplash.hx
+++ b/flixel/system/FlxSplash.hx
@@ -1,11 +1,5 @@
 package flixel.system;
 
-import openfl.display.Graphics;
-import openfl.display.Sprite;
-import openfl.Lib;
-import openfl.text.TextField;
-import openfl.text.TextFormat;
-import openfl.text.TextFormatAlign;
 import flixel.FlxG;
 import flixel.FlxState;
 import flixel.tweens.FlxEase;
@@ -13,6 +7,12 @@ import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
 import flixel.util.FlxTimer;
 import flixel.util.typeLimit.NextState;
+import openfl.Lib;
+import openfl.display.Graphics;
+import openfl.display.Sprite;
+import openfl.text.TextField;
+import openfl.text.TextFormat;
+import openfl.text.TextFormatAlign;
 
 class FlxSplash extends FlxState
 {
@@ -87,7 +87,7 @@ class FlxSplash extends FlxState
 		#if FLX_SOUND_SYSTEM
 		if (!muted)
 		{
-			FlxG.sound.load(FlxAssets.getSoundAddExtension("flixel/sounds/flixel")).play();
+			FlxG.sound.create("flixel/sounds/flixel").play();
 		}
 		#end
 	}

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -383,7 +383,7 @@ class AssetFrontEnd
 		#end
 	}
 	
-	inline function addSoundExt(id:String)
+	public inline function addSoundExt(id:String)
 	{
 		final needsExt = Path.extension(id).length == 0;
 		if (needsExt)

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -485,7 +485,7 @@ class AssetFrontEnd
 	 * @return  Returns whether the sound can be streamed or not.
 	 * @since   6.2.0
 	 */
-	public function canStreamSound(id:String):Bool
+	public dynamic function canStreamSound(id:String):Bool
 	{
 		#if lime_vorbis
 		// Check if file is really OGG/Vorbis

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -34,7 +34,7 @@ class SoundFrontEnd
 	 * Set this hook to get a callback whenever the volume changes.
 	 * Function should take the form myVolumeHandler(volume:Float).
 	 */
-	@:deprecated("volumeHandler is deprecated, use onVolumeChange, instead")
+	@:deprecated("volumeHandler is deprecated, use onVolumeChange, instead") // 5.9.0
 	public var volumeHandler:Float->Void;
 
 	/**
@@ -138,7 +138,7 @@ class SoundFrontEnd
 	 * @param   loop     Whether to loop this music.
 	 * @param   group    The group to manage this sound, if `null`, `defaultMusicGroup` is used.
 	 */
-	@:deprecated("playMusic(id, volume, loop, group) is deprecated, use playMusic(id, group, volume, loop), instead")
+	@:deprecated("playMusic(id, volume, loop, group) is deprecated, use playMusic(id, group, volume, loop), instead") // 6.2.0
 	overload public inline extern function playMusic(assetId, volume = 1.0, loop = true, group:Null<FlxSoundGroup>):Void
 	{
 		playMusic(assetId, group, volume, loop);
@@ -180,7 +180,7 @@ class SoundFrontEnd
 	 * @param   onLoad       Called when the sound finishes loading.  Called immediately for succesfully loaded embedded sounds.
 	 * @return  A FlxSound object.
 	 */
-	@:deprecated("FlxG.sound.load is deprecated, use either loadFromURL() or create(assetId).setup(...).play()")
+	@:deprecated("FlxG.sound.load is deprecated, use either createFromURL() or create(assetId).setup(...).play()") // 6.2.0
 	public function load(?asset, volume = 1.0, loop = false, ?group, autoDestroy = false, autoPlay = false,
 			?url, ?onComplete, ?onLoad)
 	{
@@ -414,7 +414,7 @@ class SoundFrontEnd
 	 * @param   onLoad       Called when the sound finishes loading.
 	 * @return  A FlxSound object.
 	 */
-	@:deprecated("FlxG.sound.stream() is deprecated, use FlxG.sound.loadFromURL() or playFromURL(), instead")
+	@:deprecated("FlxG.sound.stream() is deprecated, use FlxG.sound.createFromURL() or playFromURL(), instead") // 6.2.0
 	public function stream(url:String, volume = 1.0, loop = false, ?group:FlxSoundGroup, autoDestroy = true,
 			?onComplete:()->Void, ?onLoad:()->Void):FlxSound
 	{

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -17,6 +17,7 @@ import openfl.media.Sound;
  * Accessed via `FlxG.sound`.
  */
 @:allow(flixel.FlxG)
+@:access(flixel.sound.FlxSound)
 class SoundFrontEnd
 {
 	/**

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -340,18 +340,6 @@ class SoundFrontEnd
 			.play();
 	}
 	
-	function attemptCache(asset:FlxSoundAsset):Null<FlxSoundAsset>
-	{
-		if ((asset is String))
-		{
-			final cachedAsset = cache(cast asset);
-			if (cachedAsset != null)
-				return cachedAsset;
-		}
-		
-		return asset;
-	}
-
 	/**
 	 * Plays a sound from a URL. Tries to recycle a cached sound first
 	 *

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -87,7 +87,7 @@ class SoundFrontEnd
 	public var defaultMusicGroup:FlxSoundGroup = new FlxSoundGroup();
 
 	/**
-	 * The group sounds in load() / loadFromURL() / play() are added to unless specified otherwise.
+	 * The default, group sounds are added to in `create` and `play` methods.
 	 */
 	public var defaultSoundGroup:FlxSoundGroup = new FlxSoundGroup();
 
@@ -197,7 +197,7 @@ class SoundFrontEnd
 			}
 			else
 			{
-				final sound = loadFromURL(url, group, onLoad);
+				final sound = createFromURL(url, group, onLoad);
 				sound.setup(volume, loop, autoDestroy, onComplete);
 				if (autoPlay)
 					sound.play();
@@ -362,7 +362,7 @@ class SoundFrontEnd
 	 * 
 	 * @since 6.2.0
 	 */
-	public function loadFromURL(url:String, ?group:FlxSoundGroup, ?onLoad:()->Void):FlxSound
+	public function createFromURL(url:String, ?group:FlxSoundGroup, ?onLoad:()->Void):FlxSound
 	{
 		return recycle(group)
 			.loadFromURL(url, onLoad);
@@ -402,7 +402,6 @@ class SoundFrontEnd
 
 	/**
 	 * Plays a sound from a URL. Tries to recycle a cached sound first.
-	 * NOTE: Just calls FlxG.sound.load() with AutoPlay == true.
 	 *
 	 * @param   url          A link to an external web resource.
 	 * @param   volume       How loud to play it (0 to 1).

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -319,7 +319,7 @@ class SoundFrontEnd
 	}
 
 	/**
-	 * Plays a sound from an embedded sound. Tries to recycle a cached sound first.
+	 * Plays a sound from an embedded sound. Tries to recycle a pooled sound first.
 	 *
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 *
@@ -341,7 +341,7 @@ class SoundFrontEnd
 	}
 	
 	/**
-	 * Plays a sound from a URL. Tries to recycle a cached sound first
+	 * Plays a sound from a URL. Tries to recycle a pooled sound first
 	 *
 	 * @param   url     A link to an external web resource
 	 * @param   group   The group to manage this sound, if `null`, `defaultSoundGroup` is used
@@ -357,7 +357,7 @@ class SoundFrontEnd
 	}
 
 	/**
-	 * Plays a sound from a URL. Tries to recycle a cached sound first
+	 * Plays a sound from a URL. Tries to recycle a pooled sound first
 	 *
 	 * @param   url          A link to an external web resource
 	 * @param   group        The group to manage this sound, if `null`, `defaultSoundGroup` is used
@@ -389,7 +389,7 @@ class SoundFrontEnd
 	}
 
 	/**
-	 * Plays a sound from a URL. Tries to recycle a cached sound first.
+	 * Plays a sound from a URL. Tries to recycle a pooled sound first.
 	 *
 	 * @param   url          A link to an external web resource.
 	 * @param   volume       How loud to play it (0 to 1).

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -100,96 +100,151 @@ class SoundFrontEnd
 	 * Set this to a number between 0 and 1 to change the global volume.
 	 */
 	public var volume(default, set):Float = 1;
-
-	/**
-	 * Set up and play a looping background soundtrack.
-	 *
-	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
-	 *
-	 * @param   embeddedMusic  The sound file you want to loop in the background.
-	 * @param   volume         How loud the sound should be, from 0 to 1.
-	 * @param   looped         Whether to loop this music.
-	 * @param   group          The group to add this sound to.
-	 */
-	public function playMusic(embeddedMusic:FlxSoundAsset, volume = 1.0, looped = true, ?group:FlxSoundGroup):Void
+	
+	function recycle(?group:FlxSoundGroup)
+	{
+		final sound = list.recycle(FlxSound);
+		sound.cleanup(true);
+		sound.exists = true;
+		(group != null ? group : defaultSoundGroup).add(sound);
+		return sound;
+	}
+	
+	function recycleMusic(group:Null<FlxSoundGroup>)
 	{
 		if (group == null)
 			group = defaultMusicGroup;
 		
 		if (music == null)
 		{
-			music = new FlxSound();
+			music = recycle(group);
 		}
 		else if (music.active)
 		{
 			music.stop();
+			group.add(music);
 		}
 		
-		music.load(embeddedMusic, looped);
-		music.volume = volume;
-		music.persist = true;
-		group.add(music);
-		music.play();
+		return music;
 	}
 
+	/**
+	 * Set up and play a looping background soundtrack.
+	 *
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 *
+	 * @param   assetId  The sound file you want to loop in the background.
+	 * @param   volume   How loud the sound should be, from 0 to 1.
+	 * @param   loop     Whether to loop this music.
+	 * @param   group    The group to manage this sound, if `null`, `defaultMusicGroup` is used.
+	 */
+	@:deprecated("playMusic(id, volume, loop, group) is deprecated, use playMusic(id, group, volume, loop), instead")
+	overload public inline extern function playMusic(assetId, volume = 1.0, loop = true, group:Null<FlxSoundGroup>):Void
+	{
+		playMusic(assetId, group, volume, loop);
+	}
+	
+	/**
+	 * Set up and play a looping background soundtrack.
+	 *
+	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 *
+	 * @param   asset       The sound file you want to loop in the background.
+	 * @param   group       The group to manage this sound, if `null`, `defaultMusicGroup` is used.
+	 * @param   volume      How loud the sound should be, from 0 to 1.
+	 * @param   loop        Whether to loop this music.
+	 * @param   onComplete  Called when the sound finishes playing, before it checks whether to to loop.
+	 */
+	overload public inline extern function playMusic(asset:FlxSoundAsset, ?group, volume = 1.0, loop = true, ?onComplete):FlxSound
+	{
+		return recycleMusic(group)
+			.loadHelper(asset)
+			.setup(volume, loop, false, onComplete)
+			.play();
+	}
+	
 	/**
 	 * Creates a new FlxSound object.
 	 *
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
-	 *
-	 * @param   embeddedSound   The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
-	 * @param   volume          How loud to play it (0 to 1).
-	 * @param   looped          Whether to loop this sound.
-	 * @param   group           The group to add this sound to.
-	 * @param   autoDestroy     Whether to destroy this sound when it finishes playing.
-	 *                          Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param   autoPlay        Whether to play the sound.
-	 * @param   url             Load a sound from an external web resource instead.  Only used if EmbeddedSound = null.
-	 * @param   onComplete      Called when the sound finished playing.
-	 * @param   onLoad          Called when the sound finished loading.  Called immediately for succesfully loaded embedded sounds.
+
+	 * @param   assetId      The embedded sound resource you want to play.  To stream, use the optional URL parameter instead.
+	 * @param   volume       How loud to play it (0 to 1).
+	 * @param   loop         Whether to loop this sound.
+	 * @param   group        The group to manage this sound, if `null`, `defaultSoundGroup` is used.
+	 * @param   autoDestroy  Whether to destroy this sound when it finishes playing.
+	 *                       Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param   autoPlay     Whether to play the sound.
+	 * @param   url          Load a sound from an external web resource instead.  Only used if EmbeddedSound = null.
+	 * @param   onComplete   Called when the sound finishes playing, before it checks whether to to loop.
+	 * @param   onLoad       Called when the sound finishes loading.  Called immediately for succesfully loaded embedded sounds.
 	 * @return  A FlxSound object.
 	 */
-	public function load(?embeddedSound:FlxSoundAsset, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?url:String,
-			?onComplete:Void->Void, ?onLoad:Void->Void):FlxSound
+	@:deprecated("FlxG.sound.load is deprecated, use either loadFromURL() or create(assetId).setup(...).play()")
+	public function load(?asset, volume = 1.0, loop = false, ?group, autoDestroy = false, autoPlay = false,
+			?url, ?onComplete, ?onLoad)
 	{
-		if ((embeddedSound == null) && (url == null))
+		return if (asset == null && url == null)
 		{
 			FlxG.log.warn("FlxG.sound.load() requires either\nan embedded sound or a URL to work.");
-			return null;
+			null;
 		}
-
-		var sound:FlxSound = list.recycle(FlxSound);
-
-		if (embeddedSound != null)
+		else if (asset == null && url != null)
 		{
-			sound.load(embeddedSound, looped, autoDestroy, onComplete);
-			loadHelper(sound, volume, group, autoPlay);
-			// Call OnlLoad() because the sound already loaded
-			if (onLoad != null && sound._sound != null)
-				onLoad();
+			if (autoPlay)
+			{
+				playFromURL(url, group, onLoad, volume, loop, autoDestroy, onComplete);
+			}
+			else
+			{
+				final sound = loadFromURL(url, group, onLoad);
+				sound.setup(volume, loop, autoDestroy, onComplete);
+				if (autoPlay)
+					sound.play();
+				
+				sound;
+			}
 		}
 		else
 		{
-			var loadCallback = onLoad;
+			if (url != null)
+				FlxG.log.warn("FlxG.sound.load() received both an embedded asset and a url, ignoring url.");
+			
+			final sound = recycle(group)
+				.loadHelper(asset)
+				.setup(volume, loop, autoDestroy, onComplete);
+			
 			if (autoPlay)
-			{
-				// Auto play the sound when it's done loading
-				loadCallback = function()
-				{
-					sound.play();
-
-					if (onLoad != null)
-						onLoad();
-				}
-			}
-
-			sound.loadFromURL(url, looped, autoDestroy, onComplete, loadCallback);
-			loadHelper(sound, volume, group);
+				sound.play();
+			
+			// Call OnLoad() because the sound already loaded
+			if (onLoad != null && sound._sound != null)
+				onLoad();
+			
+			sound;
 		}
-
-		return sound;
 	}
-
+	
+	/**
+	 * Creates a new FlxSound object. It's recommended to set up sounds using chainging, for
+	 * instance:
+	 * ```haxe
+	 * FlxG.sound.create("assets/sounds/mySound").setup(1.0, true).play();
+	 * ```
+	 *
+	 * @param   asset       The embedded sound resource you want to play. Accepts various types,
+	 *                      typically an asset ID, you may omit the file extension
+	 * @param   group       The group to manage this sound, if `null`, `defaultSoundGroup` is used
+	 * @param   allowCache  Useed for asset IDs, Whether to use the asset caching system
+	 * @return  This `FlxSound` instance
+	 * 
+	 * @since 6.2.0
+	 */
+	public function create(asset:FlxSoundAsset, ?group:FlxSoundGroup, allowCache = true):FlxSound
+	{
+		return recycle(group).loadHelper(asset, false, allowCache, true);
+	}
+	
 	#if FLX_STREAM_SOUND
 	/**
 	 * Streams a sound from the given file path. Unlike the `load` method, this will load and
@@ -200,56 +255,55 @@ class SoundFrontEnd
 	 * Due to a backend limitation, audio streaming is currently only available on native targets 
 	 * and OGG/Vorbis audio files.
 	 * 
-	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
+	 * @param   assetId  The ID or asset path to the sound asset. You may omit the file extension
+	 * @param   group    The group to manage this sound, if `null`, `defaultSoundGroup` is used
+	 * @return  This `FlxSound` instance (nice for chaining stuff together, if you're into that)
 	 * 
-	 * @param   id           The ID or asset path to the sound asset.
-	 * @param   volume       How loud to play it (0 to 1).
-	 * @param   looped       Whether or not this sound should loop endlessly.
-	 * @param   group        The group to add this sound to.
+	 * @since 6.2.0
+	 */
+	public function createStreamed(assetId:String, ?group:FlxSoundGroup):FlxSound
+	{
+		return recycle(group)
+			.loadStreamedHelper(assetId, false);
+	}
+	
+	/**
+	 * Streams a sound from the given file path. Unlike the `play` method, this will load and
+	 * unload chunks of data as the sound plays, keeping memory usage low. This is recommended for
+	 * longer sounds, like music tracks. For shorter sounds like sound effects, it is better to
+	 * use the `play` method, which loads the entire sound into memory before playing it.
+	 * 
+	 * Due to a backend limitation, audio streaming is currently only available on native targets 
+	 * and OGG/Vorbis audio files.
+	 * 
+	 * @param   assetId  The ID or asset path to the sound asset. You may omit the file extension
+	 * @param   group    The group to manage this sound, if `null`, `defaultSoundGroup` is used
+	 * @param   volume   How loud to play it (0 to 1).
+	 * @param   loop     Whether or not this sound should loop endlessly.
 	 * @param   autoDestroy  Whether or not this FlxSound instance should be destroyed when the sound finishes playing.
-	 * @param   autoPlay     Whether to play the sound.
-	 * @param   onComplete   Called when the sound finishes playing.
+	 * @param   onComplete   Called when the sound finishes playing, before it checks whether to to loop.
 	 * @return  This FlxSound instance (nice for chaining stuff together, if you're into that).
 	 * 
 	 * @since 6.2.0
 	 */
-	public function loadStreamed(id:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = false, autoPlay = false, ?onComplete:()->Void):FlxSound 
+	public function playStreamed(assetId, ?group, volume = 1.0, loop = false, autoDestroy = false, ?onComplete):FlxSound 
 	{
-		final sound = list.recycle(FlxSound);
-		sound.loadStreamed(id, looped, autoDestroy, onComplete);
-		loadHelper(sound, volume, group, autoPlay);
-		return sound;
+		return createStreamed(assetId, group)
+			.setup(volume, loop, autoDestroy, onComplete)
+			.play();
 	}
 	#end
-
-	function loadHelper(sound:FlxSound, volume:Float, group:FlxSoundGroup, autoPlay = false):FlxSound
-	{
-		if (group == null)
-			group = defaultSoundGroup;
-		
-		sound.volume = volume;
-		group.add(sound);
-		
-		if (autoPlay)
-			sound.play();
-		
-		return sound;
-	}
 
 	/**
 	 * Method for sound caching (especially useful on mobile targets). The game may freeze
 	 * for some time the first time you try to play a sound if you don't use this method.
 	 *
-	 * @param   embeddedSound  Name of sound assets specified in your .xml project file
+	 * @param   assetId  Name of sound assets specified in your .xml project file
 	 * @return  Cached Sound object
 	 */
-	public inline function cache(embeddedSound:String):Sound
+	public inline function cache(assetId:String):Null<Sound>
 	{
-		// load the sound into the OpenFL assets cache
-		if (FlxG.assets.exists(embeddedSound, SOUND))
-			return FlxG.assets.getSoundUnsafe(embeddedSound, true);
-		FlxG.log.error('Could not find a Sound asset with an ID of \'$embeddedSound\'.');
-		return null;
+		return FlxG.assets.getSound(assetId, true, FlxG.log.styles.error);
 	}
 
 	/**
@@ -269,64 +323,102 @@ class SoundFrontEnd
 	 *
 	 * **Note:** If the `FLX_DEFAULT_SOUND_EXT` flag is enabled, you may omit the file extension
 	 *
-	 * @param   embeddedSound  The embedded sound resource you want to play.
-	 * @param   volume         How loud to play it (0 to 1).
-	 * @param   looped         Whether to loop this sound.
-	 * @param   group          The group to add this sound to.
-	 * @param   autoDestroy    Whether to destroy this sound when it finishes playing.
-	 *                         Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param   onComplete     Called when the sound finished playing
+	 * @param   assetId      The embedded sound resource you want to play.
+	 * @param   volume       How loud to play it (0 to 1).
+	 * @param   loop         Whether to loop this sound.
+	 * @param   group        The group to manage this sound, if `null`, `defaultSoundGroup` is used.
+	 * @param   autoDestroy  Whether to destroy this sound when it finishes playing.
+	 *                       Leave this value set to "false" if you want to re-use this FlxSound instance.
+	 * @param   onComplete   Called when the sound finishes playing, before it checks whether to to loop.
 	 * @return  A FlxSound object.
 	 */
-	public function play(embeddedSound:FlxSoundAsset, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = true, ?onComplete:Void->Void):FlxSound
+	public function play(asset:FlxSoundAsset, volume = 1.0, loop = false, ?group:FlxSoundGroup, autoDestroy = true, ?onComplete):FlxSound
 	{
-		if ((embeddedSound is String))
+		return recycle(group)
+			.loadHelper(asset)
+			.setup(volume, loop, autoDestroy, onComplete)
+			.play();
+	}
+	
+	function attemptCache(asset:FlxSoundAsset):Null<FlxSoundAsset>
+	{
+		if ((asset is String))
 		{
-			embeddedSound = cache(embeddedSound);
+			final cachedAsset = cache(cast asset);
+			if (cachedAsset != null)
+				return cachedAsset;
 		}
-		var sound = list.recycle(FlxSound).load(embeddedSound, looped, autoDestroy, onComplete);
-		return loadHelper(sound, volume, group, true);
+		
+		return asset;
+	}
+
+	/**
+	 * Plays a sound from a URL. Tries to recycle a cached sound first
+	 *
+	 * @param   url     A link to an external web resource
+	 * @param   group   The group to manage this sound, if `null`, `defaultSoundGroup` is used
+	 * @param   onLoad  Called when the sound finishes loading
+	 * @return  A FlxSound object.
+	 * 
+	 * @since 6.2.0
+	 */
+	public function loadFromURL(url:String, ?group:FlxSoundGroup, ?onLoad:()->Void):FlxSound
+	{
+		return recycle(group)
+			.loadFromURL(url, onLoad);
+	}
+
+	/**
+	 * Plays a sound from a URL. Tries to recycle a cached sound first
+	 *
+	 * @param   url          A link to an external web resource
+	 * @param   group        The group to manage this sound, if `null`, `defaultSoundGroup` is used
+	 * @param   onLoad       Called when the sound finishes loading
+	 * @param   volume       How loud to play it (0 to 1)
+	 * @param   loop         Whether to loop this sound
+	 * @param   autoDestroy  Whether to destroy this sound when it finishes playing.
+	 *                       Leave this value set to "false" if you want to re-use this FlxSound instance
+	 * @param   onLoad       Called when the sound finishes playing, before it checks whether to to loop
+	 * @return  A FlxSound object.
+	 * @since 6.2.0
+	 */
+	public function playFromURL(url:String, ?group:FlxSoundGroup, ?onLoad:()->Void, volume = 1.0, loop = false,
+			autoDestroy = false, ?onComplete:()->Void):FlxSound
+	{
+		final sound = recycle(group);
+		// Auto play the sound when it's done loading
+		function playOnLoad()
+		{
+			sound.play();
+
+			if (onLoad != null)
+				onLoad();
+		}
+		
+		return sound.loadFromURL(url, playOnLoad)
+			.setup(volume, loop, autoDestroy, onComplete)
+			.play();
 	}
 
 	/**
 	 * Plays a sound from a URL. Tries to recycle a cached sound first.
 	 * NOTE: Just calls FlxG.sound.load() with AutoPlay == true.
 	 *
-	 * @param   url          Load a sound from an external web resource instead.
+	 * @param   url          A link to an external web resource.
 	 * @param   volume       How loud to play it (0 to 1).
-	 * @param   looped       Whether to loop this sound.
-	 * @param   group        The group to add this sound to.
+	 * @param   loop         Whether to loop this sound.
+	 * @param   group        The group to manage this sound, if `null`, `defaultSoundGroup` is used.
 	 * @param   autoDestroy  Whether to destroy this sound when it finishes playing.
 	 *                       Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param   onComplete   Called when the sound finished playing
-	 * @param   onLoad       Called when the sound finished loading.
+	 * @param   onComplete   Called when the sound finishes playing, before it checks whether to to loop.
+	 * @param   onLoad       Called when the sound finishes loading.
 	 * @return  A FlxSound object.
 	 */
-	public function loadFromURL(url:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = true, ?onComplete:Void->Void,
-			?onLoad:Void->Void):FlxSound
+	@:deprecated("FlxG.sound.stream() is deprecated, use FlxG.sound.loadFromURL() or playFromURL(), instead")
+	public function stream(url:String, volume = 1.0, loop = false, ?group:FlxSoundGroup, autoDestroy = true,
+			?onComplete:()->Void, ?onLoad:()->Void):FlxSound
 	{
-		return load(null, volume, looped, group, autoDestroy, true, url, onComplete, onLoad);
-	}
-
-	/**
-	 * Plays a sound from a URL. Tries to recycle a cached sound first.
-	 * NOTE: Just calls FlxG.sound.load() with AutoPlay == true.
-	 *
-	 * @param   url          Load a sound from an external web resource instead.
-	 * @param   volume       How loud to play it (0 to 1).
-	 * @param   looped       Whether to loop this sound.
-	 * @param   group        The group to add this sound to.
-	 * @param   autoDestroy  Whether to destroy this sound when it finishes playing.
-	 *                       Leave this value set to "false" if you want to re-use this FlxSound instance.
-	 * @param   onComplete   Called when the sound finished playing
-	 * @param   onLoad       Called when the sound finished loading.
-	 * @return  A FlxSound object.
-	 */
-	@:deprecated("FlxG.sound.stream() is deprecated, use FlxG.sound.loadFromURL() instead")
-	public function stream(url:String, volume = 1.0, looped = false, ?group:FlxSoundGroup, autoDestroy = true, ?onComplete:Void->Void,
-			?onLoad:Void->Void):FlxSound
-	{
-		return loadFromURL(url, volume, looped, group, autoDestroy, onComplete, onLoad);
+		return playFromURL(url, group, onLoad, volume, loop, autoDestroy, onComplete);
 	}
 
 	/**
@@ -458,7 +550,7 @@ class SoundFrontEnd
 		return curvedVolume;
 		
 		// Example of logarithmic to linear sound curve:
-		// final clampedVolume = Math.max(minValue, Math.min(1, x));
+		// final clampedVolume = Math.max(0.001, Math.min(1, curvedVolume));
 		// return 1 - (Math.log(clampedVolume) / Math.log(0.001));
 	}
 	

--- a/flixel/system/ui/FlxSoundTray.hx
+++ b/flixel/system/ui/FlxSoundTray.hx
@@ -154,7 +154,7 @@ class FlxSoundTray extends Sprite
 	public function showAnim(volume:Float, ?sound:FlxSoundAsset, duration = 1.0, label = "VOLUME")
 	{
 		if (sound != null)
-			FlxG.sound.play(FlxG.assets.getSoundAddExt(sound));
+			FlxG.sound.play(sound.resolveSound(true, true));
 		
 		_timer = duration;
 		y = 0;

--- a/flixel/util/FlxStringUtil.hx
+++ b/flixel/util/FlxStringUtil.hx
@@ -637,7 +637,7 @@ class FlxStringUtil
 	 */
 	overload public static inline extern function imageToCSV(graphic:FlxGraphicAsset, whiteIsSolid = false, scale = 1):String
 	{
-		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, whiteIsSolid ? invertColorMap : defaultColorMap, true);
+		return bitmapToCSVHelper(graphic.assertBitmapData(), scale, whiteIsSolid ? invertColorMap : defaultColorMap, true);
 	}
 	
 	/**
@@ -651,7 +651,7 @@ class FlxStringUtil
 	 */
 	overload public static inline extern function imageToCSV(graphic:FlxGraphicAsset, scale = 1, colorMap:Array<FlxColor>):String
 	{
-		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, colorMap, true);
+		return bitmapToCSVHelper(graphic.assertBitmapData(), scale, colorMap, true);
 	}
 	
 	/**
@@ -665,7 +665,7 @@ class FlxStringUtil
 	 */
 	overload public static inline extern function image32ToCSV(graphic:FlxGraphicAsset, scale = 1, colorMap:Array<FlxColor>):String
 	{
-		return bitmapToCSVHelper(graphic.resolveBitmapData(), scale, colorMap, false);
+		return bitmapToCSVHelper(graphic.assertBitmapData(), scale, colorMap, false);
 	}
 
 	/**

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -11,16 +11,4 @@ class FlxSoundTest extends FlxTest
 		sound.load("assets/invalid");
 		sound.play();
 	}
-	
-	@Test
-	@Ignore("Unable to unit test sounds")
-	function testPlay()
-	{
-		var sound = new FlxSound();
-		sound.load("flxiel/sounds/flixel");
-		sound.play();
-		// step();
-		
-		Assert.isTrue(sound.playing);
-	}
 }

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -63,6 +63,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testDebugSound()
 	{
 		Assert.isNotNull(silence1k1);
@@ -82,6 +83,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testCallback()
 	{
 		sound1.load(silence1k1);
@@ -110,6 +112,7 @@ class FlxSoundTest extends FlxTest
 	
 	#if FLX_PITCH
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testPitch()
 	{
 		sound1.load(silence1k1);
@@ -132,6 +135,7 @@ class FlxSoundTest extends FlxTest
 	#end
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testTime()
 	{
 		sound1.load(silence1k1).play();
@@ -145,12 +149,13 @@ class FlxSoundTest extends FlxTest
 	@Test
 	function testLength()
 	{
-		sound1.load(silence100).play();
+		sound1.load(silence100);
 		
 		Assert.areEqual(100, sound1.length);
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testLooped()
 	{
 		sound1.load(silence750).setup(1.0, true).play();
@@ -163,6 +168,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testLoopUntil()
 	{
 		sound1.load(silence750).setup(1.0, 3).play();
@@ -192,6 +198,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testLoopTimes()
 	{
 		sound1.load(silence1k1);
@@ -245,6 +252,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	// #if !mac @Ignore("Sound tests not working on ubuntu") #end
 	@:access(flixel.sound.FlxSound)
 	function testProximity()
 	{
@@ -283,6 +291,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testPlay()
 	{
 		sound1.load(silence100);
@@ -306,6 +315,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testPlayPaused()
 	{
 		sound1.load(silence1k1);
@@ -335,6 +345,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testResume()
 	{
 		sound1.load(silence1k1);
@@ -366,6 +377,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testStop()
 	{
 		sound1.load(silence1k1);
@@ -403,6 +415,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testFadeOut()
 	{
 		Assert.areEqual(0, FlxG.updateFramerate % 2, 'This test requires an even updateFramerate, found ${FlxG.updateFramerate}');
@@ -441,6 +454,7 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
+	#if !mac @Ignore("Sound tests not working on ubuntu") #end
 	function testFadeIn()
 	{
 		Assert.areEqual(0, FlxG.updateFramerate % 2, 'This test requires an even updateFramerate, found ${FlxG.updateFramerate}');

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -13,7 +13,9 @@ import openfl.media.Sound;
 import openfl.media.SoundChannel;
 import openfl.media.SoundTransform;
 
-@:nullSafety(Strict)
+
+// null safety breaks on 4.2
+#if (haxe >= version("4.3.0")) @:nullSafety(Strict) #end
 class FlxSoundTest extends FlxTest
 {
 	

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -1,9 +1,52 @@
 package flixel.sound;
 
+import FlxAssert;
+import flixel.FlxG;
+import flixel.FlxObject;
+import flixel.sound.FlxSound;
+import flixel.sound.FlxSoundGroup;
 import massive.munit.Assert;
+import openfl.media.Sound;
+import openfl.media.SoundChannel;
+import openfl.media.SoundTransform;
 
 class FlxSoundTest extends FlxTest
 {
+	static final silence1k1 = new DebugSound().loadSilence(1.0);
+	static final silence1k2 = new DebugSound().loadSilence(1.0);
+	static final silence750 = new DebugSound().loadSilence(0.75);
+	static final silence100 = new DebugSound().loadSilence(0.1);
+	
+	var sound1:FlxSound;
+	var sound2:FlxSound;
+	var group:FlxSoundGroup;
+	
+	@Before
+	function before()
+	{
+		silence1k1.log = false;
+		silence1k2.log = false;
+		silence750.log = false;
+		silence100.log = false;
+		sound1 = new FlxSound();
+		sound2 = new FlxSound();
+		group = new FlxSoundGroup();
+		group.add(sound1);
+		group.add(sound2);
+		FlxG.plugins.addPlugin(sound1);
+		FlxG.plugins.addPlugin(sound2);
+	}
+	
+	override function after()
+	{
+		super.after();
+		
+		FlxG.plugins.remove(sound1);
+		FlxG.plugins.remove(sound2);
+		sound2.destroy();
+		sound1.destroy();
+	}
+	
 	@Test // #1511
 	function testLoadInvalidSoundPathNoCrash()
 	{
@@ -13,14 +56,569 @@ class FlxSoundTest extends FlxTest
 	}
 	
 	@Test
-	@Ignore("Unable to unit test sounds")
+	function testDebugSound()
+	{
+		Assert.isNotNull(silence1k1);
+		Assert.isNotNull(silence1k2);
+		Assert.isNotNull(silence750);
+		Assert.isNotNull(silence100);
+		
+		sound1.load(silence100);
+		sound1.play();
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(sound1.time, 0);
+		
+		step();
+		
+		Assert.isTrue(sound1.playing);
+		Assert.isTrue(sound1.time > 0);
+	}
+	
+	@Test
+	function testCallback()
+	{
+		sound1.load(silence1k1);
+		sound1.play();
+		var callbackCalled = false;
+		sound1.onComplete = ()->callbackCalled = true;
+		
+		step(FlxG.updateFramerate + 1);// +1 to account for float arith error
+		
+		Assert.isTrue(callbackCalled);
+	}
+	
+	@Test
+	function testAutoDestroy()
+	{
+		sound1.load(silence1k1).setup(1.0, false, false);// no autoDestroy
+		sound1.play();
+		sound2.load(silence1k2).setup(1.0, false, true);// autoDestroy
+		sound2.play();
+		
+		step(FlxG.updateFramerate + 1);// +1 to account for float arith error
+		
+		Assert.isTrue(sound1.exists);
+		Assert.isFalse(sound2.exists);
+	}
+	
+	#if FLX_PITCH
+	@Test
+	function testPitch()
+	{
+		sound1.load(silence1k1);
+		sound1.pitch = 2.0;
+		var callbackCalled = false;
+		sound1.onComplete = ()->callbackCalled = true;
+		sound1.play();
+		
+		step(Math.ceil(FlxG.updateFramerate / 2) + 1);// +1 to account for float arith error
+		
+		if (callbackCalled)
+			Assert.assertionCount++;
+		else
+		{
+			@:privateAccess
+			final channel = sound1._channel;
+			Assert.fail('Expected sound to finish playing, but sound is at ${channel.position}/${sound1.length}');
+		}
+	}
+	#end
+	
+	@Test
+	function testTime()
+	{
+		sound1.load(silence1k1).play();
+		
+		step();
+		
+		final oldTime = sound1.time;
+		Assert.isTrue(0 < sound1.time);
+	}
+	
+	@Test
+	function testLength()
+	{
+		sound1.load(silence100).play();
+		
+		Assert.areEqual(100, sound1.length);
+	}
+	
+	@Test
+	function testLooped()
+	{
+		sound1.load(silence750).setup(1.0, true).play();
+		
+		step(FlxG.updateFramerate * 10);
+		
+		Assert.areEqual(13, sound1.loopCount);
+		Assert.isTrue(sound1.playing);
+		Assert.isTrue(sound1.time < sound1.length && sound1.time > 0);
+	}
+	
+	@Test
+	function testLoopUntil()
+	{
+		sound1.load(silence750).setup(1.0, 3).play();
+		
+		step(FlxG.updateFramerate);
+		
+		Assert.areEqual(1, sound1.loopCount);
+		Assert.isTrue(sound1.playing);
+		Assert.isTrue(sound1.time < sound1.length && sound1.time > 0);
+		
+		step(FlxG.updateFramerate);
+		
+		Assert.areEqual(2, sound1.loopCount);
+		Assert.isTrue(sound1.playing);
+		Assert.isTrue(sound1.time < sound1.length && sound1.time > 0);
+		
+		step(FlxG.updateFramerate);
+		
+		Assert.areEqual(3, sound1.loopCount);
+		Assert.isTrue(sound1.playing);
+		Assert.isTrue(sound1.time < sound1.length && sound1.time > 0);
+		
+		step(FlxG.updateFramerate);
+		
+		Assert.areEqual(3, sound1.loopCount);
+		Assert.isFalse(sound1.playing);
+	}
+	
+	@Test
+	function testLoopTimes()
+	{
+		sound1.load(silence1k1);
+		sound1.play(true);
+		sound1.looped = true;
+		sound1.loopTime = 250;
+		
+		sound2.load(silence1k2);
+		sound2.play(true);
+		sound2.looped = true;
+		sound2.loopTime = 250;
+		sound2.endTime = 750;
+		
+		step(FlxG.updateFramerate + 1);// +1 to account for float arith error
+		
+		assertTimeGT(sound1, 250);
+		assertTimeGT(sound2, 500);
+	}
+	
+	@Test
+	function testSetup()
+	{
+		final func = ()->{}
+		
+		function assertFields(volume:Float, looped:Bool, loops:Int, autoDestroy:Bool, onComplete:Null<()->Void>, ?pos)
+		{
+			Assert.areEqual(volume     , sound1.volume     , 'Expected volume to be ${volume     }, found: [${sound1.volume     }]', pos);
+			Assert.areEqual(looped     , sound1.looped     , 'Expected looped to be ${looped     }, found: [${sound1.looped     }]', pos);
+			Assert.areEqual(loops      , sound1.loopUntil  , 'Expected volume to be ${loops      }, found: [${sound1.volume     }]', pos);
+			Assert.areEqual(autoDestroy, sound1.autoDestroy, 'Expected volume to be ${autoDestroy}, found: [${sound1.autoDestroy}]', pos);
+			Assert.areEqual(onComplete , sound1.onComplete , 'Expected volume to be ${onComplete }, found: [${sound1.onComplete }]', pos);
+		}
+		
+		sound1.setup(0.5, true, true, func);
+		assertFields(0.5, true, -1, true, func);
+		
+		sound1.setup();
+		assertFields(1.0, false, -1, false, null);
+		
+		sound1.setup(0.75, 3, true, func);
+		assertFields(0.75, true, 3, true, func);
+		
+		sound1.setup(0.75, 2);
+		assertFields(0.75, true, 2, false, null);
+		
+		sound1.setup(0.75, 0);
+		assertFields(0.75, true, 0, false, null);
+		
+		sound1.setup(0.75, -1);
+		assertFields(0.75, true, -1, false, null);
+	}
+	
+	@Test
+	@:access(flixel.sound.FlxSound)
+	function testProximity()
+	{
+		sound1.load(silence100).setup(0.5, true).play();
+		final transform = sound1._transform;
+		final object = new FlxObject(50, 50, 1, 1);
+		
+		sound1.proximity(50, 50, object, 50, false);
+		sound1.update(FlxG.elapsed);
+		
+		FlxAssert.areNear(0.5, transform.volume);
+		
+		sound1.proximity(75, 50, object, 50, false);
+		sound1.update(FlxG.elapsed);
+		
+		FlxAssert.areNear(0.5, sound1.volume);
+		FlxAssert.areNear(0.25, transform.volume);
+		FlxAssert.areNear(0.0, sound1.pan);
+		
+		sound1.proximity(150, 50, object, 50, false);
+		sound1.update(FlxG.elapsed);
+		
+		FlxAssert.areNear(0.0, transform.volume);
+		
+		sound1.proximity(75, 50, object, 50, true);
+		sound1.update(FlxG.elapsed);
+		
+		FlxAssert.areNear(0.25, transform.volume);
+		FlxAssert.areNear(0.5, sound1.pan);
+		
+		sound1.proximity(25, 50, object, 50, true);
+		sound1.update(FlxG.elapsed);
+		
+		FlxAssert.areNear(0.25, transform.volume);
+		FlxAssert.areNear(-0.5, sound1.pan);
+	}
+	
+	@Test
 	function testPlay()
 	{
-		var sound = new FlxSound();
-		sound.load("flxiel/sounds/flixel");
-		sound.play();
-		// step();
+		sound1.load(silence100);
+		sound1.play();
 		
-		Assert.isTrue(sound.playing);
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(0, sound1.time);
+		Assert.isNull(sound1.endTime);
+		
+		sound1.play(false, 250, 750);// no force restart, does nothing
+		
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(0, sound1.time);
+		Assert.isNull(sound1.endTime);
+		
+		sound1.play(true, 250, 750);// force restart
+		
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(250, sound1.time);
+		Assert.areEqual(750, sound1.endTime);
+	}
+	
+	@Test
+	function testPlayPaused()
+	{
+		sound1.load(silence1k1);
+		sound1.play();
+		
+		step();
+		
+		Assert.isTrue(sound1.playing);
+		
+		sound1.pause();
+		final oldTime = sound1.time;
+		
+		step(10);
+		
+		Assert.isFalse(sound1.playing);
+		Assert.areEqual(oldTime, sound1.time);
+		
+		sound1.play(false, 250, 750);
+		
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(oldTime, sound1.time);
+		Assert.areEqual(750, sound1.endTime);
+		
+		step();
+		
+		assertTimeGT(sound1, oldTime + 1);
+	}
+	
+	@Test
+	function testResume()
+	{
+		sound1.load(silence1k1);
+		sound1.play();
+		
+		step();
+		
+		Assert.isTrue(sound1.playing);
+		final oldTime = sound1.time;
+		
+		sound1.resume();// no effect
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(oldTime, sound1.time);
+		
+		sound1.pause();
+		step(10);
+		
+		Assert.isFalse(sound1.playing);
+		Assert.areEqual(oldTime, sound1.time);
+		
+		sound1.resume();
+		
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(oldTime, sound1.time);
+		
+		step();
+		
+		assertTimeGT(sound1, oldTime + 1);
+	}
+	
+	@Test
+	function testStop()
+	{
+		sound1.load(silence1k1);
+		sound1.play();
+		
+		step();
+		
+		sound1.stop();
+		
+		Assert.isFalse(sound1.playing);
+		Assert.isTrue(sound1.exists);
+		Assert.areEqual(0, sound1.time);
+		
+		step(10);
+		
+		Assert.isFalse(sound1.playing);
+		Assert.areEqual(0, sound1.time);
+		
+		sound1.resume();
+		
+		Assert.isFalse(sound1.playing);
+		Assert.areEqual(0, sound1.time);
+		
+		sound1.play(false, 250);
+		
+		Assert.isTrue(sound1.playing);
+		Assert.areEqual(250, sound1.time);
+		
+		sound1.autoDestroy = true;
+		sound1.stop();
+		
+		Assert.isFalse(sound1.playing);
+		Assert.isFalse(sound1.exists);
+		Assert.areEqual(0, sound1.time);
+	}
+	
+	@Test
+	function testFadeOut()
+	{
+		Assert.areEqual(0, FlxG.updateFramerate % 2, 'This test requires an even updateFramerate, found ${FlxG.updateFramerate}');
+		
+		sound1.load(silence1k1);
+		sound1.looped = true;
+		sound1.volume = 0.75;
+		sound1.play();
+		
+		step(FlxG.updateFramerate);
+		
+		var fadeComplete = false;
+		sound1.fadeOut(1.0, 0.25, function (tween)
+		{
+			Assert.areEqual(tween, sound1.fadeTween);
+			fadeComplete = true;
+		});
+		
+		Assert.areEqual(0.75, sound1.volume);
+		
+		step(FlxG.updateFramerate >> 1);
+		
+		Assert.areEqual(0.5, sound1.volume);
+		Assert.isFalse(fadeComplete);
+		
+		step(FlxG.updateFramerate >> 1);
+		
+		FlxAssert.areNear(0.25, sound1.volume);
+		Assert.isFalse(fadeComplete, 'Expected fadeOut to be uncompleted, was completed');
+		
+		step();// one more for tween to complete
+		
+		Assert.areEqual(0.25, sound1.volume);
+		Assert.isTrue(fadeComplete, 'Expected fadeOut to be completed, was not');
+		Assert.isTrue(sound1.playing);
+	}
+	
+	@Test
+	function testFadeIn()
+	{
+		Assert.areEqual(0, FlxG.updateFramerate % 2, 'This test requires an even updateFramerate, found ${FlxG.updateFramerate}');
+		
+		sound1.load(silence1k1);
+		sound1.looped = true;
+		Assert.isFalse(sound1.playing);
+		
+		var fadeComplete = false;
+		sound1.fadeIn(1.0, 0.25, 0.75, function (tween)
+		{
+			Assert.areEqual(tween, sound1.fadeTween);
+			fadeComplete = true;
+		});
+		
+		Assert.isTrue(sound1.playing);
+		
+		step(FlxG.updateFramerate >> 1);
+		
+		Assert.areEqual(0.5, sound1.volume);
+		Assert.isFalse(fadeComplete);
+		
+		step(FlxG.updateFramerate >> 1);
+		
+		Assert.areEqual(0.75, sound1.volume);
+		Assert.isFalse(fadeComplete, 'Expected fadeIn to be uncompleted');
+		
+		step();// one more for tween to complete
+		
+		Assert.areEqual(0.75, sound1.volume);
+		Assert.isTrue(fadeComplete, 'Expected fadeIn to be completed');
+	}
+	
+	@Test
+	function testVolume()
+	{
+		sound1.volume = 1.0;
+		Assert.areEqual(1.0, sound1.volume);
+		
+		sound1.volume = 0.0;
+		Assert.areEqual(0.0, sound1.volume);
+		
+		sound1.volume = -0.5;
+		Assert.areEqual(0.0, sound1.volume);
+		
+		sound1.volume = 1.5;
+		Assert.areEqual(1.0, sound1.volume);
+	}
+	
+	@Test
+	function testSetPosition()
+	{
+		sound1.setPosition(5);
+		Assert.areEqual(5, sound1.x);
+		Assert.areEqual(0, sound1.y);
+		
+		sound1.setPosition(10, 10);
+		Assert.areEqual(10, sound1.x);
+		Assert.areEqual(10, sound1.y);
+		
+		sound1.setPosition();
+		Assert.areEqual(0, sound1.x);
+		Assert.areEqual(0, sound1.y);
+	}
+	
+	@Test
+	@Ignore("Not implemented in openfl")
+	function testId3()
+	{
+		sound1.load(silence100);
+		Assert.areEqual('A sound .1 seconds long', sound1.name);
+		Assert.areEqual(DebugSound.ID3_ARTIST, sound1.artist);
+		
+		sound1.load(silence1k1);
+		Assert.areEqual('A sound 1 seconds long', sound1.name);
+		
+		sound1.autoDestroy = true;
+		sound1.play();
+		
+		step(FlxG.updateFramerate + 1);
+		
+		Assert.isNull(sound1.name);
+		Assert.isNull(sound1.artist);
+	}
+	
+	@Test
+	@Ignore("Not implemented in openfl")
+	function testAmplitude()
+	{
+	}
+	
+	function assertTimeGT(sound:FlxSound, expectedMin:Float, ?pos)
+	{
+		if (sound.time >= expectedMin)
+			Assert.assertionCount++;
+		else
+			Assert.fail('Expected sound.time to be at least ${expectedMin}, found ${sound.time}', pos);
+	}
+}
+
+class DebugSound extends Sound
+{
+	public static inline var ID3_ARTIST = "HaxeFlixel";
+	public static inline var ID3_ALBUM = "Unit Tests";
+	public static inline var ID3_COMMENT = "Used to test FlxSounds";
+	public static inline var ID3_GENRE = "Techno";
+	public static inline var ID3_YEAR = "2026";
+	
+	
+	static inline var SAMPLE_RATE = 44100;
+	static inline var HEADER_BYTES
+		= '524946460000000057415645666d7420100000000100010044ac000088580100020008006461746100000000';
+		// |       |       |       |       |       |   |   |       |       |       |       |       
+		// R_I_F_F_<-size->W_A_V_E_f_m_t_ _<--16--><01><ch><44100-><bytrte><blkaln><btsPer><sampls>
+	
+	public var log = false;
+	
+	public function new ()
+	{
+		super();
+	}
+	
+	public function loadSilence(seconds:Float)
+	{
+		// id3.songName = 'A sound $seconds seconds long';
+		
+		final numSamples = Std.int(SAMPLE_RATE * seconds);
+		final samples = haxe.io.Bytes.alloc(numSamples);
+		for (i in 0...numSamples)
+			samples.set(i, 0x80);
+		
+		final rawBytes = haxe.io.Bytes.ofHex(HEADER_BYTES + samples.toHex());
+		rawBytes.setInt32(4, 36 + samples.length);
+		rawBytes.setInt32(40, samples.length);
+		
+		final bytes = openfl.utils.ByteArray.fromBytes(rawBytes);
+		loadCompressedDataFromByteArray(bytes, bytes.length);
+		return this;
+	}
+	
+	var debugElapsed = 0.0;
+	var debugChannel:SoundChannel = null;
+	override function play(startTime:Float = 0.0, loops:Int = 0, sndTransform:SoundTransform = null):SoundChannel
+	{
+		if (log) trace('play($startTime, $loops, $sndTransform');
+		
+		debugChannel = super.play(startTime, loops, sndTransform);
+		debugElapsed = 0.0;
+		FlxG.signals.preUpdate.add(onStep);
+		return debugChannel;
+	}
+	
+	function onStep()
+	{
+		if (debugChannel == null)
+			return;
+		
+		@:privateAccess
+		final source = #if (openfl < "9.3.2") debugChannel.__source #else debugChannel.__audioSource #end;
+		
+		if (source == null)
+			return;
+		
+		debugElapsed += FlxG.elapsed * source.pitch;
+		final position = Std.int(1000 * debugElapsed) + source.offset;
+		if (position < length)
+		{
+			debugChannel.position = position;
+			if (log)
+				trace('step: ${debugChannel.position}');
+		}
+		else
+		{
+			debugChannel.position = length;
+			debugChannel.dispatchEvent(new openfl.events.Event(openfl.events.Event.SOUND_COMPLETE));
+			if (log)
+				trace('complete');
+		}
+		
+		// @:privateAccess 
+		// trace('step: $debugPosition-${debugChannel.position} valid: ${debugChannel.__isValid}');
+	}
+	
+	public function destroy()
+	{
+		FlxG.signals.preUpdate.remove(onStep);
 	}
 }

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -1,6 +1,8 @@
 package flixel.sound;
 
-class FlxSoundTest
+import massive.munit.Assert;
+
+class FlxSoundTest extends FlxTest
 {
 	@Test // #1511
 	function testLoadInvalidSoundPathNoCrash()
@@ -8,5 +10,17 @@ class FlxSoundTest
 		var sound = new FlxSound();
 		sound.load("assets/invalid");
 		sound.play();
+	}
+	
+	@Test
+	@Ignore("Unable to unit test sounds")
+	function testPlay()
+	{
+		var sound = new FlxSound();
+		sound.load("flxiel/sounds/flixel");
+		sound.play();
+		// step();
+		
+		Assert.isTrue(sound.playing);
 	}
 }

--- a/tests/unit/src/flixel/sound/FlxSoundTest.hx
+++ b/tests/unit/src/flixel/sound/FlxSoundTest.hx
@@ -1,5 +1,8 @@
 package flixel.sound;
 
+#if flash
+class FlxSoundTest extends FlxTest {}
+#else
 import FlxAssert;
 import flixel.FlxG;
 import flixel.FlxObject;
@@ -10,16 +13,18 @@ import openfl.media.Sound;
 import openfl.media.SoundChannel;
 import openfl.media.SoundTransform;
 
+@:nullSafety(Strict)
 class FlxSoundTest extends FlxTest
 {
+	
 	static final silence1k1 = new DebugSound().loadSilence(1.0);
 	static final silence1k2 = new DebugSound().loadSilence(1.0);
 	static final silence750 = new DebugSound().loadSilence(0.75);
 	static final silence100 = new DebugSound().loadSilence(0.1);
 	
-	var sound1:FlxSound;
-	var sound2:FlxSound;
-	var group:FlxSoundGroup;
+	var sound1:FlxSound = new FlxSound();
+	var sound2:FlxSound = new FlxSound();
+	var group:FlxSoundGroup = new FlxSoundGroup();
 	
 	@Before
 	function before()
@@ -575,12 +580,14 @@ class DebugSound extends Sound
 	}
 	
 	var debugElapsed = 0.0;
-	var debugChannel:SoundChannel = null;
+	var debugStartTime = 0.0;
+	var debugChannel:Null<SoundChannel> = null;
 	override function play(startTime:Float = 0.0, loops:Int = 0, sndTransform:SoundTransform = null):SoundChannel
 	{
 		if (log) trace('play($startTime, $loops, $sndTransform');
 		
 		debugChannel = super.play(startTime, loops, sndTransform);
+		debugStartTime = startTime;
 		debugElapsed = 0.0;
 		FlxG.signals.preUpdate.add(onStep);
 		return debugChannel;
@@ -591,14 +598,19 @@ class DebugSound extends Sound
 		if (debugChannel == null)
 			return;
 		
+		#if FLX_PITCH
 		@:privateAccess
 		final source = #if (openfl < "9.3.2") debugChannel.__source #else debugChannel.__audioSource #end;
-		
 		if (source == null)
 			return;
+		final pitch = source.pitch;
+		#else
+		final pitch = 1.0;
+		#end
 		
-		debugElapsed += FlxG.elapsed * source.pitch;
-		final position = Std.int(1000 * debugElapsed) + source.offset;
+		
+		debugElapsed += FlxG.elapsed * pitch;
+		final position = Std.int(1000 * debugElapsed) + debugStartTime;
 		if (position < length)
 		{
 			debugChannel.position = position;
@@ -622,3 +634,4 @@ class DebugSound extends Sound
 		FlxG.signals.preUpdate.remove(onStep);
 	}
 }
+#end

--- a/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
@@ -1,7 +1,10 @@
 package flixel.system.frontEnds;
 
 import flixel.FlxG;
+import flixel.sound.FlxSound;
+import flixel.sound.FlxSoundGroup;
 import massive.munit.Assert;
+import openfl.media.Sound;
 
 class SoundFrontEndTest
 {
@@ -21,7 +24,7 @@ class SoundFrontEndTest
 	@Test // #1511
 	function testLoadInvalidSoundPathNoCrash()
 	{
-		FlxG.sound.load("assets/invalid").play();
+		FlxG.sound.create("assets/invalid").play();
 	}
 
 	@Test // #1511
@@ -50,5 +53,174 @@ class SoundFrontEndTest
 		FlxAssert.areNear(0.899, FlxG.sound.reverseSoundCurve(0.5));
 		FlxAssert.areNear(0.5, FlxG.sound.reverseSoundCurve(FlxG.sound.applySoundCurve(0.5)));
 	}
+	
+	@Test
+	@:haxe.warning("-WDeprecated")
+	function testPlayMusicOverloads()
+	{
+		final group = new FlxSoundGroup();
+		final sound:Sound = debugSound(1000);
+		
+		function assertSoundProps(volume:Float, loop:Bool, inGroup:Bool)
+		{
+			final music = FlxG.sound.music;
+			Assert.areEqual(volume, music.volume);
+			Assert.areEqual(loop, music.looped);
+			Assert.areEqual(inGroup ? group : FlxG.sound.defaultMusicGroup, music.group);
+		}
+		
+		// Check that all possible overloads of the old version work with the new overloads
+		FlxG.sound.playMusic(sound, 0.5, false, null);
+		assertSoundProps(0.5, false, false);
+		
+		FlxG.sound.playMusic(sound, 0.5, false, group);
+		assertSoundProps(0.5, false, true);
+		
+		FlxG.sound.playMusic(sound, 0.5, false);
+		assertSoundProps(0.5, false, false);
+		
+		FlxG.sound.playMusic(sound, 0.5);
+		assertSoundProps(0.5, true, false);
+		
+		FlxG.sound.playMusic(sound);
+		assertSoundProps(1.0, true, false);
+		#if !flash
+		FlxG.sound.playMusic(sound, 0.5, group);
+		assertSoundProps(0.5, true, true);
+		
+		FlxG.sound.playMusic(sound, null);
+		assertSoundProps(1.0, true, false);
+		
+		FlxG.sound.playMusic(sound, group);
+		assertSoundProps(1.0, true, true);
+		
+		FlxG.sound.playMusic(sound, false);
+		assertSoundProps(1.0, false, false);
+		#end
+	}
 	#end
+	
+	@Test
+	@:haxe.warning("-WDeprecated")
+	function testAddExtDefaults()
+	{
+		final partialPath = 'assets/sounds/test';
+		final fullPath = partialPath + FlxG.assets.defaultSoundExtension;
+		final soundAsset = new DebugSound(1000);
+		
+		final oldGetFunc = FlxG.assets.getAssetUnsafe;
+		FlxG.assets.getAssetUnsafe = function (id, _, useCache = true)
+		{
+			// trace('getting: $id');
+			return id == fullPath ? soundAsset : null;
+		}
+		
+		final oldStreamFunc = FlxG.assets.streamSoundUnsafe;
+		FlxG.assets.streamSoundUnsafe = function (id)
+		{
+			// trace('streaming: $id');
+			return id == fullPath ? soundAsset : null;
+		}
+		
+		final oldExistsFunc = FlxG.assets.exists;
+		FlxG.assets.exists = function (id, ?_)
+		{
+			// trace('exists: $id');
+			return id == fullPath;
+		}
+		
+		final oldCanStreamFunc = FlxG.assets.canStreamSound;
+		FlxG.assets.canStreamSound = function (id)
+		{
+			// trace('canStream: $id');
+			return true;
+		}
+		
+		inline function assertPathSuccess(sound:FlxSound, ?pos)
+		{
+			if (sound == null)
+				Assert.fail("Expected sound instance, got null", pos);
+			
+			@:privateAccess
+			final actual = sound._sound;
+			Assert.areEqual(soundAsset, actual, pos);
+		}
+		
+		inline function assertPathFail(sound:FlxSound, ?pos)
+		{
+			// haxe.Log.trace('$sound', pos);
+			@:privateAccess
+			Assert.isNull(sound._sound, pos);
+		}
+		
+		#if FLX_DEFAULT_SOUND_EXT
+		Assert.fail("FLX_DEFAULT_SOUND_EXT was true");
+		#end
+		try
+		{
+			assertPathSuccess(FlxG.sound.load(fullPath));
+			assertPathFail(FlxG.sound.load(partialPath));
+			assertPathSuccess(FlxG.sound.create(fullPath));
+			assertPathSuccess(FlxG.sound.create(partialPath));
+			assertPathSuccess(FlxG.sound.createStreamed(fullPath));
+			assertPathSuccess(FlxG.sound.createStreamed(partialPath));
+			
+			assertPathSuccess(FlxG.sound.play(fullPath));
+			assertPathFail(FlxG.sound.play(partialPath));
+			assertPathSuccess(FlxG.sound.playMusic(fullPath));
+			assertPathFail(FlxG.sound.playMusic(partialPath));
+			assertPathSuccess(FlxG.sound.playStreamed(fullPath));
+			assertPathSuccess(FlxG.sound.playStreamed(partialPath));
+		}
+		catch(e)
+		{
+			trace('caught: ${e.message}\n@: ${e.stack}');
+			FlxG.assets.getAssetUnsafe = oldGetFunc;
+			FlxG.assets.exists = oldExistsFunc;
+			throw e;
+		}
+		
+		FlxG.assets.getAssetUnsafe = oldGetFunc;
+		FlxG.assets.streamSoundUnsafe = oldStreamFunc;
+		FlxG.assets.exists = oldExistsFunc;
+	}
+	
+	function debugSound(ms:Float)//:Sound
+	{
+		return new DebugSound(ms);
+	}
+}
+
+@:forward
+abstract DebugSound(Sound) to Sound
+{
+	public static inline var ID3_ARTIST = "HaxeFlixel";
+	public static inline var ID3_ALBUM = "Unit Tests";
+	public static inline var ID3_COMMENT = "Used to test FlxSounds";
+	public static inline var ID3_GENRE = "Techno";
+	public static inline var ID3_YEAR = "2026";
+	
+	inline static var SAMPLE_RATE = 44100;
+	inline static var HEADER_BYTES
+		= '524946460000000057415645666d7420100000000100010044ac000044ac0000020008006461746100000000';
+		// |       |       |       |       |       |   |   |       |       |   |   |       |       
+		// R_I_F_F_<-size->W_A_V_E_f_m_t_ _<--16--><01><ch><44100-><bytrte><ba><br>d_a_t_a_<sampls>
+		
+	
+	public function new (ms:Float)
+	{
+		this = new Sound();
+		
+		final numSamples = Std.int(SAMPLE_RATE * (ms / 1000));
+		final samples = haxe.io.Bytes.alloc(numSamples);
+		for (i in 0...numSamples)
+			samples.set(i, 0x80);
+		
+		final rawBytes = haxe.io.Bytes.ofHex(HEADER_BYTES + samples.toHex());
+		rawBytes.setInt32(4, 36 + samples.length);
+		rawBytes.setInt32(40, samples.length);
+		
+		final bytes = openfl.utils.ByteArray.fromBytes(rawBytes);
+		this.loadCompressedDataFromByteArray(bytes, bytes.length);
+	}
 }

--- a/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
@@ -162,15 +162,19 @@ class SoundFrontEndTest
 			assertPathFail(FlxG.sound.load(partialPath));
 			assertPathSuccess(FlxG.sound.create(fullPath));
 			assertPathSuccess(FlxG.sound.create(partialPath));
+			#if FLX_STREAM_SOUND
 			assertPathSuccess(FlxG.sound.createStreamed(fullPath));
 			assertPathSuccess(FlxG.sound.createStreamed(partialPath));
+			#end
 			
 			assertPathSuccess(FlxG.sound.play(fullPath));
 			assertPathFail(FlxG.sound.play(partialPath));
 			assertPathSuccess(FlxG.sound.playMusic(fullPath));
 			assertPathFail(FlxG.sound.playMusic(partialPath));
+			#if FLX_STREAM_SOUND
 			assertPathSuccess(FlxG.sound.playStreamed(fullPath));
 			assertPathSuccess(FlxG.sound.playStreamed(partialPath));
+			#end
 		}
 		catch(e)
 		{


### PR DESCRIPTION
## FlxSound
Add new chained setup system, I.E.:
```hx
mySound.load(path).setup(volume, numLoops, autoDestroy, onComplete).play()
```
### Changes

- Add `setup` method, to init playback fields like `volume`, `looped`, `loopUntil`, `autoDestroy` and `onComplete`
- Change some new methods from https://github.com/HaxeFlixel/flixel/pull/3479 and https://github.com/HaxeFlixel/flixel/pull/3518
    - Removes "setup" fields from `load`, `loadStreamed` and `loadFromURL`
- Small improvement to event handling
- Small improvement to amplitudes (a flash only feature)
- Add internal `updateProximity`, update positional sounds when they move, rather than the next update
- Give `SoundFrontEnd` full private access to `FlxSound`
- Add Null types in various places
- Various doc fixes
- Add unit tests (disabled on ubuntu - https://github.com/HaxeFlixel/flixel/issues/3562)

## FlxG.sound
Similar chained setup to work with FlxSound changes:
```hx
FlxG.sound.create(path).setup(volume, numLoops, autoDestroy, onComplete).play()
```
### Changes: 

- New overload of `playMusic`, deprecating the old function
- Deprecates `load` and loadStreamed for the new `create` and `createStreamed`
- Replaces loadFromURL with createFromURL
- Add Null types where needed
- Add Unit tests

## FlxG.assets

- Make `canStreamSound` dynamic
- Make `addSoundExt` public

## FlxAssets

- Add `assertBitmapData`, `assertSound` and `resolveSound`
- Add logging to `resolveBitmapData` 