### PR TITLE
FlxRect: Add clone(), set _weak once + doc

### DIFF
--- a/flixel/math/FlxRect.hx
+++ b/flixel/math/FlxRect.hx
@@ -14,27 +14,31 @@ class FlxRect implements IFlxPooled
 	static var _pool:FlxPool<FlxRect> = new FlxPool(FlxRect.new.bind(0, 0, 0, 0));
 	// With the version below, this caused weird CI issues when FLX_NO_POINT_POOL is defined
 	// static var _pool = new FlxPool<FlxRect>(FlxRect);
-
+	
+	static inline function getPooled(weak = false):FlxRect
+	{
+		final rect = _pool.get();
+		rect._inPool = false;
+		rect._weak = weak;
+		return rect;
+	}
+	
 	/**
 	 * Recycle or create new FlxRect.
 	 * Be sure to put() them back into the pool after you're done with them!
 	 */
-	public static inline function get(X:Float = 0, Y:Float = 0, Width:Float = 0, Height:Float = 0):FlxRect
+	public static inline function get(x = 0.0, y = 0.0, width = 0.0, height = 0.0):FlxRect
 	{
-		var rect = _pool.get().set(X, Y, Width, Height);
-		rect._inPool = false;
-		return rect;
+		return getPooled().set(x, y, width, height);
 	}
 
 	/**
 	 * Recycle or create a new FlxRect which will automatically be released
 	 * to the pool when passed into a flixel function.
 	 */
-	public static inline function weak(X:Float = 0, Y:Float = 0, Width:Float = 0, Height:Float = 0):FlxRect
+	public static inline function weak(x = 0.0, y = 0.0, width = 0.0, height = 0.0):FlxRect
 	{
-		var rect = get(X, Y, Width, Height);
-		rect._weak = true;
-		return rect;
+		return getPooled(true).set(x, y, width, height);
 	}
 
 	public var x:Float;
@@ -84,7 +88,6 @@ class FlxRect implements IFlxPooled
 		if (!_inPool)
 		{
 			_inPool = true;
-			_weak = false;
 			_pool.putUnsafe(this);
 		}
 	}
@@ -220,46 +223,56 @@ class FlxRect implements IFlxPooled
 	{
 		return setAbs(x1, y1, x2 - x1, y2 - y1);
 	}
-
+	
 	/**
 	 * Helper function, just copies the values from the specified rectangle.
 	 *
-	 * @param	Rect	Any FlxRect.
-	 * @return	A reference to itself.
+	 * @param   rect  Any FlxRect.
+	 * @return  A reference to itself.
 	 */
-	public inline function copyFrom(Rect:FlxRect):FlxRect
+	public inline function copyFrom(rect:FlxRect):FlxRect
 	{
-		x = Rect.x;
-		y = Rect.y;
-		width = Rect.width;
-		height = Rect.height;
-
-		Rect.putWeak();
+		x = rect.x;
+		y = rect.y;
+		width = rect.width;
+		height = rect.height;
+		
+		rect.putWeak();
 		return this;
 	}
-
+	
 	/**
 	 * Helper function, just copies the values from this rectangle to the specified rectangle.
 	 *
-	 * @param	Point	Any FlxRect.
-	 * @return	A reference to the altered rectangle parameter.
+	 * @param   point  Any FlxRect.
+	 * @return  A reference to the altered rectangle parameter.
 	 */
-	public inline function copyTo(Rect:FlxRect):FlxRect
+	public inline function copyTo(rect:FlxRect):FlxRect
 	{
-		Rect.x = x;
-		Rect.y = y;
-		Rect.width = width;
-		Rect.height = height;
-
-		Rect.putWeak();
-		return Rect;
+		rect.x = x;
+		rect.y = y;
+		rect.width = width;
+		rect.height = height;
+		
+		putWeak();
+		return rect;
 	}
 
 	/**
+	 * Copies this rect's data into a new instance (from the pool)
+	 *
+	 * @return  A new rectangle
+	 */
+	public inline function clone():FlxRect
+	{
+		return copyTo(getPooled());
+	}
+	
+	/**
 	 * Helper function, just copies the values from the specified Flash rectangle.
 	 *
-	 * @param	FlashRect	Any Rectangle.
-	 * @return	A reference to itself.
+	 * @param   flashRect	Any Rectangle.
+	 * @return  A reference to itself.
 	 */
 	public inline function copyFromFlash(FlashRect:Rectangle):FlxRect
 	{

--- a/tests/unit/src/flixel/math/FlxRectTest.hx
+++ b/tests/unit/src/flixel/math/FlxRectTest.hx
@@ -13,6 +13,10 @@ class FlxRectTest extends FlxTest
 	{
 		rect1 = new FlxRect();
 		rect2 = new FlxRect();
+		
+		// allows better testing of pooling issues
+		@:privateAccess
+		FlxRect._pool.clear();
 	}
 
 	@Test
@@ -218,5 +222,65 @@ class FlxRectTest extends FlxTest
 		
 		rect1.setBounds(50, 50, 100, 100).pad(10);
 		FlxAssert.rectsNearLTRD(50 - 10, 50 - 10, 100 + 10, 100 + 10, rect1);
+	}
+	
+	@Test
+	function testCopyTo()
+	{
+		rect1.set(10, 10, 20, 20);
+		rect1.copyTo(rect2);
+		FlxAssert.rectsNear(rect1, rect2);
+		
+		// test to weak
+		final r2 = rect1.copyTo(FlxRect.weak());
+		FlxRect.get(0, 0, 0, 0);
+		
+		FlxAssert.rectsNear(rect1, r2);
+		
+		// test from weak
+		final r2 = FlxRect.weak(10, 10, 20, 20);
+		r2.copyTo(rect1);
+		final r3 = FlxRect.get(0, 0, 0, 0);
+		
+		FlxAssert.rectsNearXYWH(10, 10, 20, 20, rect1);
+		Assert.areEqual(r2, r3);
+	}
+	
+	@Test
+	function testCopyFrom()
+	{
+		rect1.set(10, 10, 20, 20);
+		rect2.copyFrom(rect1);
+		FlxAssert.rectsNear(rect1, rect2);
+		
+		// test from weak
+		final r2 = FlxRect.weak(10, 10, 20, 20);
+		rect1.copyFrom(r2);
+		final r3 = FlxRect.get(0, 0, 0, 0);
+		
+		FlxAssert.rectsNearXYWH(10, 10, 20, 20, rect1);
+		Assert.areEqual(r2, r3);
+		
+		// test to weak
+		final r2 = FlxRect.weak().copyFrom(rect1);
+		FlxRect.get(0, 0, 0, 0);
+		
+		FlxAssert.rectsNear(rect1, r2);
+	}
+	
+	@Test
+	function testClone()
+	{
+		rect1.set(10, 10, 20, 20);
+		final r2 = rect1.clone();
+		FlxAssert.rectsNear(rect1, r2);
+		
+		// test from weak
+		final r1 = FlxRect.weak(10, 10, 20, 20);
+		final r2 = r1.clone();
+		final r3 = FlxRect.get(0, 0, 0, 0);
+		
+		FlxAssert.rectsNearXYWH(10, 10, 20, 20, r2);
+		Assert.areEqual(r1, r3);
 	}
 }


### PR DESCRIPTION
- Adds the clone() method which is copyTo but with no specified target
- Reworks the put/get process setting weak once on get, rather than in getWeak/put
- Fixes a bug where `rect.copyTo(FlxRect.weak())` would put the destination rect rather than the source rect
- Adds unit tests