### PR TITLE
Revert "Remove redundant music checks in frontend methods"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - `FlxSound` and `FlxG.sound`: Add support for music streaming ([#3518](https://github.com/HaxeFlixel/flixel/pull/3518))
 - `FlxBaseTilemap`: Add `rayAdvanced` and various `forEachInRay` helpers ([#3335](https://github.com/HaxeFlixel/flixel/pull/3335))
 - `FlxSound`: Add `loopCount` and `loopUntil` ([#3546](https://github.com/HaxeFlixel/flixel/pull/3546))
-- `FlxSound` and `FlxG.sound`: Large refactor of sound initialization ([#3558](https://github.com/HaxeFlixel/flixel/pull/3558)) ([#3586](https://github.com/HaxeFlixel/flixel/pull/3586))
+- `FlxSound` and `FlxG.sound`: Large refactor of sound initialization ([#3558](https://github.com/HaxeFlixel/flixel/pull/3558)) ([#3586](https://github.com/HaxeFlixel/flixel/pull/3586)) ([#3636](https://github.com/HaxeFlixel/flixel/pull/3636))
 - `AtlasRect`: add `l`, `r`, `t`, `b` getters ([#3588](https://github.com/HaxeFlixel/flixel/pull/3588))
 - `FlxRect`: Add `clone()`, set `_weak` once + doc ([#3587](https://github.com/HaxeFlixel/flixel/pull/3587))
 - `FlxBitmapText` and `FlxText`: Add `OUTLINE_CARDINAL` ([#3593](https://github.com/HaxeFlixel/flixel/pull/3593))

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -120,6 +120,7 @@ class SoundFrontEnd
 		else if (music.active)
 			music.stop();
 		
+		music.persist = true;
 		group.add(music);
 		
 		return music;

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -413,6 +413,11 @@ class SoundFrontEnd
 	 */
 	public function pause():Void
 	{
+		if (music != null && music.exists && music.active)
+		{
+			music.pause();
+		}
+
 		for (sound in list.members)
 		{
 			if (sound != null && sound.exists && sound.active)
@@ -427,6 +432,11 @@ class SoundFrontEnd
 	 */
 	public function resume():Void
 	{
+		if (music != null && music.exists)
+		{
+			music.resume();
+		}
+
 		for (sound in list.members)
 		{
 			if (sound != null && sound.exists)
@@ -443,6 +453,12 @@ class SoundFrontEnd
 	 */
 	public function destroy(forceDestroy = false):Void
 	{
+		if (music != null && (forceDestroy || !music.persist))
+		{
+			music.destroy();
+			music = null;
+		}
+
 		for (sound in list.members)
 		{
 			if (sound != null && (forceDestroy || !sound.persist))
@@ -538,6 +554,9 @@ class SoundFrontEnd
 	@:allow(flixel.FlxGame)
 	function update(elapsed:Float):Void
 	{
+		if (music != null && music.active)
+			music.update(elapsed);
+
 		if (list != null && list.active)
 			list.update(elapsed);
 
@@ -557,6 +576,11 @@ class SoundFrontEnd
 	@:allow(flixel.FlxGame)
 	function onFocusLost():Void
 	{
+		if (music != null)
+		{
+			music.onFocusLost();
+		}
+
 		for (sound in list.members)
 		{
 			if (sound != null)
@@ -569,6 +593,11 @@ class SoundFrontEnd
 	@:allow(flixel.FlxGame)
 	function onFocus():Void
 	{
+		if (music != null)
+		{
+			music.onFocus();
+		}
+
 		for (sound in list.members)
 		{
 			if (sound != null)

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -116,14 +116,11 @@ class SoundFrontEnd
 			group = defaultMusicGroup;
 		
 		if (music == null)
-		{
-			music = recycle(group);
-		}
+			music = new FlxSound();
 		else if (music.active)
-		{
 			music.stop();
-			group.add(music);
-		}
+		
+		group.add(music);
 		
 		return music;
 	}

--- a/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
@@ -204,6 +204,15 @@ class SoundFrontEndTest
 		FlxG.sound.onFocus();
 		Assert.areEqual(true, FlxG.sound.music.playing);
 	}
+	
+	@Test
+	function playMusicPersist()
+	{
+		final sound:Sound = debugSound(1000);
+		FlxG.sound.playMusic(sound);
+		
+		Assert.areEqual(true, FlxG.sound.music.persist);
+	}
 	#end
 	
 	function debugSound(ms:Float)//:Sound

--- a/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
@@ -98,6 +98,7 @@ class SoundFrontEndTest
 		assertSoundProps(1.0, false, false);
 		#end
 	}
+	#end
 	
 	@Test
 	@:haxe.warning("-WDeprecated")
@@ -187,24 +188,6 @@ class SoundFrontEndTest
 		FlxG.assets.streamSoundUnsafe = oldStreamFunc;
 		FlxG.assets.exists = oldExistsFunc;
 	}
-	
-	@Test
-	function playMusicFocus()
-	{
-		final sound:Sound = debugSound(1000);
-		FlxG.sound.playMusic(sound);
-		
-		Assert.areEqual(true, FlxG.sound.music.playing);
-		
-		@:privateAccess
-		FlxG.sound.onFocusLost();
-		Assert.areEqual(false, FlxG.sound.music.playing);
-		
-		@:privateAccess
-		FlxG.sound.onFocus();
-		Assert.areEqual(true, FlxG.sound.music.playing);
-	}
-	#end
 	
 	function debugSound(ms:Float)//:Sound
 	{

--- a/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
+++ b/tests/unit/src/flixel/system/frontEnds/SoundFrontEndTest.hx
@@ -98,7 +98,6 @@ class SoundFrontEndTest
 		assertSoundProps(1.0, false, false);
 		#end
 	}
-	#end
 	
 	@Test
 	@:haxe.warning("-WDeprecated")
@@ -188,6 +187,24 @@ class SoundFrontEndTest
 		FlxG.assets.streamSoundUnsafe = oldStreamFunc;
 		FlxG.assets.exists = oldExistsFunc;
 	}
+	
+	@Test
+	function playMusicFocus()
+	{
+		final sound:Sound = debugSound(1000);
+		FlxG.sound.playMusic(sound);
+		
+		Assert.areEqual(true, FlxG.sound.music.playing);
+		
+		@:privateAccess
+		FlxG.sound.onFocusLost();
+		Assert.areEqual(false, FlxG.sound.music.playing);
+		
+		@:privateAccess
+		FlxG.sound.onFocus();
+		Assert.areEqual(true, FlxG.sound.music.playing);
+	}
+	#end
 	
 	function debugSound(ms:Float)//:Sound
 	{


### PR DESCRIPTION
Reverts HaxeFlixel/flixel#3586

> This is a breaking change. It breaks any project that manually replaces `FlxG.sound.music`, most notably Funkin'.
> 
> From what I've gathered, `FlxG.sound.music` used to be updated independently of the sound list. If you wanted to replace it with a custom sound you could simply reassign it (and remove it from the sound list, if created via `FlxG.sound`). ([example](https://github.com/FunkinCrew/Funkin/blob/main/source/funkin/audio/FunkinSound.hx#L387-L397))
> 
> Since it's no longer updated independently, projects that do the aforementioned now have music that doesn't update, which is especially problematic in FNF's case as the sound time no longer updates, and therefore the gameplay gets stuck

