### PR TITLE
FlxBitmapText and FlxText: Add OUTLINE_CARDINAL

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1291,6 +1291,20 @@ class FlxBitmapText extends FlxSprite
 					func( 0,  i); // lower-middle
 					func( i,  i); // lower-right
 				}
+			case OUTLINE_CARDINAL:
+				// Render an outline around the text (4 draws | LEFT, RIGHT, UP, DOWN)
+				var iterations:Int = Std.int(borderSize * borderQuality);
+				iterations = (iterations <= 0) ? 1 : iterations;
+				final delta = Std.int(borderSize / iterations);
+				for (iter in 0...iterations)
+				{
+					final i = delta * (iter + 1);
+					func(-i, 0); // middle-left
+					func(i * 2, 0); // middle-right
+					func(-i, -i); // upper-middle
+					func(0, i * 2); // lower-middle
+				}
+
 			case OUTLINE_FAST:
 				// Render an outline around the text in each corner (4 draws)
 				var iterations:Int = Std.int(borderSize * borderQuality);

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1299,10 +1299,10 @@ class FlxBitmapText extends FlxSprite
 				for (iter in 0...iterations)
 				{
 					final i = delta * (iter + 1);
-					func(-i, 0); // middle-left
-					func(i * 2, 0); // middle-right
-					func(-i, -i); // upper-middle
-					func(0, i * 2); // lower-middle
+					func(-i, 0); // left
+					func(i, 0); // right
+					func(0, -i); // up
+					func(0, i); // down
 				}
 
 			case OUTLINE_FAST:

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -928,7 +928,7 @@ class FlxText extends FlxSprite
 				borderWidth += Math.abs(offsetX);
 				borderHeight += Math.abs(offsetY);
 			
-			case OUTLINE_FAST | OUTLINE:
+			case OUTLINE_FAST | OUTLINE | OUTLINE_CARDINAL:
 				borderWidth += Math.abs(borderSize) * 2;
 				borderHeight += Math.abs(borderSize) * 2;
 			
@@ -1095,10 +1095,10 @@ class FlxText extends FlxSprite
 				_graphicOffset.x = offsetX < 0 ? -offsetX : 0;
 				_graphicOffset.y = offsetY < 0 ? -offsetY : 0;
 			
-			case OUTLINE_FAST | OUTLINE if (borderSize < 0):
+			case OUTLINE_FAST | OUTLINE | OUTLINE_CARDINAL if (borderSize < 0):
 				_graphicOffset.set(-borderSize, -borderSize);
 			
-			case NONE | OUTLINE_FAST | OUTLINE:
+			case NONE | OUTLINE_FAST | OUTLINE | OUTLINE_CARDINAL:
 				_graphicOffset.set(0, 0);
 		}
 		_matrix.translate(_graphicOffset.x, _graphicOffset.y);
@@ -1174,6 +1174,24 @@ class FlxText extends FlxSprite
 					copyTextWithOffset(0, -curDelta); // lower-left
 					
 					_matrix.translate(curDelta, 0); // return to center
+				}
+			
+			case OUTLINE_CARDINAL:
+				// Render an outline around the text
+				// (do 4 offset draw calls just in all cardinal directions)
+				applyFormats(_formatAdjusted, true);
+				
+				final iterations = FlxMath.maxInt(1, Std.int(borderSize * borderQuality));
+				var i = iterations + 1;
+				while (i-- > 1)
+				{
+					final curDelta = borderSize / iterations * i;
+					copyTextWithOffset(-curDelta, 0); // middle-left
+					copyTextWithOffset(curDelta * 2, 0); // middle-right
+					copyTextWithOffset(-curDelta, -curDelta); // upper-middle
+					copyTextWithOffset(0, curDelta * 2); // lower-middle
+					
+					_matrix.translate(0, -curDelta); // return to center
 				}
 			
 			case OUTLINE_FAST:
@@ -1384,6 +1402,10 @@ enum FlxTextBorderStyle
 	 * Outline on all 8 sides
 	 */
 	OUTLINE;
+	/**
+	 * Outline on all 4 cardinal directions (UP, DOWN, LEFT, RIGHT)
+	 */
+	OUTLINE_CARDINAL;
 	
 	/**
 	 * Outline, optimized using only 4 draw calls

--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -1186,10 +1186,10 @@ class FlxText extends FlxSprite
 				while (i-- > 1)
 				{
 					final curDelta = borderSize / iterations * i;
-					copyTextWithOffset(-curDelta, 0); // middle-left
-					copyTextWithOffset(curDelta * 2, 0); // middle-right
-					copyTextWithOffset(-curDelta, -curDelta); // upper-middle
-					copyTextWithOffset(0, curDelta * 2); // lower-middle
+					copyTextWithOffset(-curDelta, 0); // left
+					copyTextWithOffset(curDelta * 2, 0); // right
+					copyTextWithOffset(-curDelta, -curDelta); // up
+					copyTextWithOffset(0, curDelta * 2); // down
 					
 					_matrix.translate(0, -curDelta); // return to center
 				}


### PR DESCRIPTION
Works like the fast outline method, but uses cardinal directions instead of diagonals. This generally looks better for pixelated fonts.

You could also treat this as a variant of `OUTLINE_FAST`. Renaming `OUTLINE_FAST` to `OUTLINE_DIAGONAL` might make things clearer, but it could break existing projects, so it’s probably not worth changing.

# OUTLINE_FAST (diagonal)
<img width="285" height="135" alt="image_2026-04-18_182950061" src="https://github.com/user-attachments/assets/795707d6-ed3c-4e31-9f26-2d1d9e93ffe9" />

# OUTLINE_CARDINAL
<img width="285" height="135" alt="image" src="https://github.com/user-attachments/assets/0ea49d16-1903-4335-a90c-b56099995c99" />

# OUTLINE (the normal one)
<img width="285" height="135" alt="image" src="https://github.com/user-attachments/assets/ec692b22-7733-48a6-bd4e-fd1f5f3c6dbf" />

