### PR TITLE
Fix pooled Rect leak and add asset existence checks

### DIFF
--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1249,7 +1249,6 @@ class FlxSprite extends FlxObject
 	 */
 	function transformColor(colorIn:FlxColor):FlxColor
 	{
-		final colorStr = color.toHexString();
 		if (hasColorTransform())
 		{
 			final ct = colorTransform;

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -65,7 +65,14 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 */
 	public static function fromTexturePackerJson(source:FlxGraphicAsset, description:FlxTexturePackerJsonAsset, useFrameDuration = false):FlxAtlasFrames
 	{
-		var graphic:FlxGraphic = FlxG.bitmap.add(source, false);
+		if (description == null)
+			return null;
+			
+		final data:TexturePackerAtlas = description.getData();
+		if (data == null)
+			return null;
+			
+		final graphic:FlxGraphic = FlxG.bitmap.add(source, false);
 		if (graphic == null)
 			return null;
 
@@ -74,12 +81,8 @@ class FlxAtlasFrames extends FlxFramesCollection
 		if (frames != null)
 			return frames;
 
-		if (graphic == null || description == null)
-			return null;
-
 		frames = new FlxAtlasFrames(graphic);
 
-		final data:TexturePackerAtlas = description.getData();
 		// JSON-Array
 		if (data.frames.isArray())
 		{
@@ -137,6 +140,10 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 */
 	public static function fromLibGdx(source:FlxGraphicAsset, description:String):FlxAtlasFrames
 	{
+		description = description != null && FlxG.assets.exists(description) ? FlxG.assets.getTextUnsafe(description) : null;
+		if (description == null)
+			return null;
+
 		var graphic:FlxGraphic = FlxG.bitmap.add(source);
 		if (graphic == null)
 			return null;
@@ -146,13 +153,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		if (frames != null)
 			return frames;
 
-		if ((graphic == null) || (description == null))
-			return null;
-
 		frames = new FlxAtlasFrames(graphic);
-
-		if (FlxG.assets.exists(description))
-			description = FlxG.assets.getTextUnsafe(description);
 
 		var pack:String = StringTools.trim(description);
 		var lines:Array<String> = pack.split("\n");
@@ -236,6 +237,13 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 */
 	public static function fromSparrow(source:FlxGraphicAsset, xml:FlxXmlAsset):FlxAtlasFrames
 	{
+		if (xml == null)
+			return null;
+			
+		final data:Xml = xml.getXml();
+		if (data == null)
+			return null;
+
 		var graphic:FlxGraphic = FlxG.bitmap.add(source);
 		if (graphic == null)
 			return null;
@@ -244,14 +252,11 @@ class FlxAtlasFrames extends FlxFramesCollection
 		if (frames != null)
 			return frames;
 
-		if (graphic == null || xml == null)
-			return null;
-
 		frames = new FlxAtlasFrames(graphic);
 
-		var data:Access = new Access(xml.getXml().firstElement());
+		var acs:Access = new Access(data.firstElement());
 
-		for (texture in data.nodes.SubTexture)
+		for (texture in acs.nodes.SubTexture)
 		{
 			if (!texture.has.width && texture.has.w)
 				throw "Sparrow v1 is not supported, use Sparrow v2";
@@ -294,11 +299,16 @@ class FlxAtlasFrames extends FlxFramesCollection
 
                 frame.name = name;
                 frame.offset.copyFrom(offset);
-                
+				sourceSize.put();
+				offset.put();
+				size.put();
                 continue;
             }
 
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle, flipX, flipY);
+			sourceSize.put();
+			offset.put();
+			size.put();
 		}
 
 		return frames;
@@ -314,6 +324,13 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 */
 	public static function fromTexturePackerXml(source:FlxGraphicAsset, xml:FlxXmlAsset):FlxAtlasFrames
 	{
+		if (xml == null)
+			return null;
+			
+		final data:Xml = xml.getXml();
+		if (data == null)
+			return null;
+
 		final graphic:FlxGraphic = FlxG.bitmap.add(source, false);
 		if (graphic == null)
 			return null;
@@ -323,12 +340,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		if (frames != null)
 			return frames;
 
-		if (graphic == null || xml == null)
-			return null;
-
 		frames = new FlxAtlasFrames(graphic);
-
-		final data = xml.getXml();
 
 		for (sprite in data.firstElement().elements())
 		{
@@ -363,6 +375,10 @@ class FlxAtlasFrames extends FlxFramesCollection
 	 */
 	public static function fromSpriteSheetPacker(Source:FlxGraphicAsset, Description:String):FlxAtlasFrames
 	{
+		Description = Description != null && FlxG.assets.exists(Description) ? FlxG.assets.getTextUnsafe(Description) : null;
+		if (Description == null)
+			return null;
+
 		var graphic:FlxGraphic = FlxG.bitmap.add(Source);
 		if (graphic == null)
 			return null;
@@ -372,13 +388,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 		if (frames != null)
 			return frames;
 
-		if (graphic == null || Description == null)
-			return null;
-
 		frames = new FlxAtlasFrames(graphic);
-
-		if (FlxG.assets.exists(Description))
-			Description = FlxG.assets.getTextUnsafe(Description);
 
 		var pack = StringTools.trim(Description);
 		var lines:Array<String> = pack.split("\n");

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -298,16 +298,12 @@ class FlxAtlasFrames extends FlxFramesCollection
                 var frame = frames.addEmptyFrame(size);
 
                 frame.name = name;
-                frame.offset.copyFrom(offset);
-				sourceSize.put();
-				offset.put();
+				frame.offset.copyFrom(offset);
 				size.put();
                 continue;
             }
 
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle, flipX, flipY);
-			sourceSize.put();
-			offset.put();
 			size.put();
 		}
 

--- a/flixel/graphics/frames/FlxFramesCollection.hx
+++ b/flixel/graphics/frames/FlxFramesCollection.hx
@@ -199,10 +199,6 @@ class FlxFramesCollection implements IFlxDestroyable
 		texFrame.sourceSize.set(sourceSize.x, sourceSize.y);
 		texFrame.offset.set(offset.x, offset.y);
 		texFrame.frame = checkFrame(frame, name);
-
-		sourceSize = FlxDestroyUtil.put(sourceSize);
-		offset = FlxDestroyUtil.put(offset);
-
 		return pushFrame(texFrame);
 	}
 

--- a/flixel/graphics/frames/FlxFramesCollection.hx
+++ b/flixel/graphics/frames/FlxFramesCollection.hx
@@ -199,6 +199,10 @@ class FlxFramesCollection implements IFlxDestroyable
 		texFrame.sourceSize.set(sourceSize.x, sourceSize.y);
 		texFrame.offset.set(offset.x, offset.y);
 		texFrame.frame = checkFrame(frame, name);
+
+		sourceSize = FlxDestroyUtil.put(sourceSize);
+		offset = FlxDestroyUtil.put(offset);
+
 		return pushFrame(texFrame);
 	}
 


### PR DESCRIPTION
Continued from https://github.com/HaxeFlixel/flixel/issues/3622
Fixed an issue where some `FlxRect` weren't being returned to pool (Not sure there aren't any yet)

It might be worth reconsidering
https://github.com/HaxeFlixel/flixel/blob/636c6e6c41e20b0f3ce8da9037c53daef26b38d5/flixel/graphics/frames/FlxFramesCollection.hx#L191
so that it doesn't put pooled `FlxPoint` internally
https://github.com/HaxeFlixel/flixel/blob/636c6e6c41e20b0f3ce8da9037c53daef26b38d5/flixel/graphics/frames/FlxFramesCollection.hx#L203-L204
leaving that responsibility to caller instead. Right now, only `addAtlasFrame` returns points to pool, whereas `addEmptyFrame` doesn't, which can leave pooled points unreleased when an empty frame is added.

Also I added safety checks for `.xml` and `.json` asset loading. Functions now verify that files exist before attempting to look up corresponding textures
