### PR TITLE
`pixelPerfectRender`: Round instead of flooring

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -1049,7 +1049,7 @@ class FlxObject extends FlxBasic
 
 		result.set(x, y);
 		if (pixelPerfectPosition)
-			result.floor();
+			result.round();
 
 		return result.subtract(camera.scroll.x * scrollFactor.x, camera.scroll.y * scrollFactor.y);
 	}
@@ -1090,7 +1090,7 @@ class FlxObject extends FlxBasic
 	
 	inline function getViewXHelper(camera:FlxCamera)
 	{
-		final x = pixelPerfectPosition ? Math.floor(this.x) : this.x;
+		final x = pixelPerfectPosition ? Math.round(this.x) : this.x;
 		return (x - (camera.scroll.x * scrollFactor.x) - camera.viewMarginX) * camera.zoom;
 	}
 	
@@ -1111,7 +1111,7 @@ class FlxObject extends FlxBasic
 	
 	inline function getViewYHelper(camera:FlxCamera)
 	{
-		final y = pixelPerfectPosition ? Math.floor(this.y) : this.y;
+		final y = pixelPerfectPosition ? Math.round(this.y) : this.y;
 		return (y - (camera.scroll.y * scrollFactor.y) - camera.viewMarginY) * camera.zoom;
 	}
 	
@@ -1383,7 +1383,7 @@ class FlxObject extends FlxBasic
 
 		if (isPixelPerfectRender(camera))
 		{
-			_rect.floor();
+			_rect.round();
 		}
 
 		return _rect;

--- a/flixel/FlxSprite.hx
+++ b/flixel/FlxSprite.hx
@@ -1006,7 +1006,7 @@ class FlxSprite extends FlxObject
 	{
 		getScreenPosition(_point, camera).subtract(offset);
 		if (isPixelPerfectRender(camera))
-			_point.floor();
+			_point.round();
 
 		_point.copyTo(_flashPoint);
 		camera.copyPixels(_frame, framePixels, _flashRect, _flashPoint, colorTransform, blend, antialiasing);
@@ -1049,8 +1049,8 @@ class FlxSprite extends FlxObject
 		
 		if (isPixelPerfectRender(camera))
 		{
-			matrix.tx = Math.floor(matrix.tx);
-			matrix.ty = Math.floor(matrix.ty);
+			matrix.tx = Math.round(matrix.tx);
+			matrix.ty = Math.round(matrix.ty);
 		}
 	}
 
@@ -1737,12 +1737,12 @@ class FlxSprite extends FlxObject
 		
 		newRect.setPosition(x, y);
 		if (pixelPerfectPosition)
-			newRect.floor();
+			newRect.round();
 		_scaledOrigin.set(origin.x * scale.x, origin.y * scale.y);
 		newRect.x += -Std.int(camera.scroll.x * scrollFactor.x) - offset.x + origin.x - _scaledOrigin.x;
 		newRect.y += -Std.int(camera.scroll.y * scrollFactor.y) - offset.y + origin.y - _scaledOrigin.y;
 		if (isPixelPerfectRender(camera))
-			newRect.floor();
+			newRect.round();
 		newRect.setSize(frameWidth * Math.abs(scale.x), frameHeight * Math.abs(scale.y));
 		return newRect.getRotatedBounds(angle, _scaledOrigin, newRect);
 	}

--- a/flixel/effects/FlxMatrixSprite.hx
+++ b/flixel/effects/FlxMatrixSprite.hx
@@ -55,8 +55,8 @@ class FlxMatrixSprite extends FlxSprite
 		
 		if (isPixelPerfectRender(camera))
 		{
-			matrix.tx = Math.floor(matrix.tx);
-			matrix.ty = Math.floor(matrix.ty);
+			matrix.tx = Math.round(matrix.tx);
+			matrix.ty = Math.round(matrix.ty);
 		}
 	}
 }

--- a/flixel/text/FlxBitmapText.hx
+++ b/flixel/text/FlxBitmapText.hx
@@ -379,7 +379,7 @@ class FlxBitmapText extends FlxSprite
 
 				if (isPixelPerfectRender(camera))
 				{
-					screenPos.floor();
+					screenPos.round();
 				}
 
 				updateTrig();

