### PR TITLE
FlxGraphic: Destroy all frame colections 

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -355,6 +355,7 @@ class FlxGraphic implements IFlxDestroyable
 	 * All types of frames collection which had been added to this graphic object.
 	 * It helps to avoid map iteration, which produces a lot of garbage.
 	 */
+	@deprecated("frameCollectionTypes is deprecated, iterate frameCollections, instead")
 	var frameCollectionTypes:Array<FlxFrameCollectionType>;
 
 	/**
@@ -456,11 +457,8 @@ class FlxGraphic implements IFlxDestroyable
 			return;
 
 		var collections:Array<FlxFramesCollection>;
-		for (collectionType in frameCollectionTypes)
-		{
-			collections = cast frameCollections.get(collectionType);
+		for (type => collections in frameCollections)
 			FlxDestroyUtil.destroyArray(collections);
-		}
 
 		frameCollections = null;
 		frameCollectionTypes = null;

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -251,6 +251,7 @@ class FlxAtlasFrames extends FlxFramesCollection
 
 		var data:Access = new Access(xml.getXml().firstElement());
 
+		final size = FlxRect.get();
 		for (texture in data.nodes.SubTexture)
 		{
 			if (!texture.has.width && texture.has.w)
@@ -265,14 +266,14 @@ class FlxAtlasFrames extends FlxFramesCollection
 			var rect = FlxRect.get(Std.parseFloat(texture.att.x), Std.parseFloat(texture.att.y), Std.parseFloat(texture.att.width),
 				Std.parseFloat(texture.att.height));
 			
-			var size = if (trimmed)
+			if (trimmed)
 			{
-				FlxRect.get(Std.parseInt(texture.att.frameX), Std.parseInt(texture.att.frameY), Std.parseInt(texture.att.frameWidth),
+				size.set(Std.parseInt(texture.att.frameX), Std.parseInt(texture.att.frameY), Std.parseInt(texture.att.frameWidth),
 					Std.parseInt(texture.att.frameHeight));
 			}
 			else
 			{
-				FlxRect.get(0, 0, rect.width, rect.height);
+				size.set(0, 0, rect.width, rect.height);
 			}
 			
 
@@ -299,8 +300,8 @@ class FlxAtlasFrames extends FlxFramesCollection
             }
 
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle, flipX, flipY);
-			size.put();
 		}
+		size.put();
 
 		return frames;
 	}

--- a/flixel/graphics/frames/FlxAtlasFrames.hx
+++ b/flixel/graphics/frames/FlxAtlasFrames.hx
@@ -299,6 +299,7 @@ class FlxAtlasFrames extends FlxFramesCollection
             }
 
 			frames.addAtlasFrame(rect, sourceSize, offset, name, angle, flipX, flipY);
+			size.put();
 		}
 
 		return frames;


### PR DESCRIPTION
Fixes https://github.com/HaxeFlixel/flixel/issues/3622
Ensures all frame collections are destroyed
Puts the size rect back into the pool