### PR TITLE
FlxSound: Fix global muting

### DIFF
--- a/flixel/sound/FlxSound.hx
+++ b/flixel/sound/FlxSound.hx
@@ -728,12 +728,13 @@ class FlxSound extends FlxBasic
 	{
 		_transform.volume = calcTransformVolume();
 		
+		if (_channel != null)
+			_channel.soundTransform = _transform;
+		
 		if (_transform.volume > 0)
 		{
 			if (_channel != null)
 			{
-				_channel.soundTransform = _transform;
-				
 				amplitudeLeft = _channel.leftPeak * volume;
 				amplitudeRight = _channel.rightPeak * volume;
 				amplitude = (amplitudeLeft + amplitudeRight) * 0.5;


### PR DESCRIPTION
Fixes bug introduced in https://github.com/HaxeFlixel/flixel/pull/3558

Pressing mute wasn't muting music that was already playing