### PR TITLE
FlxRandom and FlxArrayUtil: Remove generic methods

### DIFF
--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -255,7 +255,6 @@ class FlxRandom
 	 * @param   EndIndex       Optional index at which to restrict selection. Ignored if 0, which is the default value.
 	 * @return  A pseudorandomly chosen object from Objects.
 	 */
-	@:generic
 	public function getObject<T>(Objects:Array<T>, ?WeightsArray:Array<Float>, StartIndex:Int = 0, ?EndIndex:Null<Int>):T
 	{
 		var selected:Null<T> = null;
@@ -302,7 +301,6 @@ class FlxRandom
 	 * @param  array  The array to shuffle.
 	 * @since  4.2.0
 	 */
-	@:generic
 	public function shuffle<T>(array:Array<T>):Void
 	{
 		var maxValidIndex = array.length - 1;

--- a/flixel/util/FlxArrayUtil.hx
+++ b/flixel/util/FlxArrayUtil.hx
@@ -29,7 +29,6 @@ class FlxArrayUtil
 	 * @param 	element	The element to remove from the array
 	 * @return	The array
 	 */
-	@:generic
 	public static inline function fastSplice<T>(array:Array<T>, element:T):Array<T>
 	{
 		var index = array.indexOf(element);
@@ -61,7 +60,6 @@ class FlxArrayUtil
 	 * @param 	index	The index of the element to be removed from the array
 	 * @return	The array
 	 */
-	@:generic
 	public static inline function swapAndPop<T>(array:Array<T>, index:Int):Array<T>
 	{
 		array[index] = array[array.length - 1]; // swap element to remove and last element
@@ -159,7 +157,6 @@ class FlxArrayUtil
 	 * Flattens 2D arrays into 1D arrays.
 	 * Example: `[[1, 2], [3, 2], [1, 1]]` -> `[1, 2, 3, 2, 1, 1]`
 	 */
-	@:generic
 	public static function flatten2DArray<T>(array:Array<Array<T>>):Array<T>
 	{
 		var result = [];


### PR DESCRIPTION
These cause warnings in haxe 5 and don't benefit from being generic