### PR TITLE
FlxG.bitmap: Add null-safety

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -27,6 +27,7 @@ import openfl.Lib;
 import openfl.display.DisplayObject;
 import openfl.display.Stage;
 import openfl.display.StageDisplayState;
+import openfl.events.Event;
 import openfl.net.URLRequest;
 #if FLX_TOUCH
 import flixel.input.touch.FlxTouchManager;
@@ -529,6 +530,7 @@ class FlxG
 	 * Called by `FlxGame` to set up `FlxG` during `FlxGame`'s constructor.
 	 */
 	@:allow(flixel.FlxGame.new)
+	@:haxe.warning("-WDeprecated")
 	static function init(game:FlxGame, width:Int, height:Int):Void
 	{
 		if (width < 0)
@@ -586,6 +588,8 @@ class FlxG
 		#if FLX_SOUND_SYSTEM
 		sound = new SoundFrontEnd();
 		#end
+		
+		assets.onChange.add(()->bitmap.onAssetsReload(new Event(Event.CHANGE)));
 	}
 
 	static function initRenderMethod():Void

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -5,7 +5,6 @@ import flixel.system.FlxSplash;
 import flixel.util.FlxArrayUtil;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.typeLimit.NextState;
-import openfl.Assets;
 import openfl.Lib;
 import openfl.display.Sprite;
 import openfl.display.StageAlign;
@@ -351,8 +350,6 @@ class FlxGame extends Sprite
 
 		// make sure the cursor etc are properly scaled from the start
 		resizeGame(FlxG.stage.stageWidth, FlxG.stage.stageHeight);
-
-		Assets.addEventListener(Event.CHANGE, FlxG.bitmap.onAssetsReload);
 	}
 
 	function onFocus(_):Void

