### PR TITLE
FlxSpriteUtil: add putWeak to the points in drawPolygon

### DIFF
--- a/flixel/util/FlxSpriteUtil.hx
+++ b/flixel/util/FlxSpriteUtil.hx
@@ -549,9 +549,11 @@ class FlxSpriteUtil
 		beginDraw(FillColor, lineStyle);
 		var p:FlxPoint = Vertices.shift();
 		flashGfx.moveTo(p.x, p.y);
+		p.putWeak();
 		for (p in Vertices)
 		{
 			flashGfx.lineTo(p.x, p.y);
+			p.putWeak();
 		}
 		endDraw(sprite, drawStyle);
 		Vertices.unshift(p);


### PR DESCRIPTION
very simple change, was using drawPolygon with weak points, and realized it wasn't using putWeak on it to automatically put those weak points, figured it probably should be doing that.