### PR TITLE
Remove redundant music checks in frontend methods

### DIFF
--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -413,11 +413,6 @@ class SoundFrontEnd
 	 */
 	public function pause():Void
 	{
-		if (music != null && music.exists && music.active)
-		{
-			music.pause();
-		}
-
 		for (sound in list.members)
 		{
 			if (sound != null && sound.exists && sound.active)
@@ -432,11 +427,6 @@ class SoundFrontEnd
 	 */
 	public function resume():Void
 	{
-		if (music != null && music.exists)
-		{
-			music.resume();
-		}
-
 		for (sound in list.members)
 		{
 			if (sound != null && sound.exists)
@@ -453,12 +443,6 @@ class SoundFrontEnd
 	 */
 	public function destroy(forceDestroy = false):Void
 	{
-		if (music != null && (forceDestroy || !music.persist))
-		{
-			music.destroy();
-			music = null;
-		}
-
 		for (sound in list.members)
 		{
 			if (sound != null && (forceDestroy || !sound.persist))
@@ -554,9 +538,6 @@ class SoundFrontEnd
 	@:allow(flixel.FlxGame)
 	function update(elapsed:Float):Void
 	{
-		if (music != null && music.active)
-			music.update(elapsed);
-
 		if (list != null && list.active)
 			list.update(elapsed);
 
@@ -576,11 +557,6 @@ class SoundFrontEnd
 	@:allow(flixel.FlxGame)
 	function onFocusLost():Void
 	{
-		if (music != null)
-		{
-			music.onFocusLost();
-		}
-
 		for (sound in list.members)
 		{
 			if (sound != null)
@@ -593,11 +569,6 @@ class SoundFrontEnd
 	@:allow(flixel.FlxGame)
 	function onFocus():Void
 	{
-		if (music != null)
-		{
-			music.onFocus();
-		}
-
 		for (sound in list.members)
 		{
 			if (sound != null)

--- a/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
@@ -98,7 +98,6 @@ class SoundFrontEndTest
 		assertSoundProps(1.0, false, false);
 		#end
 	}
-	#end
 	
 	@Test
 	@:haxe.warning("-WDeprecated")
@@ -188,6 +187,24 @@ class SoundFrontEndTest
 		FlxG.assets.streamSoundUnsafe = oldStreamFunc;
 		FlxG.assets.exists = oldExistsFunc;
 	}
+	
+	@Test
+	function playMusicFocus()
+	{
+		final sound:Sound = debugSound(1000);
+		FlxG.sound.playMusic(sound);
+		
+		Assert.areEqual(true, FlxG.sound.music.playing);
+		
+		@:privateAccess
+		FlxG.sound.onFocusLost();
+		Assert.areEqual(false, FlxG.sound.music.playing);
+		
+		@:privateAccess
+		FlxG.sound.onFocus();
+		Assert.areEqual(true, FlxG.sound.music.playing);
+	}
+	#end
 	
 	function debugSound(ms:Float)//:Sound
 	{


### PR DESCRIPTION
Fixes #3580 

Introduced in #3558

Now that music is added to `FlxG.sound.list` (an unintended change, but not a bad thing) `FlxG.sound.onFocusLost` calls music.onFocusLost twice. the second would set _resumeOnFocus to false since it was already paused

I'm not sure why music was not added to the list, I'll check for any other unintended side effects of this change before merging. That may have been be a breaking change, as if anyone checked the if the list contains the music, it would have been false, but is now true, but that seems like an odd thing to do.

~~I don't think I can unit test this, but i'll look and see~~ Added tests