--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -25,9 +25,9 @@ class FlxGraphic implements IFlxDestroyable
 	public static var defaultPersist:Bool = false;
 
 	/**
-	 * Creates and caches FlxGraphic object from openfl.Assets key string.
+	 * Creates and caches FlxGraphic object from asset key string.
 	 *
-	 * @param   Source   `openfl.Assets` key string. For example: `"assets/image.png"`.
+	 * @param   Source   Asset key string. For example: `"assets/image.png"`.
 	 * @param   Unique   Ensures that the `BitmapData` uses a new slot in the cache.
 	 *                   If `true`, then `BitmapData` for this `FlxGraphic` will be cloned, which means extra memory.
 	 * @param   Key      Force the cache to use a specific key to index the bitmap.

--- a/flixel/graphics/frames/FlxBitmapFont.hx
+++ b/flixel/graphics/frames/FlxBitmapFont.hx
@@ -9,7 +9,6 @@ import flixel.math.FlxRect;
 import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import haxe.xml.Access;
-import openfl.Assets;
 import openfl.display.BitmapData;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;

--- a/flixel/system/FlxAssets.hx
+++ b/flixel/system/FlxAssets.hx
@@ -318,7 +318,7 @@ class FlxAssets
 	 * Takes Dynamic object as a input and tries to convert it to BitmapData:
 	 * 1) if the input is BitmapData, then it will return this BitmapData;
 	 * 2) if the input is Class<BitmapData>, then it will create BitmapData from this class;
-	 * 3) if the input is String, then it will get BitmapData from openfl.Assets;
+	 * 3) if the input is String, then it will get BitmapData from FlxG.assets;
 	 * 4) it will return null in any other case.
 	 *
 	 * @param   graphic  input data to get BitmapData object for.

--- a/flixel/system/frontEnds/AssetFrontEnd.hx
+++ b/flixel/system/frontEnds/AssetFrontEnd.hx
@@ -3,6 +3,7 @@ package flixel.system.frontEnds;
 import flixel.FlxG;
 import flixel.system.FlxAssets;
 import flixel.system.debug.log.LogStyle;
+import flixel.util.FlxSignal;
 import haxe.Json;
 import haxe.io.Bytes;
 import haxe.io.Path;
@@ -45,6 +46,11 @@ using StringTools;
  */
 class AssetFrontEnd
 {
+	/**
+	 * Dispatched whenever the availability or the contents of assets change
+	 */
+	public final onChange = new FlxSignal();
+	
 	#if FLX_CUSTOM_ASSETS_DIRECTORY
 	/**
 	 * The target directory
@@ -82,7 +88,10 @@ class AssetFrontEnd
 		return id.startsWith("flixel/") || id.contains(':');
 	}
 	#else
-	public function new () {}
+	public function new ()
+	{
+		lime.utils.Assets.onChange.add(()->onChange.dispatch());
+	}
 	#end
 	
 	#if (FLX_DEFAULT_SOUND_EXT == "1" || FLX_NO_DEFAULT_SOUND_EXT)
@@ -223,6 +232,18 @@ class AssetFrontEnd
 			case IMAGE: Assets.loadBitmapData(id, useCache);
 			case SOUND: Assets.loadSound(id, useCache);
 			case FONT: Assets.loadFont(id, useCache);
+		}
+	}
+	
+	dynamic public function removeAssetUnsafe(id:String, type:FlxAssetType)
+	{
+		switch(type)
+		{
+			case TEXT:
+			case BINARY:
+			case IMAGE: Assets.cache.removeBitmapData(id);
+			case SOUND: Assets.cache.removeSound(id);
+			case FONT: Assets.cache.removeFont(id);
 		}
 	}
 	
@@ -747,6 +768,41 @@ class AssetFrontEnd
 	public inline function parseXml(xmlText:String)
 	{
 		return Xml.parse(xmlText);
+	}
+	
+	public inline function removeAsset(id:String, type:FlxAssetType, ?logStyle:LogStyle)
+	{
+		if (logStyle == null)
+			logStyle = FlxG.log.styles.error;
+		
+		final log = FlxG.log.advanced.bind(_, logStyle);
+		
+		if (exists(id, type))
+		{
+			// if (isLocal(id, type))
+				removeAssetUnsafe(id, type);
+			// else
+			// 	log('$type asset "$id" exists, but only asynchronously');
+		}
+		else
+		{
+			log('Could not find a $type asset with ID \'$id\'.');
+		}
+	}
+	
+	public inline function removeBitmapData(id, ?logStyle)
+	{
+		removeAsset(id, IMAGE, logStyle);
+	}
+	
+	public inline function removeSound(id, ?logStyle)
+	{
+		removeAsset(id, SOUND, logStyle);
+	}
+	
+	public inline function removeFont(id, ?logStyle)
+	{
+		removeAsset(id, FONT, logStyle);
 	}
 	
 	inline function wrapFuture<T1, T2>(future:Future<T1>, converter:(T1)->T2):Future<T2>

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -66,6 +66,7 @@ class BitmapFrontEnd
 	 * @param   key  The key identifying the bitmap.
 	 * @return  Whether or not this file can be found in the cache.
 	 */
+	@:deprecated("checkCache is deprecated, use exists, instead")
 	public inline function checkCache(key:String):Bool
 	{
 		return get(key) != null;
@@ -201,7 +202,7 @@ class BitmapFrontEnd
 		if (baseKey == null)
 			baseKey = "pixels";
 
-		if (!checkCache(baseKey))
+		if (!exists(baseKey))
 			return baseKey;
 
 		var i:Int = _lastUniqueKeyIndex;
@@ -211,7 +212,7 @@ class BitmapFrontEnd
 			i++;
 			uniqueKey = baseKey + i;
 		}
-		while (checkCache(uniqueKey));
+		while (exists(uniqueKey));
 
 		_lastUniqueKeyIndex = i;
 		return uniqueKey;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -130,7 +130,18 @@ class BitmapFrontEnd
 	{
 		return _cache.get(key);
 	}
-
+	
+	/**
+	 * Checks whether a bitmap exists with the given key.
+	 * 
+	 * @param   key  The FlxGraphics key (or name).
+	 * @since 6.2.0
+	 */
+	public inline function exists(key:String):Bool
+	{
+		return _cache.exists(key);
+	}
+	
 	/**
 	 * Gets a key from a cached BitmapData.
 	 *

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -17,6 +17,8 @@ import lime.graphics.opengl.GL;
  * 
  * Accessed via `FlxG.bitmap`.
  */
+@:nullSafety(Strict)
+@:autoBuild(flixel.system.macros.FlxMacroUtil.deprecateOverride("onAssetsReload", "onAssetsReload is deprecated, use onAssetsChange, instead"))
 class BitmapFrontEnd
 {
 	#if FLX_OPENGL_AVAILABLE
@@ -37,23 +39,28 @@ class BitmapFrontEnd
 	public var whitePixel(get, never):FlxFrame;
 
 	@:allow(flixel.system.frontEnds.BitmapLogFrontEnd)
-	var _cache:Map<String, FlxGraphic>;
-
-	var _whitePixel:FlxFrame;
-
+	final _cache = new Map<String, FlxGraphic>();
+	
+	var _whitePixel:Null<FlxFrame>;
+	
 	var _lastUniqueKeyIndex:Int = 0;
-
+	
 	public function new()
 	{
 		reset();
 	}
 
+	@:deprecated("onAssetsReload is deprecated, use onAssetsChange, instead")
 	public function onAssetsReload(_):Void
 	{
-		for (key in _cache.keys())
+		onAssetsChange();
+	}
+	
+	public function onAssetsChange():Void
+	{
+		for (key => obj in _cache)
 		{
-			var obj = _cache.get(key);
-			if (obj != null && obj.canBeRefreshed)
+			if (obj.canBeRefreshed)
 			{
 				obj.onAssetsReload();
 			}
@@ -127,7 +134,7 @@ class BitmapFrontEnd
 	 * @param   key  The FlxGraphics key (or name).
 	 * @return  The FlxGraphic with the specified key, or null if the object doesn't exist.
 	 */
-	public inline function get(key:String):FlxGraphic
+	public inline function get(key:String):Null<FlxGraphic>
 	{
 		return _cache.get(key);
 	}
@@ -149,12 +156,11 @@ class BitmapFrontEnd
 	 * @param   bmd  BitmapData to find in the cache.
 	 * @return  The BitmapData's key or null if there isn't such BitmapData in cache.
 	 */
-	public function findKeyForBitmap(bmd:BitmapData):String
+	public function findKeyForBitmap(bmd:BitmapData):Null<String>
 	{
-		for (key in _cache.keys())
+		for (key => obj in _cache)
 		{
-			var obj = _cache.get(key);
-			if (obj != null && obj.bitmap == bmd)
+			if (obj.bitmap == bmd)
 				return key;
 		}
 		return null;
@@ -179,14 +185,11 @@ class BitmapFrontEnd
 	 * @param   unique     Whether generated key should be unique or not.
 	 * @return  Created key.
 	 */
-	public function generateKey(systemKey:String, userKey:String, unique = false):String
+	public function generateKey(systemKey:Null<String>, userKey:Null<String>, unique = false):String
 	{
-		var key:String = userKey;
-		if (key == null)
-			key = systemKey;
-
+		final key = userKey != null ? userKey : systemKey;
 		if (unique || key == null)
-			key = getUniqueKey(key);
+			return getUniqueKey(key);
 
 		return key;
 	}
@@ -197,11 +200,8 @@ class BitmapFrontEnd
 	 * @param   baseKey  key's prefix.
 	 * @return  unique key.
 	 */
-	public function getUniqueKey(?baseKey:String):String
+	public function getUniqueKey(baseKey = "pixels"):String
 	{
-		if (baseKey == null)
-			baseKey = "pixels";
-
 		if (!exists(baseKey))
 			return baseKey;
 
@@ -268,19 +268,17 @@ class BitmapFrontEnd
 	 */
 	public function removeByKey(key:String):Void
 	{
-		if (key != null)
+		final obj = get(key);
+		if (obj != null)
 		{
-			var obj = get(key);
 			removeKey(key);
-
-			if (obj != null)
-				obj.destroy();
+			obj.destroy();
 		}
 	}
 
 	public function removeIfNoUse(graphic:FlxGraphic):Void
 	{
-		if (graphic != null && graphic.useCount == 0 && !graphic.persist)
+		if (graphic.useCount == 0 && !graphic.persist)
 			remove(graphic);
 	}
 
@@ -290,16 +288,9 @@ class BitmapFrontEnd
 	 */
 	public function clearCache():Void
 	{
-		if (_cache == null)
+		for (key => obj in _cache)
 		{
-			_cache = new Map();
-			return;
-		}
-
-		for (key in _cache.keys())
-		{
-			var obj = get(key);
-			if (obj != null && !obj.persist && obj.useCount <= 0)
+			if (!obj.persist && obj.useCount <= 0)
 			{
 				removeKey(key);
 				obj.destroy();
@@ -309,11 +300,8 @@ class BitmapFrontEnd
 
 	inline function removeKey(key:String):Void
 	{
-		if (key != null)
-		{
-			Assets.cache.removeBitmapData(key);
-			_cache.remove(key);
-		}
+		FlxG.assets.removeAssetUnsafe(key, IMAGE);
+		_cache.remove(key);
 	}
 
 	/**
@@ -321,19 +309,10 @@ class BitmapFrontEnd
 	 */
 	public function reset():Void
 	{
-		if (_cache == null)
+		for (key => obj in _cache)
 		{
-			_cache = new Map();
-			return;
-		}
-
-		for (key in _cache.keys())
-		{
-			var obj = get(key);
 			removeKey(key);
-
-			if (obj != null)
-				obj.destroy();
+			obj.destroy();
 		}
 	}
 
@@ -343,10 +322,9 @@ class BitmapFrontEnd
 	 */
 	public function clearUnused():Void
 	{
-		for (key in _cache.keys())
+		for (key => obj in _cache)
 		{
-			var obj = _cache.get(key);
-			if (obj != null && obj.useCount <= 0 && !obj.persist && obj.destroyOnNoUse)
+			if (obj.useCount <= 0 && !obj.persist && obj.destroyOnNoUse)
 			{
 				removeByKey(key);
 			}
@@ -371,8 +349,8 @@ class BitmapFrontEnd
 		if (_whitePixel == null)
 		{
 			var bd = new BitmapData(10, 10, true, FlxColor.WHITE);
-			var graphic:FlxGraphic = FlxG.bitmap.add(bd, true, "whitePixels");
-			graphic.persist = true;
+			var graphic:FlxGraphic = add(bd, true, "whitePixels");
+			graphic.persist = true; 
 			_whitePixel = graphic.imageFrame.frame;
 		}
 

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -13,7 +13,6 @@ import flixel.system.FlxAssets;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.helpers.FlxRange;
-import openfl.Assets;
 import openfl.display.BitmapData;
 import openfl.geom.ColorTransform;
 import openfl.text.TextField;

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -1,8 +1,5 @@
 package flixel.ui;
 
-import openfl.display.BitmapData;
-import openfl.geom.Point;
-import openfl.geom.Rectangle;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.FlxGraphic;
@@ -15,6 +12,9 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxGradient;
 import flixel.util.FlxStringUtil;
+import openfl.display.BitmapData;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
 
 // TODO: better handling bars with borders (don't take border into account while drawing its front).
 
@@ -358,7 +358,7 @@ class FlxBar extends FlxSprite
 			if (showBorder)
 				emptyKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 
-			if (!FlxG.bitmap.checkCache(emptyKey))
+			if (!FlxG.bitmap.exists(emptyKey))
 			{
 				var emptyBar:BitmapData = null;
 
@@ -412,7 +412,7 @@ class FlxBar extends FlxSprite
 			if (showBorder)
 				filledKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 
-			if (!FlxG.bitmap.checkCache(filledKey))
+			if (!FlxG.bitmap.exists(filledKey))
 			{
 				var filledBar:BitmapData = null;
 
@@ -498,7 +498,7 @@ class FlxBar extends FlxSprite
 				emptyKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 			}
 
-			if (!FlxG.bitmap.checkCache(emptyKey))
+			if (!FlxG.bitmap.exists(emptyKey))
 			{
 				var emptyBar:BitmapData = null;
 
@@ -566,7 +566,7 @@ class FlxBar extends FlxSprite
 				filledKey += ",border: " + border.toHexString() + "borderSize: " + borderSize;
 			}
 
-			if (!FlxG.bitmap.checkCache(filledKey))
+			if (!FlxG.bitmap.exists(filledKey))
 			{
 				var filledBar:BitmapData = null;
 

--- a/tests/unit/src/flixel/system/frontEnds/BitmapFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/BitmapFrontEndTest.hx
@@ -1,23 +1,33 @@
 package flixel.system.frontEnds;
 
-import openfl.display.BitmapData;
 import flixel.graphics.FlxGraphic;
 import massive.munit.Assert;
+import openfl.display.BitmapData;
 
 class BitmapFrontEndTest
 {
 	@Test
 	function testGetUniqueKey()
 	{
-		var key = "test";
+		final key = "test";
 
-		Assert.isFalse(FlxG.bitmap.checkCache(key));
+		Assert.isFalse(FlxG.bitmap.exists(key));
 		Assert.areEqual(key, FlxG.bitmap.getUniqueKey(key));
 
 		FlxG.bitmap.add(FlxGraphic.fromBitmapData(new BitmapData(1, 1)), true, key);
-		Assert.isTrue(FlxG.bitmap.checkCache(key));
+		Assert.isTrue(FlxG.bitmap.exists(key));
 
-		var newKey = FlxG.bitmap.getUniqueKey("test");
+		var newKey = FlxG.bitmap.getUniqueKey(key);
 		Assert.areNotEqual(key, newKey);
+	}
+	
+	@Test
+	function testExists()
+	{
+		final key = "testExists";
+		
+		Assert.isFalse(FlxG.bitmap.exists(key));
+		FlxG.bitmap.add(new BitmapData(1, 1), true, key);
+		Assert.isTrue(FlxG.bitmap.exists(key));
 	}
 }


### PR DESCRIPTION
Breaking change, Going to create another PR for 6.2.0 to add FlxG.assets.remove*, onChange and deprecate FlxG.bitmap.onAssetsReload. 