### PR TITLE
FlxBitmapText: Ensure min textHeight of 0

### DIFF
--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -1653,6 +1653,9 @@ class FlxBitmapText extends FlxSprite
 	function get_textHeight():Int
 	{
 		checkPendingChanges(true);
+		if (_lines.length == 0)
+			return 0;
+		
 		return (lineHeight + lineSpacing) * _lines.length - lineSpacing;
 	}
 


### PR DESCRIPTION
prevent warning in empty text where `autoBounds` is true