--- a/flixel/tile/FlxTilemap.hx
+++ b/flixel/tile/FlxTilemap.hx
@@ -1042,8 +1042,8 @@ class FlxTypedTilemap<Tile:FlxTile> extends FlxBaseTilemap<Tile>
 		{
 			getScreenPosition(_point, camera).subtract(offset).copyTo(_helperPoint);
 
-			_helperPoint.x = isPixelPerfectRender(camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
-			_helperPoint.y = isPixelPerfectRender(camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;
+			_helperPoint.x = isPixelPerfectRender(camera) ? Math.round(_helperPoint.x) : _helperPoint.x;
+			_helperPoint.y = isPixelPerfectRender(camera) ? Math.round(_helperPoint.y) : _helperPoint.y;
 
 			scaledWidth = scaledTileWidth;
 			scaledHeight = scaledTileHeight;

--- a/flixel/tile/FlxTilemapBuffer.hx
+++ b/flixel/tile/FlxTilemapBuffer.hx
@@ -1,16 +1,16 @@
 package flixel.tile;
 
-import openfl.display.BitmapData;
-import openfl.geom.Point;
-import openfl.geom.Rectangle;
 import flixel.FlxCamera;
 import flixel.FlxG;
 import flixel.math.FlxMatrix;
 import flixel.tile.FlxTilemap;
 import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
+import openfl.display.BitmapData;
 import openfl.display.BlendMode;
 import openfl.geom.ColorTransform;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
 
 /**
  * A helper object to keep tilemap drawing performance decent across the new multi-camera system.
@@ -177,8 +177,8 @@ class FlxTilemapBuffer implements IFlxDestroyable
 	{
 		if (isPixelPerfectRender(camera))
 		{
-			flashPoint.x = Math.floor(flashPoint.x);
-			flashPoint.y = Math.floor(flashPoint.y);
+			flashPoint.x = Math.round(flashPoint.x);
+			flashPoint.y = Math.round(flashPoint.y);
 		}
 		
 		if (isPixelPerfectRender(camera) && (scaleX == 1.0 && scaleY == 1.0) && blend == null)

--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -1,8 +1,5 @@
 package flixel.ui;
 
-import openfl.display.BitmapData;
-import openfl.geom.Point;
-import openfl.geom.Rectangle;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.FlxGraphic;
@@ -15,6 +12,9 @@ import flixel.util.FlxColor;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxGradient;
 import flixel.util.FlxStringUtil;
+import openfl.display.BitmapData;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
 
 // TODO: better handling bars with borders (don't take border into account while drawing its front).
 
@@ -886,8 +886,8 @@ class FlxBar extends FlxSprite
 				
 				if (isPixelPerfectRender(camera))
 				{
-					_matrix.tx = Math.floor(_matrix.tx);
-					_matrix.ty = Math.floor(_matrix.ty);
+					_matrix.tx = Math.round(_matrix.tx);
+					_matrix.ty = Math.round(_matrix.ty);
 				}
 				
 				camera.drawPixels(_frontFrame, _matrix, colorTransform, blend, antialiasing, shader);

--- a/flixel/ui/FlxButton.hx
+++ b/flixel/ui/FlxButton.hx
@@ -530,8 +530,8 @@ class FlxTypedButton<T:FlxSprite> extends FlxSprite implements IFlxInput
 	{
 		if (_spriteLabel != null) // Label positioning
 		{
-			_spriteLabel.x = (pixelPerfectPosition ? Math.floor(x) : x) + labelOffsets[status.toInt()].x;
-			_spriteLabel.y = (pixelPerfectPosition ? Math.floor(y) : y) + labelOffsets[status.toInt()].y;
+			_spriteLabel.x = (pixelPerfectPosition ? Math.round(x) : x) + labelOffsets[status.toInt()].x;
+			_spriteLabel.y = (pixelPerfectPosition ? Math.round(y) : y) + labelOffsets[status.toInt()].y;
 		}
 	}
 


### PR DESCRIPTION
Tweening sprite groups or sprites often causes rounding errors when a sprite's position becomes, say: 99.9999999999 