### PR TITLE
FlxVersionMacro: Fix build error by null checking some values 

### DIFF
--- a/flixel/system/macros/FlxVersionMacro.hx
+++ b/flixel/system/macros/FlxVersionMacro.hx
@@ -76,7 +76,9 @@ class FlxVersionMacro
 				final libPath = getLibraryPath(id);
 				final sha = getGitSHA(libPath);
 				final branchRaw = getGitBranch(libPath);
-				final defaultBranch = getGitDefaultBranch(libPath).split("/").pop();
+				var defaultBranch = getGitDefaultBranch(libPath);
+				if (defaultBranch != null)
+					defaultBranch = defaultBranch.split("/").pop();
 				
 				final branch = branchRaw == defaultBranch ? null : branchRaw;
 				
@@ -124,13 +126,20 @@ class FlxVersionMacro
 	
 	public static function getGitBranch(path:String):Null<String>
 	{
-		return getProcessOutput("git", ["-C", path, "rev-parse", "--abbrev-ref", "HEAD"]).trim();
+		final output = getProcessOutput("git", ["-C", path, "rev-parse", "--abbrev-ref", "HEAD"]);
+		if (output != null)
+			output.trim();
+
+		return output;
 	}
-	
 	
 	public static function getGitDefaultBranch(path:String):Null<String>
 	{
-		return getProcessOutput("git", ["-C", path, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"]).trim();
+		final output = getProcessOutput("git", ["-C", path, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+		if (output != null)
+			output.trim();
+
+		return output;
 	}
 	
 	public static function getProcessOutput(cmd:String, args:Array<String>):Null<String>


### PR DESCRIPTION
In some rare cases I can't seem to reproduce (but people have experienced, see [relevant convo in Haxe discord](https://discord.com/channels/162395145352904705/165234904815239168/1534580726287044759)) summoning a process would fail which would in turn cause a build error as FlxVersionMacro does string operations without null-checking them first.

Very simple fix is to just null check the process outputs before doing anything with them