### PR TITLE
Deprecate IFlxSprite and IFlxBasic, remove refs

### DIFF
--- a/flixel/FlxBasic.hx
+++ b/flixel/FlxBasic.hx
@@ -267,6 +267,7 @@ enum abstract FlxType(Int)
 	var SPRITEGROUP = 4;
 }
 
+@:deprecated("IFlxBasic is deprecated and never used")
 interface IFlxBasic
 {
 	var ID:Int;

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -2080,6 +2080,7 @@ class FlxSprite extends FlxObject
 	}
 }
 
+@:deprecated("IFlxSprite is deprecated and never used")
 interface IFlxSprite extends IFlxBasic
 {
 	var x(default, set):Float;

--- a/flixel/effects/particles/FlxParticle.hx
+++ b/flixel/effects/particles/FlxParticle.hx
@@ -223,7 +223,7 @@ class FlxParticle extends FlxSprite implements IFlxParticle
 	public function onEmit():Void {}
 }
 
-interface IFlxParticle extends IFlxSprite
+interface IFlxParticle
 {
 	var lifespan:Float;
 	var age(default, null):Float;


### PR DESCRIPTION
This runs locally, if CI doesn't care, then let's deprecate IFlxSprite/Object/Basic