### PR TITLE
Add FlxMatrix pooling

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -404,8 +404,8 @@ class FlxSprite extends FlxObject
 		origin = FlxPoint.get();
 		scale = FlxPoint.get(1, 1);
 		_halfSize = FlxPoint.get();
-		_matrix = new FlxMatrix();
-		_scaledOrigin = new FlxPoint();
+		_matrix = FlxMatrix.get();
+		_scaledOrigin = FlxPoint.get();
 	}
 
 	/**
@@ -428,6 +428,7 @@ class FlxSprite extends FlxObject
 		origin = FlxDestroyUtil.put(origin);
 		scale = FlxDestroyUtil.put(scale);
 		_halfSize = FlxDestroyUtil.put(_halfSize);
+		_matrix = FlxDestroyUtil.put(_matrix);
 		_scaledOrigin = FlxDestroyUtil.put(_scaledOrigin);
 		_lastClipRect = FlxDestroyUtil.put(_lastClipRect);
 
@@ -437,7 +438,6 @@ class FlxSprite extends FlxObject
 		_flashRect = null;
 		_flashRect2 = null;
 		_flashPointZero = null;
-		_matrix = null;
 		blend = null;
 
 		frames = null;
@@ -1018,11 +1018,10 @@ class FlxSprite extends FlxObject
 		drawFrameComplex(_frame, camera);
 	}
 	
-	@:noCompletion
-	static final drawComplexMatrix = new FlxMatrix();
+
 	function drawFrameComplex(frame:FlxFrame, camera:FlxCamera):Void
 	{
-		final matrix = drawComplexMatrix; // TODO: Just use local?
+		final matrix = this._matrix;
 		prepareComplexMatrix(matrix, frame, camera);
 		
 		camera.drawPixels(frame, framePixels, matrix, colorTransform, blend, antialiasing, shader);

--- a/flixel/effects/FlxMatrixSprite.hx
+++ b/flixel/effects/FlxMatrixSprite.hx
@@ -1,5 +1,6 @@
 package flixel.effects;
 
+import flixel.util.FlxDestroyUtil;
 import flixel.FlxSprite;
 import flixel.graphics.frames.FlxFrame;
 import flixel.math.FlxMatrix;
@@ -17,14 +18,20 @@ class FlxMatrixSprite extends FlxSprite
 	 */
 	public final renderMatrix:FlxMatrix;
 	
-	public function new (x = 0.0, y = 0.0, ?simpleGraphic)
+	public function new(x:Float = 0.0, y:Float = 0.0, ?simpleGraphic:FlxGraphicAsset)
 	{
-		renderMatrix = new FlxMatrix();
+		renderMatrix = FlxMatrix.get();
 		
 		super(x, y, simpleGraphic);
 		
 		if (FlxG.renderBlit)
 			FlxG.log.warn("FlxMatrixSprites do not work on blit targets");
+	}
+	override function destroy():Void
+	{
+		renderMatrix = FlxDestroyUtil.put(renderMatrix);
+		
+		super.destroy();
 	}
 	
 	override function isSimpleRenderBlit(?cam)

--- a/flixel/math/FlxMatrix.hx
+++ b/flixel/math/FlxMatrix.hx
@@ -1,5 +1,6 @@
 package flixel.math;
 
+import flixel.util.FlxPool;
 import flixel.util.FlxStringUtil;
 import openfl.geom.Matrix;
 
@@ -8,8 +9,65 @@ import openfl.geom.Matrix;
  * It mostly copies Matrix class, but with some additions for
  * faster rotation by 90 degrees.
  */
-class FlxMatrix extends Matrix
+class FlxMatrix extends Matrix implements IFlxPooled
 {
+	static var pool:FlxPool<FlxMatrix> = new FlxPool(FlxMatrix.new.bind(1, 0, 0, 1, 0, 0));
+	
+	var _weak:Bool = false;
+	var _inPool:Bool = false;
+	
+	/**
+	 * Recycle or create new FlxMatrix.
+	 * Be sure to put() them back into the pool after you're done with them!
+	 */
+	public static inline function get(a:Float = 1, b:Float = 0, c:Float = 0, d:Float = 1, tx:Float = 0, ty:Float = 0):FlxMatrix
+	{
+		var matrix = pool.get();
+		matrix.setTo(a, b, c, d, tx, ty);
+		matrix._inPool = false;
+		return matrix;
+	}
+	
+	/**
+	 * Recycle or create a new FlxMatrix which will automatically be released
+	 * to the pool when passed into a flixel function.
+	 */
+	public static inline function weak(a:Float = 1, b:Float = 0, c:Float = 0, d:Float = 1, tx:Float = 0, ty:Float = 0):FlxMatrix
+	{
+		var matrix = get(a, b, c, d, tx, ty);
+		matrix._weak = true;
+		return matrix;
+	}
+	
+	/**
+	 * Add this FlxMatrix to the recycling pool.
+	 */
+	public inline function put():Void
+	{
+		if (!_inPool)
+		{
+			_inPool = true;
+			_weak = false;
+			pool.putUnsafe(this);
+		}
+	}
+	
+	/**
+	 * Add this FlxMatrix to the recycling pool if it's a weak reference (allocated via weak()).
+	 */
+	public inline function putWeak():Void
+	{
+		if (_weak)
+		{
+			put();
+		}
+	}
+	
+	/**
+	 * Necessary for IFlxDestroyable.
+	 */
+	public function destroy() {}
+	
 	/**
 	 * Whether this matrix is `[1, 0, 0, 1, 0, 0]` which would have no effect
 	 * 


### PR DESCRIPTION
As mentioned in https://github.com/HaxeFlixel/flixel/issues/3581 this PR implements pooling functionality to FlxMatrix to reduce the number of instances and the memory overhead caused by constantly creating and destroying FlxMatrix objects.

Keeping this as a draft for now since I believe I should implement uses of the pooling inside of the HaxeFlixel codebase first before setting it ready to merge.