### PR TITLE
FlxG.cameras: Honor defaultDrawTarget arg in insert method

### DIFF
--- a/flixel/system/frontEnds/CameraFrontEnd.hx
+++ b/flixel/system/frontEnds/CameraFrontEnd.hx
@@ -95,7 +95,7 @@ class CameraFrontEnd
 	    
 	    // invalid ranges are added (match Array.insert's behavior)
         if (position >= list.length)
-            return add(newCamera);
+            return add(newCamera, defaultDrawTarget);
         
         final childIndex = FlxG.game.getChildIndex(list[position].flashSprite);
         FlxG.game.addChildAt(newCamera.flashSprite, childIndex);

--- a/tests/unit/src/flixel/system/frontEnds/CameraFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/CameraFrontEndTest.hx
@@ -66,4 +66,19 @@ class CameraFrontEndTest extends FlxTest
 
 		FlxG.cameras.cameraRemoved.removeAll();
 	}
+
+	
+	@Test // #3605
+	function testInsert()
+	{
+		final cam1 = new FlxCamera();
+		FlxG.cameras.add(cam1, false);
+		@:privateAccess
+		Assert.isFalse(FlxG.cameras.defaults.contains(cam1), "Unexpected defaultDrawTarget");
+		
+		final cam2 = new FlxCamera();
+		FlxG.cameras.add(cam2, true);
+		@:privateAccess
+		Assert.isTrue(FlxG.cameras.defaults.contains(cam2), "Expected defaultDrawTarget");
+	}
 }


### PR DESCRIPTION
When inserting at a position higher or equal to the list length, it never included the argument for add.